### PR TITLE
feat(v4.0.17): DNA Phase 1.2 + miner UX overhaul + new checkpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,55 @@ Tracked but not yet shipped. See `git log origin/main...HEAD` on a fresh checkou
 
 ---
 
+## [v4.0.17] — 2026-04-21
+
+### Added
+- **Digital DNA propagation** now functions on DIL for the first time. Three-stage fix shipping together:
+  - Phase 1 — receiver accepts progressively enriched DNA for already-registered MIKs; sender re-broadcasts on local enrichment; discovery refreshes stale records.
+  - Phase 1.1 — relay seeds can dim-fill missing dimensions on behalf of unmapped peers while preserving data provenance (core fields stay authoritative to the miner).
+  - Phase 1.2 — discovery now sources known MIKs from the DNA registry (plus the legacy VDF cooldown tracker), unblocking the discovery loop on DIL where the cooldown tracker was always empty.
+- **Mining**: MIK registration PoW is now persisted to `mik_registration.dat` and restored on startup. Miners no longer re-solve the ~25-minute 28-bit PoW after a chain wipe or restart.
+- **Node**: `--reset-chain` flag wipes chain-derived state (blocks, chainstate, headers, dna_registry, dfmp_identity, dna_trust, wal, mempool, DFMP heat files) while preserving wallet, MIK registration, peers, and configs. Requires typing `RESET` to proceed, or `--yes` for scripts.
+- **Consensus**: peers sending headers with timestamps far in the future now receive misbehavior penalty (20 points / offense, ban after 5) instead of being silently tolerated.
+- **Wallet RPC**: `gettransaction` now returns a top-level `wallet:{category, amount, fee, to_address, time}` block and a Bitcoin-Core-style `details[]` array, enabling forensic enumeration of outbound sends.
+
+### Fixed
+- **Mining dashboard**: `blocks_accepted` counter is now rebuilt from the canonical chain via connect/disconnect callbacks. The previous optimistic counter overcounted DilV blocks 4–5× because lowest-VDF-output tiebreaks routinely displace a briefly-tip block. The dashboard now shows `accepted · submitted` session-scoped values.
+- **Wallet coin selection**: size-aware with a 999 KB per-transaction cap. Prevents building 50 MB sends that the mempool would reject, and returns a distinct "consolidate first" error instead of failing silently later.
+- **Wallet fee estimator**: `EstimateDilithiumTxSize` no longer underestimates by 2 bytes when input/output counts cross 252 (varint boundary) — fixes self-rejected sends at high input counts.
+- **Wallet REST API**: `/api/v1/utxos` and `/api/v1/balance` now filter UTXOs that are already spent by in-flight mempool transactions. Light wallets no longer broadcast double-spend attempts after the first send.
+- **Light wallet JS**: floors fee rate at consensus minimum (5000 ions/KB) so a buggy server response cannot produce sub-consensus broadcasts. Connection manager fallback raised from 1000/500 to 5000/5000.
+- **Wallet UX**: custom RPC port now persists per-chain across DIL ↔ DilV toggles. Previously the toggle overwrote the port from a hardcoded table.
+- **Wallet persistence**: outbound sends are now saved synchronously on record. Previous "mark as dirty" stub silently dropped send history if the process was killed before a block-triggered flush.
+- **Consensus auto-rebuild (BUG #277)**: chain-wipe helper now also clears `dfmp_identity/`, closing a footgun where stale identity state caused a Reference-coinbase emit before the registration block existed on the rebuilt chain.
+
+### Changed
+- **VDF tip-swap logs** on DilV are now gated behind `--verbose`. They fire ~5/min at normal steady state and were flooding the console while contending for `cs_main` against the REST API thread.
+- **`getchaintips` RPC**: filters out stale tips more than 100 blocks behind the active tip to prevent unbounded accumulation of orphaned VDF competing blocks.
+- **Mining outcome messages** (`BLOCK CONFIRMED!` / `BLOCK NOT SELECTED`) are now deferred until the round is settled — i.e. a child block has been connected on top of the candidate. Previously DilV's lowest-VDF-output tiebreak could displace a same-height tip block within ~2-15s, so users saw "Your block won this round!" followed by no reward — eroding trust. Same fix applied to DIL's RandomX and VDF block-found paths. Loss messages use friendly plain-English tone (no "orphaned"/"reorged out" jargon).
+- **`MINING REWARD CREDITED!` message** is now deferred via the wallet's per-block callback. Only one message per settled height instead of 3-8 messages from transient tip-swap reorgs. Disconnects of pending notifications drop them silently.
+
+### Security
+- **New checkpoints added** to lock in canonical chain history and accelerate IBD:
+  - DIL: height 44,000 → `0000002751fc99551f4fce1f2e92053b2432788f1dc12412fd81223204d11377`
+  - DilV: height 36,500 → `3a6c72ee0ac27508fe82b76ed561dc93bc52ee5a26825cbf3f693bbc7070fd63`
+  - `dfmpAssumeValidHeight` raised on both chains to match (skips signature validation below the assume-valid line during IBD).
+  - Verified consensus across all 4 mainnet seeds (NYC, LDN, SGP, SYD) before locking in the hashes.
+
+### Infrastructure / Developer
+- Repo hygiene: build artifacts, release tarballs, session docs, scratch scripts, and screenshots untracked. Repo-hygiene CI check added to prevent cruft regression.
+- Dependabot config hardened against consensus-breaking auto-bumps.
+- Documentation refresh: authoritative `BUILDING.md` and `RELEASING.md`; updated `CHANGELOG.md` legacy link; `THREAT-MODEL.md` refreshed for mainnet-live posture.
+- Line endings pinned via `.gitattributes` (`eol=lf`).
+- New scripts: `consolidate-wallet.py` for Tier 1 UTXO consolidation; explorer API helpers committed from NYC.
+
+### Notes for miners
+- **Required action**: none. Run the new binary and mining continues normally.
+- **Benefit**: Digital DNA coverage (bandwidth, clock drift, thermal) should begin climbing as your node broadcasts enriched samples and accepts them from peers. Check your own DNA coverage with `getmydigitaldna` and network-wide stats with `getdnamonitor`.
+- **One-time save**: MIK registration PoW now persists, so subsequent restarts or `--reset-chain` runs do not re-mine the 25-minute PoW.
+
+---
+
 ## [v4.0.16] — 2026-04-13
 
 ### Fixed

--- a/src/core/chainparams.cpp
+++ b/src/core/chainparams.cpp
@@ -67,7 +67,7 @@ ChainParams ChainParams::Mainnet() {
     // PoW and MIK signature verification skipped for historical blocks during IBD.
     // This fixes IBD where identity database is empty/incomplete.
     // NOTE: Chain built with MIK bypassed - cannot be removed, only raised
-    params.dfmpAssumeValidHeight = 34000;  // BUG #284: match checkpoint height — skip cooldown/ban validation for checkpointed blocks during IBD
+    params.dfmpAssumeValidHeight = 44000;  // v4.0.17: match new checkpoint at 44000 — skip cooldown/ban validation for checkpointed blocks during IBD
 
     // DFMP v3.0 activation - payout heat tracking, reduced free tier, dormancy decay
     params.dfmpV3ActivationHeight = 7000;
@@ -198,6 +198,7 @@ ChainParams ChainParams::Mainnet() {
     // Checkpoint at height 34000 - post v3.9.0 stabilization
     params.checkpoints.emplace_back(34000, uint256S("00000009b2312644f10b286934ed982520e92aaa54b2736e46f365a77bd92d98"));
     params.checkpoints.emplace_back(40000, uint256S("000000271909e84a5a31fe60c27a9e40a2a51828efc89c6af059a2db2f6e2576"));
+    params.checkpoints.emplace_back(44000, uint256S("0000002751fc99551f4fce1f2e92053b2432788f1dc12412fd81223204d11377"));
 
     // ASSUME-VALID: Skip DFMP penalty validation below this block
     // Empty = validate everything (populate after mainnet has established blocks)
@@ -413,7 +414,7 @@ ChainParams ChainParams::DilV() {
     // Genesis block itself is exempt (code at chain.cpp:889-890 skips height 0)
     // MIK required from block 1 onward
     params.dfmpActivationHeight = 0;
-    params.dfmpAssumeValidHeight = 18700;  // Raised: block 18619 has cooldown violation from VDF distribution race (BUG #285). Match checkpoint height.
+    params.dfmpAssumeValidHeight = 36500;  // v4.0.17: match new checkpoint at 36500 — skip cooldown/ban validation for checkpointed blocks during IBD
 
     // All DFMP versions active from genesis — use modern rules from day one
     params.dfmpV3ActivationHeight = 0;
@@ -520,6 +521,7 @@ ChainParams ChainParams::DilV() {
     params.checkpoints.emplace_back(8370, uint256S("ef1e3a7de515523cde0b224865b26dc049c92033bc5a86b31e0e32cd1ca852be"));
     params.checkpoints.emplace_back(15000, uint256S("45f5877adcc1ec2dab453412d6a5cb3fd9383fc97a184aa4ec855db55212f5d6"));
     params.checkpoints.emplace_back(18700, uint256S("1fbcf55c40c735596b68772af0072b98342a098bd5c1ff0b3bb26423720e9295"));
+    params.checkpoints.emplace_back(36500, uint256S("3a6c72ee0ac27508fe82b76ed561dc93bc52ee5a26825cbf3f693bbc7070fd63"));
 
     // No assume-valid yet
     params.defaultAssumeValid = "";

--- a/src/digital_dna/digital_dna.cpp
+++ b/src/digital_dna/digital_dna.cpp
@@ -782,6 +782,16 @@ std::vector<DigitalDNA> DigitalDNARegistry::get_all() const {
     return identities_;
 }
 
+std::vector<std::array<uint8_t, 20>> DigitalDNARegistry::get_all_miks() const {
+    std::vector<std::array<uint8_t, 20>> result;
+    result.reserve(identities_.size());
+    for (const auto& dna : identities_) {
+        if (dna.mik_identity == std::array<uint8_t, 20>{}) continue;
+        result.push_back(dna.mik_identity);
+    }
+    return result;
+}
+
 std::vector<std::pair<uint64_t, DigitalDNA>> DigitalDNARegistry::get_dna_history(
     const std::array<uint8_t, 20>& /*mik*/, size_t /*max_entries*/) const {
     // In-memory registry doesn't track history

--- a/src/digital_dna/digital_dna.h
+++ b/src/digital_dna/digital_dna.h
@@ -188,6 +188,11 @@ public:
     virtual std::vector<DigitalDNA> get_all() const = 0;
     virtual size_t count() const = 0;
 
+    /** Phase 1.2 — DNA propagation: return all MIKs known to this registry.
+     *  Used as the primary source for the discovery-request loop so DIL
+     *  (RandomX, no VDF-gated cooldown tracker) can find peers to ask. */
+    virtual std::vector<std::array<uint8_t, 20>> get_all_miks() const = 0;
+
     /** Get DNA change history for a MIK identity (oldest first).
      *  Each entry is a previous DNA snapshot archived when update_identity() was called.
      *  Single change = likely new hardware/location. Multiple regular changes = suspicious. */
@@ -319,6 +324,7 @@ public:
     SimilarityScore compare(const DigitalDNA& a, const DigitalDNA& b) const override;
     std::vector<DigitalDNA> get_all() const override;
     size_t count() const override { return identities_.size(); }
+    std::vector<std::array<uint8_t, 20>> get_all_miks() const override;
     std::vector<std::pair<uint64_t, DigitalDNA>> get_dna_history(
         const std::array<uint8_t, 20>& mik, size_t max_entries = 100) const override;
 

--- a/src/digital_dna/dna_registry_db.h
+++ b/src/digital_dna/dna_registry_db.h
@@ -105,8 +105,8 @@ public:
     verification::VerificationStatus get_verification_status(
         const std::array<uint8_t, 20>& mik) const;
 
-    /** Get all registered MIK identities (for verifier selection) */
-    std::vector<std::array<uint8_t, 20>> get_all_miks() const;
+    /** Get all registered MIK identities (for verifier selection and Phase 1.2 discovery) */
+    std::vector<std::array<uint8_t, 20>> get_all_miks() const override;
 
 private:
     std::shared_ptr<MLSybilDetector> ml_detector_;

--- a/src/node/dilithion-node.cpp
+++ b/src/node/dilithion-node.cpp
@@ -302,6 +302,18 @@ extern std::atomic<bool> g_utxo_sync_enabled;
 // Global async broadcaster pointer (initialized in main)
 CAsyncBroadcaster* g_async_broadcaster = nullptr;
 
+// v4.0.17: Pending miner-win notifications. Pushed by the block-submit
+// handler when our mined block initially becomes tip; consumed by the
+// deferred-outcome block-connect callback once a child block is connected
+// on top (settling the round). See callback registration ~line 5350 for
+// the full rationale. Mirrors the dilv-node.cpp implementation.
+struct PendingMinerWin {
+    uint256 blockHash;
+    int     height;
+};
+static std::vector<PendingMinerWin> g_pendingMinerWins;
+static std::mutex g_pendingMinerWinsMutex;
+
 // Phase 2: MIK → peer_id mapping for DNA verification routing
 // Populated when we receive DNA identity responses from peers
 static std::map<std::array<uint8_t, 20>, int> g_mik_peer_map;
@@ -848,7 +860,7 @@ bool EnsureMIKRegistered(CWallet& wallet, unsigned int nextHeight) {
                     for (auto b : g_cachedDnaHash) { if (b != 0) { allZero = false; break; } }
                     if (!allZero) {
                         g_dnaHashCached.store(true);
-                        std::cout << "[Mining] MIK registered — pre-cached DNA for future use" << std::endl;
+                        std::cout << "[Mining] MIK registered - pre-cached DNA for future use" << std::endl;
                     }
                 }
             }
@@ -1275,7 +1287,7 @@ std::optional<CBlockTemplate> BuildMiningTemplate(CBlockchainDB& blockchain, CWa
                                     std::cout << std::dec << "...)" << std::endl;
                                     // Invalidate any PoW mined without DNA — must re-mine with DNA in challenge
                                     if (g_regNonceMined.load()) {
-                                        std::cout << "[Mining] Invalidating PoW (was mined without DNA) — will re-mine" << std::endl;
+                                        std::cout << "[Mining] Invalidating PoW (was mined without DNA) - will re-mine" << std::endl;
                                         g_regNonceMined.store(false);
                                     }
                                 }
@@ -1393,7 +1405,7 @@ std::optional<CBlockTemplate> BuildMiningTemplate(CBlockchainDB& blockchain, CWa
                 if (attestAge > Attestation::ATTESTATION_VALIDITY_WINDOW - 600) {
                     std::cout << "[Mining] Attestations are " << attestAge / 60
                               << "m old (max " << Attestation::ATTESTATION_VALIDITY_WINDOW / 60
-                              << "m) — refreshing..." << std::endl;
+                              << "m) - refreshing..." << std::endl;
                     needRefresh = true;
                 }
             }
@@ -1423,7 +1435,7 @@ std::optional<CBlockTemplate> BuildMiningTemplate(CBlockchainDB& blockchain, CWa
 
             // Guard: refuse to build registration block without valid attestations
             if (needRefresh) {
-                std::cerr << "[Mining] Template rejected — registration block at height "
+                std::cerr << "[Mining] Template rejected - registration block at height "
                           << nHeight << " requires seed attestations"
                           << " (collected=" << g_attestationsCollected.load()
                           << ", dna=" << g_dnaHashCached.load()
@@ -2239,7 +2251,7 @@ int main(int argc, char* argv[]) {
         auto report = Dilithion::ResetChainState(config.datadir);
         std::cout << "\n=== Reset complete ===" << std::endl;
         std::cout << "Removed:" << std::endl;
-        if (report.removed.empty()) std::cout << "  (nothing — chain state already absent)" << std::endl;
+        if (report.removed.empty()) std::cout << "  (nothing - chain state already absent)" << std::endl;
         for (const auto& p : report.removed) std::cout << "  - " << p << std::endl;
         std::cout << "\nPreserved:" << std::endl;
         if (report.preserved.empty()) std::cout << "  (none found)" << std::endl;
@@ -4677,7 +4689,7 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                     }
                     unsigned int h = static_cast<unsigned int>(g_chainstate.GetHeight());
                     int64_t mature = wallet.GetAvailableBalance(utxo_set, h);
-                    std::cout << "  [OK] Wallet synced — balance: " << std::fixed << std::setprecision(8)
+                    std::cout << "  [OK] Wallet synced - balance: " << std::fixed << std::setprecision(8)
                               << (static_cast<double>(mature) / 100000000.0) << " DIL" << std::endl;
                 } else {
                     std::cerr << "  WARNING: Failed to load wallet" << std::endl;
@@ -5349,6 +5361,52 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
         });
         std::cout << "  [OK] VDF cooldown chain notification callbacks registered" << std::endl;
 
+        // =========================================================================
+        // v4.0.17: Deferred BLOCK CONFIRMED / BLOCK ORPHANED notifications.
+        //
+        // The previous "BLOCK CONFIRMED!" message fired at submit time when our
+        // mined block became the chain tip. While DIL (RandomX) is far less
+        // reorg-prone than DilV, brief same-height races still occur. The
+        // user-experience contract is "if we say CONFIRMED, the block is settled".
+        // We queue the win at submit time and only print CONFIRMED once a child
+        // block has been connected on top. If the pending block is no longer
+        // ancestor of the new tip at its height (a reorg displaced it), we fire
+        // BLOCK ORPHANED instead.
+        // =========================================================================
+        g_chainstate.RegisterBlockConnectCallback([](const CBlock& /*block*/, int height, const uint256& /*hash*/) {
+            std::lock_guard<std::mutex> lock(g_pendingMinerWinsMutex);
+            auto it = g_pendingMinerWins.begin();
+            while (it != g_pendingMinerWins.end()) {
+                if (it->height >= height) { ++it; continue; }  // not yet settled
+
+                CBlockIndex* tip    = g_chainstate.GetTip();
+                CBlockIndex* ourIdx = g_chainstate.GetBlockIndex(it->blockHash);
+                bool isCanonical = false;
+                if (ourIdx && tip) {
+                    CBlockIndex* ancestor = tip->GetAncestor(it->height);
+                    isCanonical = (ancestor == ourIdx);
+                }
+
+                if (isCanonical) {
+                    std::cout << std::endl
+                              << "======================================" << std::endl
+                              << "  BLOCK CONFIRMED!" << std::endl
+                              << "  Height: " << it->height << std::endl
+                              << "======================================" << std::endl;
+                } else {
+                    std::cout << std::endl
+                              << "======================================" << std::endl
+                              << "  BLOCK NOT SELECTED" << std::endl
+                              << "  Another miner's block won at height "
+                              << it->height << "." << std::endl
+                              << "  This is normal - better luck next block!" << std::endl
+                              << "======================================" << std::endl;
+                }
+                it = g_pendingMinerWins.erase(it);
+            }
+        });
+        std::cout << "  [OK] Deferred mining-outcome callback registered" << std::endl;
+
         // Digital DNA: Behavioral profile + trust scoring block hook
         g_chainstate.RegisterBlockConnectCallback([](const CBlock& block, int height, const uint256& hash) {
             int dnaAct = Dilithion::g_chainParams ?
@@ -5568,23 +5626,15 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
             // Activate best chain (handles reorg if needed)
             bool reorgOccurred = false;
             if (g_chainstate.ActivateBestChain(pblockIndexPtr, block, reorgOccurred)) {
-                if (reorgOccurred) {
-                    std::cout << std::endl;
-                    std::cout << "======================================" << std::endl;
-                    std::cout << "  BLOCK NOT ACCEPTED" << std::endl;
-                    std::cout << "  Another miner's block was selected" << std::endl;
-                    std::cout << "  by the network. This is normal." << std::endl;
-                    std::cout << "======================================" << std::endl;
-                    std::cout << std::endl;
-
-                    // Stop mining - need to reassess chain state
-                    g_node_state.new_block_found = true;
-                } else if (g_chainstate.GetTip() == pblockIndexPtr) {
-                    std::cout << std::endl;
-                    std::cout << "======================================" << std::endl;
-                    std::cout << "  BLOCK CONFIRMED!" << std::endl;
-                    std::cout << "  Height: " << pblockIndexPtr->nHeight << std::endl;
-                    std::cout << "======================================" << std::endl;
+                if (g_chainstate.GetTip() == pblockIndexPtr) {
+                    // v4.0.17: our block became tip. Queue for deferred
+                    // CONFIRMED message — only print after a child block has
+                    // settled the round, in case a reorg displaces ours.
+                    {
+                        std::lock_guard<std::mutex> lock(g_pendingMinerWinsMutex);
+                        g_pendingMinerWins.push_back({blockHash, pblockIndexPtr->nHeight});
+                    }
+                    (void)reorgOccurred;
 
                     // Session accepted-blocks counter is maintained via
                     // RegisterBlockConnectCallback below. Do NOT increment
@@ -5723,15 +5773,19 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                         g_node_state.new_block_found = true;
                     }
                 } else {
-                    // Stale block - another miner found a block at the same height
-                    // This is normal in a multi-miner network (race condition)
-                    std::cout << "[Blockchain] STALE BLOCK: Another miner found block at same height first" << std::endl;
-                    std::cout << "  Your block is valid but was beaten by: "
-                              << g_chainstate.GetTip()->GetBlockHash().GetHex().substr(0, 16)
-                              << " (height " << g_chainstate.GetHeight() << ")" << std::endl;
-                    std::cout << "  This is normal - continuing to mine on new tip" << std::endl;
-
-                    // Update template and continue mining
+                    // v4.0.17: print BLOCK NOT SELECTED immediately. We KNOW
+                    // we lost right now (block is valid but did not become
+                    // tip), so deferring would just hide the outcome behind
+                    // the next round's BLOCK PRODUCED message. Height label
+                    // distinguishes from any concurrently-firing deferred
+                    // notification for an earlier round.
+                    std::cout << std::endl
+                              << "======================================" << std::endl
+                              << "  BLOCK NOT SELECTED" << std::endl
+                              << "  Another miner's block won at height "
+                              << pblockIndexPtr->nHeight << "." << std::endl
+                              << "  This is normal - better luck next block!" << std::endl
+                              << "======================================" << std::endl;
                     g_node_state.new_block_found = true;
                 }
             } else {
@@ -5783,8 +5837,16 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
             bool reorgOccurred = false;
             if (g_chainstate.ActivateBestChain(pblockIndexPtr, block, reorgOccurred)) {
                 if (g_chainstate.GetTip() == pblockIndexPtr) {
-                    std::cout << "[VDF] Block became new chain tip at height "
-                              << pblockIndexPtr->nHeight << std::endl;
+                    // v4.0.17: defer the BLOCK CONFIRMED message — queue and
+                    // let the deferred-outcome callback print once the round
+                    // is settled (see callback registration ~line 5350).
+                    {
+                        std::lock_guard<std::mutex> lock(g_pendingMinerWinsMutex);
+                        g_pendingMinerWins.push_back({blockHash, pblockIndexPtr->nHeight});
+                    }
+                    std::cout << "[VDF] Block submitted at height "
+                              << pblockIndexPtr->nHeight
+                              << " - awaiting settlement..." << std::endl;
 
                     // Session accepted-blocks counter maintained via
                     // RegisterBlockConnectCallback (don't double-count here).
@@ -6108,7 +6170,7 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                                                     g_node_context.trust_manager->on_dna_changed(
                                                         dna_opt->address, static_cast<uint32_t>(curHeight));
                                                     std::cout << "[DNA] Core dimensions changed at height " << curHeight
-                                                              << " — trust penalty applied (-10)" << std::endl;
+                                                              << " - trust penalty applied (-10)" << std::endl;
                                                 }
                                             }
                                         }
@@ -6128,13 +6190,28 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                             now_disc - last_dna_discovery).count();
 
                         if (disc_elapsed >= 60 && g_node_context.dna_registry &&
-                            g_node_context.cooldown_tracker &&
                             g_node_context.connman && g_node_context.message_processor) {
                             int dnaActDisc = Dilithion::g_chainParams ?
                                 Dilithion::g_chainParams->digitalDnaActivationHeight : 999999999;
                             if (g_chainstate.GetHeight() >= dnaActDisc) {
                                 last_dna_discovery = now_disc;
-                                auto known_miks = g_node_context.cooldown_tracker->GetKnownAddresses();
+                                // Phase 1.2: source MIKs from dna_registry (always populated
+                                // once DNA has been received) unioned with cooldown_tracker
+                                // (VDF-only — empty on DIL). Pre-fix, DIL's discovery loop
+                                // iterated over an empty cooldown_tracker and never sent a
+                                // single dnaireq; bandwidth/clock_drift coverage stayed ~1%.
+                                std::vector<std::array<uint8_t, 20>> known_miks =
+                                    g_node_context.dna_registry->get_all_miks();
+                                if (g_node_context.cooldown_tracker) {
+                                    auto ct_miks = g_node_context.cooldown_tracker->GetKnownAddresses();
+                                    for (const auto& m : ct_miks) {
+                                        bool dup = false;
+                                        for (const auto& e : known_miks) {
+                                            if (e == m) { dup = true; break; }
+                                        }
+                                        if (!dup) known_miks.push_back(m);
+                                    }
+                                }
                                 auto nodes = g_node_context.connman->GetNodes();
                                 std::vector<int> peer_ids;
                                 for (auto* n : nodes) {

--- a/src/node/dilv-node.cpp
+++ b/src/node/dilv-node.cpp
@@ -300,6 +300,18 @@ extern std::atomic<bool> g_utxo_sync_enabled;
 // Global async broadcaster pointer (initialized in main)
 CAsyncBroadcaster* g_async_broadcaster = nullptr;
 
+// v4.0.17: Pending miner-win notifications, keyed by (blockHash, height).
+// Pushed by the VDF submit handler when our block initially becomes tip;
+// consumed by the deferred-outcome block-connect callback once a child
+// block has been connected on top (settling the round). See the callback
+// registration around line ~5420 for the full rationale.
+struct PendingMinerWin {
+    uint256 blockHash;
+    int     height;
+};
+static std::vector<PendingMinerWin> g_pendingMinerWins;
+static std::mutex g_pendingMinerWinsMutex;
+
 // Phase 2: MIK → peer_id mapping for DNA verification routing
 // Populated when we receive DNA identity responses from peers
 static std::map<std::array<uint8_t, 20>, int> g_mik_peer_map;
@@ -840,7 +852,7 @@ bool EnsureMIKRegistered(CWallet& wallet, unsigned int nextHeight) {
                     for (auto b : s_cachedDnaHash) { if (b != 0) { allZero = false; break; } }
                     if (!allZero) {
                         s_dnaHashCached.store(true);
-                        std::cout << "[Mining] MIK registered — pre-cached DNA for future use" << std::endl;
+                        std::cout << "[Mining] MIK registered - pre-cached DNA for future use" << std::endl;
                     }
                 }
             }
@@ -1247,7 +1259,7 @@ std::optional<CBlockTemplate> BuildMiningTemplate(CBlockchainDB& blockchain, CWa
                                     std::cout << std::dec << "...)" << std::endl;
                                     // Invalidate any PoW mined without DNA — must re-mine with DNA in challenge
                                     if (s_regNonceMined.load()) {
-                                        std::cout << "[Mining] Invalidating PoW (was mined without DNA) — will re-mine" << std::endl;
+                                        std::cout << "[Mining] Invalidating PoW (was mined without DNA) - will re-mine" << std::endl;
                                         s_regNonceMined.store(false);
                                     }
                                 }
@@ -1366,7 +1378,7 @@ std::optional<CBlockTemplate> BuildMiningTemplate(CBlockchainDB& blockchain, CWa
                 if (attestAge > Attestation::ATTESTATION_VALIDITY_WINDOW - 600) {
                     std::cout << "[Mining] Attestations are " << attestAge / 60
                               << "m old (max " << Attestation::ATTESTATION_VALIDITY_WINDOW / 60
-                              << "m) — refreshing..." << std::endl;
+                              << "m) - refreshing..." << std::endl;
                     needRefresh = true;
                 }
             }
@@ -1396,7 +1408,7 @@ std::optional<CBlockTemplate> BuildMiningTemplate(CBlockchainDB& blockchain, CWa
 
             // Guard: refuse to build registration block without valid attestations
             if (needRefresh) {
-                std::cerr << "[Mining] Template rejected — registration block at height "
+                std::cerr << "[Mining] Template rejected - registration block at height "
                           << nHeight << " requires seed attestations"
                           << " (collected=" << s_attestationsCollected.load()
                           << ", dna=" << s_dnaHashCached.load()
@@ -2174,7 +2186,7 @@ int main(int argc, char* argv[]) {
         auto report = Dilithion::ResetChainState(config.datadir);
         std::cout << "\n=== Reset complete ===" << std::endl;
         std::cout << "Removed:" << std::endl;
-        if (report.removed.empty()) std::cout << "  (nothing — chain state already absent)" << std::endl;
+        if (report.removed.empty()) std::cout << "  (nothing - chain state already absent)" << std::endl;
         for (const auto& p : report.removed) std::cout << "  - " << p << std::endl;
         std::cout << "\nPreserved:" << std::endl;
         if (report.preserved.empty()) std::cout << "  (none found)" << std::endl;
@@ -4734,7 +4746,7 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                     }
                     unsigned int h = static_cast<unsigned int>(g_chainstate.GetHeight());
                     int64_t mature = wallet.GetAvailableBalance(utxo_set, h);
-                    std::cout << "  [OK] Wallet synced — balance: " << std::fixed << std::setprecision(8)
+                    std::cout << "  [OK] Wallet synced - balance: " << std::fixed << std::setprecision(8)
                               << (static_cast<double>(mature) / 100000000.0) << " DilV" << std::endl;
                 } else {
                     std::cerr << "  WARNING: Failed to load wallet" << std::endl;
@@ -5417,6 +5429,55 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
         });
         std::cout << "  [OK] VDF cooldown chain notification callbacks registered" << std::endl;
 
+        // =========================================================================
+        // v4.0.17: Deferred BLOCK CONFIRMED / BLOCK ORPHANED notifications.
+        //
+        // The previous "BLOCK CONFIRMED!" message fired at submit time when our
+        // VDF block became the chain tip — but DilV's lowest-VDF-output tiebreak
+        // routinely displaces a same-height tip block within ~2-15s. Users saw
+        // "Your block won this round!" and then no reward, eroding trust.
+        //
+        // Now we queue the win at submit time (see PushPendingMinerWin lambda
+        // wired into the submit handler) and only fire CONFIRMED once a child
+        // block has been connected on top — i.e. the round is settled. If the
+        // pending block is no longer ancestor of the new tip at its height
+        // (a reorg displaced it), we fire BLOCK ORPHANED instead.
+        // =========================================================================
+        g_chainstate.RegisterBlockConnectCallback([](const CBlock& /*block*/, int height, const uint256& /*hash*/) {
+            std::lock_guard<std::mutex> lock(g_pendingMinerWinsMutex);
+            auto it = g_pendingMinerWins.begin();
+            while (it != g_pendingMinerWins.end()) {
+                if (it->height >= height) { ++it; continue; }  // not yet settled
+
+                CBlockIndex* tip    = g_chainstate.GetTip();
+                CBlockIndex* ourIdx = g_chainstate.GetBlockIndex(it->blockHash);
+                bool isCanonical = false;
+                if (ourIdx && tip) {
+                    CBlockIndex* ancestor = tip->GetAncestor(it->height);
+                    isCanonical = (ancestor == ourIdx);
+                }
+
+                if (isCanonical) {
+                    std::cout << std::endl
+                              << "======================================" << std::endl
+                              << "  BLOCK CONFIRMED!" << std::endl
+                              << "  Your block won this round!" << std::endl
+                              << "  Height: " << it->height << std::endl
+                              << "======================================" << std::endl;
+                } else {
+                    std::cout << std::endl
+                              << "======================================" << std::endl
+                              << "  BLOCK NOT SELECTED" << std::endl
+                              << "  Another miner's block won at height "
+                              << it->height << "." << std::endl
+                              << "  This is normal - better luck next block!" << std::endl
+                              << "======================================" << std::endl;
+                }
+                it = g_pendingMinerWins.erase(it);
+            }
+        });
+        std::cout << "  [OK] Deferred mining-outcome callback registered" << std::endl;
+
         // Digital DNA: Behavioral profile + trust scoring block hook
         g_chainstate.RegisterBlockConnectCallback([](const CBlock& block, int height, const uint256& hash) {
             int dnaAct = Dilithion::g_chainParams ?
@@ -5588,12 +5649,16 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
             bool reorgOccurred = false;
             if (g_chainstate.ActivateBestChain(pblockIndexPtr, block, reorgOccurred)) {
                 if (g_chainstate.GetTip() == pblockIndexPtr) {
-                    std::cout << std::endl;
-                    std::cout << "======================================" << std::endl;
-                    std::cout << "  BLOCK CONFIRMED!" << std::endl;
-                    std::cout << "  Your block won this round!" << std::endl;
-                    std::cout << "  Height: " << pblockIndexPtr->nHeight << std::endl;
-                    std::cout << "======================================" << std::endl;
+                    // v4.0.17: do NOT print "BLOCK CONFIRMED!" inline. Queue
+                    // it; the deferred-outcome block-connect callback (above)
+                    // will print CONFIRMED once a child block is connected
+                    // (round settled), or BLOCK ORPHANED if a reorg displaces
+                    // this block first. See the callback registration in main
+                    // for the full rationale.
+                    {
+                        std::lock_guard<std::mutex> lock(g_pendingMinerWinsMutex);
+                        g_pendingMinerWins.push_back({blockHash, pblockIndexPtr->nHeight});
+                    }
 
                     // NOTE: Cooldown tracker and the session accepted-blocks
                     // counter are both updated via chainstate
@@ -5666,16 +5731,21 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                         }
                     }
                 } else {
-                    // Our block was valid but another miner's block with a lower
-                    // VDF output is already the tip at this height.
-                    std::cout << std::endl;
-                    std::cout << "======================================" << std::endl;
-                    std::cout << "  BLOCK NOT SELECTED" << std::endl;
-                    std::cout << "  Another miner produced a lower VDF" << std::endl;
-                    std::cout << "  output and won this round. This is" << std::endl;
-                    std::cout << "  normal — better luck next block!" << std::endl;
-                    std::cout << "======================================" << std::endl;
-                    std::cout << std::endl;
+                    // v4.0.17: print BLOCK NOT SELECTED immediately for the
+                    // submit-time loss case. We KNOW right now we lost (our
+                    // block did not become tip), so deferring would just hide
+                    // the outcome behind the next round's BLOCK PRODUCED
+                    // message. The height label distinguishes this from any
+                    // concurrently-firing deferred notification for an
+                    // earlier round (rare: only if a previous block became
+                    // tip and was reorged out of canonical chain later).
+                    std::cout << std::endl
+                              << "======================================" << std::endl
+                              << "  BLOCK NOT SELECTED" << std::endl
+                              << "  Another miner's block won at height "
+                              << pblockIndexPtr->nHeight << "." << std::endl
+                              << "  This is normal - better luck next block!" << std::endl
+                              << "======================================" << std::endl;
                 }
                 g_node_state.new_block_found = true;
             } else {
@@ -5685,7 +5755,7 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                 if (s_attestationsCollected.load() &&
                     Dilithion::g_chainParams &&
                     !Dilithion::g_chainParams->seedAttestationIPs.empty()) {
-                    std::cout << "[VDF] Block rejected — re-collecting seed attestations..." << std::endl;
+                    std::cout << "[VDF] Block rejected - re-collecting seed attestations..." << std::endl;
                     s_attestationsCollected.store(false);
 
                     std::vector<uint8_t> mikPubkey;
@@ -5701,7 +5771,7 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                                 mikHex, dnaHex, freshAttest, attestErr)) {
                             s_cachedAttestations = std::move(freshAttest);
                             s_attestationsCollected.store(true);
-                            std::cout << "[VDF] Fresh attestations collected — next block should succeed" << std::endl;
+                            std::cout << "[VDF] Fresh attestations collected - next block should succeed" << std::endl;
                         } else {
                             std::cerr << "[VDF] WARNING: Attestation re-collection failed: " << attestErr << std::endl;
                         }
@@ -5960,7 +6030,7 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                                                     g_node_context.trust_manager->on_dna_changed(
                                                         dna_opt->address, static_cast<uint32_t>(curHeight));
                                                     std::cout << "[DNA] Core dimensions changed at height " << curHeight
-                                                              << " — trust penalty applied (-10)" << std::endl;
+                                                              << " - trust penalty applied (-10)" << std::endl;
                                                 }
                                             }
                                         }
@@ -5980,13 +6050,28 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                             now_disc - last_dna_discovery).count();
 
                         if (disc_elapsed >= 60 && g_node_context.dna_registry &&
-                            g_node_context.cooldown_tracker &&
                             g_node_context.connman && g_node_context.message_processor) {
                             int dnaActDisc = Dilithion::g_chainParams ?
                                 Dilithion::g_chainParams->digitalDnaActivationHeight : 999999999;
                             if (g_chainstate.GetHeight() >= dnaActDisc) {
                                 last_dna_discovery = now_disc;
-                                auto known_miks = g_node_context.cooldown_tracker->GetKnownAddresses();
+                                // Phase 1.2: source MIKs from dna_registry unioned with
+                                // cooldown_tracker. On DilV both sources are populated
+                                // (VDF chain), but keeping symmetry with DIL guards against
+                                // future churn and makes discovery resilient to a single
+                                // empty source.
+                                std::vector<std::array<uint8_t, 20>> known_miks =
+                                    g_node_context.dna_registry->get_all_miks();
+                                if (g_node_context.cooldown_tracker) {
+                                    auto ct_miks = g_node_context.cooldown_tracker->GetKnownAddresses();
+                                    for (const auto& m : ct_miks) {
+                                        bool dup = false;
+                                        for (const auto& e : known_miks) {
+                                            if (e == m) { dup = true; break; }
+                                        }
+                                        if (!dup) known_miks.push_back(m);
+                                    }
+                                }
                                 auto nodes = g_node_context.connman->GetNodes();
                                 std::vector<int> peer_ids;
                                 for (auto* n : nodes) {

--- a/src/test/dna_propagation_tests.cpp
+++ b/src/test/dna_propagation_tests.cpp
@@ -447,6 +447,83 @@ TEST(merge_fill_perspective_dim_is_fillable) {
 }
 
 // ---------------------------------------------------------------------------
+// Phase 1.2 — discovery MIK source (dna_registry ∪ cooldown_tracker)
+// ---------------------------------------------------------------------------
+
+// Mirrors the linear-dedup union used in the discovery block of both node
+// binaries. Tested here instead of extracted because the production site is
+// six lines and co-locating the test with the inline code would pull the
+// whole `g_node_context` graph into unit tests.
+static std::vector<std::array<uint8_t, 20>>
+union_dedupe_miks(std::vector<std::array<uint8_t, 20>> a,
+                  const std::vector<std::array<uint8_t, 20>>& b) {
+    for (const auto& m : b) {
+        bool dup = false;
+        for (const auto& e : a) { if (e == m) { dup = true; break; } }
+        if (!dup) a.push_back(m);
+    }
+    return a;
+}
+
+TEST(discovery_source_dil_empty_cooldown_tracker_returns_registry_miks) {
+    // DIL reality: cooldown_tracker is populated only via VDF block-connect
+    // callbacks, so on RandomX chains GetKnownAddresses() is always empty.
+    // The Phase 1.2 fix sources from dna_registry first so discovery can
+    // still fire. This test asserts the in-memory path used by unit tests
+    // and by relay-only nodes that haven't opened a LevelDB registry.
+    digital_dna::DigitalDNARegistry reg;
+    ASSERT(reg.register_identity(make_dna(0x10)) == IDNARegistry::RegisterResult::SUCCESS, "r1");
+    ASSERT(reg.register_identity(make_dna(0x20)) == IDNARegistry::RegisterResult::SUCCESS, "r2");
+    ASSERT(reg.register_identity(make_dna(0x30)) == IDNARegistry::RegisterResult::SUCCESS, "r3");
+
+    std::vector<std::array<uint8_t, 20>> empty_cooldown;
+    auto sourced = union_dedupe_miks(reg.get_all_miks(), empty_cooldown);
+
+    ASSERT_EQ(sourced.size(), (size_t)3, "all three registry MIKs surface when cooldown is empty");
+}
+
+TEST(discovery_source_union_dedupes_overlap) {
+    // MIKs appearing in both dna_registry and cooldown_tracker must be
+    // emitted exactly once. With 120 live miners on mainnet today a
+    // non-deduped source would blow up the round-robin window and fire
+    // duplicate dnaireq messages at the same peer.
+    digital_dna::DigitalDNARegistry reg;
+    auto dna_a = make_dna(0xA0);
+    auto dna_b = make_dna(0xB0);
+    ASSERT(reg.register_identity(dna_a) == IDNARegistry::RegisterResult::SUCCESS, "ra");
+    ASSERT(reg.register_identity(dna_b) == IDNARegistry::RegisterResult::SUCCESS, "rb");
+
+    std::vector<std::array<uint8_t, 20>> cooldown{
+        dna_a.mik_identity,              // overlap with registry
+        make_mik(0xC0),                  // unique to cooldown
+    };
+
+    auto sourced = union_dedupe_miks(reg.get_all_miks(), cooldown);
+
+    ASSERT_EQ(sourced.size(), (size_t)3, "A, B, C — A deduped to single copy");
+    size_t count_a = 0;
+    for (const auto& m : sourced) {
+        if (m == dna_a.mik_identity) ++count_a;
+    }
+    ASSERT_EQ(count_a, (size_t)1, "A appears exactly once");
+}
+
+TEST(dna_registry_db_get_all_miks_returns_stored_miks) {
+    // Parallel check: the LevelDB-backed registry (production path) exposes
+    // get_all_miks via the IDNARegistry interface after Phase 1.2.
+    ScratchDir dir("gam");
+    DNARegistryDB reg;
+    ASSERT(reg.Open(dir.path.string()), "open db");
+
+    ASSERT(reg.append_sample(make_dna(0x70)) == IDNARegistry::RegisterResult::SUCCESS, "s1");
+    ASSERT(reg.append_sample(make_dna(0x80)) == IDNARegistry::RegisterResult::SUCCESS, "s2");
+
+    IDNARegistry* iface = &reg;  // go through the interface, not the concrete class
+    auto miks = iface->get_all_miks();
+    ASSERT_EQ(miks.size(), (size_t)2, "two MIKs surfaced via interface");
+}
+
+// ---------------------------------------------------------------------------
 // main
 // ---------------------------------------------------------------------------
 
@@ -471,6 +548,11 @@ int main() {
     test_merge_fill_multiple_missing_dims_wrapper();
     test_merge_fill_then_append_sample_succeeds_with_dim_loss_guard_wrapper();
     test_merge_fill_perspective_dim_is_fillable_wrapper();
+
+    // Phase 1.2 discovery source tests
+    test_discovery_source_dil_empty_cooldown_tracker_returns_registry_miks_wrapper();
+    test_discovery_source_union_dedupes_overlap_wrapper();
+    test_dna_registry_db_get_all_miks_returns_stored_miks_wrapper();
 
     std::cout << "\n" << YELLOW_ << "=== Results ===" << RESET_ << std::endl;
     std::cout << GREEN_ << "Passed: " << g_tests_passed << RESET_ << std::endl;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -601,7 +601,12 @@ void CWallet::blockConnected(const CBlock& block, int height, const uint256& has
     std::lock_guard<std::mutex> lock(cs_wallet);
 
     // Process all transactions in the block
-    ProcessBlockTransactionsUnlocked(block, height, true /* connecting */);
+    ProcessBlockTransactionsUnlocked(block, height, true /* connecting */, hash);
+
+    // v4.0.17: any queued mining-reward notification whose block was buried
+    // by this connect (i.e. its height < current height) is now considered
+    // settled — print and drop it.
+    FlushSettledMiningNotificationsUnlocked(height);
 
     // Update best block pointer and persist to disk
     // IBD OPTIMIZATION: Use passed hash instead of computing RandomX hash
@@ -618,15 +623,19 @@ void CWallet::blockConnected(const CBlock& block, int height, const uint256& has
 void CWallet::blockDisconnected(const CBlock& block, int height, const uint256& hash) {
     std::lock_guard<std::mutex> lock(cs_wallet);
 
+    // v4.0.17: silently drop any pending mining-reward notifications for
+    // this block — it lost the round and the reward never settled.
+    DropPendingMiningNotificationsForBlockUnlocked(hash);
+
     // Process transactions in REVERSE to undo the effects
-    ProcessBlockTransactionsUnlocked(block, height, false /* disconnecting */);
+    ProcessBlockTransactionsUnlocked(block, height, false /* disconnecting */, hash);
 
     // Update best block pointer to previous block
     // Note: We use hashPrevBlock from the disconnected block
     SetLastBlockProcessedUnlocked(block.hashPrevBlock, height - 1);
 }
 
-void CWallet::ProcessBlockTransactionsUnlocked(const CBlock& block, int height, bool connecting) {
+void CWallet::ProcessBlockTransactionsUnlocked(const CBlock& block, int height, bool connecting, const uint256& blockHash) {
     // Note: Caller must hold cs_wallet lock
 
     // Build set of wallet pubkey hashes for fast lookup
@@ -700,27 +709,21 @@ void CWallet::ProcessBlockTransactionsUnlocked(const CBlock& block, int height, 
                                     }
                                 }
 
-                                double rewardDIL = static_cast<double>(out.nValue) / 100000000.0;
-                                double balanceDIL = static_cast<double>(newBalance) / 100000000.0;
-
-                                // Thread-safe formatting: use snprintf instead of
-                                // std::fixed/setprecision which modify std::cout's
-                                // persistent format state (race condition with P2P thread)
-                                char rewardStr[64], balanceStr[64];
-                                snprintf(rewardStr, sizeof(rewardStr), "%.8f", rewardDIL);
-                                snprintf(balanceStr, sizeof(balanceStr), "%.8f", balanceDIL);
-
-                                const char* coinLabel = (Dilithion::g_chainParams && Dilithion::g_chainParams->IsDilV()) ? "DilV" : "DIL";
-                                std::cout << "\n"
-                                    << "============================================================\n"
-                                    << "  MINING REWARD CREDITED!\n"
-                                    << "============================================================\n"
-                                    << "  Block Height:    " << height << "\n"
-                                    << "  Reward:          +" << rewardStr << " " << coinLabel << "\n"
-                                    << "  New Balance:     " << balanceStr << " " << coinLabel << "\n"
-                                    << "  Address:         " << addr.ToString() << "\n"
-                                    << "============================================================"
-                                    << std::endl;
+                                // v4.0.17: don't print MINING REWARD CREDITED inline.
+                                // On DilV, lowest-VDF-output tiebreaks displace this
+                                // block within ~2s in 30-50% of rounds. Queue the
+                                // notification; it will print from
+                                // FlushSettledMiningNotificationsUnlocked() once a
+                                // higher block is connected on top, or be silently
+                                // dropped from DropPendingMiningNotificationsForBlockUnlocked()
+                                // if this block loses the round.
+                                m_pendingMiningNotifications.push_back({
+                                    blockHash,
+                                    height,
+                                    static_cast<int64_t>(out.nValue),
+                                    newBalance,
+                                    addr.ToString()
+                                });
 
                                 // BUG #99 FIX: Immediately save wallet after mining reward
                                 // This ensures check-wallet-balance can see the new balance
@@ -782,6 +785,53 @@ void CWallet::ProcessBlockTransactionsUnlocked(const CBlock& block, int height, 
     }
 }
 
+void CWallet::FlushSettledMiningNotificationsUnlocked(int currentHeight) {
+    // Print and remove any pending notifications whose block has now been
+    // buried by ≥ 1 further block (the round is settled). Same-height
+    // tip-swap reorgs at the original height never reach here because the
+    // disconnect path in blockDisconnected() drops them first.
+    auto it = m_pendingMiningNotifications.begin();
+    while (it != m_pendingMiningNotifications.end()) {
+        if (it->blockHeight < currentHeight) {
+            double rewardCoins  = static_cast<double>(it->reward) / 100000000.0;
+            double balanceCoins = static_cast<double>(it->balanceSnapshot) / 100000000.0;
+
+            char rewardStr[64], balanceStr[64];
+            snprintf(rewardStr,  sizeof(rewardStr),  "%.8f", rewardCoins);
+            snprintf(balanceStr, sizeof(balanceStr), "%.8f", balanceCoins);
+
+            const char* coinLabel =
+                (Dilithion::g_chainParams && Dilithion::g_chainParams->IsDilV()) ? "DilV" : "DIL";
+
+            std::cout << "\n"
+                << "============================================================\n"
+                << "  MINING REWARD CREDITED!\n"
+                << "============================================================\n"
+                << "  Block Height:    " << it->blockHeight << "\n"
+                << "  Reward:          +" << rewardStr << " " << coinLabel << "\n"
+                << "  New Balance:     " << balanceStr << " " << coinLabel << "\n"
+                << "  Address:         " << it->addressStr << "\n"
+                << "============================================================"
+                << std::endl;
+
+            it = m_pendingMiningNotifications.erase(it);
+        } else {
+            ++it;
+        }
+    }
+}
+
+void CWallet::DropPendingMiningNotificationsForBlockUnlocked(const uint256& blockHash) {
+    m_pendingMiningNotifications.erase(
+        std::remove_if(m_pendingMiningNotifications.begin(),
+                       m_pendingMiningNotifications.end(),
+                       [&blockHash](const PendingMiningNotification& n) {
+                           return n.blockHash == blockHash;
+                       }),
+        m_pendingMiningNotifications.end()
+    );
+}
+
 void CWallet::SetLastBlockProcessedUnlocked(const uint256& hash, int height) {
     // Note: Caller must hold cs_wallet lock
 
@@ -835,7 +885,10 @@ bool CWallet::RescanFromHeight(CChainState& chainstate, CBlockchainDB& blockchai
             std::lock_guard<std::mutex> lock(cs_wallet);
 
             size_t txsBefore = mapWalletTx.size();
-            ProcessBlockTransactionsUnlocked(block, height, true);
+            ProcessBlockTransactionsUnlocked(block, height, true, blockHash);
+            // v4.0.17: rescan path is replaying historical blocks; never
+            // print mining reward popups for them. Drop anything queued.
+            DropPendingMiningNotificationsForBlockUnlocked(blockHash);
             size_t txsAfter = mapWalletTx.size();
 
             if (txsAfter > txsBefore) {

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -288,6 +288,24 @@ private:
     // WALLET-006 FIX: UTXO locking mechanism to prevent concurrent transaction conflicts
     std::set<COutPoint> setLockedCoins;  // UTXOs locked for transaction creation (protected by cs_wallet)
 
+    // v4.0.17: deferred mining-reward notifications
+    //
+    // DilV uses lowest-VDF-output tiebreak which causes 3-8 same-height tip
+    // swaps within ~2s before a round settles. The previous behaviour fired
+    // "MINING REWARD CREDITED" inline at block-connect time, so users saw
+    // 4-8 reward messages for a single height while their balance never
+    // changed. Now we queue the notification at connect, drop it silently if
+    // the same block hash is later disconnected, and only print once a
+    // higher block has been connected on top (the round is settled).
+    struct PendingMiningNotification {
+        uint256 blockHash;
+        int     blockHeight;
+        int64_t reward;
+        int64_t balanceSnapshot;
+        std::string addressStr;
+    };
+    std::vector<PendingMiningNotification> m_pendingMiningNotifications;  // protected by cs_wallet
+
     // ============================================================================
     // HD Wallet (Hierarchical Deterministic) - BIP32/BIP44
     // ============================================================================
@@ -377,7 +395,16 @@ private:
      * @param connecting True if block is being connected, false if disconnecting
      * @note Assumes caller holds cs_wallet lock
      */
-    void ProcessBlockTransactionsUnlocked(const class CBlock& block, int height, bool connecting);
+    void ProcessBlockTransactionsUnlocked(const class CBlock& block, int height, bool connecting, const uint256& blockHash);
+
+    // v4.0.17: settle / drop deferred mining-reward notifications.
+    // FlushSettled prints any queued notifications whose block has now been
+    // buried by at least one further block (round is settled). DropForBlock
+    // silently removes notifications belonging to a specific block hash —
+    // called from the disconnect path so transient tip-swap blocks never
+    // produce a visible reward message.
+    void FlushSettledMiningNotificationsUnlocked(int currentHeight);
+    void DropPendingMiningNotificationsForBlockUnlocked(const uint256& blockHash);
 
     /**
      * Update best block pointer and persist to disk (Bitcoin Core: SetLastBlockProcessed)


### PR DESCRIPTION
## Summary

- **DNA Phase 1.2**: discovery loop now sources MIKs from the DNA registry (always populated) unioned with the cooldown tracker (VDF-only, empty on DIL). Unblocks DIL discovery for the first time — pre-fix it never fired.
- **Miner UX overhaul**: `MINING REWARD CREDITED!` and `BLOCK CONFIRMED!` messages are deferred until the round is settled by a child block being connected on top, eliminating the 3–8 duplicate-looking messages users saw per DilV round from natural lowest-VDF-output tiebreak reorgs. Submit-time loss case still prints immediately so users get fast feedback. ASCII-only output (em-dashes were rendering as `ΓÇö` on Windows console).
- **New checkpoints**: DIL height 44,000 + DilV height 36,500, with `dfmpAssumeValidHeight` bumps. Verified against all 4 mainnet seeds.

This PR also bundles the v4.0.17 CHANGELOG entry covering the 40 commits already on main since v4.0.16.

## What's NOT in this PR (deferred to v4.0.18)

- DNA Phase 1.5 (signed sample envelope) — pending Cursor technical review
- MIK registration auto-recovery on startup for existing wallets — `mik_registration.dat` is currently created only on fresh PoW solve; existing miners would benefit from on-chain reconstruction. See `memory/v4_0_18_roadmap.md`.
- Light-wallet (web) JS dashboard log gating — counter is correct, console-side already deferred in this PR.
- Test rot triage — 5 standalone test binaries broken since Dec 2025 (CAddress rename / g_peer_manager removal). Not in CI scope.

## Test plan

- [x] Phase 1.2 unit tests added (3 new cases): empty-cooldown DIL behaviour, dedup overlap, IDNARegistry interface dispatch
- [x] `dna_propagation_tests` 18/18 pass
- [x] CI green on main (`test_dilithion` 431 Boost cases)
- [x] Live smoke test on local DIL + DilV nodes:
  - [x] Phase 1.2 discovery firing on DIL (`[DNA] Discovery: requested N of M missing MIKs`)
  - [x] Phase 1 propagation working (`[DNA] Appended sample for MIK ... from peer N`)
  - [x] Single `MINING REWARD CREDITED` per settled height (no more spam)
  - [x] `BLOCK CONFIRMED!` only fires after settlement; `BLOCK NOT SELECTED` immediate on submit-time loss
  - [x] No `ΓÇö` garbage in console output
- [x] Live wallet send round-trip (1 DIL self-send, kill+restart, send persists)

## Deploy plan

- NYC first (DIL only — DilV wrapper untouched per existing ops policy)
- 1h observation window for new log lines + counter behavior
- Then rolling LDN → SGP → SYD with sync confirmation between each
- Once 4 seeds healthy, cut release binary v4.0.17 (Linux on NYC, macOS/Windows via CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)