### PR TITLE
v4.0.18: fix first-time miner registration race (CRegistrationManager state machine)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -239,7 +239,8 @@ NODE_SOURCES := src/node/block_index.cpp \
                 src/node/block_validation_queue.cpp \
                 src/node/validation_watchdog.cpp \
                 src/node/resource_monitor.cpp \
-                src/node/peer_mik_tracker.cpp
+                src/node/peer_mik_tracker.cpp \
+                src/node/registration_manager.cpp
 
 PRIMITIVES_SOURCES := src/primitives/block.cpp \
                       src/primitives/transaction.cpp
@@ -336,6 +337,7 @@ TX_RELAY_TEST_SOURCE := src/test/tx_relay_tests.cpp
 MINING_INTEGRATION_TEST_SOURCE := src/test/mining_integration_tests.cpp
 DFMP_MIK_TEST_SOURCE := src/test/dfmp_mik_tests.cpp
 MIK_REG_PERSIST_TEST_SOURCE := src/test/mik_registration_persistence_tests.cpp
+REGISTRATION_MANAGER_TEST_SOURCE := src/test/registration_manager_tests.cpp
 DNA_PROPAGATION_TEST_SOURCE := src/test/dna_propagation_tests.cpp
 PASSPHRASE_VALIDATOR_TEST_SOURCE := test_passphrase_validator.cpp
 
@@ -496,6 +498,10 @@ dfmp_mik_tests: $(CORE_OBJECTS) $(OBJ_DIR)/test/dfmp_mik_tests.o $(DILITHIUM_OBJ
 	@$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LIBS)
 
 mik_registration_persistence_tests: $(CORE_OBJECTS) $(OBJ_DIR)/test/mik_registration_persistence_tests.o $(DILITHIUM_OBJECTS) $(CHIAVDF_OBJECTS)
+	@echo "$(COLOR_BLUE)[LINK]$(COLOR_RESET) $@"
+	@$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LIBS)
+
+registration_manager_tests: $(CORE_OBJECTS) $(OBJ_DIR)/test/registration_manager_tests.o $(DILITHIUM_OBJECTS) $(CHIAVDF_OBJECTS)
 	@echo "$(COLOR_BLUE)[LINK]$(COLOR_RESET) $@"
 	@$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LIBS)
 
@@ -779,7 +785,7 @@ clean:
 	@echo "$(COLOR_YELLOW)Cleaning build artifacts...$(COLOR_RESET)"
 	@rm -rf $(BUILD_DIR)
 	@rm -f dilithion-node genesis_gen
-	@rm -f phase1_test miner_tests wallet_tests rpc_tests rpc_auth_tests timestamp_tests crypter_tests wallet_encryption_integration_tests wallet_persistence_tests integration_tests net_tests tx_validation_tests tx_relay_tests mining_integration_tests dfmp_mik_tests mik_registration_persistence_tests dna_propagation_tests
+	@rm -f phase1_test miner_tests wallet_tests rpc_tests rpc_auth_tests timestamp_tests crypter_tests wallet_encryption_integration_tests wallet_persistence_tests integration_tests net_tests tx_validation_tests tx_relay_tests mining_integration_tests dfmp_mik_tests mik_registration_persistence_tests registration_manager_tests dna_propagation_tests
 	@rm -f test_dilithion
 	@rm -f $(DILITHIUM_OBJECTS)
 	@echo "$(COLOR_GREEN)✓ Clean complete$(COLOR_RESET)"

--- a/run-dil-seed-relayonly.sh
+++ b/run-dil-seed-relayonly.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
-# Auto-restart wrapper for DIL seed nodes
-# Same as run-dilv-seed.sh but for dilithion-node (DIL chain)
+# Auto-restart wrapper for DIL relay-only seed nodes (LDN/SGP/SYD).
 #
-# Usage: nohup ./run-dil-seed.sh > /root/dil-seed.log 2>&1 &
+# NYC is different: NYC's DIL node loads the bridge wallet and runs WITHOUT
+# --relay-only. Do NOT use this wrapper on NYC — NYC uses a separate
+# top-level script at /root/run-dil-seed.sh that omits --relay-only.
+# See .claude/skills/deploy/SKILL.md for the per-host wrapper matrix.
+#
+# Usage: nohup ./run-dil-seed-relayonly.sh > /root/dil-seed.log 2>&1 &
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 BINARY="$SCRIPT_DIR/dilithion-node"

--- a/run-dilv-seed-relayonly.sh
+++ b/run-dilv-seed-relayonly.sh
@@ -1,10 +1,16 @@
 #!/bin/bash
-# Auto-restart wrapper for DilV seed nodes
+# Auto-restart wrapper for DilV relay-only seed nodes (LDN/SGP/SYD).
+#
+# NYC is different: NYC's DilV node loads the bridge wallet and runs WITHOUT
+# --relay-only. Do NOT use this wrapper on NYC — NYC uses a separate
+# top-level script at /root/run-dilv-seed.sh that omits --relay-only.
+# See .claude/skills/deploy/SKILL.md for the per-host wrapper matrix.
+#
 # Handles BUG #277 auto-rebuild: if the node detects UTXO corruption,
 # it writes an auto_rebuild marker and shuts down. This script restarts
 # it, and the node's startup code handles the cleanup automatically.
 #
-# Usage: nohup ./run-dilv-seed.sh > /root/dilv-seed.log 2>&1 &
+# Usage: nohup ./run-dilv-seed-relayonly.sh > /root/dilv-seed.log 2>&1 &
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 BINARY="$SCRIPT_DIR/dilv-node"

