### PR TITLE
feat(dna): Phase 1.1 — dim-fill merge for unmapped peers

### DIFF
--- a/src/digital_dna/digital_dna.h
+++ b/src/digital_dna/digital_dna.h
@@ -379,6 +379,68 @@ inline bool core_dimensions_changed(const DigitalDNA& old_dna, const DigitalDNA&
     return false;
 }
 
+/**
+ * Phase 1.1 merge helper — "fill-only" merge for propagation from unmapped peers.
+ *
+ * Starts from `existing` (the canonical record we already trust) and fills in
+ * ONLY dimensions that are currently unpopulated, taking each filled value
+ * from `incoming`. Core fields (address, mik_identity, latency, timing,
+ * registration_{height,time}) are always preserved from `existing`.
+ *
+ * This preserves data provenance: an unmapped peer can help us fill missing
+ * dimensions (beneficial — improves coverage) but cannot overwrite existing
+ * values (which would allow a relay peer to pollute readings claimed by the
+ * miner). The mapped-peer path in the receiver continues to accept full
+ * replacements for trust-equivalent updates.
+ *
+ * If `filled_count_out` is non-null, it is set to the number of dimensions
+ * this call actually filled (0 means nothing to do — caller should drop).
+ *
+ * Populated predicates match the coverage counters used elsewhere:
+ *   - optional<T>: populated iff engaged
+ *   - perspective: populated iff total_unique_peers() > 0 OR snapshots non-empty
+ *   - latency/timing: always "populated" (core), never merged from incoming
+ */
+inline DigitalDNA merge_fill_missing_dims(const DigitalDNA& existing,
+                                          const DigitalDNA& incoming,
+                                          int* filled_count_out = nullptr) {
+    DigitalDNA merged = existing;
+    int filled = 0;
+
+    if (!existing.memory && incoming.memory) {
+        merged.memory = incoming.memory;
+        ++filled;
+    }
+    if (!existing.clock_drift && incoming.clock_drift) {
+        merged.clock_drift = incoming.clock_drift;
+        ++filled;
+    }
+    if (!existing.bandwidth && incoming.bandwidth) {
+        merged.bandwidth = incoming.bandwidth;
+        ++filled;
+    }
+    if (!existing.thermal && incoming.thermal) {
+        merged.thermal = incoming.thermal;
+        ++filled;
+    }
+    if (!existing.behavioral && incoming.behavioral) {
+        merged.behavioral = incoming.behavioral;
+        ++filled;
+    }
+    // Perspective is not optional<T> but has a populated predicate.
+    bool existing_has_perspective = (existing.perspective.total_unique_peers() > 0
+                                     || !existing.perspective.snapshots.empty());
+    bool incoming_has_perspective = (incoming.perspective.total_unique_peers() > 0
+                                     || !incoming.perspective.snapshots.empty());
+    if (!existing_has_perspective && incoming_has_perspective) {
+        merged.perspective = incoming.perspective;
+        ++filled;
+    }
+
+    if (filled_count_out) *filled_count_out = filled;
+    return merged;
+}
+
 } // namespace digital_dna
 
 #endif // DILITHION_DIGITAL_DNA_H

--- a/src/node/dilithion-node.cpp
+++ b/src/node/dilithion-node.cpp
@@ -4381,13 +4381,12 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                     auto it = g_mik_peer_map.find(mik);
                     mapped = (it != g_mik_peer_map.end() && it->second == peer_id);
                 }
