### PR TITLE
chore: harden dependabot config against consensus-breaking auto-bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,12 @@ updates:
     labels:
       - "dependencies"
       - "bridge"
+    # Major version bumps require manual migration work (e.g. Hardhat v2→v3
+    # is ESM-only and breaks the entire config). Skip them — we'll do majors
+    # as deliberate migration PRs if and when we decide to.
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     # Group minor + patch updates into a single PR per week.
     groups:
       bridge-minor-patch:
@@ -52,6 +58,10 @@ updates:
     labels:
       - "dependencies"
       - "x402"
+    # Major version bumps require manual migration — skip them.
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     groups:
       x402-minor-patch:
         patterns:
@@ -60,7 +70,21 @@ updates:
           - "minor"
           - "patch"
 
-  # Git submodules (Dilithium ref, RandomX, chiavdf).
+  # Git submodules.
+  #
+  # CRITICAL: the randomx and chiavdf submodules implement DIL and DilV
+  # consensus respectively. Any commit bump can be a hard fork (see
+  # https://github.com/dilithion/dilithion/pull/7 — a dependabot PR that
+  # silently included "RandomX v2", a breaking PoW algorithm change).
+  # Consensus-critical submodules are only bumped manually via a dedicated
+  # hard-fork activation plan, never auto-merged.
+  #
+  # openssl-src is unused by any build (macOS/Linux/Windows all link
+  # system libssl via brew/apt/msys2). Leave it out of auto-bumps until
+  # we either delete the submodule or wire it in.
+  #
+  # dilithium and leveldb are left auto-tracked — they're library deps,
+  # not consensus-critical.
   - package-ecosystem: "gitsubmodule"
     directory: "/"
     schedule:
@@ -72,3 +96,7 @@ updates:
     labels:
       - "dependencies"
       - "submodules"
+    ignore:
+      - dependency-name: "depends/randomx"      # DIL consensus — manual bump only
+      - dependency-name: "depends/chiavdf"      # DilV VDF consensus — manual bump only
+      - dependency-name: "depends/openssl-src"  # unused submodule — delete or pin before enabling


### PR DESCRIPTION
## Summary

PR #7 (depends/randomx bump) was a routine-looking dependency update that silently contained a hard fork — commit `bb6ed2c` "RandomX v2" changed the PoW algorithm itself (program size 256→384, CFROUND tweaked, register mix changed, dataset prefetch changed). An unthinking squash-merge would have forked the DIL chain the moment an updated node produced a block.

Dependabot has no awareness of which dependencies carry consensus semantics. Fix that in config.

## Changes

1. **Ignore consensus-critical submodules entirely**
   - `depends/randomx` — DIL PoW algorithm
   - `depends/chiavdf` — DilV VDF algorithm
   
   These are only bumped via a deliberate hard-fork activation plan.

2. **Ignore `depends/openssl-src`**
   
   Unused by any build path today — macOS builds use `brew install openssl`, Linux uses `libssl-dev`, Windows uses `mingw-w64-x86_64-openssl`. Re-enable after we either delete the submodule or wire it into the build.

3. **Block npm major version bumps in `/bridge` and `/x402-sdk`**
   
   Majors (e.g. Hardhat v2→v3 which is ESM-only) require migration work. Dependabot still opens minor+patch PRs for security fixes. Majors happen as deliberate migration PRs when we choose to do them.

## What stays on auto-pilot

- GitHub Actions workflow bumps (low risk)
- npm minor + patch updates in `/bridge` and `/x402-sdk` (security fixes)
- Non-consensus submodules (dilithium ref, leveldb)
- **Dependabot Security Alerts** (CVE-driven, show up in Security tab regardless of config)

## Test plan

- [x] YAML structural checks pass (3 submodule ignores, 2 npm major blocks, no tabs, version: 2)
- [x] Repo hygiene script passes
- [ ] After merge: confirm next Monday's Dependabot run does NOT re-open PRs equivalent to #7, #8, #9, #10
- [ ] After merge: close PRs #7 and #8 manually; new bumps for those submodules will no longer appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)