--- a/scripts/check-repo-hygiene.sh
+++ b/scripts/check-repo-hygiene.sh
@@ -89,10 +89,11 @@ ALLOWED_ROOT_FILES=(
   start-miner-gui.sh
   start-mining.sh
 
-  # Seed-node ops
+  # Seed-node ops (relay-only variants — LDN/SGP/SYD. NYC uses its own
+  # top-level /root/run-*-seed.sh which omits --relay-only for bridge)
   restart-seed-node.sh
-  run-dil-seed.sh
-  run-dilv-seed.sh
+  run-dil-seed-relayonly.sh
+  run-dilv-seed-relayonly.sh
 
   # Runtime data (read by node code)
   datacenter-asns.txt

--- a/src/core/globals.cpp
+++ b/src/core/globals.cpp
@@ -42,21 +42,27 @@ struct NodeState {
 
 NodeState g_node_state;
 
-// BUG #278 FIX: MIK registration PoW cache — shared between dilithion-node.cpp and server.cpp
-// Defined here so all link targets (dilithion-node, dilv-node, genesis_gen, check-wallet-balance) resolve them
-uint64_t g_regCachedNonce = 0;
-std::atomic<bool> g_regNonceMined{false};
-std::atomic<bool> g_regPowInProgress{false};
-DFMP::Identity g_regNonceIdentity;
+// v4.0.18: MIK registration is now owned by CRegistrationManager. The old
+// g_regCachedNonce / g_regNonceMined / g_regPowInProgress / g_regNonceIdentity
+// / g_cachedAttestations / g_attestationsCollected / g_cachedDnaHash /
+// g_dnaHashCached globals have been removed — they were the race-condition
+// anchor point for Zach's-friend-style registration failures.
+//
+// Both the miner loop (dilithion-node.cpp / dilv-node.cpp) and the RPC
+// server (rpc/server.cpp) now reach the single live CRegistrationManager
+// via the accessor below. The accessor is set once in main() after the
+// manager is constructed; it returns nullptr in genesis_gen and
+// check-wallet-balance (which don't have a manager).
 
-// Phase 2+3: Cached seed attestations (collected before registration PoW, embedded in coinbase)
-Attestation::CAttestationSet g_cachedAttestations;
-std::atomic<bool> g_attestationsCollected{false};
+class CRegistrationManager;  // forward decl — avoids pulling node/registration_manager.h into utility link targets
 
-// Cached DNA hash for registration (DNA → attestation → PoW all use same hash)
-// Shared between dilithion-node.cpp and server.cpp so RPC startmining can bind DNA to PoW.
-std::array<uint8_t, 32> g_cachedDnaHash{};
-std::atomic<bool> g_dnaHashCached{false};
+static CRegistrationManager* s_registrationManagerGlobal = nullptr;
+void SetRegistrationManager(CRegistrationManager* mgr) {
+    s_registrationManagerGlobal = mgr;
+}
+CRegistrationManager* GetRegistrationManager() {
+    return s_registrationManagerGlobal;
+}
 
 // Data directory of the running node. Set in main() so utilities like the MIK
 // registration file persistence can find the right location without threading

--- a/src/net/upnp.cpp
+++ b/src/net/upnp.cpp
@@ -28,6 +28,7 @@ inline const char* strupnperror(int) { return ""; }
 
 #include <cstdio>
 #include <cstring>
+#include <chrono>
 
 namespace UPnP {
 
@@ -42,11 +43,33 @@ static uint16_t s_mappedPort = 0;
 bool MapPort(uint16_t port, std::string& externalIP) {
     int error = 0;
 
-    // Discover UPnP devices (2 second timeout)
-    s_devlist = upnpDiscover(2000, nullptr, nullptr, 0, 0, 2, &error);
+    // Discover UPnP devices with retry + elapsed-time logging.
+    //
+    // A single 2-second SSDP M-SEARCH was the #1 cause of intermittent
+    // startup failures: many consumer routers need 3-5+ seconds to respond
+    // under load, so we'd miss them on the first burst and give up. Now we
+    // try twice with longer windows and log how long each attempt took so
+    // future failures are diagnosable (was the router slow, or just absent).
+    const int discovery_timeouts_ms[] = {5000, 8000};
+    for (size_t attempt = 0; attempt < sizeof(discovery_timeouts_ms) / sizeof(discovery_timeouts_ms[0]); ++attempt) {
+        auto t_start = std::chrono::steady_clock::now();
+        s_devlist = upnpDiscover(discovery_timeouts_ms[attempt], nullptr, nullptr, 0, 0, 2, &error);
+        auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - t_start).count();
+
+        if (s_devlist) {
+            LogPrintf(NET, INFO, "[UPnP] Discovery succeeded on attempt %zu (elapsed=%ldms, timeout=%dms)\n",
+                      attempt + 1, static_cast<long>(elapsed_ms), discovery_timeouts_ms[attempt]);
+            break;
+        }
+
+        LogPrintf(NET, WARN, "[UPnP] Discovery attempt %zu returned no devices (elapsed=%ldms, timeout=%dms, error=%d)\n",
+                  attempt + 1, static_cast<long>(elapsed_ms), discovery_timeouts_ms[attempt], error);
+    }
+
     if (!s_devlist) {
-        s_lastError = "No UPnP devices found on network";
-        LogPrintf(NET, WARN, "[UPnP] %s (error=%d)\n", s_lastError.c_str(), error);
+        s_lastError = "No UPnP devices found on network after 2 attempts";
+        LogPrintf(NET, WARN, "[UPnP] %s\n", s_lastError.c_str());
         return false;
     }
 

--- a/src/node/dilithion-node.cpp
+++ b/src/node/dilithion-node.cpp
@@ -67,6 +67,7 @@
 #include <dfmp/identity_db.h>      // DFMP: Identity persistence
 #include <dfmp/mik.h>              // DFMP v2.0: Mining Identity Key
 #include <dfmp/mik_registration_file.h>  // Persistent MIK registration PoW
+#include <node/registration_manager.h>   // v4.0.18: first-time registration state machine
 #include <util/chain_reset.h>      // --reset-chain helper
 #include <consensus/tx_validation.h>  // BUG #108 FIX: For CTransactionValidator
 #include <consensus/signature_batch_verifier.h>  // Phase 3.2: Batch signature verification
@@ -778,62 +779,59 @@ struct NodeConfig {
 static CTransactionRef g_currentCoinbase;
 static std::mutex g_coinbaseMutex;
 
-// MIK registration PoW cache (defined in globals.cpp, also accessed by RPC server)
-// Shared between EnsureMIKRegistered(), BuildMiningTemplate(), and RPC_StartMining()
-extern uint64_t g_regCachedNonce;
-extern std::atomic<bool> g_regNonceMined;
-extern std::atomic<bool> g_regPowInProgress;
-extern DFMP::Identity g_regNonceIdentity;
-
-// Phase 2+3: Cached seed attestations (defined in globals.cpp)
-extern Attestation::CAttestationSet g_cachedAttestations;
-extern std::atomic<bool> g_attestationsCollected;
-
-// Cached DNA hash for registration (DNA → attestation → PoW all use same hash)
-// Must be collected before attestation request and registration PoW so all three
-// are bound to the same hardware fingerprint.
-// Defined in globals.cpp — shared with RPC server for startmining path.
-extern std::array<uint8_t, 32> g_cachedDnaHash;
-extern std::atomic<bool> g_dnaHashCached;
+// v4.0.18: CRegistrationManager owns all first-time MIK registration state.
+// BuildMiningTemplate is now a pure reader of its published snapshot. The old
+// g_regCachedNonce / g_regNonceMined / g_regPowInProgress / g_regNonceIdentity
+// / g_cachedAttestations / g_attestationsCollected / g_cachedDnaHash /
+// g_dnaHashCached globals have been removed from globals.cpp — they were the
+// race-condition anchor point.
+//
+// The RPC server reaches the live manager via GetRegistrationManager();
+// the miner loop holds its own unique_ptr and also publishes via
+// SetRegistrationManager() so the RPC server sees the same instance.
+static std::unique_ptr<CRegistrationManager> s_registrationManager;
+void SetRegistrationManager(CRegistrationManager* mgr);  // defined in globals.cpp
 
 // Data directory (defined in globals.cpp, set in main before any PoW save/load).
 extern std::string g_datadir;
 
-// Persist the solved registration PoW so miners don't re-solve on restart.
-// Best-effort: failure is logged but does not block mining.
-static void PersistRegistrationPoW(const std::vector<uint8_t>& pubkey) {
-    if (g_datadir.empty() || pubkey.empty()) return;
-    std::array<uint8_t, 32> dnaHash{};
-    if (g_dnaHashCached.load()) dnaHash = g_cachedDnaHash;
-    int64_t now = static_cast<int64_t>(std::time(nullptr));
-    if (DFMP::SaveMIKRegistration(g_datadir, pubkey, dnaHash, g_regCachedNonce, now)) {
-        std::cout << "  [Mining] Registration PoW saved to disk (skips re-solve on restart)" << std::endl;
-    } else {
-        std::cerr << "  [Mining] WARNING: failed to persist registration PoW" << std::endl;
-    }
+/**
+ * Ensure the registration manager exists; lazily construct on first call.
+ * Requires wallet + g_node_context + g_chainParams to be fully initialized.
+ */
+static void EnsureRegistrationManagerInitialized(CWallet& wallet) {
+    if (s_registrationManager) return;
+    if (!Dilithion::g_chainParams) return;  // too early
+
+    auto env = std::make_shared<CProductionRegistrationEnv>(
+        wallet,
+        g_node_context,
+        g_datadir,
+        Dilithion::g_chainParams->registrationPowBits,
+        Dilithion::g_chainParams->dnaCommitmentActivationHeight,
+        Dilithion::g_chainParams->seedAttestationActivationHeight);
+    s_registrationManager = std::make_unique<CRegistrationManager>(std::move(env));
+    // Publish to the global accessor so the RPC server can reach the same
+    // instance (prevents two parallel registration flows / double-PoW).
+    SetRegistrationManager(s_registrationManager.get());
 }
 
 /**
- * Ensure MIK identity is registered before mining begins.
- * This is a one-time operation for new miners (~10-15 minutes).
- * Must be called before BuildMiningTemplate() on the startup path
- * so the user sees clear progress instead of cryptic template errors.
+ * Drive the CRegistrationManager and block until registration is ready or
+ * a fatal error occurs. Replaces the old inline DNA/attestation/PoW flow.
  *
- * @param wallet Reference to wallet (for MIK identity)
- * @param nextHeight The height of the next block to be mined
- * @return true if registration is complete (or not needed), false on failure
+ * Semantics match the old EnsureMIKRegistered():
+ *   - true:  registration is ready (CanMine() == true) OR node below activation height
+ *   - false: fatal or user-actionable error; mining must be deferred
  */
 bool EnsureMIKRegistered(CWallet& wallet, unsigned int nextHeight) {
-    // Guard: identity DB must be available
     if (!DFMP::g_identityDb) return true;
-
-    // Guard: DFMP v3 PoW only required at/above activation height
     if (!Dilithion::g_chainParams ||
         static_cast<int>(nextHeight) < Dilithion::g_chainParams->dfmpV3ActivationHeight) {
         return true;
     }
 
-    // Get or generate MIK identity
+    // Generate MIK identity if wallet does not have one yet.
     DFMP::Identity identity = wallet.GetMIKIdentity();
     if (identity.IsNull()) {
         if (!wallet.GenerateMIK()) {
@@ -844,241 +842,51 @@ bool EnsureMIKRegistered(CWallet& wallet, unsigned int nextHeight) {
         std::cout << "[Mining] Generated new miner identity: " << identity.GetHex() << std::endl;
     }
 
-    // Already registered in identity DB?
-    if (DFMP::g_identityDb->HasMIKPubKey(identity)) {
-        // BUG #284: Pre-cache DNA even when MIK is registered, in case the
-        // registration block gets orphaned later. Without cached DNA, the
-        // template builder cannot re-collect attestations for re-registration.
-        if (!g_dnaHashCached.load() && Dilithion::g_chainParams &&
-            static_cast<int>(nextHeight) >= Dilithion::g_chainParams->dnaCommitmentActivationHeight) {
-            auto collector = g_node_context.GetDNACollector();
-            if (collector) {
-                auto dna = collector->get_dna();
-                if (dna) {
-                    g_cachedDnaHash = dna->hash();
-                    bool allZero = true;
-                    for (auto b : g_cachedDnaHash) { if (b != 0) { allZero = false; break; } }
-                    if (!allZero) {
-                        g_dnaHashCached.store(true);
-                        std::cout << "[Mining] MIK registered - pre-cached DNA for future use" << std::endl;
-                    }
-                }
-            }
-        }
-        return true;
-    }
+    EnsureRegistrationManagerInitialized(wallet);
+    if (!s_registrationManager) return false;
 
-    // Already cached from a previous call?
-    if (g_regNonceMined.load() && g_regNonceIdentity == identity) return true;
+    // Drive the manager and wait for readiness. The manager's worker thread
+    // does DNA collection, seed attestations, and PoW; we poll the snapshot
+    // and log progress as the mine-gate reason changes.
+    auto tipHeight = (g_chainstate.GetTip() ? g_chainstate.GetTip()->nHeight : 0);
+    s_registrationManager->Tick(tipHeight, g_node_state.running.load());
 
-    // Get public key for PoW
-    std::vector<uint8_t> mikPubkey;
-    if (!wallet.GetMIKPubKey(mikPubkey)) {
-        std::cerr << "[Mining] WARNING: Failed to get MIK public key (wallet may be locked)" << std::endl;
-        return false;
-    }
+    using State = CRegistrationManager::State;
+    using Reason = CRegistrationManager::MineGateReason;
+    Reason lastReason = Reason::BLOCKED_UNINITIALIZED;
+    while (g_node_state.running.load()) {
+        auto snap = s_registrationManager->GetSnapshot();
 
-    // ========================================================================
-    // Step 0: Attempt to restore a previously-solved registration PoW from disk.
-    // If the cached pubkey matches this wallet's MIK, we skip the ~25 min PoW.
-    // This handles the case where the node restarted (or chain was reset) but
-    // wallet.dat + mik_registration.dat survived.
-    // ========================================================================
-    if (!g_regNonceMined.load() && !g_datadir.empty()) {
-        DFMP::MIKRegistrationFile rec;
-        auto res = DFMP::LoadMIKRegistration(g_datadir, mikPubkey, rec);
-        if (res == DFMP::MIKRegFileLoadResult::OK) {
-            g_regCachedNonce = rec.nonce;
-            g_regNonceIdentity = identity;
-            g_regNonceMined.store(true);
-            // Reuse the DNA hash the PoW was solved against — the on-chain PoW
-            // verifier checks SHA3-256(pubkey||dnaHash||nonce), so DNA hash must
-            // match what we solved with, not a freshly collected one.
-            g_cachedDnaHash = rec.dnaHash;
-            bool nonZeroDna = false;
-            for (auto b : rec.dnaHash) { if (b != 0) { nonZeroDna = true; break; } }
-            if (nonZeroDna) g_dnaHashCached.store(true);
-            std::cout << "  [Mining] MIK registration restored from disk (saves ~25 min PoW)" << std::endl;
-        } else if (res == DFMP::MIKRegFileLoadResult::PubkeyMismatch) {
-            std::cout << "  [Mining] Found stale mik_registration.dat (wallet MIK changed), ignoring" << std::endl;
-        } else if (res == DFMP::MIKRegFileLoadResult::Corrupt) {
-            std::cerr << "  [Mining] mik_registration.dat corrupt, solving new PoW" << std::endl;
-        }
-    }
-
-    if (g_regNonceMined.load() && g_regNonceIdentity == identity) return true;
-
-    // ========================================================================
-    // Step 1: Collect Digital DNA (required after dnaCommitmentActivationHeight)
-    // ========================================================================
-    // DNA must be collected before attestation and registration PoW.
-    // The DNA hash binds the miner's hardware identity to their MIK.
-    if (!g_dnaHashCached.load()) {
-        int dnaCommitHeight = Dilithion::g_chainParams ?
-            Dilithion::g_chainParams->dnaCommitmentActivationHeight : 999999999;
-
-        if (static_cast<int>(nextHeight) >= dnaCommitHeight) {
-            std::cout << std::endl;
-            std::cout << "  [Mining] Collecting Digital DNA fingerprint..." << std::endl;
-            std::cout << "  [Mining] DNA binds your hardware identity to your miner key." << std::endl;
-
-            // Wait for DNA collector to have data (up to 120s)
-            auto collector = g_node_context.GetDNACollector();
-            int waitSec = 0;
-            const int maxWaitSec = 120;
-            while (g_node_state.running && waitSec < maxWaitSec) {
-                if (collector) {
-                    auto dna = collector->get_dna();
-                    if (dna) {
-                        g_cachedDnaHash = dna->hash();
-                        // Verify non-zero
-                        bool allZero = true;
-                        for (auto b : g_cachedDnaHash) { if (b != 0) { allZero = false; break; } }
-                        if (!allZero) {
-                            g_dnaHashCached.store(true);
-                            std::cout << "  [Mining] DNA collected (hash " << std::hex;
-                            for (int i = 0; i < 4; i++) std::cout << std::setfill('0') << std::setw(2) << (int)g_cachedDnaHash[i];
-                            std::cout << std::dec << "...)" << std::endl;
-                            break;
-                        }
-                    }
-                }
-                if (waitSec % 10 == 0 && waitSec > 0) {
-                    std::cout << "  [Mining] Waiting for DNA collection... (" << waitSec << "s / " << maxWaitSec << "s)" << std::endl;
-                }
-                std::this_thread::sleep_for(std::chrono::seconds(1));
-                waitSec++;
-            }
-
-            if (!g_dnaHashCached.load()) {
-                if (!g_node_state.running) return false;
-                std::cerr << "  [Mining] ERROR: DNA collection timed out after " << maxWaitSec << "s." << std::endl;
-                std::cerr << "  [Mining] DNA is required for registration after height " << dnaCommitHeight << ". Retrying next cycle." << std::endl;
-                return false;
-            }
-        }
-    }
-
-    // ========================================================================
-    // Step 2: Collect seed attestations (both DIL and DilV)
-    // ========================================================================
-    // Seeds sign: MIK_pubkey + DNA_hash + timestamp + seed_id
-    // BUG FIX: Was previously gated to IsDilV() only, but DIL also requires
-    // attestations after seedAttestationActivationHeight (40,000).
-    if (!g_attestationsCollected.load() &&
-        Dilithion::g_chainParams &&
-        !Dilithion::g_chainParams->seedAttestationIPs.empty()) {
-
-        int attestationHeight = Dilithion::g_chainParams->seedAttestationActivationHeight;
-        if (static_cast<int>(nextHeight) >= attestationHeight) {
-            std::cout << std::endl;
-            std::cout << "  [Mining] Requesting seed attestations for MIK registration..." << std::endl;
-
-            std::string mikPubkeyHex = HexStr(mikPubkey);
-            std::string dnaHashHex = HexStr(g_cachedDnaHash.data(), 32);
-
-            Attestation::CAttestationSet attestations;
-            std::string attestError;
-            bool gotAttestations = Attestation::CollectAttestations(
-                Dilithion::g_chainParams->seedAttestationIPs,
-                Dilithion::g_chainParams->seedAttestationRPCPort,
-                mikPubkeyHex, dnaHashHex,
-                attestations, attestError);
-
-            if (gotAttestations) {
-                g_cachedAttestations = std::move(attestations);
-                g_attestationsCollected.store(true);
-                std::cout << "  [Mining] Seed attestations collected successfully!" << std::endl;
-            } else {
-                std::cerr << "  [Mining] WARNING: " << attestError << std::endl;
-                std::cerr << "  [Mining] Attestations required. Retrying next cycle." << std::endl;
-                return false;
-            }
-            std::cout << std::endl;
-        }
-    }
-
-    // ========================================================================
-    // Step 3: Mine registration PoW (includes DNA hash in challenge)
-    // ========================================================================
-    // PoW challenge: SHA3-256(pubkey || dna_hash || nonce)
-    // BUG FIX: Previously mined WITHOUT DNA hash, but validator included it
-    // when present in block → PoW mismatch → block rejected.
-    int regPowBits = Dilithion::g_chainParams ?
-        Dilithion::g_chainParams->registrationPowBits : DFMP::REGISTRATION_POW_BITS;
-
-    std::cout << std::endl;
-    std::cout << "  [Mining] First-time setup: Registering miner identity..." << std::endl;
-    std::cout << "  [Mining] Registration PoW: " << regPowBits << " bits" << std::endl;
-    if (g_dnaHashCached.load()) {
-        std::cout << "  [Mining] DNA-bound: yes (hardware fingerprint included in PoW challenge)" << std::endl;
-    }
-    std::cout << "  [Mining] This is a one-time process. Mining starts automatically after." << std::endl;
-    std::cout << std::endl;
-
-    // Determine DNA hash pointer for PoW (null if DNA not active at this height)
-    const std::array<uint8_t, 32>* dnaForPow = g_dnaHashCached.load() ? &g_cachedDnaHash : nullptr;
-
-    if (!g_regPowInProgress.exchange(true)) {
-        uint64_t nonce = 0;
-        if (DFMP::MineRegistrationPoW(mikPubkey, regPowBits, nonce, &g_node_state.running, dnaForPow)) {
-            g_regCachedNonce = nonce;
-            g_regNonceIdentity = identity;
-            g_regNonceMined.store(true);
-            g_regPowInProgress.store(false);
-            PersistRegistrationPoW(mikPubkey);
-            std::cout << std::endl;
-            std::cout << "  [Mining] Miner identity registered successfully!" << std::endl;
-            std::cout << std::endl;
+        if (snap->state == State::CONFIRMED ||
+            snap->state == State::READY ||
+            snap->state == State::SUBMITTED) {
             return true;
-        } else {
-            g_regPowInProgress.store(false);
-            if (!g_node_state.running) {
-                std::cout << "[Mining] Registration PoW cancelled (shutting down)" << std::endl;
-            } else {
-                std::cerr << "[Mining] WARNING: Failed to mine registration PoW" << std::endl;
+        }
+        if (snap->state == State::FAILED_FATAL) {
+            std::cerr << "[Mining] Registration fatal error: " << snap->lastError << std::endl;
+            return false;
+        }
+        if (snap->state == State::LONG_BACKOFF_USER_ACTIONABLE) {
+            std::cerr << "[Mining] Registration blocked: " << snap->lastError << std::endl;
+            if (!snap->userActionHint.empty()) {
+                std::cerr << "[Mining]   -> " << snap->userActionHint << std::endl;
             }
             return false;
         }
-    } else {
-        // BUG #278 FIX: Another thread is already mining registration PoW.
-        // Wait for it to finish instead of returning true (which caused the caller
-        // to proceed to BuildMiningTemplate before the nonce was cached, resulting
-        // in "Template rejected - no MIK data" loops for new miners).
-        std::cout << "  [Mining] Registration PoW already in progress on another thread, waiting..." << std::endl;
-        int wait_sec = 0;
-        while (g_regPowInProgress.load(std::memory_order_acquire) && g_node_state.running) {
-            std::this_thread::sleep_for(std::chrono::seconds(1));
-            wait_sec++;
-            if (wait_sec % 30 == 0) {
-                std::cout << "  [Mining] Still waiting for registration PoW... (" << wait_sec << "s)" << std::endl;
-            }
+
+        if (snap->mineGate != lastReason) {
+            auto status = s_registrationManager->GetStatusForUI();
+            std::cout << "  [Mining] Phase: " << status.phase
+                      << " — " << status.message;
+            if (!status.etaText.empty()) std::cout << " (" << status.etaText << ")";
+            std::cout << std::endl;
+            lastReason = snap->mineGate;
         }
-        if (!g_node_state.running) return false;
-        // Check if the other thread succeeded
-        if (g_regNonceMined.load() && g_regNonceIdentity == identity) {
-            std::cout << "  [Mining] Registration PoW completed by other thread!" << std::endl;
-            return true;
-        }
-        // Other thread failed — we need to try ourselves
-        std::cerr << "[Mining] WARNING: Registration PoW failed on other thread, retrying..." << std::endl;
-        if (!g_regPowInProgress.exchange(true)) {
-            uint64_t nonce = 0;
-            if (DFMP::MineRegistrationPoW(mikPubkey, regPowBits, nonce, &g_node_state.running, dnaForPow)) {
-                g_regCachedNonce = nonce;
-                g_regNonceIdentity = identity;
-                g_regNonceMined.store(true);
-                g_regPowInProgress.store(false);
-                PersistRegistrationPoW(mikPubkey);
-                std::cout << "  [Mining] Miner identity registered successfully!" << std::endl;
-                return true;
-            } else {
-                g_regPowInProgress.store(false);
-                return false;
-            }
-        }
-        return false;
+
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+        s_registrationManager->Tick(tipHeight, g_node_state.running.load());
     }
+    return false;
 }
 
 /**
@@ -1263,72 +1071,24 @@ std::optional<CBlockTemplate> BuildMiningTemplate(CBlockchainDB& blockchain, CWa
             bool isRegistered = DFMP::g_identityDb && DFMP::g_identityDb->HasMIKPubKey(mikIdentity);
 
             if (!isRegistered) {
-                // First block with this MIK - include full pubkey (registration)
+                // Registration path — all registration material comes from the
+                // RegistrationManager's snapshot. BuildMiningTemplate is a PURE
+                // READER: no inline PoW mining, no DNA collection, no attestation
+                // RPC, no state mutation. All that work happens in the manager's
+                // worker thread, gated through CanMine().
                 std::vector<uint8_t> mikPubkey;
-                if (wallet.GetMIKPubKey(mikPubkey)) {
-                    // BUG #284 FIX: Ensure DNA is cached before registration PoW.
-                    // If EnsureMIKRegistered() returned early (MIK was registered at
-                    // startup but later orphaned by reorg), g_dnaHashCached is false.
-                    // Without DNA, PoW is mined without it and attestation re-collection
-                    // is impossible, causing infinite template rejection loops.
-                    if (!g_dnaHashCached.load() && Dilithion::g_chainParams &&
-                        static_cast<int>(nHeight) >= Dilithion::g_chainParams->dnaCommitmentActivationHeight) {
-                        auto collector = g_node_context.GetDNACollector();
-                        if (collector) {
-                            auto dna = collector->get_dna();
-                            if (dna) {
-                                g_cachedDnaHash = dna->hash();
-                                bool allZero = true;
-                                for (auto b : g_cachedDnaHash) { if (b != 0) { allZero = false; break; } }
-                                if (!allZero) {
-                                    g_dnaHashCached.store(true);
-                                    std::cout << "[Mining] DNA collected inline for registration (hash " << std::hex;
-                                    for (int i = 0; i < 4; i++) std::cout << std::setfill('0') << std::setw(2) << (int)g_cachedDnaHash[i];
-                                    std::cout << std::dec << "...)" << std::endl;
-                                    // Invalidate any PoW mined without DNA — must re-mine with DNA in challenge
-                                    if (g_regNonceMined.load()) {
-                                        std::cout << "[Mining] Invalidating PoW (was mined without DNA) - will re-mine" << std::endl;
-                                        g_regNonceMined.store(false);
-                                    }
-                                }
-                            }
-                        }
-                    }
+                std::shared_ptr<const CRegistrationManager::Snapshot> regSnap;
+                if (s_registrationManager) regSnap = s_registrationManager->GetSnapshot();
 
-                    // DFMP v3.0: Mine registration PoW nonce (cached to avoid re-mining)
-                    // Thread-safety: atomic flag prevents duplicate PoW mining when
-                    // BuildMiningTemplate is called concurrently (e.g. main thread
-                    // startup + chain tip callback from P2P thread)
-                    // NOTE: g_regCachedNonce, g_regNonceMined, g_regPowInProgress,
-                    // g_regNonceIdentity are file-scope (shared with EnsureMIKRegistered)
-                    uint64_t regNonce = 0;
-                    if (Dilithion::g_chainParams && nHeight >= Dilithion::g_chainParams->dfmpV3ActivationHeight) {
-                        if (g_regNonceMined.load() && g_regNonceIdentity == mikIdentity) {
-                            regNonce = g_regCachedNonce;
-                        } else if (!g_regPowInProgress.exchange(true)) {
-                            // We acquired the lock - mine the PoW
-                            std::cout << "[DFMP v3.0] Mining registration PoW for new MIK identity..." << std::endl;
-                            int rpBits = Dilithion::g_chainParams ? Dilithion::g_chainParams->registrationPowBits : DFMP::REGISTRATION_POW_BITS;
-                            const std::array<uint8_t, 32>* dnaPtr = g_dnaHashCached.load() ? &g_cachedDnaHash : nullptr;
-                            if (DFMP::MineRegistrationPoW(mikPubkey, rpBits, regNonce, &g_node_state.running, dnaPtr)) {
-                                g_regCachedNonce = regNonce;
-                                g_regNonceIdentity = mikIdentity;
-                                g_regNonceMined.store(true);
-                                PersistRegistrationPoW(mikPubkey);
-                            } else {
-                                std::cerr << "[DFMP v3.0] Failed to mine registration PoW!" << std::endl;
-                                regNonce = UINT64_MAX;  // Sentinel: skip registration (prevents nonce=0 template)
-                            }
-                            g_regPowInProgress.store(false);
-                        } else {
-                            // Another thread is already mining registration PoW - skip MIK for this template.
-                            // The next template rebuild (after PoW completes) will include the cached nonce.
-                            std::cout << "[DFMP v3.0] Registration PoW already in progress on another thread, skipping MIK..." << std::endl;
-                            regNonce = UINT64_MAX;  // Sentinel: skip registration
-                        }
+                if (!regSnap || !regSnap->hasRegNonce || !regSnap->hasDnaHash ||
+                    regSnap->mikPubkey.empty()) {
+                    if (verbose) {
+                        std::cout << "  MIK: Skipped (registration manager not ready)" << std::endl;
                     }
-
-                    if (regNonce != UINT64_MAX && DFMP::BuildMIKScriptSigRegistration(mikPubkey, mikSignature, regNonce, mikData)) {
+                } else {
+                    mikPubkey = regSnap->mikPubkey;
+                    uint64_t regNonce = regSnap->regNonce;
+                    if (DFMP::BuildMIKScriptSigRegistration(mikPubkey, mikSignature, regNonce, mikData)) {
                         scriptSig.insert(scriptSig.end(), mikData.begin(), mikData.end());
                         mikDataIncluded = true;
                         if (verbose) {
@@ -1353,20 +1113,23 @@ std::optional<CBlockTemplate> BuildMiningTemplate(CBlockchainDB& blockchain, CWa
         std::cerr << "[Mining] WARNING: No MIK identity in wallet" << std::endl;
     }
 
-    // Digital DNA commitment: append 0xDD + 32-byte hash after MIK data
-    // For registration blocks: use the cached DNA hash (same one used for attestation + PoW)
-    // For normal blocks: use live DNA from collector
+    // Digital DNA commitment: append 0xDD + 32-byte hash after MIK data.
+    // For registration blocks: use the manager's session DNA hash (consensus-
+    // consistent with attestation + PoW since all three were locked together).
+    // For normal blocks: use live DNA from collector.
     if (mikDataIncluded && Dilithion::g_chainParams &&
         static_cast<int>(nHeight) >= Dilithion::g_chainParams->dnaCommitmentActivationHeight) {
         bool isRegBlock = DFMP::g_identityDb && !mikIdentity.IsNull() &&
             !DFMP::g_identityDb->HasMIKPubKey(mikIdentity);
 
-        if (isRegBlock && g_dnaHashCached.load()) {
-            // Registration block: use cached DNA hash for consistency with attestation + PoW
-            DFMP::BuildDNACommitment(g_cachedDnaHash, scriptSig);
+        std::shared_ptr<const CRegistrationManager::Snapshot> regSnap;
+        if (s_registrationManager) regSnap = s_registrationManager->GetSnapshot();
+
+        if (isRegBlock && regSnap && regSnap->hasDnaHash) {
+            DFMP::BuildDNACommitment(regSnap->dnaHash, scriptSig);
             if (verbose) {
-                std::cout << "  DNA: Registration commitment (cached hash " << std::hex;
-                for (int i = 0; i < 4; i++) std::cout << std::setfill('0') << std::setw(2) << (int)g_cachedDnaHash[i];
+                std::cout << "  DNA: Registration commitment (session hash " << std::hex;
+                for (int i = 0; i < 4; i++) std::cout << std::setfill('0') << std::setw(2) << (int)regSnap->dnaHash[i];
                 std::cout << std::dec << "...)" << std::endl;
             }
         } else {
@@ -1386,7 +1149,11 @@ std::optional<CBlockTemplate> BuildMiningTemplate(CBlockchainDB& blockchain, CWa
         }
     }
 
-    // Phase 2+3: Append seed attestation data after DNA commitment (registration blocks only)
+    // Phase 2+3: Append seed attestation data after DNA commitment (registration blocks only).
+    // The CRegistrationManager owns attestation collection + freshness — BuildMiningTemplate
+    // only READS the attestation set from the snapshot. Stale attestations are refreshed
+    // automatically by the manager's worker (HandleReady_). If the manager doesn't have
+    // a fresh attestation set, we return nullopt and the miner waits for the next template.
     bool isRegistrationBlock = mikDataIncluded &&
         DFMP::g_identityDb && !mikIdentity.IsNull() &&
         !DFMP::g_identityDb->HasMIKPubKey(mikIdentity);
@@ -1394,63 +1161,27 @@ std::optional<CBlockTemplate> BuildMiningTemplate(CBlockchainDB& blockchain, CWa
         int activationHeight = Dilithion::g_chainParams ?
             Dilithion::g_chainParams->seedAttestationActivationHeight : 999999999;
 
+        std::shared_ptr<const CRegistrationManager::Snapshot> regSnap;
+        if (s_registrationManager) regSnap = s_registrationManager->GetSnapshot();
+
         if (static_cast<int>(nHeight) >= activationHeight) {
-            // BUG #283 FIX (ported from DilV): Re-collect stale attestations inline.
-            // EnsureMIKRegistered() only runs once at startup. If attestations expire
-            // (1-hour validity window) or the rejection handler clears the cache, the
-            // template builder must handle re-collection itself.
-            bool needRefresh = !g_attestationsCollected.load() || !g_cachedAttestations.HasMinimum();
-            if (!needRefresh) {
-                int64_t attestAge = std::time(nullptr) - static_cast<int64_t>(g_cachedAttestations.attestations[0].timestamp);
-                if (attestAge > Attestation::ATTESTATION_VALIDITY_WINDOW - 600) {
-                    std::cout << "[Mining] Attestations are " << attestAge / 60
-                              << "m old (max " << Attestation::ATTESTATION_VALIDITY_WINDOW / 60
-                              << "m) - refreshing..." << std::endl;
-                    needRefresh = true;
-                }
-            }
-
-            if (needRefresh && Dilithion::g_chainParams &&
-                !Dilithion::g_chainParams->seedAttestationIPs.empty() &&
-                g_dnaHashCached.load()) {  // DNA hash must be valid — attestations are bound to it
-                std::vector<uint8_t> mikPubkey;
-                if (wallet.GetMIKPubKey(mikPubkey)) {
-                    std::string mikHex = HexStr(mikPubkey);
-                    std::string dnaHex = HexStr(g_cachedDnaHash.data(), 32);
-                    Attestation::CAttestationSet freshAttest;
-                    std::string attestErr;
-                    if (Attestation::CollectAttestations(
-                            Dilithion::g_chainParams->seedAttestationIPs,
-                            Dilithion::g_chainParams->seedAttestationRPCPort,
-                            mikHex, dnaHex, freshAttest, attestErr)) {
-                        g_cachedAttestations = std::move(freshAttest);
-                        g_attestationsCollected.store(true);
-                        std::cout << "[Mining] Fresh attestations collected for registration block" << std::endl;
-                        needRefresh = false;
-                    } else {
-                        std::cerr << "[Mining] Attestation re-collection failed: " << attestErr << std::endl;
-                    }
-                }
-            }
-
-            // Guard: refuse to build registration block without valid attestations
-            if (needRefresh) {
-                std::cerr << "[Mining] Template rejected - registration block at height "
-                          << nHeight << " requires seed attestations"
-                          << " (collected=" << g_attestationsCollected.load()
-                          << ", dna=" << g_dnaHashCached.load()
-                          << ", mikPub=" << (wallet.HasMIK() ? "yes" : "no") << ")" << std::endl;
+            if (!regSnap || !regSnap->hasAttestations || !regSnap->attestations ||
+                !regSnap->attestations->HasMinimum()) {
+                std::cerr << "[Mining] Template deferred - registration block at height "
+                          << nHeight << " waiting for seed attestations (manager state="
+                          << StateToString(regSnap ? regSnap->state
+                                                    : CRegistrationManager::State::UNINITIALIZED)
+                          << ")" << std::endl;
                 return std::nullopt;
             }
         }
 
-        // Include attestations in coinbase (must meet consensus quorum)
-        if (g_attestationsCollected.load() && g_cachedAttestations.HasMinimum()) {
+        if (regSnap && regSnap->attestations && regSnap->attestations->HasMinimum()) {
             std::vector<uint8_t> attestData;
-            if (Attestation::BuildAttestationScriptData(g_cachedAttestations, attestData)) {
+            if (Attestation::BuildAttestationScriptData(*regSnap->attestations, attestData)) {
                 scriptSig.insert(scriptSig.end(), attestData.begin(), attestData.end());
                 if (verbose) {
-                    std::cout << "  Attestations: " << g_cachedAttestations.Count()
+                    std::cout << "  Attestations: " << regSnap->attestations->Count()
                               << " seed attestations included ("
                               << attestData.size() << " bytes)" << std::endl;
                 }
@@ -3084,14 +2815,12 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
 
         // BUG #32 FIX: Register callback for mining template updates on chain tip change
         SetChainTipUpdateCallback([&blockchain](CBlockchainDB& db, int new_height, bool is_reorg) {
-            // Only update if mining is enabled and not in IBD
-            // Without the IBD check, BuildMiningTemplate runs on every block during sync,
-            // and at height 7000+ triggers MineRegistrationPoW which blocks the processing
-            // thread for ~10-15 minutes, stalling IBD.
-            // BUG #278 FIX: Also skip during registration PoW to avoid flooding logs
-            // with "Registration PoW already in progress" warnings
+            // Only update if mining is enabled and not in IBD. BUG #278's extra
+            // "skip during PoW" guard is no longer needed — BuildMiningTemplate
+            // now returns nullopt when the CRegistrationManager isn't READY, so
+            // concurrent calls during registration PoW are harmless no-ops.
             if (g_node_state.miner && g_node_state.wallet && g_node_state.mining_enabled.load()
-                && !IsInitialBlockDownload() && !g_regPowInProgress.load(std::memory_order_relaxed)) {
+                && !IsInitialBlockDownload()) {
                 std::cout << "[Mining] " << (is_reorg ? "Reorg" : "New tip")
                           << " detected - updating template immediately..." << std::endl;
                 auto templateOpt = BuildMiningTemplate(db, *g_node_state.wallet, false, g_node_state.mining_address_override);
@@ -6915,6 +6644,14 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
         // Main loop
         while (g_node_state.running) {
             std::this_thread::sleep_for(std::chrono::seconds(1));
+
+            // v4.0.18: keep the RegistrationManager driving on every iteration.
+            // Non-blocking: just publishes fresh inputs and wakes its worker.
+            if (s_registrationManager) {
+                auto tipH = g_chainstate.GetTip() ? g_chainstate.GetTip()->nHeight : 0;
+                s_registrationManager->Tick(static_cast<uint32_t>(tipH),
+                                             g_node_state.running.load());
+            }
 
             // Check if new block was found and mining template needs update
             if (g_node_state.new_block_found.load()) {

--- a/src/node/dilithion-node.cpp
+++ b/src/node/dilithion-node.cpp
@@ -6571,47 +6571,50 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                 unsigned int current_height = g_chainstate.GetTip() ? g_chainstate.GetTip()->nHeight : 0;
                 std::cout << "  [OK] Current blockchain height: " << current_height << std::endl;
 
-                // Ensure MIK identity is registered before mining
-                // (one-time ~10-15 min PoW for new miners — blocks main thread)
-                if (!EnsureMIKRegistered(wallet, current_height + 1)) {
-                    std::cerr << "[Mining] WARNING: MIK registration failed. Mining may not work correctly." << std::endl;
-                }
+                // Ensure MIK identity is registered before mining. If this
+                // fails (wallet locked, seeds unreachable, etc.), do NOT start
+                // any miner — Handler 1's CanMine() gate in the main loop
+                // will start it once RegistrationManager reaches READY.
+                if (EnsureMIKRegistered(wallet, current_height + 1)) {
+                    if (shouldUseVDF(current_height + 1)) {
+                        // VDF mining mode
+                        std::cout << "  [VDF] VDF mining active (activation height: " << vdf_activation << ")" << std::endl;
+                        std::cout << "  [VDF] Iterations: " << vdf_iterations << std::endl;
 
-                if (shouldUseVDF(current_height + 1)) {
-                    // VDF mining mode
-                    std::cout << "  [VDF] VDF mining active (activation height: " << vdf_activation << ")" << std::endl;
-                    std::cout << "  [VDF] Iterations: " << vdf_iterations << std::endl;
-
-                    // Set miner address from wallet
-                    std::vector<uint8_t> pubKeyHash = wallet.GetPubKeyHash();
-                    if (pubKeyHash.size() >= 20) {
-                        std::array<uint8_t, 20> addr{};
-                        std::copy(pubKeyHash.begin(), pubKeyHash.begin() + 20, addr.begin());
-                        vdf_miner.SetMinerAddress(addr);
-                    }
-
-                    vdf_miner.Start();
-                    std::cout << "  [OK] VDF mining started (single-threaded, deterministic)" << std::endl;
-                } else {
-                    // RandomX mining mode
-                    auto templateOpt = BuildMiningTemplate(blockchain, wallet, true, config.mining_address_override);
-                    if (!templateOpt) {
-                        // Retry up to 3 times (safety net — registration should already be done)
-                        for (int attempt = 1; attempt <= 3 && !templateOpt; attempt++) {
-                            std::cerr << "[Mining] Template build failed, retrying (" << attempt << "/3)..." << std::endl;
-                            std::this_thread::sleep_for(std::chrono::seconds(1));
-                            templateOpt = BuildMiningTemplate(blockchain, wallet, true, config.mining_address_override);
+                        // Set miner address from wallet
+                        std::vector<uint8_t> pubKeyHash = wallet.GetPubKeyHash();
+                        if (pubKeyHash.size() >= 20) {
+                            std::array<uint8_t, 20> addr{};
+                            std::copy(pubKeyHash.begin(), pubKeyHash.begin() + 20, addr.begin());
+                            vdf_miner.SetMinerAddress(addr);
                         }
+
+                        vdf_miner.Start();
+                        std::cout << "  [OK] VDF mining started (single-threaded, deterministic)" << std::endl;
+                    } else {
+                        // RandomX mining mode
+                        auto templateOpt = BuildMiningTemplate(blockchain, wallet, true, config.mining_address_override);
                         if (!templateOpt) {
-                            std::cerr << "ERROR: Failed to build mining template after retries" << std::endl;
-                            return 1;
+                            // Retry up to 3 times (safety net — registration should already be done)
+                            for (int attempt = 1; attempt <= 3 && !templateOpt; attempt++) {
+                                std::cerr << "[Mining] Template build failed, retrying (" << attempt << "/3)..." << std::endl;
+                                std::this_thread::sleep_for(std::chrono::seconds(1));
+                                templateOpt = BuildMiningTemplate(blockchain, wallet, true, config.mining_address_override);
+                            }
+                            if (!templateOpt) {
+                                std::cerr << "ERROR: Failed to build mining template after retries" << std::endl;
+                                return 1;
+                            }
                         }
+
+                        miner.StartMining(*templateOpt);
+
+                        std::cout << "  [OK] RandomX mining started with " << mining_threads << " threads" << std::endl;
+                        std::cout << "  Expected hash rate: ~" << (mining_threads * 65) << " H/s" << std::endl;
                     }
-
-                    miner.StartMining(*templateOpt);
-
-                    std::cout << "  [OK] RandomX mining started with " << mining_threads << " threads" << std::endl;
-                    std::cout << "  Expected hash rate: ~" << (mining_threads * 65) << " H/s" << std::endl;
+                } else {
+                    std::cerr << "[Mining] MIK registration not ready — mining NOT started." << std::endl;
+                    std::cerr << "[Mining] Main loop will retry via RegistrationManager; see manager status." << std::endl;
                 }
             }
         }
@@ -6791,38 +6794,44 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                     unsigned int current_height = g_chainstate.GetTip() ? g_chainstate.GetTip()->nHeight : 0;
                     std::cout << "  [OK] Current blockchain height: " << current_height << std::endl;
 
-                    // Ensure MIK identity is registered before mining
-                    if (!EnsureMIKRegistered(wallet, current_height + 1)) {
-                        std::cerr << "[Mining] WARNING: MIK registration failed. Mining may not work correctly." << std::endl;
-                    }
-
-                    if (shouldUseVDF(current_height + 1)) {
-                        std::cout << "  [VDF] Starting VDF mining after IBD" << std::endl;
-                        std::vector<uint8_t> pubKeyHash = wallet.GetPubKeyHash();
-                        if (pubKeyHash.size() >= 20) {
-                            std::array<uint8_t, 20> addr{};
-                            std::copy(pubKeyHash.begin(), pubKeyHash.begin() + 20, addr.begin());
-                            vdf_miner.SetMinerAddress(addr);
-                        }
-                        vdf_miner.Start();
-                        mining_deferred_for_ibd = false;
-                    } else {
-                        auto templateOpt = BuildMiningTemplate(blockchain, wallet, true, config.mining_address_override);
-                        if (!templateOpt) {
-                            // Retry up to 3 times with 1s delays
-                            for (int attempt = 1; attempt <= 3 && !templateOpt; attempt++) {
-                                std::cerr << "[Mining] Template build failed, retrying (" << attempt << "/3)..." << std::endl;
-                                std::this_thread::sleep_for(std::chrono::seconds(1));
-                                templateOpt = BuildMiningTemplate(blockchain, wallet, true, config.mining_address_override);
+                    // Ensure MIK identity is registered before mining. If this
+                    // fails (wallet locked, seeds unreachable, etc.), do NOT
+                    // start any miner — Handler 1's CanMine() gate in the
+                    // main loop will start it once RegistrationManager
+                    // reaches READY.
+                    if (EnsureMIKRegistered(wallet, current_height + 1)) {
+                        if (shouldUseVDF(current_height + 1)) {
+                            std::cout << "  [VDF] Starting VDF mining after IBD" << std::endl;
+                            std::vector<uint8_t> pubKeyHash = wallet.GetPubKeyHash();
+                            if (pubKeyHash.size() >= 20) {
+                                std::array<uint8_t, 20> addr{};
+                                std::copy(pubKeyHash.begin(), pubKeyHash.begin() + 20, addr.begin());
+                                vdf_miner.SetMinerAddress(addr);
                             }
-                        }
-                        if (templateOpt) {
-                            miner.StartMining(*templateOpt);
-                            std::cout << "  [OK] Mining started with " << mining_threads << " threads" << std::endl;
+                            vdf_miner.Start();
                             mining_deferred_for_ibd = false;
                         } else {
-                            std::cerr << "[ERROR] Failed to build mining template after retries!" << std::endl;
+                            auto templateOpt = BuildMiningTemplate(blockchain, wallet, true, config.mining_address_override);
+                            if (!templateOpt) {
+                                // Retry up to 3 times with 1s delays
+                                for (int attempt = 1; attempt <= 3 && !templateOpt; attempt++) {
+                                    std::cerr << "[Mining] Template build failed, retrying (" << attempt << "/3)..." << std::endl;
+                                    std::this_thread::sleep_for(std::chrono::seconds(1));
+                                    templateOpt = BuildMiningTemplate(blockchain, wallet, true, config.mining_address_override);
+                                }
+                            }
+                            if (templateOpt) {
+                                miner.StartMining(*templateOpt);
+                                std::cout << "  [OK] Mining started with " << mining_threads << " threads" << std::endl;
+                                mining_deferred_for_ibd = false;
+                            } else {
+                                std::cerr << "[ERROR] Failed to build mining template after retries!" << std::endl;
+                            }
                         }
+                    } else {
+                        std::cerr << "[Mining] MIK registration not ready after IBD — mining deferred." << std::endl;
+                        std::cerr << "[Mining] Main loop will retry via RegistrationManager." << std::endl;
+                        mining_deferred_for_ibd = false;
                     }
                 } else if (ibd_progress_counter % 10 == 0) {
                     // Show progress every 10 seconds

--- a/src/node/dilithion-node.cpp
+++ b/src/node/dilithion-node.cpp
@@ -845,6 +845,35 @@ bool EnsureMIKRegistered(CWallet& wallet, unsigned int nextHeight) {
     EnsureRegistrationManagerInitialized(wallet);
     if (!s_registrationManager) return false;
 
+    // First-time miner banner — fires once per process lifetime, only for
+    // unregistered MIKs. Sets accurate expectations so users don't think
+    // the node is stuck during the DNA-bound registration PoW.
+    static bool s_bannerShown = false;
+    if (!s_bannerShown && !DFMP::g_identityDb->HasMIKPubKey(identity)) {
+        std::cout << std::endl;
+        std::cout << "+----------------------------------------------------------------------+" << std::endl;
+        std::cout << "|  FIRST-TIME MINER SETUP (DIL)                                        |" << std::endl;
+        std::cout << "|                                                                      |" << std::endl;
+        std::cout << "|  Your miner identity is not yet registered on DIL. Before your       |" << std::endl;
+        std::cout << "|  first block, the node runs a ONE-TIME setup sequence:               |" << std::endl;
+        std::cout << "|                                                                      |" << std::endl;
+        std::cout << "|    1. Digital DNA fingerprint (hardware-bound, passive)              |" << std::endl;
+        std::cout << "|    2. Seed attestations (3-of-4, required above height 40000)        |" << std::endl;
+        std::cout << "|    3. Registration proof-of-work (DNA-bound)                         |" << std::endl;
+        std::cout << "|                                                                      |" << std::endl;
+        std::cout << "|  The proof-of-work dominates total time. On a modern CPU, typical    |" << std::endl;
+        std::cout << "|  completion is 15-30 minutes. PoW is RANDOMLY PROBABILISTIC: you     |" << std::endl;
+        std::cout << "|  may finish significantly faster, and ~12% of miners see 2x or       |" << std::endl;
+        std::cout << "|  more (up to an hour). Both fast and slow outcomes are NORMAL hash   |" << std::endl;
+        std::cout << "|  luck, not a stuck node. Let it run.                                 |" << std::endl;
+        std::cout << "|                                                                      |" << std::endl;
+        std::cout << "|  After setup, the solved PoW is saved to mik_registration.dat --     |" << std::endl;
+        std::cout << "|  subsequent restarts skip all of this and begin mining immediately.  |" << std::endl;
+        std::cout << "+----------------------------------------------------------------------+" << std::endl;
+        std::cout << std::endl;
+        s_bannerShown = true;
+    }
+
     // Drive the manager and wait for readiness. The manager's worker thread
     // does DNA collection, seed attestations, and PoW; we poll the snapshot
     // and log progress as the mine-gate reason changes.

--- a/src/node/dilv-node.cpp
+++ b/src/node/dilv-node.cpp
@@ -840,6 +840,35 @@ bool EnsureMIKRegistered(CWallet& wallet, unsigned int nextHeight) {
     EnsureRegistrationManagerInitialized(wallet);
     if (!s_registrationManager) return false;
 
+    // First-time miner banner — fires once per process lifetime, only for
+    // unregistered MIKs. Sets accurate expectations so users don't think
+    // the node is stuck during the DNA-bound registration PoW.
+    static bool s_bannerShown = false;
+    if (!s_bannerShown && !DFMP::g_identityDb->HasMIKPubKey(identity)) {
+        std::cout << std::endl;
+        std::cout << "+----------------------------------------------------------------------+" << std::endl;
+        std::cout << "|  FIRST-TIME MINER SETUP (DilV)                                       |" << std::endl;
+        std::cout << "|                                                                      |" << std::endl;
+        std::cout << "|  Your miner identity is not yet registered on DilV. Before your      |" << std::endl;
+        std::cout << "|  first block, the node runs a ONE-TIME setup sequence:               |" << std::endl;
+        std::cout << "|                                                                      |" << std::endl;
+        std::cout << "|    1. Digital DNA fingerprint (hardware-bound, passive)              |" << std::endl;
+        std::cout << "|    2. Seed attestations (need 3 of 4 seed signatures, seconds)       |" << std::endl;
+        std::cout << "|    3. Registration proof-of-work (DNA-bound)                         |" << std::endl;
+        std::cout << "|                                                                      |" << std::endl;
+        std::cout << "|  The proof-of-work dominates total time. On a modern CPU, typical    |" << std::endl;
+        std::cout << "|  completion is 15-30 minutes. PoW is RANDOMLY PROBABILISTIC: you     |" << std::endl;
+        std::cout << "|  may finish significantly faster, and ~12% of miners see 2x or       |" << std::endl;
+        std::cout << "|  more (up to an hour). Both fast and slow outcomes are NORMAL hash   |" << std::endl;
+        std::cout << "|  luck, not a stuck node. Let it run.                                 |" << std::endl;
+        std::cout << "|                                                                      |" << std::endl;
+        std::cout << "|  After setup, the solved PoW is saved to mik_registration.dat --     |" << std::endl;
+        std::cout << "|  subsequent restarts skip all of this and begin mining immediately.  |" << std::endl;
+        std::cout << "+----------------------------------------------------------------------+" << std::endl;
+        std::cout << std::endl;
+        s_bannerShown = true;
+    }
+
     // Drive the manager and wait for readiness. The manager's worker thread
     // does DNA collection, seed attestations, and PoW; we poll the snapshot
     // and log progress every 10s.

--- a/src/node/dilv-node.cpp
+++ b/src/node/dilv-node.cpp
@@ -5535,15 +5535,14 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                 }
                 g_node_state.new_block_found = true;
             } else {
-                // Block rejected. Notify the RegistrationManager so it can decide
-                // whether to re-collect attestations (SUBMITTED → ATTEST_PENDING) or
-                // retry submission (SUBMITTED → READY). Bounded retry budget inside
-                // the manager prevents infinite re-collect loops.
+                // Block rejected. Notify the RegistrationManager so it can
+                // decide whether to re-collect attestations or retry the
+                // submission. Bounded retry budget inside the manager
+                // prevents infinite re-collect loops; when exhausted it
+                // escalates to LONG_BACKOFF_USER_ACTIONABLE.
                 if (s_registrationManager) {
                     std::cout << "[VDF] Block rejected - notifying registration manager" << std::endl;
-                    s_registrationManager->TestingInjectEvent(
-                        CRegistrationManager::Event::SUBMIT_TIMEOUT_OR_REJECTED,
-                        "block rejected by validation");
+                    s_registrationManager->NotifyBlockRejected("block rejected by validation");
                 }
             }
         });
@@ -6415,34 +6414,39 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                 unsigned int current_height = g_chainstate.GetTip() ? g_chainstate.GetTip()->nHeight : 0;
                 std::cout << "  [OK] Current blockchain height: " << current_height << std::endl;
 
-                // Ensure MIK identity is registered before mining
-                if (!EnsureMIKRegistered(wallet, current_height + 1)) {
-                    std::cerr << "[Mining] WARNING: MIK registration failed. Mining may not work correctly." << std::endl;
-                }
+                // Ensure MIK identity is registered before mining. If this
+                // fails (wallet locked, seeds unreachable, etc.), do NOT start
+                // vdf_miner — it would just spin on empty templates. The main
+                // loop's RegistrationManager->Tick() will keep driving the
+                // manager; when it reaches READY/CONFIRMED, Handler 1's
+                // CanMine() gate will start the miner automatically.
+                if (EnsureMIKRegistered(wallet, current_height + 1)) {
+                    std::cout << "  [VDF] VDF mining active" << std::endl;
+                    std::cout << "  [VDF] Iterations: " << vdf_iterations << std::endl;
 
-                // DilV: Always VDF mining
-                std::cout << "  [VDF] VDF mining active" << std::endl;
-                std::cout << "  [VDF] Iterations: " << vdf_iterations << std::endl;
-
-                std::vector<uint8_t> pubKeyHash = wallet.GetPubKeyHash();
-                if (pubKeyHash.size() >= 20) {
-                    std::array<uint8_t, 20> addr{};
-                    std::copy(pubKeyHash.begin(), pubKeyHash.begin() + 20, addr.begin());
-                    vdf_miner.SetMinerAddress(addr);
-                }
-
-                // Set MIK identity for cooldown tracking (prevents address rotation bypass)
-                {
-                    DFMP::Identity mikId = wallet.GetMIKIdentity();
-                    if (!mikId.IsNull()) {
-                        std::array<uint8_t, 20> mikArr{};
-                        std::memcpy(mikArr.data(), mikId.data, 20);
-                        vdf_miner.SetMIKIdentity(mikArr);
+                    std::vector<uint8_t> pubKeyHash = wallet.GetPubKeyHash();
+                    if (pubKeyHash.size() >= 20) {
+                        std::array<uint8_t, 20> addr{};
+                        std::copy(pubKeyHash.begin(), pubKeyHash.begin() + 20, addr.begin());
+                        vdf_miner.SetMinerAddress(addr);
                     }
-                }
 
-                vdf_miner.Start();
-                std::cout << "  [OK] VDF mining started (single-threaded, deterministic)" << std::endl;
+                    // Set MIK identity for cooldown tracking (prevents address rotation bypass)
+                    {
+                        DFMP::Identity mikId = wallet.GetMIKIdentity();
+                        if (!mikId.IsNull()) {
+                            std::array<uint8_t, 20> mikArr{};
+                            std::memcpy(mikArr.data(), mikId.data, 20);
+                            vdf_miner.SetMIKIdentity(mikArr);
+                        }
+                    }
+
+                    vdf_miner.Start();
+                    std::cout << "  [OK] VDF mining started (single-threaded, deterministic)" << std::endl;
+                } else {
+                    std::cerr << "[Mining] MIK registration not ready — VDF mining NOT started." << std::endl;
+                    std::cerr << "[Mining] Main loop will retry via RegistrationManager; see manager status." << std::endl;
+                }
             }
         }
 
@@ -6590,29 +6594,33 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                     unsigned int current_height = g_chainstate.GetTip() ? g_chainstate.GetTip()->nHeight : 0;
                     std::cout << "  [OK] Current blockchain height: " << current_height << std::endl;
 
-                    // Ensure MIK identity is registered before mining
-                    if (!EnsureMIKRegistered(wallet, current_height + 1)) {
-                        std::cerr << "[Mining] WARNING: MIK registration failed. Mining may not work correctly." << std::endl;
-                    }
-
-                    // DilV: Always VDF mining
-                    std::cout << "  [VDF] Starting VDF mining after IBD" << std::endl;
-                    std::vector<uint8_t> pubKeyHash = wallet.GetPubKeyHash();
-                    if (pubKeyHash.size() >= 20) {
-                        std::array<uint8_t, 20> addr{};
-                        std::copy(pubKeyHash.begin(), pubKeyHash.begin() + 20, addr.begin());
-                        vdf_miner.SetMinerAddress(addr);
-                    }
-                    {
-                        DFMP::Identity mikId = wallet.GetMIKIdentity();
-                        if (!mikId.IsNull()) {
-                            std::array<uint8_t, 20> mikArr{};
-                            std::memcpy(mikArr.data(), mikId.data, 20);
-                            vdf_miner.SetMIKIdentity(mikArr);
+                    // Ensure MIK identity is registered before mining. If this
+                    // fails (wallet locked, seeds unreachable, etc.), do NOT start
+                    // vdf_miner — Handler 1's CanMine() gate in the main loop
+                    // will start it once RegistrationManager reaches READY.
+                    if (EnsureMIKRegistered(wallet, current_height + 1)) {
+                        std::cout << "  [VDF] Starting VDF mining after IBD" << std::endl;
+                        std::vector<uint8_t> pubKeyHash = wallet.GetPubKeyHash();
+                        if (pubKeyHash.size() >= 20) {
+                            std::array<uint8_t, 20> addr{};
+                            std::copy(pubKeyHash.begin(), pubKeyHash.begin() + 20, addr.begin());
+                            vdf_miner.SetMinerAddress(addr);
                         }
+                        {
+                            DFMP::Identity mikId = wallet.GetMIKIdentity();
+                            if (!mikId.IsNull()) {
+                                std::array<uint8_t, 20> mikArr{};
+                                std::memcpy(mikArr.data(), mikId.data, 20);
+                                vdf_miner.SetMIKIdentity(mikArr);
+                            }
+                        }
+                        vdf_miner.Start();
+                        mining_deferred_for_ibd = false;
+                    } else {
+                        std::cerr << "[Mining] MIK registration not ready after IBD — VDF mining deferred." << std::endl;
+                        std::cerr << "[Mining] Main loop will retry via RegistrationManager." << std::endl;
+                        mining_deferred_for_ibd = false;  // stop the deferral log spam; Handler 1 takes over
                     }
-                    vdf_miner.Start();
-                    mining_deferred_for_ibd = false;
                 } else if (ibd_progress_counter % 10 == 0) {
                     // Show progress every 10 seconds
                     int height = g_chainstate.GetTip() ? g_chainstate.GetTip()->nHeight : 0;

--- a/src/node/dilv-node.cpp
+++ b/src/node/dilv-node.cpp
@@ -52,6 +52,7 @@
 #include <vdf/vdf.h>
 #include <vdf/cooldown_tracker.h>
 #include <node/peer_mik_tracker.h>
+#include <node/registration_manager.h>  // v4.0.18: first-time registration state machine
 #include <consensus/vdf_validation.h>
 #include <wallet/wallet.h>
 #include <wallet/passphrase_validator.h>
@@ -775,57 +776,54 @@ struct NodeConfig {
 static CTransactionRef g_currentCoinbase;
 static std::mutex g_coinbaseMutex;
 
-// File-scope MIK registration PoW cache
-// Shared between EnsureMIKRegistered() and BuildMiningTemplate()
-static uint64_t s_cachedRegNonce = 0;
-static std::atomic<bool> s_regNonceMined{false};
-static std::atomic<bool> s_regPowInProgress{false};
-static DFMP::Identity s_regNonceIdentity;
-
-// Phase 2+3: Cached seed attestations (collected before registration PoW, embedded in coinbase)
-static Attestation::CAttestationSet s_cachedAttestations;
-static std::atomic<bool> s_attestationsCollected{false};
-
-// Cached DNA hash from registration (used for attestation, PoW, and block commitment consistency)
-static std::array<uint8_t, 32> s_cachedDnaHash{};
-static std::atomic<bool> s_dnaHashCached{false};
+// v4.0.18: CRegistrationManager owns all first-time MIK registration state.
+// BuildMiningTemplate is now a pure reader of its published snapshot.
+// The old s_cachedRegNonce / s_regNonceMined / s_cachedDnaHash / s_cachedAttestations
+// file-scope statics have been removed — they were the race-condition anchor point.
+static std::unique_ptr<CRegistrationManager> s_registrationManager;
 
 // DilV data directory for MIK registration persistence (set in main before PoW).
 extern std::string g_datadir;
 
-static void PersistRegistrationPoW_DilV(const std::vector<uint8_t>& pubkey) {
-    if (g_datadir.empty() || pubkey.empty()) return;
-    std::array<uint8_t, 32> dnaHash{};
-    if (s_dnaHashCached.load()) dnaHash = s_cachedDnaHash;
-    int64_t now = static_cast<int64_t>(std::time(nullptr));
-    if (DFMP::SaveMIKRegistration(g_datadir, pubkey, dnaHash, s_cachedRegNonce, now)) {
-        std::cout << "  [Mining] Registration PoW saved to disk (skips re-solve on restart)" << std::endl;
-    } else {
-        std::cerr << "  [Mining] WARNING: failed to persist registration PoW" << std::endl;
-    }
+/**
+ * Ensure the registration manager exists; lazily construct on first call.
+ * Requires wallet + g_node_context + g_chainParams to be fully initialized.
+ */
+static void EnsureRegistrationManagerInitialized(CWallet& wallet) {
+    if (s_registrationManager) return;
+    if (!Dilithion::g_chainParams) return;  // too early
+
+    auto env = std::make_shared<CProductionRegistrationEnv>(
+        wallet,
+        g_node_context,
+        g_datadir,
+        Dilithion::g_chainParams->registrationPowBits,
+        Dilithion::g_chainParams->dnaCommitmentActivationHeight,
+        Dilithion::g_chainParams->seedAttestationActivationHeight);
+    s_registrationManager = std::make_unique<CRegistrationManager>(std::move(env));
 }
 
 /**
- * Ensure MIK identity is registered before mining begins.
- * This is a one-time operation for new miners (~10-15 minutes).
- * Must be called before BuildMiningTemplate() on the startup path
- * so the user sees clear progress instead of cryptic template errors.
+ * Drive the CRegistrationManager and block until registration is ready or
+ * a fatal error occurs. Replaces the old inline DNA/attestation/PoW flow.
  *
- * @param wallet Reference to wallet (for MIK identity)
- * @param nextHeight The height of the next block to be mined
- * @return true if registration is complete (or not needed), false on failure
+ * Semantics match the old EnsureMIKRegistered():
+ *   - true:  registration is ready (CanMine() == true) OR node below activation height
+ *   - false: fatal or user-actionable error; mining must be deferred
+ *
+ * Progress logging is driven off the manager's Snapshot/StatusForUI so the
+ * user always knows which phase they are in. The old silent 30-minute waits
+ * on BuildMiningTemplate's inline PoW path are gone; this path is now the
+ * single place registration work can happen.
  */
 bool EnsureMIKRegistered(CWallet& wallet, unsigned int nextHeight) {
-    // Guard: identity DB must be available
     if (!DFMP::g_identityDb) return true;
-
-    // Guard: DFMP v3 PoW only required at/above activation height
     if (!Dilithion::g_chainParams ||
         static_cast<int>(nextHeight) < Dilithion::g_chainParams->dfmpV3ActivationHeight) {
         return true;
     }
 
-    // Get or generate MIK identity
+    // Generate MIK identity if wallet does not have one yet.
     DFMP::Identity identity = wallet.GetMIKIdentity();
     if (identity.IsNull()) {
         if (!wallet.GenerateMIK()) {
@@ -836,224 +834,53 @@ bool EnsureMIKRegistered(CWallet& wallet, unsigned int nextHeight) {
         std::cout << "[Mining] Generated new miner identity: " << identity.GetHex() << std::endl;
     }
 
-    // Already registered in identity DB?
-    if (DFMP::g_identityDb->HasMIKPubKey(identity)) {
-        // BUG #284: Pre-cache DNA even when MIK is registered, in case the
-        // registration block gets orphaned later. Without cached DNA, the
-        // template builder cannot re-collect attestations for re-registration.
-        if (!s_dnaHashCached.load() && Dilithion::g_chainParams &&
-            static_cast<int>(nextHeight) >= Dilithion::g_chainParams->dnaCommitmentActivationHeight) {
-            auto collector = g_node_context.GetDNACollector();
-            if (collector) {
-                auto dna = collector->get_dna();
-                if (dna) {
-                    s_cachedDnaHash = dna->hash();
-                    bool allZero = true;
-                    for (auto b : s_cachedDnaHash) { if (b != 0) { allZero = false; break; } }
-                    if (!allZero) {
-                        s_dnaHashCached.store(true);
-                        std::cout << "[Mining] MIK registered - pre-cached DNA for future use" << std::endl;
-                    }
-                }
-            }
-        }
-        return true;
-    }
+    EnsureRegistrationManagerInitialized(wallet);
+    if (!s_registrationManager) return false;
 
-    // Already cached from a previous call?
-    if (s_regNonceMined.load() && s_regNonceIdentity == identity) return true;
+    // Drive the manager and wait for readiness. The manager's worker thread
+    // does DNA collection, seed attestations, and PoW; we poll the snapshot
+    // and log progress every 10s.
+    auto tipHeight = (g_chainstate.GetTip() ? g_chainstate.GetTip()->nHeight : 0);
+    s_registrationManager->Tick(tipHeight, g_node_state.running.load());
 
-    // Get public key for PoW
-    std::vector<uint8_t> mikPubkey;
-    if (!wallet.GetMIKPubKey(mikPubkey)) {
-        std::cerr << "[Mining] WARNING: Failed to get MIK public key (wallet may be locked)" << std::endl;
-        return false;
-    }
+    using State = CRegistrationManager::State;
+    using Reason = CRegistrationManager::MineGateReason;
+    Reason lastReason = Reason::BLOCKED_UNINITIALIZED;
+    int waitSec = 0;
+    while (g_node_state.running.load()) {
+        auto snap = s_registrationManager->GetSnapshot();
 
-    // Restore cached registration PoW from mik_registration.dat if present.
-    // Survives --reset-chain and normal restarts so miners don't re-solve the
-    // ~25 min PoW every time chain state is wiped.
-    if (!s_regNonceMined.load() && !g_datadir.empty()) {
-        DFMP::MIKRegistrationFile rec;
-        auto res = DFMP::LoadMIKRegistration(g_datadir, mikPubkey, rec);
-        if (res == DFMP::MIKRegFileLoadResult::OK) {
-            s_cachedRegNonce = rec.nonce;
-            s_regNonceIdentity = identity;
-            s_regNonceMined.store(true);
-            s_cachedDnaHash = rec.dnaHash;
-            bool nonZeroDna = false;
-            for (auto b : rec.dnaHash) { if (b != 0) { nonZeroDna = true; break; } }
-            if (nonZeroDna) s_dnaHashCached.store(true);
-            std::cout << "  [Mining] MIK registration restored from disk (saves ~25 min PoW)" << std::endl;
-        } else if (res == DFMP::MIKRegFileLoadResult::PubkeyMismatch) {
-            std::cout << "  [Mining] Found stale mik_registration.dat (wallet MIK changed), ignoring" << std::endl;
-        } else if (res == DFMP::MIKRegFileLoadResult::Corrupt) {
-            std::cerr << "  [Mining] mik_registration.dat corrupt, solving new PoW" << std::endl;
-        }
-    }
-
-    if (s_regNonceMined.load() && s_regNonceIdentity == identity) return true;
-
-    // ========================================================================
-    // Step 1: Collect Digital DNA (mandatory on DilV from block 1)
-    // ========================================================================
-    // DNA must be collected before attestation and registration PoW.
-    // The DNA hash binds the miner's hardware identity to their MIK.
-    if (!s_dnaHashCached.load()) {
-        int dnaCommitHeight = Dilithion::g_chainParams ?
-            Dilithion::g_chainParams->dnaCommitmentActivationHeight : 999999999;
-
-        if (static_cast<int>(nextHeight) >= dnaCommitHeight) {
-            std::cout << std::endl;
-            std::cout << "  [Mining] Collecting Digital DNA fingerprint..." << std::endl;
-            std::cout << "  [Mining] DNA binds your hardware identity to your miner key." << std::endl;
-
-            // Wait for DNA collector to have data (up to 120s)
-            auto collector = g_node_context.GetDNACollector();
-            int waitSec = 0;
-            const int maxWaitSec = 120;
-            while (g_node_state.running && waitSec < maxWaitSec) {
-                if (collector) {
-                    auto dna = collector->get_dna();
-                    if (dna) {
-                        s_cachedDnaHash = dna->hash();
-                        // Verify non-zero
-                        bool allZero = true;
-                        for (auto b : s_cachedDnaHash) { if (b != 0) { allZero = false; break; } }
-                        if (!allZero) {
-                            s_dnaHashCached.store(true);
-                            std::cout << "  [Mining] DNA collected (hash " << std::hex;
-                            for (int i = 0; i < 4; i++) std::cout << std::setfill('0') << std::setw(2) << (int)s_cachedDnaHash[i];
-                            std::cout << std::dec << "...)" << std::endl;
-                            break;
-                        }
-                    }
-                }
-                if (waitSec % 10 == 0 && waitSec > 0) {
-                    std::cout << "  [Mining] Waiting for DNA collection... (" << waitSec << "s / " << maxWaitSec << "s)" << std::endl;
-                }
-                std::this_thread::sleep_for(std::chrono::seconds(1));
-                waitSec++;
-            }
-
-            if (!s_dnaHashCached.load()) {
-                if (!g_node_state.running) return false;
-                std::cerr << "  [Mining] ERROR: DNA collection timed out after " << maxWaitSec << "s." << std::endl;
-                std::cerr << "  [Mining] DNA is mandatory for mining. Retrying next cycle." << std::endl;
-                return false;
-            }
-        }
-    }
-
-    // ========================================================================
-    // Step 2: Collect seed attestations (DilV only, uses DNA hash)
-    // ========================================================================
-    // Seeds sign: MIK_pubkey + DNA_hash + timestamp + seed_id
-    if (!s_attestationsCollected.load() &&
-        Dilithion::g_chainParams &&
-        !Dilithion::g_chainParams->seedAttestationIPs.empty()) {
-
-        int attestationHeight = Dilithion::g_chainParams->seedAttestationActivationHeight;
-        if (static_cast<int>(nextHeight) >= attestationHeight) {
-            std::cout << std::endl;
-            std::cout << "  [Mining] Requesting seed attestations for MIK registration..." << std::endl;
-
-            std::string mikPubkeyHex = HexStr(mikPubkey);
-            std::string dnaHashHex = HexStr(s_cachedDnaHash.data(), 32);
-
-            Attestation::CAttestationSet attestations;
-            std::string attestError;
-            bool gotAttestations = Attestation::CollectAttestations(
-                Dilithion::g_chainParams->seedAttestationIPs,
-                Dilithion::g_chainParams->seedAttestationRPCPort,
-                mikPubkeyHex, dnaHashHex,
-                attestations, attestError);
-
-            if (gotAttestations) {
-                s_cachedAttestations = std::move(attestations);
-                s_attestationsCollected.store(true);
-                std::cout << "  [Mining] Seed attestations collected successfully!" << std::endl;
-            } else {
-                std::cerr << "  [Mining] WARNING: " << attestError << std::endl;
-                std::cerr << "  [Mining] Attestations required. Retrying next cycle." << std::endl;
-                return false;
-            }
-            std::cout << std::endl;
-        }
-    }
-
-    // ========================================================================
-    // Step 3: Mine registration PoW (includes DNA hash in challenge)
-    // ========================================================================
-    // PoW challenge: SHA3-256(pubkey || dna_hash || nonce)
-    int regPowBits = Dilithion::g_chainParams ?
-        Dilithion::g_chainParams->registrationPowBits : 30;
-
-    std::cout << std::endl;
-    std::cout << "  [Mining] First-time setup: Registering miner identity..." << std::endl;
-    std::cout << "  [Mining] Registration PoW: " << regPowBits << " bits (~"
-              << (regPowBits >= 30 ? "40-60 min" : "1-2 min") << ")" << std::endl;
-    std::cout << "  [Mining] DNA-bound: yes (hardware fingerprint included in PoW challenge)" << std::endl;
-    std::cout << std::endl;
-
-    // Determine DNA hash pointer for PoW (null if DNA not active at this height)
-    const std::array<uint8_t, 32>* dnaForPow = s_dnaHashCached.load() ? &s_cachedDnaHash : nullptr;
-
-    if (!s_regPowInProgress.exchange(true)) {
-        uint64_t nonce = 0;
-        if (DFMP::MineRegistrationPoW(mikPubkey, regPowBits, nonce, &g_node_state.running, dnaForPow)) {
-            s_cachedRegNonce = nonce;
-            s_regNonceIdentity = identity;
-            s_regNonceMined.store(true);
-            s_regPowInProgress.store(false);
-            PersistRegistrationPoW_DilV(mikPubkey);
-            std::cout << std::endl;
-            std::cout << "  [Mining] Miner identity registered successfully!" << std::endl;
-            std::cout << std::endl;
+        if (snap->state == State::CONFIRMED ||
+            snap->state == State::READY ||
+            snap->state == State::SUBMITTED) {
             return true;
-        } else {
-            s_regPowInProgress.store(false);
-            if (!g_node_state.running) {
-                std::cout << "[Mining] Registration PoW cancelled (shutting down)" << std::endl;
-            } else {
-                std::cerr << "[Mining] WARNING: Failed to mine registration PoW" << std::endl;
+        }
+        if (snap->state == State::FAILED_FATAL) {
+            std::cerr << "[Mining] Registration fatal error: " << snap->lastError << std::endl;
+            return false;
+        }
+        if (snap->state == State::LONG_BACKOFF_USER_ACTIONABLE) {
+            std::cerr << "[Mining] Registration blocked: " << snap->lastError << std::endl;
+            if (!snap->userActionHint.empty()) {
+                std::cerr << "[Mining]   -> " << snap->userActionHint << std::endl;
             }
             return false;
         }
-    } else {
-        // BUG #278 FIX: Another thread is already mining registration PoW.
-        std::cout << "  [Mining] Registration PoW already in progress on another thread, waiting..." << std::endl;
-        int wait_sec = 0;
-        while (s_regPowInProgress.load(std::memory_order_acquire) && g_node_state.running) {
-            std::this_thread::sleep_for(std::chrono::seconds(1));
-            wait_sec++;
-            if (wait_sec % 30 == 0) {
-                std::cout << "  [Mining] Still waiting for registration PoW... (" << wait_sec << "s)" << std::endl;
-            }
+
+        if (snap->mineGate != lastReason) {
+            auto status = s_registrationManager->GetStatusForUI();
+            std::cout << "  [Mining] Phase: " << status.phase
+                      << " — " << status.message;
+            if (!status.etaText.empty()) std::cout << " (" << status.etaText << ")";
+            std::cout << std::endl;
+            lastReason = snap->mineGate;
         }
-        if (!g_node_state.running) return false;
-        if (s_regNonceMined.load() && s_regNonceIdentity == identity) {
-            std::cout << "  [Mining] Registration PoW completed by other thread!" << std::endl;
-            return true;
-        }
-        std::cerr << "[Mining] WARNING: Registration PoW failed on other thread, retrying..." << std::endl;
-        if (!s_regPowInProgress.exchange(true)) {
-            uint64_t nonce = 0;
-            if (DFMP::MineRegistrationPoW(mikPubkey, regPowBits, nonce, &g_node_state.running, dnaForPow)) {
-                s_cachedRegNonce = nonce;
-                s_regNonceIdentity = identity;
-                s_regNonceMined.store(true);
-                s_regPowInProgress.store(false);
-                PersistRegistrationPoW_DilV(mikPubkey);
-                std::cout << "  [Mining] Miner identity registered successfully!" << std::endl;
-                return true;
-            } else {
-                s_regPowInProgress.store(false);
-                return false;
-            }
-        }
-        return false;
+
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+        waitSec++;
+        s_registrationManager->Tick(tipHeight, g_node_state.running.load());
     }
+    return false;
 }
 
 /**
@@ -1235,72 +1062,27 @@ std::optional<CBlockTemplate> BuildMiningTemplate(CBlockchainDB& blockchain, CWa
             bool isRegistered = DFMP::g_identityDb && DFMP::g_identityDb->HasMIKPubKey(mikIdentity);
 
             if (!isRegistered) {
-                // First block with this MIK - include full pubkey (registration)
+                // First block with this MIK — registration path. All registration
+                // material (pubkey, DNA hash, attestations, nonce) comes from the
+                // RegistrationManager's published snapshot. BuildMiningTemplate is
+                // a PURE READER — it never mines PoW, collects DNA, or requests
+                // attestations. That work lives in the manager's worker thread.
                 std::vector<uint8_t> mikPubkey;
-                if (wallet.GetMIKPubKey(mikPubkey)) {
-                    // BUG #284 FIX: Ensure DNA is cached before registration PoW.
-                    // If EnsureMIKRegistered() returned early (MIK was registered at
-                    // startup but later orphaned by reorg), s_dnaHashCached is false.
-                    // Without DNA, PoW is mined without it and attestation re-collection
-                    // is impossible, causing infinite template rejection loops.
-                    if (!s_dnaHashCached.load() && Dilithion::g_chainParams &&
-                        static_cast<int>(nHeight) >= Dilithion::g_chainParams->dnaCommitmentActivationHeight) {
-                        auto collector = g_node_context.GetDNACollector();
-                        if (collector) {
-                            auto dna = collector->get_dna();
-                            if (dna) {
-                                s_cachedDnaHash = dna->hash();
-                                bool allZero = true;
-                                for (auto b : s_cachedDnaHash) { if (b != 0) { allZero = false; break; } }
-                                if (!allZero) {
-                                    s_dnaHashCached.store(true);
-                                    std::cout << "[Mining] DNA collected inline for registration (hash " << std::hex;
-                                    for (int i = 0; i < 4; i++) std::cout << std::setfill('0') << std::setw(2) << (int)s_cachedDnaHash[i];
-                                    std::cout << std::dec << "...)" << std::endl;
-                                    // Invalidate any PoW mined without DNA — must re-mine with DNA in challenge
-                                    if (s_regNonceMined.load()) {
-                                        std::cout << "[Mining] Invalidating PoW (was mined without DNA) - will re-mine" << std::endl;
-                                        s_regNonceMined.store(false);
-                                    }
-                                }
-                            }
-                        }
-                    }
+                std::shared_ptr<const CRegistrationManager::Snapshot> regSnap;
+                if (s_registrationManager) regSnap = s_registrationManager->GetSnapshot();
 
-                    // DFMP v3.0: Mine registration PoW nonce (cached to avoid re-mining)
-                    // Thread-safety: atomic flag prevents duplicate PoW mining when
-                    // BuildMiningTemplate is called concurrently (e.g. main thread
-                    // startup + chain tip callback from P2P thread)
-                    // NOTE: s_cachedRegNonce, s_regNonceMined, s_regPowInProgress,
-                    // s_regNonceIdentity are file-scope (shared with EnsureMIKRegistered)
-                    uint64_t regNonce = 0;
-                    if (Dilithion::g_chainParams && nHeight >= Dilithion::g_chainParams->dfmpV3ActivationHeight) {
-                        if (s_regNonceMined.load() && s_regNonceIdentity == mikIdentity) {
-                            regNonce = s_cachedRegNonce;
-                        } else if (!s_regPowInProgress.exchange(true)) {
-                            // We acquired the lock - mine the PoW
-                            std::cout << "[DFMP v3.0] Mining registration PoW for new MIK identity..." << std::endl;
-                            int rpBits = Dilithion::g_chainParams ? Dilithion::g_chainParams->registrationPowBits : 30;
-                            const std::array<uint8_t, 32>* dnaPtr = s_dnaHashCached.load() ? &s_cachedDnaHash : nullptr;
-                            if (DFMP::MineRegistrationPoW(mikPubkey, rpBits, regNonce, &g_node_state.running, dnaPtr)) {
-                                s_cachedRegNonce = regNonce;
-                                s_regNonceIdentity = mikIdentity;
-                                s_regNonceMined.store(true);
-                                PersistRegistrationPoW_DilV(mikPubkey);
-                            } else {
-                                std::cerr << "[DFMP v3.0] Failed to mine registration PoW!" << std::endl;
-                                regNonce = UINT64_MAX;  // Sentinel: skip registration (prevents nonce=0 template)
-                            }
-                            s_regPowInProgress.store(false);
-                        } else {
-                            // Another thread is already mining registration PoW - skip MIK for this template.
-                            // The next template rebuild (after PoW completes) will include the cached nonce.
-                            std::cout << "[DFMP v3.0] Registration PoW already in progress on another thread, skipping MIK..." << std::endl;
-                            regNonce = UINT64_MAX;  // Sentinel: skip registration
-                        }
+                if (!regSnap || !regSnap->hasRegNonce || !regSnap->hasDnaHash ||
+                    regSnap->mikPubkey.empty()) {
+                    // Manager not ready — skip the registration MIK data for this
+                    // template. The guard block below returns nullopt if we're
+                    // past dfmpAssumeValidHeight and no MIK data was included.
+                    if (verbose) {
+                        std::cout << "  MIK: Skipped (registration manager not ready)" << std::endl;
                     }
-
-                    if (regNonce != UINT64_MAX && DFMP::BuildMIKScriptSigRegistration(mikPubkey, mikSignature, regNonce, mikData)) {
+                } else {
+                    mikPubkey = regSnap->mikPubkey;
+                    uint64_t regNonce = regSnap->regNonce;
+                    if (DFMP::BuildMIKScriptSigRegistration(mikPubkey, mikSignature, regNonce, mikData)) {
                         scriptSig.insert(scriptSig.end(), mikData.begin(), mikData.end());
                         mikDataIncluded = true;
                         if (verbose) {
@@ -1326,19 +1108,23 @@ std::optional<CBlockTemplate> BuildMiningTemplate(CBlockchainDB& blockchain, CWa
     }
 
     // Digital DNA commitment: append 0xDD + 32-byte hash after MIK data (VDF blocks only)
-    // For registration blocks: use the cached DNA hash (same one used for attestation + PoW)
-    // For normal blocks: use live DNA from collector
+    // For registration blocks: use the manager's cached DNA hash (consensus-consistent
+    // with attestation + PoW since all three were locked together at session start).
+    // For normal blocks: use live DNA from collector.
     if (mikDataIncluded && Dilithion::g_chainParams &&
         static_cast<int>(nHeight) >= Dilithion::g_chainParams->dnaCommitmentActivationHeight) {
         bool isRegBlock = DFMP::g_identityDb && !mikIdentity.IsNull() &&
             !DFMP::g_identityDb->HasMIKPubKey(mikIdentity);
 
-        if (isRegBlock && s_dnaHashCached.load()) {
-            // Registration block: use cached DNA hash for consistency with attestation + PoW
-            DFMP::BuildDNACommitment(s_cachedDnaHash, scriptSig);
+        std::shared_ptr<const CRegistrationManager::Snapshot> regSnap;
+        if (s_registrationManager) regSnap = s_registrationManager->GetSnapshot();
+
+        if (isRegBlock && regSnap && regSnap->hasDnaHash) {
+            // Registration block: use session DNA hash for consistency with attestation + PoW
+            DFMP::BuildDNACommitment(regSnap->dnaHash, scriptSig);
             if (verbose) {
-                std::cout << "  DNA: Registration commitment (cached hash " << std::hex;
-                for (int i = 0; i < 4; i++) std::cout << std::setfill('0') << std::setw(2) << (int)s_cachedDnaHash[i];
+                std::cout << "  DNA: Registration commitment (session hash " << std::hex;
+                for (int i = 0; i < 4; i++) std::cout << std::setfill('0') << std::setw(2) << (int)regSnap->dnaHash[i];
                 std::cout << std::dec << "...)" << std::endl;
             }
         } else {
@@ -1358,7 +1144,11 @@ std::optional<CBlockTemplate> BuildMiningTemplate(CBlockchainDB& blockchain, CWa
         }
     }
 
-    // Phase 2+3: Append seed attestation data after DNA commitment (registration blocks only)
+    // Phase 2+3: Append seed attestation data after DNA commitment (registration blocks only).
+    // The CRegistrationManager owns attestation collection + freshness — BuildMiningTemplate
+    // only READS the attestation set from the snapshot. Stale attestations are refreshed
+    // automatically by the manager's worker (HandleReady_). If the manager doesn't have
+    // a fresh attestation set, we return nullopt and the miner waits for the next template.
     bool isRegistrationBlock = mikDataIncluded &&
         DFMP::g_identityDb && !mikIdentity.IsNull() &&
         !DFMP::g_identityDb->HasMIKPubKey(mikIdentity);
@@ -1366,64 +1156,28 @@ std::optional<CBlockTemplate> BuildMiningTemplate(CBlockchainDB& blockchain, CWa
         int activationHeight = Dilithion::g_chainParams ?
             Dilithion::g_chainParams->seedAttestationActivationHeight : 999999999;
 
+        std::shared_ptr<const CRegistrationManager::Snapshot> regSnap;
+        if (s_registrationManager) regSnap = s_registrationManager->GetSnapshot();
+
         if (static_cast<int>(nHeight) >= activationHeight) {
-            // BUG #283 FIX: Re-collect stale attestations inline.
-            // EnsureMIKRegistered() only runs once at startup. If attestations expire
-            // (1-hour validity window) or the rejection handler clears the cache, the
-            // template builder must handle re-collection itself — otherwise every
-            // registration block is built without attestations and rejected by consensus.
-            bool needRefresh = !s_attestationsCollected.load() || !s_cachedAttestations.HasMinimum();
-            if (!needRefresh) {
-                int64_t attestAge = std::time(nullptr) - static_cast<int64_t>(s_cachedAttestations.attestations[0].timestamp);
-                if (attestAge > Attestation::ATTESTATION_VALIDITY_WINDOW - 600) {
-                    std::cout << "[Mining] Attestations are " << attestAge / 60
-                              << "m old (max " << Attestation::ATTESTATION_VALIDITY_WINDOW / 60
-                              << "m) - refreshing..." << std::endl;
-                    needRefresh = true;
-                }
-            }
-
-            if (needRefresh && Dilithion::g_chainParams &&
-                !Dilithion::g_chainParams->seedAttestationIPs.empty() &&
-                s_dnaHashCached.load()) {  // DNA hash must be valid — attestations are bound to it
-                std::vector<uint8_t> mikPubkey;
-                if (wallet.GetMIKPubKey(mikPubkey)) {
-                    std::string mikHex = HexStr(mikPubkey);
-                    std::string dnaHex = HexStr(s_cachedDnaHash.data(), 32);
-                    Attestation::CAttestationSet freshAttest;
-                    std::string attestErr;
-                    if (Attestation::CollectAttestations(
-                            Dilithion::g_chainParams->seedAttestationIPs,
-                            Dilithion::g_chainParams->seedAttestationRPCPort,
-                            mikHex, dnaHex, freshAttest, attestErr)) {
-                        s_cachedAttestations = std::move(freshAttest);
-                        s_attestationsCollected.store(true);
-                        std::cout << "[Mining] Fresh attestations collected for registration block" << std::endl;
-                        needRefresh = false;
-                    } else {
-                        std::cerr << "[Mining] Attestation re-collection failed: " << attestErr << std::endl;
-                    }
-                }
-            }
-
-            // Guard: refuse to build registration block without valid attestations
-            if (needRefresh) {
-                std::cerr << "[Mining] Template rejected - registration block at height "
-                          << nHeight << " requires seed attestations"
-                          << " (collected=" << s_attestationsCollected.load()
-                          << ", dna=" << s_dnaHashCached.load()
-                          << ", mikPub=" << (wallet.HasMIK() ? "yes" : "no") << ")" << std::endl;
+            if (!regSnap || !regSnap->hasAttestations || !regSnap->attestations ||
+                !regSnap->attestations->HasMinimum()) {
+                std::cerr << "[Mining] Template deferred - registration block at height "
+                          << nHeight << " waiting for seed attestations (manager state="
+                          << StateToString(regSnap ? regSnap->state
+                                                    : CRegistrationManager::State::UNINITIALIZED)
+                          << ")" << std::endl;
                 return std::nullopt;
             }
         }
 
-        // Include attestations in coinbase (must meet consensus quorum)
-        if (s_attestationsCollected.load() && s_cachedAttestations.HasMinimum()) {
+        // Include attestations in coinbase (manager guarantees quorum).
+        if (regSnap && regSnap->attestations && regSnap->attestations->HasMinimum()) {
             std::vector<uint8_t> attestData;
-            if (Attestation::BuildAttestationScriptData(s_cachedAttestations, attestData)) {
+            if (Attestation::BuildAttestationScriptData(*regSnap->attestations, attestData)) {
                 scriptSig.insert(scriptSig.end(), attestData.begin(), attestData.end());
                 if (verbose) {
-                    std::cout << "  Attestations: " << s_cachedAttestations.Count()
+                    std::cout << "  Attestations: " << regSnap->attestations->Count()
                               << " seed attestations included ("
                               << attestData.size() << " bytes)" << std::endl;
                 }
@@ -5749,33 +5503,15 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                 }
                 g_node_state.new_block_found = true;
             } else {
-                // Block rejected — if attestation cache is stale, re-collect
-                // This handles seed_id changes, key rotations, or expired attestations
-                // without requiring a full node restart or PoW redo
-                if (s_attestationsCollected.load() &&
-                    Dilithion::g_chainParams &&
-                    !Dilithion::g_chainParams->seedAttestationIPs.empty()) {
-                    std::cout << "[VDF] Block rejected - re-collecting seed attestations..." << std::endl;
-                    s_attestationsCollected.store(false);
-
-                    std::vector<uint8_t> mikPubkey;
-                    if (wallet.GetMIKPubKey(mikPubkey) && s_dnaHashCached.load()) {
-                        std::string mikHex = HexStr(mikPubkey);
-                        std::string dnaHex = HexStr(s_cachedDnaHash.data(), 32);
-
-                        Attestation::CAttestationSet freshAttest;
-                        std::string attestErr;
-                        if (Attestation::CollectAttestations(
-                                Dilithion::g_chainParams->seedAttestationIPs,
-                                Dilithion::g_chainParams->seedAttestationRPCPort,
-                                mikHex, dnaHex, freshAttest, attestErr)) {
-                            s_cachedAttestations = std::move(freshAttest);
-                            s_attestationsCollected.store(true);
-                            std::cout << "[VDF] Fresh attestations collected - next block should succeed" << std::endl;
-                        } else {
-                            std::cerr << "[VDF] WARNING: Attestation re-collection failed: " << attestErr << std::endl;
-                        }
-                    }
+                // Block rejected. Notify the RegistrationManager so it can decide
+                // whether to re-collect attestations (SUBMITTED → ATTEST_PENDING) or
+                // retry submission (SUBMITTED → READY). Bounded retry budget inside
+                // the manager prevents infinite re-collect loops.
+                if (s_registrationManager) {
+                    std::cout << "[VDF] Block rejected - notifying registration manager" << std::endl;
+                    s_registrationManager->TestingInjectEvent(
+                        CRegistrationManager::Event::SUBMIT_TIMEOUT_OR_REJECTED,
+                        "block rejected by validation");
                 }
             }
         });
@@ -6734,6 +6470,13 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
 
         // Main loop
         while (g_node_state.running) {
+            // v4.0.18: keep the RegistrationManager driving on every iteration.
+            // Non-blocking: just publishes fresh inputs and wakes its worker.
+            if (s_registrationManager) {
+                auto tipH = g_chainstate.GetTip() ? g_chainstate.GetTip()->nHeight : 0;
+                s_registrationManager->Tick(static_cast<uint32_t>(tipH),
+                                             g_node_state.running.load());
+            }
             std::this_thread::sleep_for(std::chrono::seconds(1));
 
             // Check if new block was found and mining template needs update
@@ -6754,27 +6497,45 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                 // DilV: VDF miner handles new blocks via OnNewBlock() above
                 // No RandomX template rebuild needed
 
-                // Resume VDF mining if it was paused and conditions allow
+                // Resume VDF mining if it was paused and conditions allow.
+                // v4.0.18 FIX: gate on RegistrationManager.CanMine() — this used to
+                // be the race-condition path where the P2P tip callback started VDF
+                // mining before EnsureMIKRegistered had completed DNA collection,
+                // producing a PoW bound to an empty DNA hash that was later invalidated
+                // (the 30-minute-waste loop observed in v4.0.17).
                 if (g_node_state.mining_enabled.load() && !IsInitialBlockDownload()
                     && !mining_paused_no_peers && !mining_paused_fork && !mining_paused_consensus_fork
                     && !mining_paused_tip_divergence && !vdf_miner.IsRunning()) {
 
-                    std::cout << "[Mining] Resuming VDF mining at height " << next_height << std::endl;
-                    std::vector<uint8_t> pubKeyHash = wallet.GetPubKeyHash();
-                    if (pubKeyHash.size() >= 20) {
-                        std::array<uint8_t, 20> addr{};
-                        std::copy(pubKeyHash.begin(), pubKeyHash.begin() + 20, addr.begin());
-                        vdf_miner.SetMinerAddress(addr);
-                    }
-                    {
-                        DFMP::Identity mikId = wallet.GetMIKIdentity();
-                        if (!mikId.IsNull()) {
-                            std::array<uint8_t, 20> mikArr{};
-                            std::memcpy(mikArr.data(), mikId.data, 20);
-                            vdf_miner.SetMIKIdentity(mikArr);
+                    if (s_registrationManager) {
+                        CRegistrationManager::MineGateReason reason;
+                        if (!s_registrationManager->CanMine(&reason)) {
+                            static CRegistrationManager::MineGateReason s_lastLoggedReason =
+                                CRegistrationManager::MineGateReason::OK_REGISTERED;
+                            if (reason != s_lastLoggedReason) {
+                                std::cout << "[Mining] Deferred VDF start at height " << next_height
+                                          << " — " << MineGateReasonToString(reason) << std::endl;
+                                s_lastLoggedReason = reason;
+                            }
+                        } else {
+                            std::cout << "[Mining] Resuming VDF mining at height " << next_height << std::endl;
+                            std::vector<uint8_t> pubKeyHash = wallet.GetPubKeyHash();
+                            if (pubKeyHash.size() >= 20) {
+                                std::array<uint8_t, 20> addr{};
+                                std::copy(pubKeyHash.begin(), pubKeyHash.begin() + 20, addr.begin());
+                                vdf_miner.SetMinerAddress(addr);
+                            }
+                            {
+                                DFMP::Identity mikId = wallet.GetMIKIdentity();
+                                if (!mikId.IsNull()) {
+                                    std::array<uint8_t, 20> mikArr{};
+                                    std::memcpy(mikArr.data(), mikId.data, 20);
+                                    vdf_miner.SetMIKIdentity(mikArr);
+                                }
+                            }
+                            vdf_miner.Start();
                         }
                     }
-                    vdf_miner.Start();
                 }
 
                 // Clear flag

--- a/src/node/dilv-node.cpp
+++ b/src/node/dilv-node.cpp
@@ -781,6 +781,7 @@ static std::mutex g_coinbaseMutex;
 // The old s_cachedRegNonce / s_regNonceMined / s_cachedDnaHash / s_cachedAttestations
 // file-scope statics have been removed — they were the race-condition anchor point.
 static std::unique_ptr<CRegistrationManager> s_registrationManager;
+void SetRegistrationManager(CRegistrationManager* mgr);  // defined in globals.cpp
 
 // DilV data directory for MIK registration persistence (set in main before PoW).
 extern std::string g_datadir;
@@ -801,6 +802,8 @@ static void EnsureRegistrationManagerInitialized(CWallet& wallet) {
         Dilithion::g_chainParams->dnaCommitmentActivationHeight,
         Dilithion::g_chainParams->seedAttestationActivationHeight);
     s_registrationManager = std::make_unique<CRegistrationManager>(std::move(env));
+    // Publish to the global accessor so rpc/server.cpp sees the same instance.
+    SetRegistrationManager(s_registrationManager.get());
 }
 
 /**

--- a/src/node/registration_manager.cpp
+++ b/src/node/registration_manager.cpp
@@ -1,0 +1,891 @@
+// Copyright (c) 2026 The Dilithion Core developers
+// Distributed under the MIT software license
+
+#include <node/registration_manager.h>
+
+#include <algorithm>
+#include <chrono>
+#include <ctime>
+#include <filesystem>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <utility>
+
+// Production-env dependencies (only pulled in when CProductionRegistrationEnv
+// is instantiated; the pure state machine doesn't need any of this).
+#include <attestation/seed_attestation.h>
+#include <core/chainparams.h>
+#include <core/node_context.h>
+#include <dfmp/dfmp.h>
+#include <dfmp/identity_db.h>
+#include <dfmp/mik.h>
+#include <dfmp/mik_registration_file.h>
+#include <digital_dna/digital_dna.h>
+#include <wallet/wallet.h>
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+const char* StateToString(CRegistrationManager::State s) {
+    using S = CRegistrationManager::State;
+    switch (s) {
+        case S::UNINITIALIZED:                   return "UNINITIALIZED";
+        case S::CHECK_ELIGIBILITY:               return "CHECK_ELIGIBILITY";
+        case S::DNA_PENDING:                     return "DNA_PENDING";
+        case S::ATTEST_PENDING:                  return "ATTEST_PENDING";
+        case S::POW_PENDING:                     return "POW_PENDING";
+        case S::READY:                           return "READY";
+        case S::SUBMITTED:                       return "SUBMITTED";
+        case S::CONFIRMED:                       return "CONFIRMED";
+        case S::LONG_BACKOFF_USER_ACTIONABLE:    return "LONG_BACKOFF_USER_ACTIONABLE";
+        case S::FAILED_FATAL:                    return "FAILED_FATAL";
+        case S::SHUTTING_DOWN:                   return "SHUTTING_DOWN";
+        case S::STOPPED:                         return "STOPPED";
+    }
+    return "UNKNOWN";
+}
+
+const char* MineGateReasonToString(CRegistrationManager::MineGateReason r) {
+    using R = CRegistrationManager::MineGateReason;
+    switch (r) {
+        case R::OK_REGISTERED:                        return "registered";
+        case R::OK_REGISTRATION_IN_PROGRESS:          return "registration-in-progress";
+        case R::BLOCKED_UNINITIALIZED:                return "uninitialized";
+        case R::BLOCKED_DNA_PENDING:                  return "collecting DNA";
+        case R::BLOCKED_ATTEST_PENDING:               return "collecting attestations";
+        case R::BLOCKED_POW_PENDING:                  return "mining registration PoW";
+        case R::BLOCKED_RETRYING_SUBMISSION:          return "retrying registration block submission";
+        case R::BLOCKED_LONG_BACKOFF_USER_ACTIONABLE: return "waiting on user action";
+        case R::BLOCKED_FATAL:                        return "fatal registration error";
+        case R::BLOCKED_SHUTTING_DOWN:                return "shutting down";
+    }
+    return "unknown";
+}
+
+// ============================================================================
+// Snapshot copy (unique_ptr member requires explicit handling)
+// ============================================================================
+
+CRegistrationManager::Snapshot&
+CRegistrationManager::Snapshot::operator=(const Snapshot& other) {
+    if (this == &other) return *this;
+    state = other.state;
+    sequence = other.sequence;
+    tipHeight = other.tipHeight;
+    registrationRequired = other.registrationRequired;
+    canBuildRegistrationTemplate = other.canBuildRegistrationTemplate;
+    sessionId = other.sessionId;
+    mikPubkey = other.mikPubkey;
+    dnaHash = other.dnaHash;
+    hasDnaHash = other.hasDnaHash;
+    hasAttestations = other.hasAttestations;
+    regNonce = other.regNonce;
+    hasRegNonce = other.hasRegNonce;
+    attestations = other.attestations
+                       ? std::make_unique<Attestation::CAttestationSet>(*other.attestations)
+                       : nullptr;
+    submitRetriesUsed = other.submitRetriesUsed;
+    submitRetriesMax = other.submitRetriesMax;
+    nextRetryAt = other.nextRetryAt;
+    lastError = other.lastError;
+    userActionHint = other.userActionHint;
+    mineGate = other.mineGate;
+    return *this;
+}
+
+// ============================================================================
+// Lifecycle
+// ============================================================================
+
+CRegistrationManager::CRegistrationManager(std::shared_ptr<IRegistrationEnv> env)
+    : env_(std::move(env)) {
+    // Publish initial snapshot so GetSnapshot() never returns null.
+    auto snap = std::make_shared<Snapshot>();
+    snap->state = State::UNINITIALIZED;
+    snap->mineGate = MineGateReason::BLOCKED_UNINITIALIZED;
+    {
+        std::lock_guard<std::mutex> lk(snapshotMutex_);
+        publishedSnapshot_ = snap;
+    }
+}
+
+CRegistrationManager::~CRegistrationManager() {
+    Shutdown();
+}
+
+void CRegistrationManager::EnsureWorkerStarted_() {
+    // Idempotent — only starts the worker on the first call.
+    bool expected = false;
+    if (!workerStarted_.compare_exchange_strong(expected, true)) return;
+    worker_ = std::thread([this] { WorkerMain_(); });
+}
+
+void CRegistrationManager::Shutdown() {
+    if (!workerStarted_.load()) {
+        // Worker was never started; nothing to clean up.
+        return;
+    }
+    RequestShutdown_();
+    if (worker_.joinable()) worker_.join();
+}
+
+void CRegistrationManager::RequestShutdown_() {
+    shutdownRequested_.store(true);
+    powRunning_.store(false);  // cancel any in-flight PoW
+    latestNodeRunning_.store(false);
+    stateCv_.notify_all();
+}
+
+// ============================================================================
+// Driver API (thread-safe)
+// ============================================================================
+
+void CRegistrationManager::Tick(uint32_t tipHeight, bool nodeRunning) {
+    latestTipHeight_.store(tipHeight);
+    latestNodeRunning_.store(nodeRunning);
+    if (!nodeRunning) RequestShutdown_();
+    EnsureWorkerStarted_();
+    stateCv_.notify_one();
+}
+
+// ============================================================================
+// Read-only query API
+// ============================================================================
+
+std::shared_ptr<const CRegistrationManager::Snapshot>
+CRegistrationManager::GetSnapshot() const {
+    std::lock_guard<std::mutex> lk(snapshotMutex_);
+    return publishedSnapshot_;
+}
+
+bool CRegistrationManager::CanMine(MineGateReason* reasonOut) const {
+    auto snap = GetSnapshot();
+    if (reasonOut) *reasonOut = snap->mineGate;
+    return snap->mineGate == MineGateReason::OK_REGISTERED ||
+           snap->mineGate == MineGateReason::OK_REGISTRATION_IN_PROGRESS;
+}
+
+CRegistrationManager::StatusForUI CRegistrationManager::GetStatusForUI() const {
+    auto snap = GetSnapshot();
+    StatusForUI s;
+    s.retryUsed = snap->submitRetriesUsed;
+    s.retryMax = snap->submitRetriesMax;
+    s.actionHint = snap->userActionHint;
+
+    switch (snap->state) {
+        case State::UNINITIALIZED:
+            s.phase = "INIT"; s.message = "Initializing registration manager"; break;
+        case State::CHECK_ELIGIBILITY:
+            s.phase = "CHECK"; s.message = "Checking miner registration status"; break;
+        case State::DNA_PENDING:
+            s.phase = "DNA";
+            s.message = "Collecting hardware fingerprint (Digital DNA)";
+            s.etaText = "up to 30 min on a fresh node";
+            break;
+        case State::ATTEST_PENDING:
+            s.phase = "ATTEST";
+            s.message = "Requesting seed attestations (need 3 of 4)";
+            s.etaText = "a few seconds";
+            break;
+        case State::POW_PENDING:
+            s.phase = "POW";
+            s.message = "Solving registration proof-of-work";
+            s.etaText = "about 15-30 min (CPU dependent)";
+            break;
+        case State::READY:
+            s.phase = "READY"; s.message = "Registration material ready, mining registration block"; break;
+        case State::SUBMITTED:
+            s.phase = "SUBMITTED"; s.message = "Registration block building/mining"; break;
+        case State::CONFIRMED:
+            s.phase = "CONFIRMED"; s.message = "Registered — mining normally"; break;
+        case State::LONG_BACKOFF_USER_ACTIONABLE:
+            s.phase = "BACKOFF";
+            s.message = snap->lastError.empty() ? "Waiting on user action" : snap->lastError;
+            break;
+        case State::FAILED_FATAL:
+            s.phase = "FATAL"; s.message = snap->lastError; break;
+        case State::SHUTTING_DOWN:
+            s.phase = "SHUTDOWN"; s.message = "Shutting down cleanly"; break;
+        case State::STOPPED:
+            s.phase = "STOPPED"; s.message = "Registration manager stopped"; break;
+    }
+    return s;
+}
+
+void CRegistrationManager::ForceRestart(const std::string& why) {
+    std::lock_guard<std::mutex> lk(stateMutex_);
+    AbandonSession_(std::string("ForceRestart: ") + why, /*persistNothing=*/true);
+    EnterState_(State::CHECK_ELIGIBILITY);
+    PublishSnapshot_();
+    stateCv_.notify_all();
+}
+
+// ============================================================================
+// Test hooks
+// ============================================================================
+
+CRegistrationManager::State CRegistrationManager::TestingStepWorkerOnce() {
+    std::unique_lock<std::mutex> lk(stateMutex_);
+    WorkerIterationLocked_(lk);
+    return state_;
+}
+
+void CRegistrationManager::TestingInjectEvent(Event ev, const std::string& detail) {
+    std::lock_guard<std::mutex> lk(stateMutex_);
+    Transition_(ev, detail);
+    PublishSnapshot_();
+}
+
+// ============================================================================
+// Worker main loop
+// ============================================================================
+
+void CRegistrationManager::WorkerMain_() {
+    std::unique_lock<std::mutex> lk(stateMutex_);
+
+    // Initial transition: UNINITIALIZED -> CHECK_ELIGIBILITY
+    Transition_(Event::STARTUP);
+    PublishSnapshot_();
+
+    while (!shutdownRequested_.load()) {
+        // If we have a scheduled retry, sleep until then or until woken.
+        auto now = std::chrono::system_clock::now();
+        if (nextRetryAt_ > now) {
+            stateCv_.wait_until(lk, nextRetryAt_, [this] {
+                return shutdownRequested_.load();
+            });
+            if (shutdownRequested_.load()) break;
+            now = std::chrono::system_clock::now();
+            if (nextRetryAt_ > now) continue; // spurious wake
+            nextRetryAt_ = {};
+        }
+
+        // Dispatch to appropriate handler. Handlers may release/re-acquire
+        // the lock for long-running ops.
+        WorkerIterationLocked_(lk);
+
+        // If we have no scheduled retry and no pending transition,
+        // wait for the next Tick() to wake us.
+        if (nextRetryAt_ == std::chrono::system_clock::time_point{}) {
+            // No timed work. Wait for Tick() or shutdown.
+            // But only wait if we're in a terminal-for-now state.
+            if (state_ == State::CONFIRMED ||
+                state_ == State::READY ||
+                state_ == State::SUBMITTED ||
+                state_ == State::LONG_BACKOFF_USER_ACTIONABLE ||
+                state_ == State::FAILED_FATAL ||
+                state_ == State::DNA_PENDING) {
+                stateCv_.wait_for(lk, std::chrono::seconds(1), [this] {
+                    return shutdownRequested_.load();
+                });
+            }
+        }
+    }
+
+    // Clean shutdown: abandon any in-progress session, no partial persistence.
+    Transition_(Event::SHUTDOWN_REQUESTED);
+    AbandonSession_("shutdown", /*persistNothing=*/true);
+    EnterState_(State::STOPPED);
+    Transition_(Event::WORKER_STOPPED);
+    PublishSnapshot_();
+}
+
+void CRegistrationManager::WorkerIterationLocked_(std::unique_lock<std::mutex>& /*lk*/) {
+    switch (state_) {
+        case State::UNINITIALIZED:
+        case State::CHECK_ELIGIBILITY:           HandleCheckEligibility_(); break;
+        case State::DNA_PENDING:                 HandleDnaPending_(); break;
+        case State::ATTEST_PENDING:              HandleAttestPending_(); break;
+        case State::POW_PENDING:                 HandlePowPending_(); break;
+        case State::READY:                       HandleReady_(); break;
+        case State::SUBMITTED:                   HandleSubmitted_(); break;
+        case State::CONFIRMED:                   HandleConfirmed_(); break;
+        case State::LONG_BACKOFF_USER_ACTIONABLE: HandleLongBackoff_(); break;
+        case State::FAILED_FATAL:                break; // terminal; wait for Shutdown or ForceRestart
+        case State::SHUTTING_DOWN:               break;
+        case State::STOPPED:                     break;
+    }
+    PublishSnapshot_();
+}
+
+// ============================================================================
+// State handlers (worker thread only; stateMutex_ is held on entry/exit)
+// ============================================================================
+
+void CRegistrationManager::HandleCheckEligibility_() {
+    // Need MIK pubkey + identity to proceed.
+    std::vector<uint8_t> pubkey;
+    DFMP::Identity identity;
+    if (!env_->GetMIKPubKey(pubkey) || !env_->GetMIKIdentity(identity) ||
+        identity.IsNull()) {
+        OnUserActionRequired_(
+            "Wallet locked or MIK not yet generated",
+            "Unlock the wallet; mining will resume automatically.",
+            userActionBackoff_);
+        return;
+    }
+
+    // Already registered on the canonical chain?
+    if (env_->HasMIKRegistered(identity)) {
+        // Fast path — nothing to do.
+        session_.mikPubkey = pubkey;
+        session_.mikIdentity = identity;
+        EnterState_(State::CONFIRMED);
+        Transition_(Event::REGISTRATION_SEEN_ONCHAIN);
+        return;
+    }
+
+    // Start a fresh session.
+    StartNewSession_(latestTipHeight_.load());
+    session_.mikPubkey = pubkey;
+    session_.mikIdentity = identity;
+
+    // Can we short-circuit with a valid persisted nonce?
+    if (TryRestorePersistedNonce_()) {
+        // Still need fresh attestations (expire after 1h) before submitting.
+        EnterState_(State::ATTEST_PENDING);
+        return;
+    }
+
+    // Normal path: collect DNA first.
+    EnterState_(State::DNA_PENDING);
+}
+
+void CRegistrationManager::HandleDnaPending_() {
+    session_.dnaPolls++;
+    std::array<uint8_t, 32> hash{};
+    if (env_->TryGetDNAHash(hash)) {
+        // Verify non-zero (defense in depth against env returning a cleared array).
+        bool allZero = std::all_of(hash.begin(), hash.end(),
+                                   [](uint8_t b) { return b == 0; });
+        if (!allZero) {
+            session_.dnaHash = hash;
+            session_.hasDnaHash = true;
+            Transition_(Event::DNA_READY);
+            EnterState_(State::ATTEST_PENDING);
+            return;
+        }
+    }
+    // Not ready yet — wake again in dnaPollInterval_.
+    nextRetryAt_ = std::chrono::system_clock::now() + dnaPollInterval_;
+}
+
+void CRegistrationManager::HandleAttestPending_() {
+    if (!session_.hasDnaHash) {
+        // Sanity: should never happen per transition rules.
+        OnFatalError_("ATTEST_PENDING without DNA hash — invariant violated");
+        return;
+    }
+
+    // Snapshot inputs so the long-running RPC runs without holding state.
+    std::vector<uint8_t> pubkey = session_.mikPubkey;
+    std::array<uint8_t, 32> dnaHash = session_.dnaHash;
+    uint64_t sessionId = session_.sessionId;
+
+    stateMutex_.unlock();
+    Attestation::CAttestationSet fresh;
+    std::string err;
+    bool ok = env_->CollectAttestations(pubkey, dnaHash, fresh, err);
+    stateMutex_.lock();
+
+    // Session may have been abandoned while the lock was released (reorg,
+    // DNA change, shutdown). Discard stale results.
+    if (session_.sessionId != sessionId || shutdownRequested_.load()) return;
+
+    if (ok) {
+        session_.attestations =
+            std::make_unique<Attestation::CAttestationSet>(std::move(fresh));
+        session_.hasValidAttestations = true;
+        session_.attestationRetries = 0;
+        currentAttestBackoff_ = std::chrono::seconds(0);
+        Transition_(Event::ATTEST_READY);
+        EnterState_(State::POW_PENDING);
+        return;
+    }
+
+    // Transient failure — exponential backoff up to maxAttestationRetries_.
+    session_.attestationRetries++;
+    if (session_.attestationRetries >= maxAttestationRetries_) {
+        OnUserActionRequired_(
+            "Could not reach enough seed nodes (" + err + ")",
+            "Check firewall/router for outbound TCP to seed nodes.",
+            userActionBackoff_);
+        return;
+    }
+    currentAttestBackoff_ = currentAttestBackoff_.count() == 0
+        ? attestInitialBackoff_
+        : std::chrono::seconds(std::min<int64_t>(currentAttestBackoff_.count() * 2,
+                                                 attestMaxBackoff_.count()));
+    OnTransientError_("Attestation RPC failed: " + err, currentAttestBackoff_);
+}
+
+void CRegistrationManager::HandlePowPending_() {
+    if (!session_.hasDnaHash) {
+        OnFatalError_("POW_PENDING without DNA hash — invariant violated");
+        return;
+    }
+
+    // Snapshot inputs; release state lock for the ~15-30 min PoW.
+    std::vector<uint8_t> pubkey = session_.mikPubkey;
+    std::array<uint8_t, 32> dnaHash = session_.dnaHash;
+    uint64_t sessionId = session_.sessionId;
+    int bits = env_->RegistrationPowBits();
+
+    powRunning_.store(true);
+    stateMutex_.unlock();
+    uint64_t nonce = 0;
+    bool ok = env_->MineRegistrationPoW(pubkey, bits, dnaHash, nonce, powRunning_);
+    stateMutex_.lock();
+
+    if (session_.sessionId != sessionId || shutdownRequested_.load()) {
+        // Session abandoned (reorg, shutdown, FORCE_RESTART). Do NOT persist.
+        return;
+    }
+
+    if (ok) {
+        session_.regNonce = nonce;
+        session_.hasRegNonce = true;
+        // Persist only once we have a fully coherent (pubkey, dna, nonce).
+        if (!PersistSolvedNonceAtomically_()) {
+            // Persistence failed — not fatal; we keep the in-memory nonce and
+            // just log. Worst case, a restart redoes the PoW.
+            lastError_ = "Failed to persist registration PoW to disk (non-fatal)";
+        }
+        Transition_(Event::POW_READY);
+        EnterState_(State::READY);
+    } else {
+        // Either shutdown cancelled us (handled above) or PoW genuinely failed.
+        OnTransientError_("Registration PoW failed", std::chrono::seconds(5));
+    }
+}
+
+void CRegistrationManager::HandleReady_() {
+    // READY is a quiescent state. The VDF miner reads our snapshot and mines
+    // a registration template. When it succeeds and submits a block, external
+    // code will call TestingInjectEvent(TEMPLATE_BUILT_AND_MINER_STARTED) or
+    // we'll detect the on-chain registration via TIP_UPDATED.
+    //
+    // Meanwhile, we check that the attestations are still fresh. If they're
+    // about to expire, proactively refresh.
+    if (session_.attestations && !env_->IsAttestationFreshEnough(
+            *session_.attestations, env_->NowSeconds())) {
+        session_.hasValidAttestations = false;
+        session_.attestations.reset();
+        EnterState_(State::ATTEST_PENDING);
+        return;
+    }
+    // Nothing to do right now — snooze until the next Tick() or event.
+    // (Worker main loop sleeps us back into the cv_wait.)
+}
+
+void CRegistrationManager::HandleSubmitted_() {
+    // Same as READY for now — we're waiting for the chain to confirm us.
+    // The submission retry machinery is driven by external events
+    // (SUBMIT_TIMEOUT_OR_REJECTED / REGISTRATION_SEEN_ONCHAIN) from the
+    // block submission pipeline.
+    HandleReady_();
+}
+
+void CRegistrationManager::HandleConfirmed_() {
+    // Quiescent. Wait for a TIP_UPDATED event that might indicate a reorg
+    // has pulled the registration out of the canonical chain.
+    if (!session_.mikIdentity.IsNull() &&
+        !env_->HasMIKRegistered(session_.mikIdentity)) {
+        // Reorg — we're no longer registered on the canonical chain.
+        InvalidateSessionForReorg_();
+        EnterState_(State::CHECK_ELIGIBILITY);
+        Transition_(Event::REGISTRATION_MISSING_ONCHAIN);
+    }
+}
+
+void CRegistrationManager::HandleLongBackoff_() {
+    // Just waiting for nextRetryAt_ to elapse. When it does, the main loop
+    // will call us again and we'll transition back to CHECK_ELIGIBILITY.
+    if (std::chrono::system_clock::now() >= nextRetryAt_) {
+        EnterState_(State::CHECK_ELIGIBILITY);
+        nextRetryAt_ = {};
+    }
+}
+
+// ============================================================================
+// Event + state transitions
+// ============================================================================
+
+void CRegistrationManager::Transition_(Event ev, const std::string& detail) {
+    // The vast majority of state changes happen via EnterState_. Transition_
+    // exists to capture named events for logging and to gate certain
+    // conditional transitions. Most handlers call EnterState_ directly; this
+    // function is used mainly for events that come from OUTSIDE the worker
+    // thread (REGISTRATION_SEEN_ONCHAIN, SUBMIT_TIMEOUT_OR_REJECTED etc.)
+    // or from state handlers for bookkeeping.
+    switch (ev) {
+        case Event::REGISTRATION_MISSING_ONCHAIN:
+            if (state_ == State::CONFIRMED ||
+                state_ == State::READY ||
+                state_ == State::SUBMITTED) {
+                InvalidateSessionForReorg_();
+                EnterState_(State::CHECK_ELIGIBILITY);
+            }
+            break;
+        case Event::REGISTRATION_SEEN_ONCHAIN:
+            EnterState_(State::CONFIRMED);
+            lastError_.clear();
+            userActionHint_.clear();
+            break;
+        case Event::TEMPLATE_BUILT_AND_MINER_STARTED:
+            if (state_ == State::READY) EnterState_(State::SUBMITTED);
+            break;
+        case Event::SUBMIT_TIMEOUT_OR_REJECTED: {
+            if (state_ != State::SUBMITTED) break;
+            session_.submitRetries++;
+            if (session_.submitRetries >= maxSubmitRetries_) {
+                Transition_(Event::SUBMIT_RETRY_BUDGET_EXHAUSTED);
+                break;
+            }
+            // Decide which state to fall back to based on attestation freshness.
+            bool attestFresh = session_.attestations &&
+                env_->IsAttestationFreshEnough(*session_.attestations, env_->NowSeconds());
+            EnterState_(attestFresh ? State::READY : State::ATTEST_PENDING);
+            if (!attestFresh) session_.attestations.reset();
+            nextRetryAt_ = std::chrono::system_clock::now() + submitRetryBackoff_;
+            break;
+        }
+        case Event::SUBMIT_RETRY_BUDGET_EXHAUSTED:
+            OnUserActionRequired_(
+                "Registration block submission failed " + std::to_string(maxSubmitRetries_) + " times",
+                "Check logs for rejection reason.",
+                userActionBackoff_);
+            break;
+        case Event::FORCE_RESTART:
+            AbandonSession_("force-restart: " + detail, /*persistNothing=*/true);
+            EnterState_(State::CHECK_ELIGIBILITY);
+            break;
+        case Event::UNRECOVERABLE_ERROR:
+            OnFatalError_(detail);
+            break;
+        case Event::SHUTDOWN_REQUESTED:
+            EnterState_(State::SHUTTING_DOWN);
+            break;
+        case Event::WORKER_STOPPED:
+            EnterState_(State::STOPPED);
+            break;
+        case Event::STARTUP:
+            if (state_ == State::UNINITIALIZED) {
+                EnterState_(State::CHECK_ELIGIBILITY);
+            }
+            break;
+        // Event-only markers (no transition, used for logging)
+        case Event::TIP_UPDATED:
+        case Event::SESSION_STARTED:
+        case Event::DNA_READY:
+        case Event::ATTEST_READY:
+        case Event::POW_READY:
+        case Event::TRANSIENT_ERROR:
+        case Event::USER_ACTION_REQUIRED:
+            break;
+    }
+}
+
+void CRegistrationManager::EnterState_(State s) {
+    if (state_ == s) return;
+    state_ = s;
+    // Clear retry timer when transitioning to a non-backoff state.
+    if (s != State::LONG_BACKOFF_USER_ACTIONABLE &&
+        s != State::SHUTTING_DOWN &&
+        s != State::STOPPED) {
+        // Leave nextRetryAt_ as-is for DNA_PENDING polls etc.; handlers set it.
+    }
+}
+
+// ============================================================================
+// Snapshot publishing
+// ============================================================================
+
+void CRegistrationManager::PublishSnapshot_() {
+    auto snap = std::make_shared<Snapshot>();
+    snap->state = state_;
+    snap->sequence = ++snapshotSeq_;
+    snap->tipHeight = latestTipHeight_.load();
+    snap->registrationRequired = (state_ != State::CONFIRMED);
+    snap->canBuildRegistrationTemplate = (state_ == State::READY ||
+                                           state_ == State::SUBMITTED);
+    snap->sessionId = session_.sessionId;
+    snap->mikPubkey = session_.mikPubkey;
+    snap->dnaHash = session_.dnaHash;
+    snap->hasDnaHash = session_.hasDnaHash;
+    snap->hasAttestations = session_.hasValidAttestations;
+    snap->regNonce = session_.regNonce;
+    snap->hasRegNonce = session_.hasRegNonce;
+    if (session_.attestations) {
+        snap->attestations =
+            std::make_unique<Attestation::CAttestationSet>(*session_.attestations);
+    }
+    snap->submitRetriesUsed = session_.submitRetries;
+    snap->submitRetriesMax = maxSubmitRetries_;
+    snap->nextRetryAt = nextRetryAt_;
+    snap->lastError = lastError_;
+    snap->userActionHint = userActionHint_;
+
+    // Mine-gate decision
+    switch (state_) {
+        case State::CONFIRMED:                snap->mineGate = MineGateReason::OK_REGISTERED; break;
+        case State::READY:
+        case State::SUBMITTED:                snap->mineGate = MineGateReason::OK_REGISTRATION_IN_PROGRESS; break;
+        case State::UNINITIALIZED:            snap->mineGate = MineGateReason::BLOCKED_UNINITIALIZED; break;
+        case State::CHECK_ELIGIBILITY:
+        case State::DNA_PENDING:              snap->mineGate = MineGateReason::BLOCKED_DNA_PENDING; break;
+        case State::ATTEST_PENDING:           snap->mineGate = MineGateReason::BLOCKED_ATTEST_PENDING; break;
+        case State::POW_PENDING:              snap->mineGate = MineGateReason::BLOCKED_POW_PENDING; break;
+        case State::LONG_BACKOFF_USER_ACTIONABLE:
+            snap->mineGate = MineGateReason::BLOCKED_LONG_BACKOFF_USER_ACTIONABLE; break;
+        case State::FAILED_FATAL:             snap->mineGate = MineGateReason::BLOCKED_FATAL; break;
+        case State::SHUTTING_DOWN:
+        case State::STOPPED:                  snap->mineGate = MineGateReason::BLOCKED_SHUTTING_DOWN; break;
+    }
+
+    {
+        std::lock_guard<std::mutex> lk(snapshotMutex_);
+        publishedSnapshot_ = snap;
+    }
+}
+
+// ============================================================================
+// Session management
+// ============================================================================
+
+void CRegistrationManager::StartNewSession_(uint32_t tipHeight) {
+    session_ = SessionData{};
+    session_.sessionId = nextSessionId_++;
+    session_.startHeight = tipHeight;
+    currentAttestBackoff_ = std::chrono::seconds(0);
+    lastError_.clear();
+    userActionHint_.clear();
+}
+
+void CRegistrationManager::AbandonSession_(const std::string& reason,
+                                           bool persistNothing) {
+    if (session_.sessionId == 0) return; // no session active
+    if (!reason.empty()) lastError_ = reason;
+    if (persistNothing) {
+        // Intentional: do NOT call PersistSolvedNonceAtomically_ here.
+        // Partial sessions must never poison the mik_registration.dat file.
+    }
+    session_ = SessionData{};
+    powRunning_.store(false);  // cancel any in-flight PoW for this session
+}
+
+void CRegistrationManager::InvalidateSessionForReorg_() {
+    AbandonSession_("registration reorged out of canonical chain",
+                    /*persistNothing=*/true);
+    // On the next CHECK_ELIGIBILITY, we may also want to delete the stale
+    // persisted file since its nonce corresponds to a now-stale chain
+    // history. But the file is keyed by (pubkey, dnaHash), not height, so
+    // it's still cryptographically valid — leave it, it may be reusable.
+}
+
+bool CRegistrationManager::ValidateSessionCoherence_() const {
+    if (session_.sessionId == 0) return false;
+    if (session_.mikPubkey.empty()) return false;
+    if (session_.hasRegNonce && !session_.hasDnaHash) return false;
+    if (session_.hasValidAttestations && !session_.hasDnaHash) return false;
+    return true;
+}
+
+// ============================================================================
+// Persistence (with zero-DNA safety)
+// ============================================================================
+
+bool CRegistrationManager::TryRestorePersistedNonce_() {
+    if (session_.mikPubkey.empty()) return false;
+    DFMP::MIKRegistrationFile rec;
+    auto res = env_->LoadRegistration(session_.mikPubkey, rec);
+    if (res != DFMP::MIKRegFileLoadResult::OK) {
+        if (res == DFMP::MIKRegFileLoadResult::Corrupt ||
+            res == DFMP::MIKRegFileLoadResult::PubkeyMismatch) {
+            // Best-effort cleanup; LoadMIKRegistration has already renamed
+            // the file to .corrupt/.stale on these paths.
+        }
+        return false;
+    }
+
+    // Poisoned-file check: refuse to load a zero-DNA record.
+    bool allZero = std::all_of(rec.dnaHash.begin(), rec.dnaHash.end(),
+                               [](uint8_t b) { return b == 0; });
+    if (allZero) {
+        env_->DeletePersistedRegistration();
+        lastError_ = "Deleted poisoned mik_registration.dat (zero DNA hash)";
+        return false;
+    }
+
+    session_.dnaHash = rec.dnaHash;
+    session_.hasDnaHash = true;
+    session_.regNonce = rec.nonce;
+    session_.hasRegNonce = true;
+    return true;
+}
+
+bool CRegistrationManager::PersistSolvedNonceAtomically_() {
+    if (!session_.hasDnaHash || !session_.hasRegNonce ||
+        session_.mikPubkey.empty()) {
+        return false;
+    }
+    // Second-line defense: never write a zero-DNA record.
+    bool allZero = std::all_of(session_.dnaHash.begin(), session_.dnaHash.end(),
+                               [](uint8_t b) { return b == 0; });
+    if (allZero) return false;
+    return env_->SaveRegistration(session_.mikPubkey,
+                                   session_.dnaHash,
+                                   session_.regNonce,
+                                   env_->NowSeconds());
+}
+
+void CRegistrationManager::ClearPersistedNonceIfStale_() {
+    env_->DeletePersistedRegistration();
+}
+
+// ============================================================================
+// Error / backoff helpers
+// ============================================================================
+
+void CRegistrationManager::OnTransientError_(const std::string& err,
+                                             std::chrono::seconds backoff) {
+    lastError_ = err;
+    nextRetryAt_ = std::chrono::system_clock::now() + backoff;
+}
+
+void CRegistrationManager::OnUserActionRequired_(const std::string& err,
+                                                  const std::string& hint,
+                                                  std::chrono::minutes backoff) {
+    lastError_ = err;
+    userActionHint_ = hint;
+    nextRetryAt_ = std::chrono::system_clock::now() + backoff;
+    EnterState_(State::LONG_BACKOFF_USER_ACTIONABLE);
+}
+
+void CRegistrationManager::OnFatalError_(const std::string& err) {
+    lastError_ = err;
+    EnterState_(State::FAILED_FATAL);
+}
+
+// ============================================================================
+// CProductionRegistrationEnv — wraps the live node subsystems
+// ============================================================================
+
+CProductionRegistrationEnv::CProductionRegistrationEnv(
+    CWallet& wallet,
+    NodeContext& nodeContext,
+    const std::string& datadir,
+    int registrationPowBits,
+    int dnaCommitmentActivationHeight,
+    int seedAttestationActivationHeight)
+    : wallet_(wallet),
+      nodeContext_(nodeContext),
+      datadir_(datadir),
+      registrationPowBits_(registrationPowBits),
+      dnaCommitmentActivationHeight_(dnaCommitmentActivationHeight),
+      seedAttestationActivationHeight_(seedAttestationActivationHeight) {}
+
+bool CProductionRegistrationEnv::GetMIKPubKey(std::vector<uint8_t>& out) {
+    if (!wallet_.HasMIK()) return false;
+    return wallet_.GetMIKPubKey(out);
+}
+
+bool CProductionRegistrationEnv::GetMIKIdentity(DFMP::Identity& out) {
+    if (!wallet_.HasMIK()) return false;
+    out = wallet_.GetMIKIdentity();
+    return !out.IsNull();
+}
+
+bool CProductionRegistrationEnv::HasMIKRegistered(
+    const DFMP::Identity& identity) const {
+    if (!DFMP::g_identityDb) return false;
+    return DFMP::g_identityDb->HasMIKPubKey(identity);
+}
+
+bool CProductionRegistrationEnv::TryGetDNAHash(std::array<uint8_t, 32>& out) {
+    auto collector = nodeContext_.GetDNACollector();
+    if (!collector) return false;
+    auto dna = collector->get_dna();
+    if (!dna) return false;
+    out = dna->hash();
+    return true;
+}
+
+bool CProductionRegistrationEnv::CollectAttestations(
+    const std::vector<uint8_t>& pubkey,
+    const std::array<uint8_t, 32>& dnaHash,
+    Attestation::CAttestationSet& out,
+    std::string& errOut) {
+    if (!Dilithion::g_chainParams ||
+        Dilithion::g_chainParams->seedAttestationIPs.empty()) {
+        errOut = "no seed attestation IPs configured";
+        return false;
+    }
+    std::string mikHex = /* HexStr(pubkey) */ [&pubkey] {
+        static const char* const hex = "0123456789abcdef";
+        std::string s; s.reserve(pubkey.size() * 2);
+        for (uint8_t b : pubkey) { s.push_back(hex[b >> 4]); s.push_back(hex[b & 0xF]); }
+        return s;
+    }();
+    std::string dnaHex = [&dnaHash] {
+        static const char* const hex = "0123456789abcdef";
+        std::string s; s.reserve(64);
+        for (uint8_t b : dnaHash) { s.push_back(hex[b >> 4]); s.push_back(hex[b & 0xF]); }
+        return s;
+    }();
+    return Attestation::CollectAttestations(
+        Dilithion::g_chainParams->seedAttestationIPs,
+        Dilithion::g_chainParams->seedAttestationRPCPort,
+        mikHex, dnaHex, out, errOut);
+}
+
+bool CProductionRegistrationEnv::IsAttestationFreshEnough(
+    const Attestation::CAttestationSet& attest,
+    int64_t nowSec) const {
+    if (attest.attestations.empty()) return false;
+    int64_t age = nowSec - static_cast<int64_t>(attest.attestations[0].timestamp);
+    // Refresh within 10 minutes of expiry.
+    return age < (Attestation::ATTESTATION_VALIDITY_WINDOW - 600);
+}
+
+bool CProductionRegistrationEnv::MineRegistrationPoW(
+    const std::vector<uint8_t>& pubkey,
+    int bits,
+    const std::array<uint8_t, 32>& dnaHash,
+    uint64_t& outNonce,
+    const std::atomic<bool>& running) {
+    // DFMP API takes a non-const pointer to const atomic<bool>; our signature
+    // is const ref for clean ownership. It reads only; cast is safe.
+    auto* runningPtr = const_cast<std::atomic<bool>*>(&running);
+    return DFMP::MineRegistrationPoW(pubkey, bits, outNonce, runningPtr, &dnaHash);
+}
+
+bool CProductionRegistrationEnv::SaveRegistration(
+    const std::vector<uint8_t>& pubkey,
+    const std::array<uint8_t, 32>& dnaHash,
+    uint64_t nonce,
+    int64_t timestamp) {
+    return DFMP::SaveMIKRegistration(datadir_, pubkey, dnaHash, nonce, timestamp);
+}
+
+DFMP::MIKRegFileLoadResult CProductionRegistrationEnv::LoadRegistration(
+    const std::vector<uint8_t>& pubkey,
+    DFMP::MIKRegistrationFile& out) {
+    return DFMP::LoadMIKRegistration(datadir_, pubkey, out);
+}
+
+void CProductionRegistrationEnv::DeletePersistedRegistration() {
+    // Best-effort: remove the canonical file path.
+    try {
+        std::filesystem::remove(
+            std::filesystem::path(datadir_) / DFMP::MIK_REGISTRATION_FILENAME);
+    } catch (...) {
+        // Ignore — file may not exist.
+    }
+}
+
+int64_t CProductionRegistrationEnv::NowSeconds() const {
+    return static_cast<int64_t>(std::time(nullptr));
+}

--- a/src/node/registration_manager.cpp
+++ b/src/node/registration_manager.cpp
@@ -222,6 +222,13 @@ void CRegistrationManager::ForceRestart(const std::string& why) {
     stateCv_.notify_all();
 }
 
+void CRegistrationManager::NotifyBlockRejected(const std::string& reason) {
+    std::lock_guard<std::mutex> lk(stateMutex_);
+    Transition_(Event::SUBMIT_TIMEOUT_OR_REJECTED, reason);
+    PublishSnapshot_();
+    stateCv_.notify_all();
+}
+
 // ============================================================================
 // Test hooks
 // ============================================================================
@@ -463,12 +470,21 @@ void CRegistrationManager::HandlePowPending_() {
 
 void CRegistrationManager::HandleReady_() {
     // READY is a quiescent state. The VDF miner reads our snapshot and mines
-    // a registration template. When it succeeds and submits a block, external
-    // code will call TestingInjectEvent(TEMPLATE_BUILT_AND_MINER_STARTED) or
-    // we'll detect the on-chain registration via TIP_UPDATED.
-    //
-    // Meanwhile, we check that the attestations are still fresh. If they're
-    // about to expire, proactively refresh.
+    // a registration template, then submits the block. We detect on-chain
+    // registration by polling the identity DB — when our MIK appears there,
+    // we transition to CONFIRMED. This matches the reorg-detection poll that
+    // HandleConfirmed_ does, and avoids needing an external
+    // REGISTRATION_SEEN_ONCHAIN event emission from the block pipeline.
+    if (!session_.mikIdentity.IsNull() &&
+        env_->HasMIKRegistered(session_.mikIdentity)) {
+        lastError_.clear();
+        userActionHint_.clear();
+        EnterState_(State::CONFIRMED);
+        return;
+    }
+
+    // Check that attestations are still fresh. If they're about to expire,
+    // proactively refresh so the next registration block doesn't get rejected.
     if (session_.attestations && !env_->IsAttestationFreshEnough(
             *session_.attestations, env_->NowSeconds())) {
         session_.hasValidAttestations = false;
@@ -538,7 +554,13 @@ void CRegistrationManager::Transition_(Event ev, const std::string& detail) {
             if (state_ == State::READY) EnterState_(State::SUBMITTED);
             break;
         case Event::SUBMIT_TIMEOUT_OR_REJECTED: {
-            if (state_ != State::SUBMITTED) break;
+            // v4.0.18: production flow reaches READY and stays there — we
+            // poll HasMIKRegistered() instead of emitting
+            // TEMPLATE_BUILT_AND_MINER_STARTED + REGISTRATION_SEEN_ONCHAIN.
+            // So this event must also be accepted from READY, otherwise the
+            // submit retry budget is unreachable in practice. SUBMITTED is
+            // still valid for test cases that drive the original flow.
+            if (state_ != State::SUBMITTED && state_ != State::READY) break;
             session_.submitRetries++;
             if (session_.submitRetries >= maxSubmitRetries_) {
                 Transition_(Event::SUBMIT_RETRY_BUDGET_EXHAUSTED);

--- a/src/node/registration_manager.h
+++ b/src/node/registration_manager.h
@@ -320,6 +320,13 @@ public:
      *  logs a reason line. */
     void ForceRestart(const std::string& why);
 
+    /** Called by the block-submission pipeline when a mined registration
+     *  block was rejected by validation. Drives the manager's bounded
+     *  submit-retry budget and falls back to READY or ATTEST_PENDING
+     *  depending on attestation freshness. When the budget is exhausted,
+     *  transitions to LONG_BACKOFF_USER_ACTIONABLE with a diagnostic hint. */
+    void NotifyBlockRejected(const std::string& reason);
+
     // ------------------------------------------------------------------
     // Test hooks — only used by registration_manager_*_tests.cpp
     // ------------------------------------------------------------------

--- a/src/node/registration_manager.h
+++ b/src/node/registration_manager.h
@@ -1,0 +1,503 @@
+// Copyright (c) 2026 The Dilithion Core developers
+// Distributed under the MIT software license
+
+#ifndef DILITHION_NODE_REGISTRATION_MANAGER_H
+#define DILITHION_NODE_REGISTRATION_MANAGER_H
+
+/**
+ * First-time MIK Registration State Machine.
+ *
+ * Owns the complete registration workflow for a new miner:
+ *   1. Collect Digital DNA fingerprint (waits for collector)
+ *   2. Request seed attestations (3-of-4 quorum)
+ *   3. Mine the DNA-bound registration PoW
+ *   4. Persist the solved nonce atomically
+ *   5. Gate vdf_miner.Start() until registration is ready
+ *
+ * Design invariants (these are load-bearing — do not remove):
+ *   - BuildMiningTemplate is a pure function of the published Snapshot.
+ *     It NEVER mines PoW, collects DNA, requests attestations, or mutates state.
+ *   - A single immutable (sessionId, mikPubkey, dnaHash) triple anchors each
+ *     registration attempt. If any input changes, the session is abandoned
+ *     and a fresh one is started. No partial-state reuse.
+ *   - Persistence only ever writes a fully-coherent (pubkey, dnaHash, nonce).
+ *     Zero-DNA saves are refused; zero-DNA files on load are auto-deleted.
+ *   - Tick() is non-blocking. All I/O and PoW happen on an internal worker
+ *     thread. Tick() just publishes fresh inputs and wakes the worker.
+ *
+ * This header is designed for testability via IRegistrationEnv — the state
+ * machine's external dependencies (wallet, identity DB, DNA collector,
+ * attestation RPC, PoW miner, persistence, clock) are all dispatched through
+ * an interface so unit tests can inject deterministic fakes.
+ */
+
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <dfmp/dfmp.h>
+#include <dfmp/mik_registration_file.h>
+#include <attestation/seed_attestation.h>
+
+// ============================================================================
+// Environment interface (production impl wraps the real subsystems;
+// test impl returns deterministic fakes)
+// ============================================================================
+
+class IRegistrationEnv {
+public:
+    virtual ~IRegistrationEnv() = default;
+
+    // ---- Identity / wallet ----
+
+    /** Fetch the miner's MIK public key. Returns false if wallet is locked
+     *  or MIK is not yet generated. */
+    virtual bool GetMIKPubKey(std::vector<uint8_t>& out) = 0;
+
+    /** Fetch the miner's MIK identity (20-byte hash used as DB key). Returns
+     *  false if wallet has no MIK. */
+    virtual bool GetMIKIdentity(DFMP::Identity& out) = 0;
+
+    /** True if this MIK identity is already recorded in the identity DB
+     *  as registered on the current canonical chain. */
+    virtual bool HasMIKRegistered(const DFMP::Identity& identity) const = 0;
+
+    // ---- DNA collection ----
+
+    /** Try to get a complete DNA hash. Returns false if the collector does
+     *  not yet have enough samples (get_dna() returned nullopt). */
+    virtual bool TryGetDNAHash(std::array<uint8_t, 32>& out) = 0;
+
+    // ---- Seed attestations ----
+
+    /** Synchronously request attestations from the configured seed nodes.
+     *  Returns true iff >= MIN_ATTESTATIONS valid signatures were collected.
+     *  errOut is populated on failure (e.g. "seeds unreachable", "datacenter IP"). */
+    virtual bool CollectAttestations(
+        const std::vector<uint8_t>& pubkey,
+        const std::array<uint8_t, 32>& dnaHash,
+        Attestation::CAttestationSet& out,
+        std::string& errOut) = 0;
+
+    /** True if the attestation set is still within the validity window
+     *  (ATTESTATION_VALIDITY_WINDOW - refresh_threshold). */
+    virtual bool IsAttestationFreshEnough(
+        const Attestation::CAttestationSet& attest,
+        int64_t nowSec) const = 0;
+
+    // ---- Registration PoW ----
+
+    /** Mine the registration PoW bound to (pubkey, dnaHash). Must honor the
+     *  running flag (true = keep going, false = abort); long-running call
+     *  (minutes). Signature matches DFMP::MineRegistrationPoW. */
+    virtual bool MineRegistrationPoW(
+        const std::vector<uint8_t>& pubkey,
+        int bits,
+        const std::array<uint8_t, 32>& dnaHash,
+        uint64_t& outNonce,
+        const std::atomic<bool>& running) = 0;
+
+    // ---- Persistence ----
+
+    /** Save a coherent (pubkey, dnaHash, nonce). The real impl calls
+     *  DFMP::SaveMIKRegistration; the manager guarantees dnaHash is non-zero. */
+    virtual bool SaveRegistration(
+        const std::vector<uint8_t>& pubkey,
+        const std::array<uint8_t, 32>& dnaHash,
+        uint64_t nonce,
+        int64_t timestamp) = 0;
+
+    /** Load the persisted registration for this MIK. */
+    virtual DFMP::MIKRegFileLoadResult LoadRegistration(
+        const std::vector<uint8_t>& pubkey,
+        DFMP::MIKRegistrationFile& out) = 0;
+
+    /** Delete any poisoned-file artifact (zero DNA hash etc.) from disk. */
+    virtual void DeletePersistedRegistration() = 0;
+
+    // ---- Chain params ----
+
+    virtual int RegistrationPowBits() const = 0;
+    virtual int DNACommitmentActivationHeight() const = 0;
+    virtual int SeedAttestationActivationHeight() const = 0;
+
+    // ---- Clock (injectable for tests) ----
+
+    virtual int64_t NowSeconds() const = 0;
+};
+
+// ============================================================================
+// RegistrationManager
+// ============================================================================
+
+class CRegistrationManager {
+public:
+    // ------------------------------------------------------------------
+    // States
+    // ------------------------------------------------------------------
+    enum class State : uint8_t {
+        UNINITIALIZED,                    // created, waiting for first Tick
+        CHECK_ELIGIBILITY,                // examining wallet/DB/persisted state
+        DNA_PENDING,                      // waiting for collector to produce a hash
+        ATTEST_PENDING,                   // requesting seed attestations
+        POW_PENDING,                      // mining registration PoW
+        READY,                            // coherent (pubkey, dna, attest, nonce) held
+        SUBMITTED,                        // miner building/mining reg template
+        CONFIRMED,                        // MIK observed as registered on-chain
+        LONG_BACKOFF_USER_ACTIONABLE,     // recoverable error (wallet locked, seeds unreachable)
+        FAILED_FATAL,                     // unrecoverable invariant violation
+        SHUTTING_DOWN,                    // clean-up in progress, no new work
+        STOPPED                           // worker thread has exited
+    };
+
+    // ------------------------------------------------------------------
+    // Events (internal state-machine input)
+    // ------------------------------------------------------------------
+    enum class Event : uint8_t {
+        STARTUP,
+        TIP_UPDATED,
+        SESSION_STARTED,
+        DNA_READY,
+        ATTEST_READY,
+        POW_READY,
+        TEMPLATE_BUILT_AND_MINER_STARTED,
+        REGISTRATION_SEEN_ONCHAIN,
+        REGISTRATION_MISSING_ONCHAIN,      // reorg pulled us back
+        SUBMIT_TIMEOUT_OR_REJECTED,
+        SUBMIT_RETRY_BUDGET_EXHAUSTED,
+        TRANSIENT_ERROR,
+        USER_ACTION_REQUIRED,
+        UNRECOVERABLE_ERROR,
+        SHUTDOWN_REQUESTED,
+        WORKER_STOPPED,
+        FORCE_RESTART
+    };
+
+    // ------------------------------------------------------------------
+    // Reason codes for CanMine() — lets callers log precisely WHY mining
+    // is blocked without parsing state enum.
+    // ------------------------------------------------------------------
+    enum class MineGateReason : uint8_t {
+        OK_REGISTERED,                    // MIK is registered; mine normally
+        OK_REGISTRATION_IN_PROGRESS,      // READY/SUBMITTED — allowed to build reg template
+        BLOCKED_UNINITIALIZED,
+        BLOCKED_DNA_PENDING,
+        BLOCKED_ATTEST_PENDING,
+        BLOCKED_POW_PENDING,
+        BLOCKED_RETRYING_SUBMISSION,
+        BLOCKED_LONG_BACKOFF_USER_ACTIONABLE,
+        BLOCKED_FATAL,
+        BLOCKED_SHUTTING_DOWN
+    };
+
+    // ------------------------------------------------------------------
+    // Session data (mutated only by the worker; copied into Snapshot
+    // under the snapshot mutex).
+    // ------------------------------------------------------------------
+    struct SessionData {
+        uint64_t sessionId = 0;
+        uint32_t startHeight = 0;
+        std::vector<uint8_t> mikPubkey;                              // immutable for session
+        DFMP::Identity mikIdentity;                                  // immutable for session
+        std::array<uint8_t, 32> dnaHash{};                           // immutable after set
+        bool hasDnaHash = false;
+        std::unique_ptr<Attestation::CAttestationSet> attestations;  // may be null
+        bool hasValidAttestations = false;
+        uint64_t regNonce = 0;
+        bool hasRegNonce = false;
+        int submitRetries = 0;
+        int attestationRetries = 0;
+        int dnaPolls = 0;
+    };
+
+    // ------------------------------------------------------------------
+    // Published snapshot — returned by GetSnapshot(), safe to read
+    // concurrently from any thread. Copy-on-publish via atomic shared_ptr.
+    // ------------------------------------------------------------------
+    struct Snapshot {
+        State state = State::UNINITIALIZED;
+        uint64_t sequence = 0;                  // monotonic version counter
+        uint32_t tipHeight = 0;
+        bool registrationRequired = true;       // false once CONFIRMED at this tip
+        bool canBuildRegistrationTemplate = false; // only true in READY/SUBMITTED
+
+        // Session progress (copies, so Snapshot is self-contained)
+        uint64_t sessionId = 0;
+        std::vector<uint8_t> mikPubkey;
+        std::array<uint8_t, 32> dnaHash{};
+        bool hasDnaHash = false;
+        bool hasAttestations = false;
+        uint64_t regNonce = 0;
+        bool hasRegNonce = false;
+        std::unique_ptr<Attestation::CAttestationSet> attestations; // nullptr if !hasAttestations
+
+        int submitRetriesUsed = 0;
+        int submitRetriesMax = 0;
+        std::chrono::system_clock::time_point nextRetryAt{};
+        std::string lastError;
+        std::string userActionHint;
+        MineGateReason mineGate = MineGateReason::BLOCKED_UNINITIALIZED;
+
+        Snapshot() = default;
+        Snapshot(const Snapshot& other) { *this = other; }
+        Snapshot& operator=(const Snapshot& other);
+    };
+
+    // ------------------------------------------------------------------
+    // UI-facing condensed status (for the FTUX log lines)
+    // ------------------------------------------------------------------
+    struct StatusForUI {
+        std::string phase;       // "DNA", "ATTEST", "POW", "READY", "CONFIRMED", ...
+        std::string message;     // concise human-readable status
+        int percent = 0;         // phase-local progress estimate (0-100)
+        int retryUsed = 0;
+        int retryMax = 0;
+        std::string etaText;     // "about 10-20 min"
+        std::string actionHint;  // populated for LONG_BACKOFF_USER_ACTIONABLE only
+    };
+
+public:
+    // ------------------------------------------------------------------
+    // Lifecycle
+    // ------------------------------------------------------------------
+
+    /** Construct with an environment implementation. The env must outlive
+     *  this manager (typically a shared_ptr held by the node). */
+    explicit CRegistrationManager(std::shared_ptr<IRegistrationEnv> env);
+
+    /** Destructor. Joins the worker thread after a clean shutdown. */
+    ~CRegistrationManager();
+
+    // Non-copyable, non-movable (owns a worker thread)
+    CRegistrationManager(const CRegistrationManager&) = delete;
+    CRegistrationManager& operator=(const CRegistrationManager&) = delete;
+
+    // ------------------------------------------------------------------
+    // Driver API — called from the node's main loop and tip callback
+    // ------------------------------------------------------------------
+
+    /** Advance the state machine with the latest chain tip.
+     *  Non-blocking: just publishes inputs and nudges the worker.
+     *  Safe to call concurrently from multiple threads.
+     *
+     *  @param tipHeight    Current canonical chain tip height.
+     *  @param nodeRunning  False if the node is shutting down.
+     */
+    void Tick(uint32_t tipHeight, bool nodeRunning);
+
+    /** Request graceful shutdown and join the worker thread. Idempotent. */
+    void Shutdown();
+
+    // ------------------------------------------------------------------
+    // Read-only query API — callable from any thread, never blocks the worker
+    // ------------------------------------------------------------------
+
+    /** Get the latest published snapshot. Thread-safe. */
+    std::shared_ptr<const Snapshot> GetSnapshot() const;
+
+    /** Decide if mining is currently allowed. If mining is blocked, the
+     *  reason code is returned via the optional out-param so the caller
+     *  can log a concise reason without pattern-matching on State. */
+    bool CanMine(MineGateReason* reasonOut = nullptr) const;
+
+    /** Condensed UI status for logs/RPC. */
+    StatusForUI GetStatusForUI() const;
+
+    // ------------------------------------------------------------------
+    // Debug / test-only
+    // ------------------------------------------------------------------
+
+    /** Force the state machine back to CHECK_ELIGIBILITY, abandoning any
+     *  in-progress session. For tests and emergency operator use only;
+     *  logs a reason line. */
+    void ForceRestart(const std::string& why);
+
+    // ------------------------------------------------------------------
+    // Test hooks — only used by registration_manager_*_tests.cpp
+    // ------------------------------------------------------------------
+
+    /** Drive one worker iteration synchronously (tests only). Returns
+     *  the post-iteration state for assertion. */
+    State TestingStepWorkerOnce();
+
+    /** Inject an event directly (tests only). */
+    void TestingInjectEvent(Event ev, const std::string& detail = {});
+
+private:
+    // ------------------------------------------------------------------
+    // Worker thread lifecycle
+    // ------------------------------------------------------------------
+    void EnsureWorkerStarted_();
+    void RequestShutdown_();
+    void WorkerMain_();
+    void WorkerIterationLocked_(std::unique_lock<std::mutex>& lk);
+
+    // ------------------------------------------------------------------
+    // Event dispatch (worker thread only, holds stateMutex_)
+    // ------------------------------------------------------------------
+    void Transition_(Event ev, const std::string& detail = {});
+    void EnterState_(State s);
+    void PublishSnapshot_();
+
+    // ------------------------------------------------------------------
+    // State handlers (worker thread only)
+    // ------------------------------------------------------------------
+    void HandleCheckEligibility_();
+    void HandleDnaPending_();
+    void HandleAttestPending_();
+    void HandlePowPending_();
+    void HandleReady_();
+    void HandleSubmitted_();
+    void HandleConfirmed_();
+    void HandleLongBackoff_();
+
+    // ------------------------------------------------------------------
+    // Session management
+    // ------------------------------------------------------------------
+    void StartNewSession_(uint32_t tipHeight);
+    void AbandonSession_(const std::string& reason, bool persistNothing);
+    void InvalidateSessionForReorg_();
+    bool ValidateSessionCoherence_() const;
+
+    // ------------------------------------------------------------------
+    // Persistence wrappers (enforce "never zero-DNA" invariants)
+    // ------------------------------------------------------------------
+    bool TryRestorePersistedNonce_();
+    bool PersistSolvedNonceAtomically_();
+    void ClearPersistedNonceIfStale_();
+
+    // ------------------------------------------------------------------
+    // Error / backoff policy
+    // ------------------------------------------------------------------
+    void OnTransientError_(const std::string& err, std::chrono::seconds backoff);
+    void OnUserActionRequired_(const std::string& err,
+                               const std::string& hint,
+                               std::chrono::minutes backoff);
+    void OnFatalError_(const std::string& err);
+
+    // ------------------------------------------------------------------
+    // Config (can be tweaked for tests)
+    // ------------------------------------------------------------------
+    int maxSubmitRetries_ = 3;
+    int maxAttestationRetries_ = 8;
+    std::chrono::seconds dnaPollInterval_{1};
+    std::chrono::seconds attestInitialBackoff_{5};
+    std::chrono::seconds attestMaxBackoff_{60};
+    std::chrono::seconds submitRetryBackoff_{15};
+    std::chrono::minutes userActionBackoff_{10};
+    int64_t attestRefreshThresholdSec_ = 600; // refresh within 10m of expiry
+
+    // ------------------------------------------------------------------
+    // Injected environment
+    // ------------------------------------------------------------------
+    std::shared_ptr<IRegistrationEnv> env_;
+
+    // ------------------------------------------------------------------
+    // Worker thread
+    // ------------------------------------------------------------------
+    std::thread worker_;
+    std::atomic<bool> workerStarted_{false};
+    std::atomic<bool> shutdownRequested_{false};
+    std::atomic<bool> powRunning_{true};   // true = keep PoW running; set false to cancel
+
+    // ------------------------------------------------------------------
+    // Tick-fed context (latest)
+    // ------------------------------------------------------------------
+    std::atomic<uint32_t> latestTipHeight_{0};
+    std::atomic<bool> latestNodeRunning_{true};
+
+    // ------------------------------------------------------------------
+    // Core state (owned by worker; mutated under stateMutex_)
+    // ------------------------------------------------------------------
+    mutable std::mutex stateMutex_;
+    std::condition_variable stateCv_;
+    State state_{State::UNINITIALIZED};
+    SessionData session_;
+    std::chrono::system_clock::time_point nextRetryAt_{};
+    std::string lastError_;
+    std::string userActionHint_;
+    std::chrono::seconds currentAttestBackoff_{0};
+    uint64_t nextSessionId_ = 1;
+
+    // ------------------------------------------------------------------
+    // Published snapshot (atomic shared_ptr for lock-free readers)
+    // ------------------------------------------------------------------
+    mutable std::mutex snapshotMutex_;
+    std::shared_ptr<const Snapshot> publishedSnapshot_;
+    uint64_t snapshotSeq_ = 0;
+};
+
+// ============================================================================
+// Production environment implementation
+// ============================================================================
+
+class CWallet;
+struct NodeContext;
+
+/**
+ * Concrete IRegistrationEnv backed by the live node subsystems.
+ * Takes raw references; assumes the referenced objects outlive this env
+ * (node lifecycle). Constructed once during mining init.
+ */
+class CProductionRegistrationEnv : public IRegistrationEnv {
+public:
+    CProductionRegistrationEnv(CWallet& wallet,
+                               NodeContext& nodeContext,
+                               const std::string& datadir,
+                               int registrationPowBits,
+                               int dnaCommitmentActivationHeight,
+                               int seedAttestationActivationHeight);
+
+    // IRegistrationEnv
+    bool GetMIKPubKey(std::vector<uint8_t>& out) override;
+    bool GetMIKIdentity(DFMP::Identity& out) override;
+    bool HasMIKRegistered(const DFMP::Identity& identity) const override;
+    bool TryGetDNAHash(std::array<uint8_t, 32>& out) override;
+    bool CollectAttestations(const std::vector<uint8_t>& pubkey,
+                             const std::array<uint8_t, 32>& dnaHash,
+                             Attestation::CAttestationSet& out,
+                             std::string& errOut) override;
+    bool IsAttestationFreshEnough(const Attestation::CAttestationSet& attest,
+                                  int64_t nowSec) const override;
+    bool MineRegistrationPoW(const std::vector<uint8_t>& pubkey,
+                             int bits,
+                             const std::array<uint8_t, 32>& dnaHash,
+                             uint64_t& outNonce,
+                             const std::atomic<bool>& running) override;
+    bool SaveRegistration(const std::vector<uint8_t>& pubkey,
+                          const std::array<uint8_t, 32>& dnaHash,
+                          uint64_t nonce,
+                          int64_t timestamp) override;
+    DFMP::MIKRegFileLoadResult LoadRegistration(const std::vector<uint8_t>& pubkey,
+                                                DFMP::MIKRegistrationFile& out) override;
+    void DeletePersistedRegistration() override;
+    int RegistrationPowBits() const override { return registrationPowBits_; }
+    int DNACommitmentActivationHeight() const override { return dnaCommitmentActivationHeight_; }
+    int SeedAttestationActivationHeight() const override { return seedAttestationActivationHeight_; }
+    int64_t NowSeconds() const override;
+
+private:
+    CWallet& wallet_;
+    NodeContext& nodeContext_;
+    std::string datadir_;
+    int registrationPowBits_;
+    int dnaCommitmentActivationHeight_;
+    int seedAttestationActivationHeight_;
+};
+
+// ============================================================================
+// Helpers (also useful in RPC / debug output)
+// ============================================================================
+
+const char* StateToString(CRegistrationManager::State s);
+const char* MineGateReasonToString(CRegistrationManager::MineGateReason r);
+
+#endif // DILITHION_NODE_REGISTRATION_MANAGER_H

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -4,6 +4,7 @@
 #include <rpc/server.h>
 #include <rpc/auth.h>
 #include <node/block_processing.h>  // BanMIK/UnbanMIK/ListBannedMIKs
+#include <node/registration_manager.h>  // v4.0.18: CRegistrationManager snapshot accessor
 #include <net/sock.h>
 #include <net/dns.h>
 #include <core/version.h>
@@ -86,20 +87,14 @@ struct NodeState {
 };
 extern NodeState g_node_state;
 
-// BUG #278 FIX: Access cached MIK registration PoW nonce from dilithion-node.cpp
-// Prevents RPC_StartMining from re-mining PoW when it's already cached or in progress
-extern uint64_t g_regCachedNonce;
-extern std::atomic<bool> g_regNonceMined;
-extern std::atomic<bool> g_regPowInProgress;
-extern DFMP::Identity g_regNonceIdentity;
+// v4.0.18: MIK registration is owned by CRegistrationManager. RPC handlers
+// that previously called g_regNonceMined / g_cachedDnaHash etc. now reach the
+// live manager via this accessor (set in main() by dilithion-node / dilv-node).
+class CRegistrationManager;
+CRegistrationManager* GetRegistrationManager();
 
 // Data directory for persisting registration PoW (defined in globals.cpp).
 extern std::string g_datadir;
-
-// Cached DNA hash for registration — defined in globals.cpp
-// Needed so RPC startmining can bind DNA hash to registration PoW.
-extern std::array<uint8_t, 32> g_cachedDnaHash;
-extern std::atomic<bool> g_dnaHashCached;
 
 #ifdef _WIN32
     #include <winsock2.h>
@@ -4541,62 +4536,51 @@ std::string CRPCServer::RPC_StartMining(const std::string& params) {
 
         std::cout << "[RPC] MIK not registered - will include full pubkey in coinbase" << std::endl;
 
-        // DFMP v3.0: Registration PoW nonce (required at/above v3 activation height)
-        // BUG #278 FIX: Check cached nonce first (from EnsureMIKRegistered or BuildMiningTemplate)
-        // to avoid re-mining and blocking the RPC handler for 10-15 minutes
+        // DFMP v3.0: Registration PoW nonce (required at/above v3 activation height).
+        // v4.0.18: RPC handler now delegates to the live CRegistrationManager instead
+        // of mining inline. This keeps a single source of truth for registration state
+        // (no double-PoW between miner loop and RPC handler) and inherits the manager's
+        // race-safe DNA/attestation/PoW sequencing.
         int dfmpV3Height = Dilithion::g_chainParams ?
             Dilithion::g_chainParams->dfmpV3ActivationHeight : 0;
         if (static_cast<int>(nHeight) >= dfmpV3Height) {
-            uint64_t regNonce = 0;
-            if (g_regNonceMined.load() && g_regNonceIdentity == mikData.identity) {
-                // Cached from startup path — use immediately
-                regNonce = g_regCachedNonce;
-                std::cout << "[RPC] Using cached registration PoW nonce" << std::endl;
-            } else if (g_regPowInProgress.load()) {
-                // Another thread is mining — wait for it
-                std::cout << "[RPC] Registration PoW in progress, waiting for completion..." << std::endl;
-                int wait_sec = 0;
-                while (g_regPowInProgress.load() && g_node_state.running.load()) {
-                    std::this_thread::sleep_for(std::chrono::seconds(1));
-                    wait_sec++;
-                    if (wait_sec % 30 == 0) {
-                        std::cout << "[RPC] Still waiting for registration PoW... (" << wait_sec << "s)" << std::endl;
-                    }
-                    if (wait_sec > 1200) {
-                        throw std::runtime_error("Registration PoW timeout (20 min)");
-                    }
-                }
-                if (g_regNonceMined.load() && g_regNonceIdentity == mikData.identity) {
-                    regNonce = g_regCachedNonce;
-                    std::cout << "[RPC] Registration PoW completed!" << std::endl;
-                } else {
-                    throw std::runtime_error("Registration PoW failed on other thread");
-                }
-            } else {
-                // Not cached and not in progress — mine it ourselves
-                std::cout << "[RPC] Mining registration PoW (one-time, ~10-15 minutes)..." << std::endl;
-                g_regPowInProgress.store(true);
-                int rpBits = Dilithion::g_chainParams ? Dilithion::g_chainParams->registrationPowBits : DFMP::REGISTRATION_POW_BITS;
-                const std::array<uint8_t, 32>* dnaForPow = g_dnaHashCached.load() ? &g_cachedDnaHash : nullptr;
-                if (DFMP::MineRegistrationPoW(mikData.pubkey, rpBits, regNonce, &g_node_state.running, dnaForPow)) {
-                    g_regCachedNonce = regNonce;
-                    g_regNonceIdentity = mikData.identity;
-                    g_regNonceMined.store(true);
-                    g_regPowInProgress.store(false);
-                    // Persist to mik_registration.dat so a restart doesn't waste the PoW.
-                    if (!g_datadir.empty()) {
-                        std::array<uint8_t, 32> dnaHash{};
-                        if (g_dnaHashCached.load()) dnaHash = g_cachedDnaHash;
-                        int64_t now = static_cast<int64_t>(std::time(nullptr));
-                        DFMP::SaveMIKRegistration(g_datadir, mikData.pubkey, dnaHash, regNonce, now);
-                    }
-                    std::cout << "[RPC] Registration PoW complete!" << std::endl;
-                } else {
-                    g_regPowInProgress.store(false);
-                    throw std::runtime_error("Failed to mine registration PoW nonce");
-                }
+            auto* mgr = GetRegistrationManager();
+            if (!mgr) {
+                throw std::runtime_error("Registration manager not initialized");
             }
-            mikData.registrationNonce = regNonce;
+
+            // Poll the manager until it reaches a state that has a valid nonce
+            // (READY / SUBMITTED / CONFIRMED). The manager's worker thread does
+            // the actual DNA + attestation + PoW work; we just wait.
+            using State = CRegistrationManager::State;
+            int wait_sec = 0;
+            while (g_node_state.running.load()) {
+                auto snap = mgr->GetSnapshot();
+                if (snap->hasRegNonce && snap->mikPubkey == mikData.pubkey) {
+                    mikData.registrationNonce = snap->regNonce;
+                    std::cout << "[RPC] Registration PoW ready (nonce from manager snapshot)" << std::endl;
+                    break;
+                }
+                if (snap->state == State::FAILED_FATAL) {
+                    throw std::runtime_error("Registration failed: " + snap->lastError);
+                }
+                if (snap->state == State::LONG_BACKOFF_USER_ACTIONABLE) {
+                    throw std::runtime_error("Registration blocked: " + snap->lastError);
+                }
+                if (wait_sec > 1800) {
+                    throw std::runtime_error("Registration PoW timeout (30 min)");
+                }
+                if (wait_sec % 30 == 0) {
+                    auto status = mgr->GetStatusForUI();
+                    std::cout << "[RPC] Waiting for registration (" << status.phase
+                              << " — " << status.message << ")" << std::endl;
+                }
+                std::this_thread::sleep_for(std::chrono::seconds(1));
+                wait_sec++;
+            }
+            if (!g_node_state.running.load()) {
+                throw std::runtime_error("Node shutting down during registration");
+            }
         }
     }
 

--- a/src/test/registration_manager_tests.cpp
+++ b/src/test/registration_manager_tests.cpp
@@ -1,0 +1,670 @@
+// Copyright (c) 2026 The Dilithion Core developers
+// Distributed under the MIT software license
+
+/**
+ * CRegistrationManager unit tests.
+ *
+ * Covers the 14 cases from the Registration Manager Test Plan:
+ *   1. Reorg handling (CONFIRMED -> CHECK_ELIGIBILITY)
+ *   2. SUBMITTED bounded retry (-> READY / -> ATTEST_PENDING)
+ *   3. SUBMITTED retry exhaustion (-> LONG_BACKOFF_USER_ACTIONABLE)
+ *   4. Shutdown from DNA_PENDING (no partial persistence)
+ *   5. Shutdown from ATTEST_PENDING (no partial persistence)
+ *   6. Shutdown from POW_PENDING (cancel long PoW, no partial persistence)
+ *   7. Poisoned file rejection (zero-DNA variant — the one we actually see in prod)
+ *   8. Tick non-blocking contract
+ *   9. Worker owns side effects (all I/O on worker thread)
+ *  10. Session coherence (DNA changes -> invalidate nonce + attestations)
+ *  11. ForceRestart debug behavior
+ *  12. CanMine gate correctness matrix
+ *  13. Snapshot monotonicity + consistency
+ *  14. Long-backoff recovery (time elapses -> CHECK_ELIGIBILITY)
+ *
+ * All tests drive the state machine synchronously via TestingStepWorkerOnce()
+ * — no real worker thread is started, which makes every test deterministic.
+ * The handful of tests that require an actual worker thread (shutdown,
+ * non-blocking Tick, worker-owns-I/O) start it explicitly.
+ */
+
+#include <node/registration_manager.h>
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <exception>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <dfmp/dfmp.h>
+#include <dfmp/mik_registration_file.h>
+#include <attestation/seed_attestation.h>
+
+// ---------------------------------------------------------------------------
+// Test framework (matches project convention — see mik_registration_persistence_tests.cpp)
+// ---------------------------------------------------------------------------
+
+#define RESET   "\033[0m"
+#define GREEN   "\033[32m"
+#define RED     "\033[31m"
+#define YELLOW  "\033[33m"
+#define BLUE    "\033[34m"
+
+static int g_tests_passed = 0;
+static int g_tests_failed = 0;
+static std::vector<std::function<void()>> g_test_fns;
+
+#define TEST(name) \
+    static void test_##name(); \
+    struct Reg_##name { \
+        Reg_##name() { g_test_fns.push_back([]{ \
+            std::cout << BLUE << "[TEST] " << #name << RESET << std::endl; \
+            try { \
+                test_##name(); \
+                std::cout << GREEN << "  PASSED" << RESET << std::endl; \
+                g_tests_passed++; \
+            } catch (const std::exception& e) { \
+                std::cout << RED << "  FAILED: " << e.what() << RESET << std::endl; \
+                g_tests_failed++; \
+            } catch (...) { \
+                std::cout << RED << "  FAILED: unknown exception" << RESET << std::endl; \
+                g_tests_failed++; \
+            } \
+        }); } \
+    }; \
+    static Reg_##name g_reg_##name; \
+    static void test_##name()
+
+#define ASSERT(cond, msg) \
+    do { if (!(cond)) throw std::runtime_error(std::string(__FILE__) + ":" + \
+         std::to_string(__LINE__) + " " + (msg)); } while (0)
+
+#define ASSERT_EQ(a, b, msg) \
+    do { if ((a) != (b)) throw std::runtime_error( \
+         std::string(__FILE__) + ":" + std::to_string(__LINE__) + " " + (msg) + \
+         " (got vs expected differ)"); } while (0)
+
+#define ASSERT_STATE(mgr, expected) \
+    do { auto __s = (mgr).GetSnapshot(); \
+         if (__s->state != CRegistrationManager::State::expected) { \
+             throw std::runtime_error(std::string(__FILE__) + ":" + \
+                 std::to_string(__LINE__) + " expected state " #expected \
+                 ", got " + StateToString(__s->state)); } \
+    } while (0)
+
+// ---------------------------------------------------------------------------
+// MockRegistrationEnv: a configurable IRegistrationEnv for unit tests.
+//
+// All behavior is controlled by public member fields; tests mutate the mock
+// directly. Every external call is recorded (call count + calling thread id)
+// so tests can assert on side effects and threading.
+// ---------------------------------------------------------------------------
+
+class MockRegistrationEnv : public IRegistrationEnv {
+public:
+    // ---- Identity / wallet ----
+    std::optional<std::vector<uint8_t>> mikPubkey;  // nullopt => GetMIKPubKey fails
+    std::optional<DFMP::Identity> mikIdentity;      // nullopt => GetMIKIdentity fails
+    std::set<std::vector<uint8_t>> registeredIdentities;  // encoded as 20-byte vectors
+
+    // ---- DNA ----
+    std::optional<std::array<uint8_t, 32>> dnaHashToReturn;
+    std::atomic<int> tryGetDNAHashCalls{0};
+
+    // ---- Attestations ----
+    bool attestationSucceeds = true;
+    std::string attestationError;
+    Attestation::CAttestationSet attestationToReturn;
+    bool attestationIsFresh = true;
+    std::atomic<int> collectAttestationCalls{0};
+
+    // ---- PoW ----
+    bool powSucceeds = true;
+    uint64_t powNonceToReturn = 42;
+    std::chrono::milliseconds powDuration{0};   // simulated blocking duration
+    std::atomic<int> powCallCount{0};
+    std::atomic<bool> powWasCancelled{false};
+    std::atomic<std::thread::id> lastPowCallerThread;
+
+    // ---- Persistence ----
+    std::optional<DFMP::MIKRegistrationFile> persistedFile;
+    std::atomic<int> saveCalls{0};
+    std::atomic<int> deleteCalls{0};
+    std::atomic<int> loadCalls{0};
+
+    // ---- Chain params ----
+    int regPowBits = 4;  // deliberately tiny for speed; PoW path is exercised via duration
+    int dnaActivation = 0;
+    int attestActivation = 2000;
+
+    // ---- Clock ----
+    std::atomic<int64_t> fakeNowSec{1700000000};
+
+    // ---- Threading observability ----
+    std::atomic<std::thread::id> lastAnyCallThread;
+
+    // --------------------------------------------------------------
+    // IRegistrationEnv impl
+    // --------------------------------------------------------------
+
+    bool GetMIKPubKey(std::vector<uint8_t>& out) override {
+        lastAnyCallThread = std::this_thread::get_id();
+        if (!mikPubkey) return false;
+        out = *mikPubkey;
+        return true;
+    }
+
+    bool GetMIKIdentity(DFMP::Identity& out) override {
+        lastAnyCallThread = std::this_thread::get_id();
+        if (!mikIdentity) return false;
+        out = *mikIdentity;
+        return !out.IsNull();
+    }
+
+    bool HasMIKRegistered(const DFMP::Identity& identity) const override {
+        std::vector<uint8_t> key(identity.data, identity.data + 20);
+        return registeredIdentities.count(key) > 0;
+    }
+
+    bool TryGetDNAHash(std::array<uint8_t, 32>& out) override {
+        lastAnyCallThread = std::this_thread::get_id();
+        tryGetDNAHashCalls++;
+        if (!dnaHashToReturn) return false;
+        out = *dnaHashToReturn;
+        return true;
+    }
+
+    bool CollectAttestations(const std::vector<uint8_t>& /*pubkey*/,
+                             const std::array<uint8_t, 32>& /*dnaHash*/,
+                             Attestation::CAttestationSet& out,
+                             std::string& errOut) override {
+        lastAnyCallThread = std::this_thread::get_id();
+        collectAttestationCalls++;
+        if (!attestationSucceeds) {
+            errOut = attestationError;
+            return false;
+        }
+        out = attestationToReturn;
+        return true;
+    }
+
+    bool IsAttestationFreshEnough(const Attestation::CAttestationSet& /*attest*/,
+                                  int64_t /*nowSec*/) const override {
+        return attestationIsFresh;
+    }
+
+    bool MineRegistrationPoW(const std::vector<uint8_t>& /*pubkey*/,
+                             int /*bits*/,
+                             const std::array<uint8_t, 32>& /*dnaHash*/,
+                             uint64_t& outNonce,
+                             const std::atomic<bool>& running) override {
+        lastAnyCallThread = std::this_thread::get_id();
+        lastPowCallerThread = std::this_thread::get_id();
+        powCallCount++;
+        // Simulate a long-running PoW that honors the cancel signal.
+        auto deadline = std::chrono::steady_clock::now() + powDuration;
+        while (std::chrono::steady_clock::now() < deadline) {
+            if (!running.load()) {
+                powWasCancelled = true;
+                return false;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        }
+        if (!running.load()) {
+            powWasCancelled = true;
+            return false;
+        }
+        if (!powSucceeds) return false;
+        outNonce = powNonceToReturn;
+        return true;
+    }
+
+    bool SaveRegistration(const std::vector<uint8_t>& pubkey,
+                          const std::array<uint8_t, 32>& dnaHash,
+                          uint64_t nonce,
+                          int64_t timestamp) override {
+        lastAnyCallThread = std::this_thread::get_id();
+        saveCalls++;
+        DFMP::MIKRegistrationFile rec;
+        rec.pubkey = pubkey;
+        rec.dnaHash = dnaHash;
+        rec.nonce = nonce;
+        rec.timestamp = timestamp;
+        persistedFile = rec;
+        return true;
+    }
+
+    DFMP::MIKRegFileLoadResult LoadRegistration(const std::vector<uint8_t>& pubkey,
+                                                DFMP::MIKRegistrationFile& out) override {
+        loadCalls++;
+        if (!persistedFile) return DFMP::MIKRegFileLoadResult::Missing;
+        if (persistedFile->pubkey != pubkey)
+            return DFMP::MIKRegFileLoadResult::PubkeyMismatch;
+        out = *persistedFile;
+        return DFMP::MIKRegFileLoadResult::OK;
+    }
+
+    void DeletePersistedRegistration() override {
+        lastAnyCallThread = std::this_thread::get_id();
+        deleteCalls++;
+        persistedFile.reset();
+    }
+
+    int RegistrationPowBits() const override { return regPowBits; }
+    int DNACommitmentActivationHeight() const override { return dnaActivation; }
+    int SeedAttestationActivationHeight() const override { return attestActivation; }
+    int64_t NowSeconds() const override { return fakeNowSec.load(); }
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+static std::vector<uint8_t> FakePubkey(uint8_t seed = 0x11) {
+    std::vector<uint8_t> pk(DFMP::MIK_PUBKEY_SIZE, seed);
+    for (size_t i = 0; i < pk.size(); ++i) pk[i] = static_cast<uint8_t>((i + seed) & 0xFF);
+    return pk;
+}
+
+static DFMP::Identity FakeIdentity(uint8_t seed = 0x11) {
+    DFMP::Identity id;
+    for (int i = 0; i < 20; ++i) id.data[i] = static_cast<uint8_t>((i + seed) & 0xFF);
+    return id;
+}
+
+static std::array<uint8_t, 32> FakeDnaHash(uint8_t seed = 0x22) {
+    std::array<uint8_t, 32> h{};
+    for (size_t i = 0; i < 32; ++i) h[i] = static_cast<uint8_t>((i + seed) & 0xFF);
+    return h;
+}
+
+static Attestation::CAttestationSet FakeAttestationSet() {
+    Attestation::CAttestationSet set;
+    // Populate MIN_ATTESTATIONS (3) fake entries so HasMinimum() is true.
+    for (int i = 0; i < Attestation::MIN_ATTESTATIONS; ++i) {
+        Attestation::CAttestation a;
+        a.seedId = static_cast<uint8_t>(i);
+        a.timestamp = 1700000000;
+        a.signature.assign(DFMP::MIK_SIGNATURE_SIZE, static_cast<uint8_t>(0xAA + i));
+        set.attestations.push_back(a);
+    }
+    return set;
+}
+
+/** Standard "happy path" mock env: all calls succeed. */
+static std::shared_ptr<MockRegistrationEnv> MakeHappyEnv() {
+    auto env = std::make_shared<MockRegistrationEnv>();
+    env->mikPubkey = FakePubkey();
+    env->mikIdentity = FakeIdentity();
+    env->dnaHashToReturn = FakeDnaHash();
+    env->attestationToReturn = FakeAttestationSet();
+    return env;
+}
+
+/** Drive the state machine forward until the state stabilizes OR max steps. */
+static void StepUntilState(CRegistrationManager& mgr,
+                           CRegistrationManager::State target,
+                           int maxSteps = 20) {
+    for (int i = 0; i < maxSteps; ++i) {
+        mgr.TestingStepWorkerOnce();
+        if (mgr.GetSnapshot()->state == target) return;
+    }
+    throw std::runtime_error(std::string("did not reach state ") +
+                             StateToString(target) + " after " +
+                             std::to_string(maxSteps) + " steps (final state: " +
+                             StateToString(mgr.GetSnapshot()->state) + ")");
+}
+
+// ===========================================================================
+// TEST CASES
+// ===========================================================================
+
+// ---- 1. Reorg handling: CONFIRMED -> CHECK_ELIGIBILITY -------------------
+
+TEST(reorg_confirmed_to_check_eligibility) {
+    auto env = MakeHappyEnv();
+    // MIK already registered on chain
+    env->registeredIdentities.insert({env->mikIdentity->data,
+                                       env->mikIdentity->data + 20});
+
+    CRegistrationManager mgr(env);
+    mgr.TestingStepWorkerOnce();
+    ASSERT_STATE(mgr, CONFIRMED);
+
+    // Simulate reorg: identity no longer in DB.
+    env->registeredIdentities.clear();
+
+    // Next worker iteration from CONFIRMED detects the drop.
+    mgr.TestingStepWorkerOnce();
+    auto s = mgr.GetSnapshot();
+    ASSERT(s->state == CRegistrationManager::State::CHECK_ELIGIBILITY ||
+           s->state == CRegistrationManager::State::DNA_PENDING,
+           "expected CHECK_ELIGIBILITY or DNA_PENDING after reorg");
+    ASSERT(s->registrationRequired, "registrationRequired should be true after reorg");
+}
+
+// ---- 2. SUBMITTED bounded retry -------------------------------------------
+
+TEST(submitted_retry_to_ready_when_attestations_fresh) {
+    auto env = MakeHappyEnv();
+    CRegistrationManager mgr(env);
+    // Advance to READY.
+    StepUntilState(mgr, CRegistrationManager::State::READY, 10);
+
+    // Simulate the miner building a registration template and submitting.
+    mgr.TestingInjectEvent(CRegistrationManager::Event::TEMPLATE_BUILT_AND_MINER_STARTED);
+    ASSERT_STATE(mgr, SUBMITTED);
+
+    // Submission rejected, attestations still fresh.
+    env->attestationIsFresh = true;
+    mgr.TestingInjectEvent(CRegistrationManager::Event::SUBMIT_TIMEOUT_OR_REJECTED);
+    ASSERT_STATE(mgr, READY);
+    ASSERT_EQ(mgr.GetSnapshot()->submitRetriesUsed, 1, "retry counter not incremented");
+}
+
+TEST(submitted_retry_to_attest_pending_when_attestations_stale) {
+    auto env = MakeHappyEnv();
+    CRegistrationManager mgr(env);
+    StepUntilState(mgr, CRegistrationManager::State::READY, 10);
+    mgr.TestingInjectEvent(CRegistrationManager::Event::TEMPLATE_BUILT_AND_MINER_STARTED);
+    ASSERT_STATE(mgr, SUBMITTED);
+
+    // Submission rejected, attestations expired.
+    env->attestationIsFresh = false;
+    mgr.TestingInjectEvent(CRegistrationManager::Event::SUBMIT_TIMEOUT_OR_REJECTED);
+    ASSERT_STATE(mgr, ATTEST_PENDING);
+}
+
+// ---- 3. SUBMITTED retry exhaustion -> LONG_BACKOFF_USER_ACTIONABLE --------
+
+TEST(submitted_retry_exhaustion_to_long_backoff) {
+    auto env = MakeHappyEnv();
+    CRegistrationManager mgr(env);
+    StepUntilState(mgr, CRegistrationManager::State::READY, 10);
+
+    // Exhaust the retry budget.
+    for (int i = 0; i < 3; ++i) {
+        mgr.TestingInjectEvent(CRegistrationManager::Event::TEMPLATE_BUILT_AND_MINER_STARTED);
+        env->attestationIsFresh = true;
+        mgr.TestingInjectEvent(CRegistrationManager::Event::SUBMIT_TIMEOUT_OR_REJECTED);
+    }
+    // Third reject should have exhausted budget -> LONG_BACKOFF.
+    auto s = mgr.GetSnapshot();
+    ASSERT(s->state == CRegistrationManager::State::LONG_BACKOFF_USER_ACTIONABLE,
+           "expected LONG_BACKOFF after 3 retries");
+    ASSERT(!s->userActionHint.empty(), "userActionHint should be populated");
+}
+
+// ---- 4-6. Shutdown from pending states (no partial persistence) ----------
+
+TEST(shutdown_from_dna_pending_no_persist) {
+    auto env = MakeHappyEnv();
+    env->dnaHashToReturn.reset();  // DNA never ready
+    CRegistrationManager mgr(env);
+    StepUntilState(mgr, CRegistrationManager::State::DNA_PENDING, 10);
+
+    mgr.Shutdown();
+    ASSERT_EQ(env->saveCalls.load(), 0, "no save should happen on shutdown from DNA_PENDING");
+    ASSERT(!env->persistedFile.has_value(), "no persistence artifact expected");
+}
+
+TEST(shutdown_from_attest_pending_no_persist) {
+    auto env = MakeHappyEnv();
+    env->attestationSucceeds = false;
+    env->attestationError = "seeds unreachable";
+    CRegistrationManager mgr(env);
+    // Drive to ATTEST_PENDING (may bounce through a transient-error state).
+    for (int i = 0; i < 10; ++i) mgr.TestingStepWorkerOnce();
+
+    mgr.Shutdown();
+    ASSERT_EQ(env->saveCalls.load(), 0, "no save should happen on shutdown from ATTEST_PENDING");
+}
+
+TEST(shutdown_from_pow_pending_cancels_and_no_persist) {
+    auto env = MakeHappyEnv();
+    // Make PoW take long enough that Shutdown() catches it mid-flight.
+    env->powDuration = std::chrono::milliseconds(500);
+
+    auto mgr = std::make_unique<CRegistrationManager>(env);
+    mgr->Tick(/*tipHeight=*/41000, /*nodeRunning=*/true);
+
+    // Wait until PoW is actually in flight.
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(3);
+    while (env->powCallCount.load() == 0 &&
+           std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    ASSERT(env->powCallCount.load() >= 1, "PoW should have started");
+
+    // Request shutdown while PoW is running.
+    mgr->Shutdown();
+    ASSERT(env->powWasCancelled.load(), "PoW should have been cancelled by running=false");
+    ASSERT_EQ(env->saveCalls.load(), 0, "no save should happen when PoW cancelled mid-flight");
+}
+
+// ---- 7. Poisoned file rejection on startup -------------------------------
+
+TEST(poisoned_file_rejected_on_startup) {
+    auto env = MakeHappyEnv();
+    // Pre-populate a poisoned (zero-DNA) persisted file.
+    DFMP::MIKRegistrationFile poisoned;
+    poisoned.pubkey = *env->mikPubkey;
+    poisoned.dnaHash = {};  // all zeros
+    poisoned.nonce = 0xDEADBEEF;
+    poisoned.timestamp = 1700000000;
+    env->persistedFile = poisoned;
+
+    CRegistrationManager mgr(env);
+    mgr.TestingStepWorkerOnce();
+
+    // Poisoned file should be detected and deleted; manager proceeds with fresh DNA.
+    ASSERT_EQ(env->deleteCalls.load(), 1, "poisoned file should be deleted");
+    ASSERT(!env->persistedFile.has_value(), "persisted file should be gone after delete");
+    auto s = mgr.GetSnapshot();
+    // The nonce from the poisoned file must NOT have been accepted.
+    ASSERT(!s->hasRegNonce || s->regNonce != 0xDEADBEEF,
+           "poisoned nonce must not be accepted");
+}
+
+// ---- 8. Tick non-blocking contract ---------------------------------------
+
+TEST(tick_non_blocking) {
+    auto env = MakeHappyEnv();
+    env->powDuration = std::chrono::milliseconds(300);  // slow-ish PoW
+
+    CRegistrationManager mgr(env);
+    // Kick the worker thread.
+    mgr.Tick(/*tipHeight=*/41000, /*nodeRunning=*/true);
+
+    // Now call Tick() repeatedly under stopwatch.
+    const int N = 50;
+    auto t0 = std::chrono::steady_clock::now();
+    for (int i = 0; i < N; ++i) mgr.Tick(41000 + i, true);
+    auto t1 = std::chrono::steady_clock::now();
+    auto avgUs = std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count() / N;
+
+    // Each Tick should take well under the PoW duration. Generous bound: 10ms avg.
+    ASSERT(avgUs < 10000, std::string("Tick() avg=") + std::to_string(avgUs) +
+                           "us should be <10000us (non-blocking)");
+    mgr.Shutdown();
+}
+
+// ---- 9. Worker owns side effects ------------------------------------------
+
+TEST(worker_owns_side_effects) {
+    auto env = MakeHappyEnv();
+    env->powDuration = std::chrono::milliseconds(50);
+    auto testThreadId = std::this_thread::get_id();
+
+    CRegistrationManager mgr(env);
+    mgr.Tick(41000, true);
+
+    // Wait for PoW to fire.
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(3);
+    while (env->powCallCount.load() == 0 &&
+           std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    ASSERT(env->powCallCount.load() >= 1, "PoW should have been called");
+    ASSERT(env->lastPowCallerThread.load() != testThreadId,
+           "PoW must not be called from the test thread");
+    mgr.Shutdown();
+}
+
+// ---- 10. Session coherence (ForceRestart clears session) ------------------
+
+TEST(session_coherence_force_restart_invalidates_nonce) {
+    auto env = MakeHappyEnv();
+    CRegistrationManager mgr(env);
+    StepUntilState(mgr, CRegistrationManager::State::READY, 10);
+    ASSERT(mgr.GetSnapshot()->hasRegNonce, "nonce should be set in READY");
+    uint64_t sessionA = mgr.GetSnapshot()->sessionId;
+
+    // Force a restart; session should be reset.
+    mgr.ForceRestart("test-trigger");
+    auto s = mgr.GetSnapshot();
+    ASSERT_STATE(mgr, CHECK_ELIGIBILITY);
+    ASSERT(!s->hasRegNonce, "nonce should be cleared after ForceRestart");
+    // A fresh session should be started on the next step, with a new id.
+    mgr.TestingStepWorkerOnce();
+    uint64_t sessionB = mgr.GetSnapshot()->sessionId;
+    ASSERT(sessionB != sessionA, "new session id expected after ForceRestart");
+}
+
+// ---- 11. ForceRestart debug behavior (terminal state recovery) ------------
+
+TEST(force_restart_from_fatal_recovers) {
+    auto env = MakeHappyEnv();
+    CRegistrationManager mgr(env);
+    mgr.TestingInjectEvent(CRegistrationManager::Event::UNRECOVERABLE_ERROR,
+                           "synthetic fatal");
+    ASSERT_STATE(mgr, FAILED_FATAL);
+
+    mgr.ForceRestart("recovery");
+    ASSERT_STATE(mgr, CHECK_ELIGIBILITY);
+}
+
+// ---- 12. CanMine gate correctness matrix ---------------------------------
+
+TEST(canmine_matrix) {
+    using S = CRegistrationManager::State;
+    using R = CRegistrationManager::MineGateReason;
+
+    auto env = MakeHappyEnv();
+
+    // CONFIRMED -> mining allowed (OK_REGISTERED).
+    {
+        auto e = MakeHappyEnv();
+        e->registeredIdentities.insert({e->mikIdentity->data,
+                                         e->mikIdentity->data + 20});
+        CRegistrationManager mgr(e);
+        mgr.TestingStepWorkerOnce();
+        R reason;
+        ASSERT(mgr.CanMine(&reason), "CanMine should be true when CONFIRMED");
+        ASSERT(reason == R::OK_REGISTERED, "reason should be OK_REGISTERED");
+    }
+    // READY -> mining allowed (OK_REGISTRATION_IN_PROGRESS).
+    {
+        auto e = MakeHappyEnv();
+        CRegistrationManager mgr(e);
+        StepUntilState(mgr, S::READY, 10);
+        R reason;
+        ASSERT(mgr.CanMine(&reason), "CanMine true in READY");
+        ASSERT(reason == R::OK_REGISTRATION_IN_PROGRESS, "reason should be OK_IN_PROGRESS");
+    }
+    // DNA_PENDING -> blocked.
+    {
+        auto e = MakeHappyEnv();
+        e->dnaHashToReturn.reset();
+        CRegistrationManager mgr(e);
+        mgr.TestingStepWorkerOnce();  // UNINITIALIZED -> HandleCheckEligibility -> DNA_PENDING
+        R reason;
+        ASSERT(!mgr.CanMine(&reason), "CanMine false in DNA_PENDING");
+        ASSERT(reason == R::BLOCKED_DNA_PENDING, "reason should be BLOCKED_DNA_PENDING");
+    }
+    // FAILED_FATAL -> blocked.
+    {
+        auto e = MakeHappyEnv();
+        CRegistrationManager mgr(e);
+        mgr.TestingInjectEvent(CRegistrationManager::Event::UNRECOVERABLE_ERROR, "x");
+        R reason;
+        ASSERT(!mgr.CanMine(&reason), "CanMine false in FAILED_FATAL");
+        ASSERT(reason == R::BLOCKED_FATAL, "reason should be BLOCKED_FATAL");
+    }
+}
+
+// ---- 13. Snapshot monotonicity + consistency -----------------------------
+
+TEST(snapshot_monotonic_and_consistent) {
+    auto env = MakeHappyEnv();
+    CRegistrationManager mgr(env);
+
+    uint64_t lastSeq = 0;
+    for (int i = 0; i < 5; ++i) {
+        mgr.TestingStepWorkerOnce();
+        auto s = mgr.GetSnapshot();
+        ASSERT(s->sequence > lastSeq, "snapshot sequence must be strictly monotonic");
+        lastSeq = s->sequence;
+
+        // Consistency: hasRegNonce implies sessionId non-zero.
+        if (s->hasRegNonce) {
+            ASSERT(s->sessionId != 0, "hasRegNonce without sessionId is inconsistent");
+        }
+        // hasDnaHash implies we have a MIK pubkey.
+        if (s->hasDnaHash) {
+            ASSERT(!s->mikPubkey.empty(), "hasDnaHash without mikPubkey is inconsistent");
+        }
+    }
+}
+
+// ---- 14. Long-backoff recovery -------------------------------------------
+
+TEST(long_backoff_recovery) {
+    auto env = MakeHappyEnv();
+    env->mikPubkey.reset();  // wallet locked
+    CRegistrationManager mgr(env);
+    mgr.TestingStepWorkerOnce();
+    ASSERT_STATE(mgr, LONG_BACKOFF_USER_ACTIONABLE);
+
+    // Unlock the wallet.
+    env->mikPubkey = FakePubkey();
+    env->mikIdentity = FakeIdentity();
+
+    // ForceRestart simulates "user came back, tick again" — the cleanest
+    // deterministic way to exit LONG_BACKOFF without relying on wall-clock
+    // backoff timers in a unit test.
+    mgr.ForceRestart("recovery");
+    ASSERT_STATE(mgr, CHECK_ELIGIBILITY);
+    // Now a fresh step should proceed (DNA available, identity available).
+    mgr.TestingStepWorkerOnce();
+    auto s = mgr.GetSnapshot();
+    ASSERT(s->state == CRegistrationManager::State::DNA_PENDING ||
+           s->state == CRegistrationManager::State::ATTEST_PENDING ||
+           s->state == CRegistrationManager::State::POW_PENDING ||
+           s->state == CRegistrationManager::State::READY,
+           "should have progressed past CHECK_ELIGIBILITY");
+}
+
+// ===========================================================================
+// main()
+// ===========================================================================
+
+int main(int /*argc*/, char** /*argv*/) {
+    std::cout << BLUE << "=== CRegistrationManager unit tests ===" << RESET << std::endl;
+    for (auto& fn : g_test_fns) fn();
+    std::cout << std::endl
+              << BLUE << "=== Summary ===" << RESET << std::endl
+              << GREEN << "  Passed: " << g_tests_passed << RESET << std::endl
+              << RED   << "  Failed: " << g_tests_failed << RESET << std::endl;
+    return g_tests_failed == 0 ? 0 : 1;
+}

--- a/src/test/registration_manager_tests.cpp
+++ b/src/test/registration_manager_tests.cpp
@@ -405,6 +405,63 @@ TEST(submitted_retry_exhaustion_to_long_backoff) {
     ASSERT(!s->userActionHint.empty(), "userActionHint should be populated");
 }
 
+// ---- 2c. SUBMIT_TIMEOUT_OR_REJECTED works from READY (v4.0.18 / PR #23 post-Cursor fix) ----
+// Production flow skips SUBMITTED (we poll HasMIKRegistered instead of emitting
+// TEMPLATE_BUILT_AND_MINER_STARTED). The event must be accepted from READY so
+// the retry budget is actually reachable.
+
+TEST(submit_rejected_from_ready_increments_retries) {
+    auto env = MakeHappyEnv();
+    CRegistrationManager mgr(env);
+    StepUntilState(mgr, CRegistrationManager::State::READY, 10);
+
+    ASSERT_EQ(mgr.GetSnapshot()->submitRetriesUsed, 0, "initial retries should be 0");
+
+    // Inject a rejection directly in READY — production path.
+    mgr.NotifyBlockRejected("synthetic test rejection");
+
+    auto s = mgr.GetSnapshot();
+    ASSERT_EQ(s->submitRetriesUsed, 1, "retry counter should increment from READY");
+    ASSERT(s->state == CRegistrationManager::State::READY,
+           "should remain in READY when attestations still fresh");
+}
+
+// ---- 2d. Public NotifyBlockRejected() is thread-safe + equivalent to event
+//         inject + publishes snapshot -----------------------------------------
+
+TEST(notify_block_rejected_publishes_snapshot_monotonically) {
+    auto env = MakeHappyEnv();
+    CRegistrationManager mgr(env);
+    StepUntilState(mgr, CRegistrationManager::State::READY, 10);
+
+    uint64_t seqBefore = mgr.GetSnapshot()->sequence;
+    mgr.NotifyBlockRejected("snapshot-test");
+    uint64_t seqAfter = mgr.GetSnapshot()->sequence;
+
+    ASSERT(seqAfter > seqBefore, "snapshot sequence must advance after NotifyBlockRejected");
+}
+
+// ---- 1b. READY -> CONFIRMED via polling HasMIKRegistered -------------------
+// Production path: no external REGISTRATION_SEEN_ONCHAIN event; HandleReady_
+// polls env->HasMIKRegistered() on every Tick. When the MIK appears in the
+// identity DB, manager transitions to CONFIRMED.
+
+TEST(ready_to_confirmed_via_poll) {
+    auto env = MakeHappyEnv();
+    CRegistrationManager mgr(env);
+    StepUntilState(mgr, CRegistrationManager::State::READY, 10);
+
+    // Simulate the registration block landing on-chain.
+    env->registeredIdentities.insert({env->mikIdentity->data,
+                                       env->mikIdentity->data + 20});
+
+    // Next worker iteration from READY polls HasMIKRegistered and transitions.
+    mgr.TestingStepWorkerOnce();
+    ASSERT_STATE(mgr, CONFIRMED);
+    ASSERT(!mgr.GetSnapshot()->registrationRequired,
+           "registrationRequired should be false after CONFIRMED");
+}
+
 // ---- 4-6. Shutdown from pending states (no partial persistence) ----------
 
 TEST(shutdown_from_dna_pending_no_persist) {


### PR DESCRIPTION
## Summary

- Fixes the race condition a new miner hit in v4.0.17 where `BuildMiningTemplate` started registration PoW without a cached DNA hash, wasted 30 minutes, then invalidated the result via the BUG #284 inline check.
- Introduces `CRegistrationManager` — a worker-thread-owned state machine that sequences DNA → attestations → PoW with explicit states, bounded retries, atomic snapshot publishing, and poisoned-file rejection on load.
- Makes `BuildMiningTemplate` a pure reader of the manager's published snapshot — no inline PoW, no inline DNA fetch, no state mutation. Same guarantee applies to the RPC server's register-DNA path.

## Why this is an improvement over the pre-existing code

- Race is now **architecturally impossible**, not "usually avoided by lucky ordering". Any future code path that calls `BuildMiningTemplate` cannot mine PoW because `BuildMiningTemplate` has no way to do so.
- Two previously-parallel registration mechanisms (the miner loop and the RPC server's `registerdigitaldna`) now share a single manager via `GetRegistrationManager()`, so they cannot race each other.
- Deletes the BUG #283 and BUG #284 inline patches — they existed because the underlying architecture was racy. Root-cause fix means the patches are unnecessary.
- Net production code change is only ~+300 lines despite a 1,100-line refactor; most of the delta is replacing 800 lines of interleaved globals+patches with 1,000 lines of clean state machine and tests.

## Commits in this PR

| SHA | What |
|---|---|
| `300d66c` | `CRegistrationManager` state machine + 15-case unit test suite + Makefile wiring |
| `80c7218` | DilV integration: `dilv-node.cpp` refactored (-239 net lines) |
| `5202a4d` | DIL + RPC integration: `dilithion-node.cpp` + `rpc/server.cpp` + `globals.cpp` refactored (-270 net lines) |
| `f3088d7` | First-time miner setup banner with honest probabilistic-PoW wording |

## Test results

- `registration_manager_tests`: **15/15 passing** — reorg handling, submit retry budgets, shutdown-from-pending, poisoned-file rejection on load, `Tick()` non-blocking contract, worker-owns-I/O, session coherence, `ForceRestart`, `CanMine` matrix, snapshot monotonicity, long-backoff recovery.
- **Manual Test 1 — fresh miner full flow: PASSED.** Fresh datadir, DilV mainnet. Total 39 min end-to-end (25 min IBD + 3 sec manager sequence + 8.5 min lucky PoW + 5 min wait for next block slot). MIK `2bfd146f0c6e36886dac9e040cf7bfe2a3d9214d` registered on-chain at block 42085, broadcast to 4 peers. Zero `Invalidating PoW` messages in 188,677 log lines.
- **Manual Test 4 — registered-miner regression: PASSED.** Restart of same datadir with MIK already registered. Manager transitions straight to `CONFIRMED`, no banner, no phase messages, no registration work. Mining resumes ~2 sec after IBD exit.
- Manual Tests 2 (poisoned-file live) and 3 (mid-PoW restart) deferred — code paths covered by `poisoned_file_rejected_on_startup` and `shutdown_from_pow_pending_cancels_and_no_persist` unit tests.

## Banner wording (commit 4)

Fires once per process for unregistered MIKs. Explicitly calls out that PoW is RANDOMLY PROBABILISTIC — roughly 12% of miners will see 2x or more (up to an hour), which is normal hash luck, not a stuck node. Suppressed for registered miners so restart has no ceremony.

## Test plan

- [x] Compile clean via MSYS2 MinGW64 — verified locally
- [x] Unit tests green (15/15)
- [x] Manual fresh-miner live run on DilV mainnet — registered MIK, mined first block, zero failure signals
- [x] Manual registered-miner regression — restart produced no banner, no phase messages, immediate mining
- [ ] Cross-check by a reviewer reading commits 2/3 for the `g_reg*` / `s_reg*` deletions and the `BuildMiningTemplate` refactor
- [ ] (Optional) second reviewer running the live test on a different fresh-datadir machine

## Known pre-existing test rot (not from this PR)

`git diff main..HEAD -- src/dfmp/` is empty yet several tests fail on `main` too: `dfmp_mik_tests` 4/10 fail (outdated constants), `mik_registration_persistence_tests` all fail on `Permission denied` scratch-dir issue (MSYS2 quirk), `wallet_encryption_integration_tests` / `wallet_persistence_tests` / `net_tests` compile-fail on removed APIs. To be addressed in a follow-up branch after this PR lands.

## Release

Holding the v4.0.18 tag until a separate in-flight bug fix PR is also ready. This PR can merge independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


