### PR TITLE
fix(dna): only set g_mik_peer_map on successful registration

### DIFF
--- a/src/node/dilithion-node.cpp
+++ b/src/node/dilithion-node.cpp
@@ -4372,12 +4372,22 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                 // miner's initial-registration broadcast establishes the peer_id→MIK
                 // mapping that subsequent samples rely on for plausibility.
                 auto result = g_node_context.dna_registry->register_identity(*dna);
-                (void)result;
-                char hex[9];
-                snprintf(hex, sizeof(hex), "%02x%02x%02x%02x", mik[0], mik[1], mik[2], mik[3]);
-                std::cout << "[DNA] Stored DNA for MIK " << hex << "... from peer "
-                          << peer_id << " (registry=" << g_node_context.dna_registry->count()
-                          << ")" << std::endl;
+                const bool stored =
+                    (result == digital_dna::IDNARegistry::RegisterResult::SUCCESS ||
+                     result == digital_dna::IDNARegistry::RegisterResult::SYBIL_FLAGGED);
+                if (stored) {
+                    // Set mapping only on successful registration. Never set on
+                    // merge-fill or silent-drop paths below — doing so would let any
+                    // relay forwarding a benign dnaires become "mapped" for a MIK,
+                    // bypassing the skip-crypto trust gate on later full replacements.
+                    std::lock_guard<std::mutex> lock(g_mik_peer_mutex);
+                    g_mik_peer_map[mik] = peer_id;
+                    char hex[9];
+                    snprintf(hex, sizeof(hex), "%02x%02x%02x%02x", mik[0], mik[1], mik[2], mik[3]);
+                    std::cout << "[DNA] Stored DNA for MIK " << hex << "... from peer "
+                              << peer_id << " (registry=" << g_node_context.dna_registry->count()
+                              << ")" << std::endl;
+                }
             } else {
                 // DNA Propagation Phase 1: accept enriched sample for already-registered MIK.
                 //   1. Plausibility — sender must be the currently-mapped peer for this MIK
@@ -4418,6 +4428,12 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                     // data provenance from relay-peer pollution while unblocking
                     // propagation for the common case (discovery response from a
                     // peer that happens to have enriched DNA for this MIK).
+                    //
+                    // The mapping is NOT updated here. Unmapped merge-fill is a
+                    // weak-trust path; promoting its sender to mapped status would
+                    // let any relay gain full-replacement authority on subsequent
+                    // messages. The signed-envelope path (Phase 1.5) provides the
+                    // authenticated way for unmapped peers to push full updates.
                     int filled = 0;
                     auto merged = digital_dna::merge_fill_missing_dims(*existing, *dna, &filled);
                     if (filled == 0) {
@@ -4435,12 +4451,6 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                         }
                     }
                 }
-            }
-
-            // Phase 2: Track MIK -> peer_id mapping for verification routing
-            {
-                std::lock_guard<std::mutex> lock(g_mik_peer_mutex);
-                g_mik_peer_map[mik] = peer_id;
             }
         });
 

--- a/src/node/dilv-node.cpp
+++ b/src/node/dilv-node.cpp
@@ -4248,12 +4248,22 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                 // miner's initial-registration broadcast establishes the peer_id→MIK
                 // mapping that subsequent samples rely on for plausibility.
                 auto result = g_node_context.dna_registry->register_identity(*dna);