-                if (!mapped) {
-                    // Not the mapped peer — silently drop. Mapping will be updated below
-                    // so future samples from this peer for this MIK can pass.
-                } else {
-                    uint64_t now_sec = static_cast<uint64_t>(
-                        std::chrono::duration_cast<std::chrono::seconds>(
-                            std::chrono::system_clock::now().time_since_epoch()).count());
+                uint64_t now_sec = static_cast<uint64_t>(
+                    std::chrono::duration_cast<std::chrono::seconds>(
+                        std::chrono::system_clock::now().time_since_epoch()).count());
+
+                if (mapped) {
+                    // Full-trust path (Phase 1): mapped peer can overwrite any field.
                     if (g_dna_sample_limiter.allow(peer_id, mik, now_sec)) {
                         auto result = g_node_context.dna_registry->append_sample(*dna);
                         if (result == digital_dna::IDNARegistry::RegisterResult::UPDATED ||
@@ -4400,6 +4399,28 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                         }
                         // INVALID_DNA (dim-loss) and DB_ERROR are silent — expected under
                         // mixed-version propagation and transient storage issues.
+                    }
+                } else {
+                    // Phase 1.1 dim-fill path: unmapped peers can fill missing
+                    // dimensions but cannot overwrite existing values. Protects
+                    // data provenance from relay-peer pollution while unblocking
+                    // propagation for the common case (discovery response from a
+                    // peer that happens to have enriched DNA for this MIK).
+                    int filled = 0;
+                    auto merged = digital_dna::merge_fill_missing_dims(*existing, *dna, &filled);
+                    if (filled == 0) {
+                        // Nothing to add — unmapped peer has no new info. Silent drop.
+                    } else if (g_dna_sample_limiter.allow(peer_id, mik, now_sec)) {
+                        auto result = g_node_context.dna_registry->append_sample(merged);
+                        if (result == digital_dna::IDNARegistry::RegisterResult::UPDATED ||
+                            result == digital_dna::IDNARegistry::RegisterResult::DNA_CHANGED) {
+                            char hex[9];
+                            snprintf(hex, sizeof(hex), "%02x%02x%02x%02x",
+                                     mik[0], mik[1], mik[2], mik[3]);
+                            std::cout << "[DNA] Filled " << filled << " dim(s) for MIK "
+                                      << hex << "... from peer " << peer_id
+                                      << " (unmapped)" << std::endl;
+                        }
                     }
                 }
             }

--- a/src/node/dilv-node.cpp
+++ b/src/node/dilv-node.cpp
@@ -4256,10 +4256,12 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                     auto it = g_mik_peer_map.find(mik);
                     mapped = (it != g_mik_peer_map.end() && it->second == peer_id);
                 }
+                uint64_t now_sec = static_cast<uint64_t>(
+                    std::chrono::duration_cast<std::chrono::seconds>(
+                        std::chrono::system_clock::now().time_since_epoch()).count());
+
                 if (mapped) {
-                    uint64_t now_sec = static_cast<uint64_t>(
-                        std::chrono::duration_cast<std::chrono::seconds>(
-                            std::chrono::system_clock::now().time_since_epoch()).count());
+                    // Full-trust path (Phase 1): mapped peer can overwrite any field.
                     if (g_dna_sample_limiter.allow(peer_id, mik, now_sec)) {
                         auto result = g_node_context.dna_registry->append_sample(*dna);
                         if (result == digital_dna::IDNARegistry::RegisterResult::UPDATED ||
@@ -4273,9 +4275,29 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                         // INVALID_DNA (dim-loss) and DB_ERROR are silent — expected under
                         // mixed-version propagation and transient storage issues.
                     }
+                } else {
+                    // Phase 1.1 dim-fill path: unmapped peers can fill missing
+                    // dimensions but cannot overwrite existing values. Protects
+                    // data provenance from relay-peer pollution while unblocking
+                    // propagation for the common case (discovery response from a
+                    // peer that happens to have enriched DNA for this MIK).
+                    int filled = 0;
+                    auto merged = digital_dna::merge_fill_missing_dims(*existing, *dna, &filled);
+                    if (filled == 0) {
+                        // Nothing to add — unmapped peer has no new info. Silent drop.
+                    } else if (g_dna_sample_limiter.allow(peer_id, mik, now_sec)) {
+                        auto result = g_node_context.dna_registry->append_sample(merged);
+                        if (result == digital_dna::IDNARegistry::RegisterResult::UPDATED ||
+                            result == digital_dna::IDNARegistry::RegisterResult::DNA_CHANGED) {
+                            char hex[9];
+                            snprintf(hex, sizeof(hex), "%02x%02x%02x%02x",
+                                     mik[0], mik[1], mik[2], mik[3]);
+                            std::cout << "[DNA] Filled " << filled << " dim(s) for MIK "
+                                      << hex << "... from peer " << peer_id
+                                      << " (unmapped)" << std::endl;
+                        }
+                    }
                 }
-                // Unmapped peer: silent drop. The mapping update below lets future
-                // samples from this peer for this MIK pass.
             }
 
             // Phase 2: Track MIK -> peer_id mapping for verification routing