-                (void)result;
-                char hex[9];
-                snprintf(hex, sizeof(hex), "%02x%02x%02x%02x", mik[0], mik[1], mik[2], mik[3]);
-                std::cout << "[DNA] Stored DNA for MIK " << hex << "... from peer "
-                          << peer_id << " (registry=" << g_node_context.dna_registry->count()
-                          << ")" << std::endl;
+                const bool stored =
+                    (result == digital_dna::IDNARegistry::RegisterResult::SUCCESS ||
+                     result == digital_dna::IDNARegistry::RegisterResult::SYBIL_FLAGGED);
+                if (stored) {
+                    // Set mapping only on successful registration. Never set on
+                    // merge-fill or silent-drop paths below — doing so would let any
+                    // relay forwarding a benign dnaires become "mapped" for a MIK,
+                    // bypassing the skip-crypto trust gate on later full replacements.
+                    std::lock_guard<std::mutex> lock(g_mik_peer_mutex);
+                    g_mik_peer_map[mik] = peer_id;
+                    char hex[9];
+                    snprintf(hex, sizeof(hex), "%02x%02x%02x%02x", mik[0], mik[1], mik[2], mik[3]);
+                    std::cout << "[DNA] Stored DNA for MIK " << hex << "... from peer "
+                              << peer_id << " (registry=" << g_node_context.dna_registry->count()
+                              << ")" << std::endl;
+                }
             } else {
                 // DNA Propagation Phase 1: accept enriched sample for already-registered MIK.
                 //   1. Plausibility — sender must be the currently-mapped peer for this MIK.
@@ -4293,6 +4303,12 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                     // data provenance from relay-peer pollution while unblocking
                     // propagation for the common case (discovery response from a
                     // peer that happens to have enriched DNA for this MIK).
+                    //
+                    // The mapping is NOT updated here. Unmapped merge-fill is a
+                    // weak-trust path; promoting its sender to mapped status would
+                    // let any relay gain full-replacement authority on subsequent
+                    // messages. The signed-envelope path (Phase 1.5) provides the
+                    // authenticated way for unmapped peers to push full updates.
                     int filled = 0;
                     auto merged = digital_dna::merge_fill_missing_dims(*existing, *dna, &filled);
                     if (filled == 0) {
@@ -4310,12 +4326,6 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                         }
                     }
                 }
-            }
-
-            // Phase 2: Track MIK -> peer_id mapping for verification routing
-            {
-                std::lock_guard<std::mutex> lock(g_mik_peer_mutex);
-                g_mik_peer_map[mik] = peer_id;
             }
         });
 

--- a/src/test/dna_propagation_tests.cpp
+++ b/src/test/dna_propagation_tests.cpp
@@ -12,6 +12,15 @@
  * Wire-level receiver handler rewrite (which uses both of the above plus
  * `g_mik_peer_map` plausibility) is exercised in-process when the node binary
  * runs; end-to-end two-node scenarios are deferred to manual deploy testing.
+ *
+ * Mapping semantics (post-`fix/mik-peer-map-semantics`, 2026-04-23):
+ *   `g_mik_peer_map[mik] = peer_id` is set ONLY when `register_identity`
+ *   succeeds on a previously-unseen MIK (SUCCESS or SYBIL_FLAGGED result).
+ *   Merge-fill paths and silent-drop paths MUST NOT update the mapping.
+ *   This prevents relays from promoting themselves to mapped-peer status
+ *   simply by forwarding a benign `dnaires`. The signed-envelope path
+ *   (Phase 1.5) is the authenticated route for unmapped peers to push
+ *   full replacements.
  */
 
 #include <digital_dna/digital_dna.h>


### PR DESCRIPTION
## Summary

- Fixes a Phase 1 trust-model bug: the DNA identity response handler was setting `g_mik_peer_map[mik] = peer_id` unconditionally on every accepted `dnaires`, including no-op merge-fill paths. That meant any relay forwarding a benign merge-fill could promote itself to "mapped peer" for a MIK, bypassing the skip-crypto trust gate on later full replacements.
- Now: mapping is set only when `register_identity` stores a previously-unseen MIK (SUCCESS or SYBIL_FLAGGED). Merge-fill, silent drops, and rate-limit rejections never update the mapping.
- Flagged by Cursor during 2026-04-23 Phase 1.5 technical review; shipped standalone as a pre-requisite since it's a live bug independent of Phase 1.5.

Scope: symmetric fix in both `src/node/dilithion-node.cpp` and `src/node/dilv-node.cpp`. No consensus change, no wire-format change, no new tests infrastructure.

## Test plan

- [x] Build clean on MSYS2 — both `dilithion-node` and `dilv-node` link successfully
- [x] 18/18 `dna_propagation_tests` green (no regression in rate limiter, registry, merge-fill)
- [x] Boost test suite builds clean
- [ ] CI green (Linux + macOS + Windows workflows)
- [ ] Code review

🤖 Generated with [Claude Code](https://claude.com/claude-code)