--- a/src/test/dna_propagation_tests.cpp
+++ b/src/test/dna_propagation_tests.cpp
@@ -325,11 +325,133 @@ TEST(rate_limiter_reject_leaves_state_unchanged) {
 }
 
 // ---------------------------------------------------------------------------
+// Phase 1.1 merge-fill tests
+// ---------------------------------------------------------------------------
+
+TEST(merge_fill_fills_missing_dimension) {
+    // existing has no bandwidth; incoming has bandwidth → merged has bandwidth.
+    auto existing = make_dna(0xA0, true, true, false, false, false);  // mem+thermal
+    auto incoming = make_dna(0xA0, true, true, false, true,  false);  // mem+thermal+bw
+
+    int filled = -1;
+    auto merged = digital_dna::merge_fill_missing_dims(existing, incoming, &filled);
+
+    ASSERT_EQ(filled, 1, "should fill exactly one dim (bandwidth)");
+    ASSERT(merged.bandwidth.has_value(), "merged has bandwidth");
+    ASSERT(merged.memory.has_value(), "merged keeps memory");
+    ASSERT(merged.thermal.has_value(), "merged keeps thermal");
+    ASSERT(!merged.clock_drift.has_value(), "merged doesn't invent clock_drift");
+    ASSERT(!merged.behavioral.has_value(), "merged doesn't invent behavioral");
+}
+
+TEST(merge_fill_no_gap_returns_existing_with_zero_filled) {
+    // Both have the same populated set → filled=0.
+    auto existing = make_dna(0xA1, true, true, false, false, false);
+    auto incoming = make_dna(0xA1, true, true, false, false, false);
+
+    int filled = -1;
+    auto merged = digital_dna::merge_fill_missing_dims(existing, incoming, &filled);
+
+    ASSERT_EQ(filled, 0, "no dims to fill when both have same set");
+    // merged should be equivalent to existing.
+    ASSERT(merged.memory.has_value() == existing.memory.has_value(), "memory preserved");
+    ASSERT(merged.thermal.has_value() == existing.thermal.has_value(), "thermal preserved");
+    ASSERT(!merged.bandwidth.has_value(), "bandwidth still absent");
+}
+
+TEST(merge_fill_preserves_existing_values_on_conflict) {
+    // existing has memory populated; incoming has memory populated with a
+    // different marker. Merge must keep existing's value.
+    auto existing = make_dna(0xA2, true, true, false, false, false);
+    existing.timing.iterations_per_second = 100000.0;  // distinguishing marker
+
+    auto incoming = make_dna(0xA2, true, true, false, true, false);
+    incoming.timing.iterations_per_second = 777777.0;  // different value — must NOT win
+
+    int filled = 0;
+    auto merged = digital_dna::merge_fill_missing_dims(existing, incoming, &filled);
+
+    ASSERT_EQ(filled, 1, "only bandwidth filled");
+    ASSERT(merged.bandwidth.has_value(), "bandwidth now present");
+    // Core field (timing.iterations_per_second) must come from existing.
+    if (std::abs(merged.timing.iterations_per_second - 100000.0) > 1.0)
+        throw std::runtime_error("timing IPS must be preserved from existing, not overwritten");
+}
+
+TEST(merge_fill_multiple_missing_dims) {
+    auto existing = make_dna(0xA3, false, false, false, false, false);  // only core
+    auto incoming = make_dna(0xA3, true,  true,  true,  true,  true);   // all enriched
+
+    int filled = 0;
+    auto merged = digital_dna::merge_fill_missing_dims(existing, incoming, &filled);
+
+    // Counts: memory, thermal, clock_drift, bandwidth, behavioral = 5.
+    ASSERT_EQ(filled, 5, "should fill 5 dims");
+    ASSERT(merged.memory.has_value(), "memory filled");
+    ASSERT(merged.thermal.has_value(), "thermal filled");
+    ASSERT(merged.clock_drift.has_value(), "clock_drift filled");
+    ASSERT(merged.bandwidth.has_value(), "bandwidth filled");
+    ASSERT(merged.behavioral.has_value(), "behavioral filled");
+}
+
+TEST(merge_fill_then_append_sample_succeeds_with_dim_loss_guard) {
+    // End-to-end: seed the registry with a thin DNA (mapped-peer-equivalent,
+    // via append_sample on fresh MIK), then simulate an unmapped peer
+    // providing an enriched sample. Call merge + append and verify the
+    // canonical record has the new dim.
+    ScratchDir dir("mf_e2e");
+    DNARegistryDB reg;
+    ASSERT(reg.Open(dir.path.string()), "open db");
+
+    auto slim = make_dna(0xA4, true, true, false, false, false);   // 4 dims
+    ASSERT(reg.append_sample(slim) == IDNARegistry::RegisterResult::SUCCESS, "seed");
+
+    auto enriched_from_relay = make_dna(0xA4, true, true, false, true, false);  // +bw
+    int filled = 0;
+    auto merged = digital_dna::merge_fill_missing_dims(slim, enriched_from_relay, &filled);
+    ASSERT_EQ(filled, 1, "relay fills bandwidth");
+
+    auto r = reg.append_sample(merged);
+    ASSERT(r == IDNARegistry::RegisterResult::UPDATED ||
+           r == IDNARegistry::RegisterResult::DNA_CHANGED,
+           "merged sample should be accepted by append_sample");
+
+    auto canonical = reg.get_identity(slim.address);
+    ASSERT(canonical.has_value(), "canonical present");
+    ASSERT(canonical->bandwidth.has_value(), "canonical now has bandwidth after merge-append");
+}
+
+TEST(merge_fill_perspective_dim_is_fillable) {
+    // perspective isn't optional<T> — it has its own populated predicate.
+    // Verify merge treats it correctly.
+    auto existing = make_dna(0xA5, false, false, false, false, false);
+    // existing has zero peers in perspective by default.
+    ASSERT_EQ(existing.perspective.total_unique_peers(), (size_t)0, "existing has no peer data");
+
+    auto incoming = existing;  // same address
+    // Simulate incoming perspective with a snapshot.
+    digital_dna::PerspectiveSnapshot snap;
+    snap.timestamp = 1700000000;
+    snap.block_height = 100;
+    for (size_t i = 0; i < 20; ++i) {
+        std::array<uint8_t, 20> peer{};
+        for (size_t j = 0; j < 20; ++j) peer[j] = static_cast<uint8_t>(i + j);
+        snap.active_peers.push_back(peer);
+    }
+    incoming.perspective.snapshots.push_back(snap);
+
+    int filled = 0;
+    auto merged = digital_dna::merge_fill_missing_dims(existing, incoming, &filled);
+    ASSERT(filled >= 1, "perspective should count as a filled dim");
+    ASSERT(!merged.perspective.snapshots.empty(), "merged got the perspective snapshot");
+}
+
+// ---------------------------------------------------------------------------
 // main
 // ---------------------------------------------------------------------------
 
 int main() {
-    std::cout << "\n" << YELLOW_ << "=== DNA Propagation Phase 1 Tests ===" << RESET_ << "\n" << std::endl;
+    std::cout << "\n" << YELLOW_ << "=== DNA Propagation Phase 1 + 1.1 Tests ===" << RESET_ << "\n" << std::endl;
 
     test_append_sample_unregistered_registers_wrapper();
     test_append_sample_enriches_and_archives_wrapper();
@@ -341,6 +463,14 @@ int main() {
     test_rate_limiter_per_mik_global_wrapper();
     test_rate_limiter_per_mik_per_peer_wrapper();
     test_rate_limiter_reject_leaves_state_unchanged_wrapper();
+
+    // Phase 1.1 merge-fill tests
+    test_merge_fill_fills_missing_dimension_wrapper();
+    test_merge_fill_no_gap_returns_existing_with_zero_filled_wrapper();
+    test_merge_fill_preserves_existing_values_on_conflict_wrapper();
+    test_merge_fill_multiple_missing_dims_wrapper();
+    test_merge_fill_then_append_sample_succeeds_with_dim_loss_guard_wrapper();
+    test_merge_fill_perspective_dim_is_fillable_wrapper();
 
     std::cout << "\n" << YELLOW_ << "=== Results ===" << RESET_ << std::endl;
     std::cout << GREEN_ << "Passed: " << g_tests_passed << RESET_ << std::endl;


### PR DESCRIPTION
## Summary

- Phase 1 (cb46aa1) fixed 3 propagation gates but kept a strict plausibility check (`g_mik_peer_map[mik] == peer_id`). After 24h on all 4 mainnet seeds, bandwidth/clock_drift coverage didn't move — discovery refresh responses come from relay peers whose peer_id doesn't match the mapping, so every response was silently dropped. `/root/node.log` on NYC showed zero `[DNA] Appended sample` events in 12h.
- Phase 1.1 extends the receiver with a **dim-fill merge path** for unmapped peers. Mapped peers keep full-trust (can overwrite any field); unmapped peers can only fill dimensions we don't already have — cannot overwrite existing values. Preserves data provenance while unblocking propagation.
- 6 new unit tests + 253/253 existing DNA regression green. No consensus changes, no new wire format, no miner update required.
- Phase 1.5 (signed MIK-bound envelope) will follow and ships alongside the next miner release — that's when unmapped peers will be able to push full replacements.

## Key design property

The merge helper `digital_dna::merge_fill_missing_dims(existing, incoming)` starts from `existing` and fills only dims that were unpopulated. Core fields (`latency`, `timing`, `address`, `mik_identity`) always come from `existing`. A malicious relay peer can only help us (add missing dims) — it cannot pollute existing readings, which matters when Phase 2 anomaly detection arrives.

## What changes

- `src/digital_dna/digital_dna.h` — new `merge_fill_missing_dims()` free function (inline, pure)
- `src/node/dilithion-node.cpp` — receiver handler: mapped path unchanged, unmapped path = merge + rate-limit + `append_sample(merged)`
- `src/node/dilv-node.cpp` — same change
- `src/test/dna_propagation_tests.cpp` — 6 new tests (fills missing dim, no-gap drop, preserves existing values, multi-dim fill, end-to-end with append_sample, perspective non-optional dim)

Log prefixes make post-deploy monitoring trivial:
- `[DNA] Appended sample for MIK xxx... from peer Y` — mapped path (unchanged)
- `[DNA] Filled N dim(s) for MIK xxx... from peer Y (unmapped)` — new path

## What doesn't change

- `DigitalDNA::hash()` — untouched
- Consensus-layer files — zero changes (`git diff --name-only` verified)
- P2P wire format — `dnaires` message unchanged
- Trust score / core-dims-changed semantics — untouched
- Mapped-peer fast path behaviour — Phase 1 preserved exactly
- Rate limiter — same 3-layer limits, both paths contend for the same quotas

## Test plan

- [x] `dna_propagation_tests` — 15/15 pass (9 from Phase 1 + 6 new)
- [x] Regression: `dna_serialization_test` (123), `dna_history_test` (19), `dna_p2p_test` (38), `dna_monitor_test` (25), `dna_detection_test` (34), `mik_registration_persistence_tests` (14) — all green
- [x] Both node binaries build clean on MSYS2
- [ ] Deploy to NYC first, watch `/root/node.log` for `[DNA] Filled N dim(s)` entries within 1h
- [ ] Rolling LDN → SGP → SYD if NYC shows expected log activity
- [ ] 24h `getdnamonitor` re-check — expect bandwidth + clock_drift to climb meaningfully from the ~1% baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)