### PR TITLE
feat(dna): Phase 1.5 — signed MIK-bound sample envelope (v4.0.18)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,9 @@ DIGITAL_DNA_SOURCES := src/digital_dna/digital_dna.cpp \
                        src/digital_dna/trust_score.cpp \
                        src/digital_dna/dna_verification.cpp \
                        src/digital_dna/verification_manager.cpp \
-                       src/digital_dna/sample_rate_limiter.cpp
+                       src/digital_dna/sample_rate_limiter.cpp \
+                       src/digital_dna/sample_envelope.cpp \
+                       src/digital_dna/mik_pubkey_cache.cpp
 
 # VDF (Verifiable Delay Function) sources - uses chiavdf class group VDF
 VDF_SOURCES := src/vdf/vdf.cpp \

--- a/src/core/node_context.h
+++ b/src/core/node_context.h
@@ -41,6 +41,7 @@ class CPeerMIKTracker;   // Sybil defense: block relay source tracking
 #include <digital_dna/dna_registry_db.h>
 #include <digital_dna/trust_score.h>
 #include <digital_dna/verification_manager.h>
+#include <digital_dna/mik_pubkey_cache.h>  // Phase 1.5: MIK -> Dilithium3 pubkey cache
 
 /**
  * NodeContext - Bitcoin Core-style global state management
@@ -96,6 +97,9 @@ struct NodeContext {
     std::unique_ptr<digital_dna::TrustScoreManager> trust_manager;
     // Phase 2: Verification & attestation
     std::unique_ptr<digital_dna::verification::VerificationManager> verification_manager;
+    // Phase 1.5: signed sample envelope — pubkey cache for signature verification.
+    // Populated by block-connect callbacks, read-through fallback to DFMP::g_identityDb.
+    std::unique_ptr<digital_dna::MikPubkeyCache> mik_pubkey_cache;
     // Phase 4: Trust-weighted network — resolves peer_id to trust score
     // Returns 0.0-100.0 if known, -1.0 if unknown (grace period)
     std::function<double(int)> GetPeerTrustScore;

--- a/src/digital_dna/mik_pubkey_cache.cpp
+++ b/src/digital_dna/mik_pubkey_cache.cpp
@@ -1,0 +1,130 @@
+// Copyright (c) 2026 The Dilithion Core developers
+// Distributed under the MIT software license
+
+#include <digital_dna/mik_pubkey_cache.h>
+
+#include <dfmp/dfmp.h>          // Identity
+#include <dfmp/identity_db.h>   // CIdentityDB
+#include <dfmp/mik.h>           // MIK_PUBKEY_SIZE
+
+#include <algorithm>
+
+namespace digital_dna {
+
+namespace {
+inline bool IsZeroMIK(const std::array<uint8_t, 20>& mik) {
+    for (auto b : mik) if (b != 0) return false;
+    return true;
+}
+} // namespace
+
+MikPubkeyCache::MikPubkeyCache(const DFMP::CIdentityDB* identity_db)
+    : identity_db_(identity_db) {}
+
+void MikPubkeyCache::Insert(const std::array<uint8_t, 20>& mik,
+                            const std::vector<uint8_t>& pubkey) {
+    if (IsZeroMIK(mik)) return;
+    if (pubkey.size() != DFMP::MIK_PUBKEY_SIZE) return;
+
+    std::lock_guard<std::mutex> lk(mu_);
+
+    auto it = index_.find(mik);
+    if (it != index_.end()) {
+        // Already cached (pubkeys are immutable per MIK). Just refresh LRU.
+        TouchLocked(it->second);
+        return;
+    }
+
+    lru_.push_front(Entry{mik, pubkey});
+    index_[mik] = lru_.begin();
+    TrimLocked();
+}
+
+bool MikPubkeyCache::Lookup(const std::array<uint8_t, 20>& mik,
+                            std::vector<uint8_t>& pubkey_out) {
+    if (IsZeroMIK(mik)) return false;
+
+    {
+        std::lock_guard<std::mutex> lk(mu_);
+        auto it = index_.find(mik);
+        if (it != index_.end()) {
+            pubkey_out = it->second->pubkey;
+            TouchLocked(it->second);
+            return true;
+        }
+    }
+
+    // Cache miss — read through to LevelDB if available.
+    if (!identity_db_) return false;
+
+    DFMP::Identity id(mik.data());
+    std::vector<uint8_t> db_pubkey;
+    if (!identity_db_->GetMIKPubKey(id, db_pubkey)) {
+        return false;
+    }
+    if (db_pubkey.size() != DFMP::MIK_PUBKEY_SIZE) {
+        return false;  // Defensive; DB should never store wrong-size pubkey.
+    }
+
+    pubkey_out = db_pubkey;
+
+    // Cache for next lookup. Insert() handles duplicates if another thread
+    // raced us here.
+    std::lock_guard<std::mutex> lk(mu_);
+    auto it = index_.find(mik);
+    if (it != index_.end()) {
+        TouchLocked(it->second);
+    } else {
+        lru_.push_front(Entry{mik, std::move(db_pubkey)});
+        index_[mik] = lru_.begin();
+        TrimLocked();
+    }
+    return true;
+}
+
+void MikPubkeyCache::Evict(const std::array<uint8_t, 20>& mik) {
+    std::lock_guard<std::mutex> lk(mu_);
+    auto it = index_.find(mik);
+    if (it == index_.end()) return;
+    lru_.erase(it->second);
+    index_.erase(it);
+}
+
+void MikPubkeyCache::Clear() {
+    std::lock_guard<std::mutex> lk(mu_);
+    lru_.clear();
+    index_.clear();
+}
+
+bool MikPubkeyCache::DbStillHasMIK(const std::array<uint8_t, 20>& mik) const {
+    if (!identity_db_) return true;  // Cache-only mode: defer to cache state.
+    DFMP::Identity id(mik.data());
+    return identity_db_->HasMIKPubKey(id);
+}
+
+size_t MikPubkeyCache::Size() const {
+    std::lock_guard<std::mutex> lk(mu_);
+    return index_.size();
+}
+
+void MikPubkeyCache::SetCapacityForTests(size_t new_max) {
+    std::lock_guard<std::mutex> lk(mu_);
+    max_entries_ = std::max<size_t>(new_max, 1);
+    TrimLocked();
+}
+
+void MikPubkeyCache::TouchLocked(ListIt it) {
+    // Move `it` to the front of `lru_`.
+    if (it == lru_.begin()) return;
+    lru_.splice(lru_.begin(), lru_, it);
+}
+
+void MikPubkeyCache::TrimLocked() {
+    while (lru_.size() > max_entries_) {
+        auto& back = lru_.back();
+        index_.erase(back.mik);
+        lru_.pop_back();
+    }
+}
+
+} // namespace digital_dna

--- a/src/digital_dna/mik_pubkey_cache.h
+++ b/src/digital_dna/mik_pubkey_cache.h
@@ -1,0 +1,110 @@
+// Copyright (c) 2026 The Dilithion Core developers
+// Distributed under the MIT software license
+
+#ifndef DILITHION_DIGITAL_DNA_MIK_PUBKEY_CACHE_H
+#define DILITHION_DIGITAL_DNA_MIK_PUBKEY_CACHE_H
+
+/**
+ * MIK → Dilithium3 pubkey cache (Phase 1.5 "Option D").
+ *
+ * Serves signature verification on the net thread without taking the
+ * LevelDB path on every verify.
+ *
+ *   - Populated by block-connect callbacks: when a coinbase carries a
+ *     registration-PoW MIK payload, the node inserts (mik, pubkey).
+ *   - Read-through on miss: if we don't have the pubkey cached, we fall
+ *     back to `CIdentityDB::GetMIKPubKey` and cache the result.
+ *   - LRU-bounded at 10,000 entries (~120 active miners today, 100x
+ *     headroom; 10k * ~2KB pubkey ≈ 20 MiB worst-case).
+ *
+ * Reorg handling: pubkeys are PoW-bound and usually immutable, but
+ * `CIdentityDB::RemoveMIKPubKey` can drop a pubkey on chain disconnect
+ * when `firstSeen == disconnect_height`. Rather than mirror every
+ * disconnect event, the receiver calls `HasMIKPubKey` on the identity
+ * database after a cache hit, before running Dilithium verify — if the
+ * DB disagrees with the cache, the entry is evicted and the sample is
+ * silently dropped. Cheap (microsecond-level DB existence check) and
+ * strictly defensive: the DB is the source of truth.
+ *
+ * Thread model:
+ *   - Writes from block-callback thread (Insert).
+ *   - Reads from net thread (Lookup).
+ *   - Evictions can come from either thread.
+ *   - Single internal std::mutex; all operations O(log N) on the index.
+ */
+
+#include <array>
+#include <cstdint>
+#include <list>
+#include <map>
+#include <mutex>
+#include <vector>
+
+namespace DFMP { class CIdentityDB; }
+
+namespace digital_dna {
+
+class MikPubkeyCache {
+public:
+    /// Upper bound for LRU eviction. Tests may override via SetCapacityForTests.
+    static constexpr size_t DEFAULT_MAX_ENTRIES = 10000;
+
+    /// `identity_db` is the read-through source on cache miss. May be null
+    /// (e.g. in unit tests that don't need fallback); a null source skips
+    /// read-through and returns false on miss.
+    explicit MikPubkeyCache(const DFMP::CIdentityDB* identity_db);
+
+    /// Insert (mik, pubkey). If mik already present, this is a no-op and the
+    /// LRU position is refreshed. Zero-MIK is rejected. Wrong-size pubkeys
+    /// are rejected.
+    void Insert(const std::array<uint8_t, 20>& mik,
+                const std::vector<uint8_t>& pubkey);
+
+    /// Lookup pubkey for MIK. On cache miss, falls back to the identity DB
+    /// (if configured) and caches a hit. Returns true iff a pubkey was found.
+    bool Lookup(const std::array<uint8_t, 20>& mik,
+                std::vector<uint8_t>& pubkey_out);
+
+    /// Remove an entry (called on reorg-driven disconnect or post-hit sanity
+    /// check mismatch). Safe no-op if MIK not present.
+    void Evict(const std::array<uint8_t, 20>& mik);
+
+    /// Clear the cache. Mainly for tests.
+    void Clear();
+
+    /// Returns true if the identity DB still knows this MIK. Receiver calls
+    /// this after a cache hit, before signature verification, to defend
+    /// against stale cache entries after a reorg. Returns true if no DB is
+    /// configured (cache-only mode, e.g. tests).
+    bool DbStillHasMIK(const std::array<uint8_t, 20>& mik) const;
+
+    /// Current number of cached entries. Mainly for tests and diagnostics.
+    size_t Size() const;
+
+    /// Test hook to lower the LRU cap for unit-testing eviction behaviour.
+    /// Do not call outside tests.
+    void SetCapacityForTests(size_t new_max);
+
+private:
+    struct Entry {
+        std::array<uint8_t, 20> mik;
+        std::vector<uint8_t> pubkey;
+    };
+    using ListIt = std::list<Entry>::iterator;
+
+    // LRU bookkeeping (must be called under `mu_`). Moves `it` to the front.
+    void TouchLocked(ListIt it);
+
+    // Evict oldest entries until size <= max_entries_ (under `mu_`).
+    void TrimLocked();
+
+    const DFMP::CIdentityDB* identity_db_;
+    mutable std::mutex mu_;
+    std::list<Entry> lru_;  // front = most-recently-used
+    std::map<std::array<uint8_t, 20>, ListIt> index_;
+    size_t max_entries_ = DEFAULT_MAX_ENTRIES;
+};
+
+} // namespace digital_dna
+
+#endif // DILITHION_DIGITAL_DNA_MIK_PUBKEY_CACHE_H

--- a/src/digital_dna/sample_envelope.cpp
+++ b/src/digital_dna/sample_envelope.cpp
@@ -1,0 +1,130 @@
+// Copyright (c) 2026 The Dilithion Core developers
+// Distributed under the MIT software license
+
+#include <digital_dna/sample_envelope.h>
+
+#include <crypto/sha3.h>
+#include <dfmp/mik.h>  // For MIK_PUBKEY_SIZE / MIK_PRIVKEY_SIZE / MIK_SIGNATURE_SIZE
+
+#include <cstring>
+
+// Dilithium3 reference implementation — same primitive used by MIK block
+// signatures in src/dfmp/mik.cpp. Re-declared here to avoid coupling the
+// digital_dna subsystem to the dfmp internal headers beyond size constants.
+extern "C" {
+    int pqcrystals_dilithium3_ref_signature(uint8_t *sig, size_t *siglen,
+                                            const uint8_t *m, size_t mlen,
+                                            const uint8_t *ctx, size_t ctxlen,
+                                            const uint8_t *sk);
+    int pqcrystals_dilithium3_ref_verify(const uint8_t *sig, size_t siglen,
+                                         const uint8_t *m, size_t mlen,
+                                         const uint8_t *ctx, size_t ctxlen,
+                                         const uint8_t *pk);
+}
+
+namespace digital_dna {
+
+// Serialize a uint64 as 8 little-endian bytes into `out`, which must have
+// at least 8 bytes of capacity already reserved.
+static inline void append_le64(std::vector<uint8_t>& out, uint64_t v) {
+    for (int i = 0; i < 8; ++i) {
+        out.push_back(static_cast<uint8_t>((v >> (8 * i)) & 0xFFu));
+    }
+}
+
+std::vector<uint8_t> SampleEnvelope::BuildSignTarget(
+    const std::array<uint8_t, 20>& mik,
+    uint64_t timestamp,
+    uint64_t nonce,
+    const std::vector<uint8_t>& dna_data)
+{
+    // Total: 7 (domain) + 20 (mik) + 8 (ts) + 8 (nonce) + 32 (SHA3-256) = 75 bytes
+    std::vector<uint8_t> msg;
+    msg.reserve(DOMAIN_LEN + mik.size() + 8 + 8 + 32);
+
+    // Domain separator (raw ASCII, no terminator)
+    msg.insert(msg.end(),
+               reinterpret_cast<const uint8_t*>(DOMAIN),
+               reinterpret_cast<const uint8_t*>(DOMAIN) + DOMAIN_LEN);
+
+    // MIK
+    msg.insert(msg.end(), mik.begin(), mik.end());
+
+    // Timestamp + nonce (little-endian)
+    append_le64(msg, timestamp);
+    append_le64(msg, nonce);
+
+    // SHA3-256 of the exact dna_data wire bytes. Binding to the wire bytes
+    // (not to a canonical structural hash) keeps verify independent of
+    // serializer drift across versions.
+    uint8_t digest[32];
+    if (dna_data.empty()) {
+        SHA3_256(nullptr, 0, digest);
+    } else {
+        SHA3_256(dna_data.data(), dna_data.size(), digest);
+    }
+    msg.insert(msg.end(), digest, digest + 32);
+
+    return msg;
+}
+
+bool SampleEnvelope::Sign(
+    const std::vector<uint8_t>& mik_privkey,
+    const std::array<uint8_t, 20>& mik,
+    uint64_t timestamp,
+    uint64_t nonce,
+    const std::vector<uint8_t>& dna_data,
+    std::vector<uint8_t>& signature_out)
+{
+    signature_out.clear();
+    if (mik_privkey.size() != DFMP::MIK_PRIVKEY_SIZE) {
+        return false;
+    }
+
+    auto msg = BuildSignTarget(mik, timestamp, nonce, dna_data);
+
+    signature_out.resize(DFMP::MIK_SIGNATURE_SIZE);
+    size_t siglen = 0;
+
+    // Empty context — matches MIK block signing in src/dfmp/mik.cpp:111.
+    int result = pqcrystals_dilithium3_ref_signature(
+        signature_out.data(), &siglen,
+        msg.data(), msg.size(),
+        nullptr, 0,
+        mik_privkey.data()
+    );
+
+    if (result != 0 || siglen != DFMP::MIK_SIGNATURE_SIZE) {
+        signature_out.clear();
+        return false;
+    }
+    return true;
+}
+
+bool SampleEnvelope::Verify(
+    const std::vector<uint8_t>& mik_pubkey,
+    const std::array<uint8_t, 20>& mik,
+    uint64_t timestamp,
+    uint64_t nonce,
+    const std::vector<uint8_t>& dna_data,
+    const std::vector<uint8_t>& signature)
+{
+    if (mik_pubkey.size() != DFMP::MIK_PUBKEY_SIZE) {
+        return false;
+    }
+    if (signature.size() != DFMP::MIK_SIGNATURE_SIZE) {
+        return false;
+    }
+
+    auto msg = BuildSignTarget(mik, timestamp, nonce, dna_data);
+
+    int result = pqcrystals_dilithium3_ref_verify(
+        signature.data(), signature.size(),
+        msg.data(), msg.size(),
+        nullptr, 0,
+        mik_pubkey.data()
+    );
+    return result == 0;
+}
+
+} // namespace digital_dna

--- a/src/digital_dna/sample_envelope.cpp
+++ b/src/digital_dna/sample_envelope.cpp
@@ -69,7 +69,7 @@ std::vector<uint8_t> SampleEnvelope::BuildSignTarget(
 }
 
 bool SampleEnvelope::Sign(
-    const std::vector<uint8_t>& mik_privkey,
+    const uint8_t* mik_privkey, size_t mik_privkey_len,
     const std::array<uint8_t, 20>& mik,
     uint64_t timestamp,
     uint64_t nonce,
@@ -77,7 +77,7 @@ bool SampleEnvelope::Sign(
     std::vector<uint8_t>& signature_out)
 {
     signature_out.clear();
-    if (mik_privkey.size() != DFMP::MIK_PRIVKEY_SIZE) {
+    if (mik_privkey == nullptr || mik_privkey_len != DFMP::MIK_PRIVKEY_SIZE) {
         return false;
     }
 
@@ -91,7 +91,7 @@ bool SampleEnvelope::Sign(
         signature_out.data(), &siglen,
         msg.data(), msg.size(),
         nullptr, 0,
-        mik_privkey.data()
+        mik_privkey
     );
 
     if (result != 0 || siglen != DFMP::MIK_SIGNATURE_SIZE) {
@@ -125,6 +125,110 @@ bool SampleEnvelope::Verify(
         mik_pubkey.data()
     );
     return result == 0;
+}
+
+static inline uint64_t read_le64(const uint8_t* p) {
+    uint64_t v = 0;
+    for (int i = 0; i < 8; ++i) {
+        v |= static_cast<uint64_t>(p[i]) << (8 * i);
+    }
+    return v;
+}
+
+static inline uint16_t read_le16(const uint8_t* p) {
+    return static_cast<uint16_t>(p[0]) |
+           (static_cast<uint16_t>(p[1]) << 8);
+}
+
+SampleEnvelope::ParseResult SampleEnvelope::TryParse(
+    const std::vector<uint8_t>& trailer_bytes,
+    SampleEnvelope& out)
+{
+    out = SampleEnvelope{};  // reset
+
+    // No bytes after dna_data — unsigned payload from a pre-1.5 sender.
+    if (trailer_bytes.empty()) {
+        return ParseResult::NONE;
+    }
+
+    // Fewer bytes than the minimum magic length → definitionally malformed
+    // (can't even tell what the magic is). Penalize.
+    if (trailer_bytes.size() < MAGIC.size()) {
+        return ParseResult::MALFORMED;
+    }
+
+    // Magic match check. Unknown magic = forward-compat silent-ignore.
+    if (!std::equal(MAGIC.begin(), MAGIC.end(), trailer_bytes.begin())) {
+        return ParseResult::UNKNOWN_MAGIC;
+    }
+
+    // SMP1 layout: magic(4) | ts_le(8) | nonce_le(8) | sig_len_le(2) | sig
+    constexpr size_t HEADER_SIZE = 4 + 8 + 8 + 2;  // 22 bytes before signature
+    if (trailer_bytes.size() < HEADER_SIZE) {
+        return ParseResult::MALFORMED;  // truncated timestamp/nonce/sig_len
+    }
+
+    size_t off = MAGIC.size();
+    uint64_t ts = read_le64(trailer_bytes.data() + off); off += 8;
+    uint64_t nonce = read_le64(trailer_bytes.data() + off); off += 8;
+    uint16_t sig_len = read_le16(trailer_bytes.data() + off); off += 2;
+
+    size_t remaining = trailer_bytes.size() - off;
+
+    // sig_len = 0 with non-zero trailing bytes — malformed (strict).
+    // sig_len = 0 with zero trailing bytes — malformed too; an unsigned SMP1
+    // trailer is meaningless (spec always pairs SMP1 with a real signature).
+    if (sig_len == 0) {
+        return ParseResult::MALFORMED;
+    }
+
+    // sig_len must match Dilithium3 signature size exactly. Any other size
+    // is a protocol violation — penalize.
+    if (sig_len != DFMP::MIK_SIGNATURE_SIZE) {
+        return ParseResult::MALFORMED;
+    }
+
+    // Signature must fit exactly — no trailing bytes after signature (strict).
+    if (sig_len != remaining) {
+        return ParseResult::MALFORMED;
+    }
+
+    // Scan for a second SMP1 magic inside the trailer region. Parser defense
+    // against ambiguous dual-interpretation: if a second magic occurs inside
+    // the signature bytes (by coincidence or attacker design), that's fine
+    // cryptographically — signature verification will fail or succeed based
+    // on the bytes — but flag it so we don't later interpret those bytes as
+    // a second trailer. The sig is 3309 bytes and the magic is 4 bytes, so
+    // coincidental matches are rare but not zero. Reject to be strict.
+    for (size_t i = 1; i + MAGIC.size() <= trailer_bytes.size(); ++i) {
+        if (std::equal(MAGIC.begin(), MAGIC.end(), trailer_bytes.begin() + i)) {
+            return ParseResult::MALFORMED;
+        }
+    }
+
+    // All structural checks passed — copy the signature and return SIGNED.
+    out.timestamp_sec = ts;
+    out.nonce = nonce;
+    out.signature.assign(trailer_bytes.begin() + off,
+                         trailer_bytes.begin() + off + sig_len);
+    return ParseResult::SIGNED;
+}
+
+std::vector<uint8_t> SampleEnvelope::ToWireBytes() const {
+    std::vector<uint8_t> out;
+    if (signature.size() != DFMP::MIK_SIGNATURE_SIZE) {
+        // Caller error — return empty so sender falls back to unsigned.
+        return out;
+    }
+    out.reserve(MAGIC.size() + 8 + 8 + 2 + signature.size());
+    out.insert(out.end(), MAGIC.begin(), MAGIC.end());
+    append_le64(out, timestamp_sec);
+    append_le64(out, nonce);
+    uint16_t sig_len = static_cast<uint16_t>(signature.size());
+    out.push_back(static_cast<uint8_t>(sig_len & 0xFF));
+    out.push_back(static_cast<uint8_t>((sig_len >> 8) & 0xFF));
+    out.insert(out.end(), signature.begin(), signature.end());
+    return out;
 }
 
 } // namespace digital_dna

--- a/src/digital_dna/sample_envelope.h
+++ b/src/digital_dna/sample_envelope.h
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 The Dilithion Core developers
+// Distributed under the MIT software license
+
+#ifndef DILITHION_DIGITAL_DNA_SAMPLE_ENVELOPE_H
+#define DILITHION_DIGITAL_DNA_SAMPLE_ENVELOPE_H
+
+/**
+ * DNA sample envelope (Phase 1.5 signed propagation).
+ *
+ * Wraps a DNA broadcast with a Dilithium3 signature so any peer can verify
+ * the sample authentically originated from the MIK holder. Lets unmapped
+ * peers push full-replacement updates (not just dim-fill), which closes the
+ * propagation gap left after Phase 1.1 for legitimate updates that arrive
+ * via relay chains.
+ *
+ * Wire trailer format (appended to existing `dnaires` payload):
+ *   magic(4)          = 'S','M','P','1'
+ *   timestamp_sec(8)  uint64 LE — sender's wall clock at signing
+ *   nonce(8)          uint64 LE — random, unique per sample (replay defense)
+ *   sig_len(2)        uint16 LE
+ *   signature(sig_len) Dilithium3 sig, MIK_SIGNATURE_SIZE when present
+ *
+ * Sign target — domain-separated so the sig cannot be reused in any other
+ * MIK-keyed protocol (block signing, future envelopes):
+ *   sig_msg = "DNASMP1" || mik(20) || ts_le(8) || nonce_le(8) || SHA3_256(dna_data)
+ *
+ * This module is pure crypto — no long-lived state, no threading concerns.
+ * Lookup of the MIK's Dilithium3 pubkey is handled separately by
+ * `MikPubkeyCache` (populated by block-connect callbacks, read-through to
+ * `dfmp_identity/` LevelDB).
+ */
+
+#include <array>
+#include <cstdint>
+#include <vector>
+
+namespace digital_dna {
+
+struct SampleEnvelope {
+    /// 4-byte magic identifying the signed trailer.
+    static constexpr std::array<uint8_t, 4> MAGIC = {'S', 'M', 'P', '1'};
+
+    /// 7-byte domain separator inside the signed bytes.
+    /// Prevents cross-protocol reuse against MIK block signatures.
+    static constexpr char DOMAIN[] = "DNASMP1";
+    static constexpr size_t DOMAIN_LEN = 7;  // strlen("DNASMP1")
+
+    uint64_t timestamp_sec = 0;
+    uint64_t nonce = 0;
+    std::vector<uint8_t> signature;  // empty = unsigned
+
+    /// Build the exact byte string that gets signed/verified.
+    /// sig_msg = DOMAIN || mik(20) || ts_le(8) || nonce_le(8) || SHA3_256(dna_data)
+    static std::vector<uint8_t> BuildSignTarget(
+        const std::array<uint8_t, 20>& mik,
+        uint64_t timestamp,
+        uint64_t nonce,
+        const std::vector<uint8_t>& dna_data);
+
+    /// Sign a DNA sample. `mik_privkey` must be a valid Dilithium3 secret key
+    /// (`MIK_PRIVKEY_SIZE` bytes). `signature_out` is resized to the signature
+    /// length on success (`MIK_SIGNATURE_SIZE`), cleared on failure.
+    /// Returns true iff the signature was produced.
+    static bool Sign(const std::vector<uint8_t>& mik_privkey,
+                     const std::array<uint8_t, 20>& mik,
+                     uint64_t timestamp,
+                     uint64_t nonce,
+                     const std::vector<uint8_t>& dna_data,
+                     std::vector<uint8_t>& signature_out);
+
+    /// Verify a signed DNA sample. `mik_pubkey` must be the MIK's registered
+    /// Dilithium3 public key (`MIK_PUBKEY_SIZE` bytes). Constant-time at the
+    /// Dilithium3 library level.
+    /// Returns true iff the signature validates against the reconstructed
+    /// sign-target bytes.
+    static bool Verify(const std::vector<uint8_t>& mik_pubkey,
+                       const std::array<uint8_t, 20>& mik,
+                       uint64_t timestamp,
+                       uint64_t nonce,
+                       const std::vector<uint8_t>& dna_data,
+                       const std::vector<uint8_t>& signature);
+};
+
+} // namespace digital_dna
+
+#endif // DILITHION_DIGITAL_DNA_SAMPLE_ENVELOPE_H

--- a/src/digital_dna/sample_envelope.h
+++ b/src/digital_dna/sample_envelope.h
@@ -32,6 +32,7 @@
 
 #include <array>
 #include <cstdint>
+#include <optional>
 #include <vector>
 
 namespace digital_dna {
@@ -44,6 +45,22 @@ struct SampleEnvelope {
     /// Prevents cross-protocol reuse against MIK block signatures.
     static constexpr char DOMAIN[] = "DNASMP1";
     static constexpr size_t DOMAIN_LEN = 7;  // strlen("DNASMP1")
+
+    /// Result of TryParse — distinguishes unsigned/no-trailer from malformed.
+    enum class ParseResult {
+        /// No trailer bytes present (pre-Phase-1.5 sender).
+        NONE,
+        /// Valid SMP1 trailer parsed into the struct.
+        SIGNED,
+        /// Unknown magic at trailer offset — silent-ignore (forward-compat
+        /// slot for hypothetical future trailer formats like SMP2). Not a
+        /// misbehaviour.
+        UNKNOWN_MAGIC,
+        /// SMP1 magic matched but bytes malformed (truncated fields, bad
+        /// sig_len, duplicate magic, trailing garbage). Peer should be
+        /// penalised — misbehaviour 10 at the caller.
+        MALFORMED,
+    };
 
     uint64_t timestamp_sec = 0;
     uint64_t nonce = 0;
@@ -58,10 +75,13 @@ struct SampleEnvelope {
         const std::vector<uint8_t>& dna_data);
 
     /// Sign a DNA sample. `mik_privkey` must be a valid Dilithium3 secret key
-    /// (`MIK_PRIVKEY_SIZE` bytes). `signature_out` is resized to the signature
+    /// (`MIK_PRIVKEY_SIZE` bytes). Takes raw pointer + length so callers can
+    /// pass keys from secure-allocator containers (e.g. the wallet's
+    /// SecureAllocator-backed privkey) without copying into an unprotected
+    /// `std::vector<uint8_t>`. `signature_out` is resized to the signature
     /// length on success (`MIK_SIGNATURE_SIZE`), cleared on failure.
     /// Returns true iff the signature was produced.
-    static bool Sign(const std::vector<uint8_t>& mik_privkey,
+    static bool Sign(const uint8_t* mik_privkey, size_t mik_privkey_len,
                      const std::array<uint8_t, 20>& mik,
                      uint64_t timestamp,
                      uint64_t nonce,
@@ -79,6 +99,24 @@ struct SampleEnvelope {
                        uint64_t nonce,
                        const std::vector<uint8_t>& dna_data,
                        const std::vector<uint8_t>& signature);
+
+    /// Parse the optional trailer bytes that appear after `dna_data` in a
+    /// `dnaires` payload. `trailer_bytes` is the tail of the payload starting
+    /// at offset `header + data_len` (empty if no bytes remain after the DNA
+    /// blob). The receiver MUST NOT pass bytes from inside `dna_data` here —
+    /// the offset rule is part of Phase 1.5 security (no dual-parse).
+    ///
+    /// On `SIGNED`, the returned envelope is populated and the signature
+    /// field is exactly MIK_SIGNATURE_SIZE bytes (3309). Caller still needs
+    /// to run `Verify()` to check authenticity.
+    static ParseResult TryParse(const std::vector<uint8_t>& trailer_bytes,
+                                SampleEnvelope& out);
+
+    /// Build the trailer byte string for an already-signed envelope. Used
+    /// by the sender to append after `dna_data` when the peer supports
+    /// Phase 1.5. Returns the raw bytes:
+    ///   magic(4) | ts_le(8) | nonce_le(8) | sig_len_le(2) | signature
+    std::vector<uint8_t> ToWireBytes() const;
 };
 
 } // namespace digital_dna

--- a/src/digital_dna/sample_rate_limiter.cpp
+++ b/src/digital_dna/sample_rate_limiter.cpp
@@ -3,6 +3,8 @@
 
 #include "sample_rate_limiter.h"
 
+#include <crypto/sha3.h>
+
 #include <algorithm>
 
 namespace digital_dna {
@@ -13,6 +15,47 @@ void DNASampleRateLimiter::refill(TokenBucket& b, uint64_t now_sec) {
     double added = static_cast<double>(elapsed) / PEER_BUCKET_REFILL_SEC;
     b.tokens = std::min(PEER_BUCKET_BURST, b.tokens + added);
     b.last_refill_sec = now_sec;
+}
+
+DNASampleRateLimiter::TokenBucket&
+DNASampleRateLimiter::get_bucket_locked(int peer_id, uint64_t now_sec) {
+    auto& bucket = peer_buckets_[peer_id];
+    if (bucket.last_refill_sec == 0) {
+        // First observation of this peer: start at full burst.
+        bucket.tokens = PEER_BUCKET_BURST;
+        bucket.last_refill_sec = now_sec;
+    } else {
+        refill(bucket, now_sec);
+    }
+    return bucket;
+}
+
+bool DNASampleRateLimiter::check_mik_locked(
+    int peer_id,
+    const std::array<uint8_t, 20>& mik,
+    uint64_t now_sec) const
+{
+    auto mik_it = mik_last_accept_.find(mik);
+    if (mik_it != mik_last_accept_.end() &&
+        now_sec < mik_it->second + MIK_GLOBAL_MIN_SEC) {
+        return false;
+    }
+    auto pair_key = std::make_pair(mik, peer_id);
+    auto mp_it = mik_peer_last_accept_.find(pair_key);
+    if (mp_it != mik_peer_last_accept_.end() &&
+        now_sec < mp_it->second + MIK_PEER_MIN_SEC) {
+        return false;
+    }
+    return true;
+}
+
+void DNASampleRateLimiter::commit_mik_locked(
+    int peer_id,
+    const std::array<uint8_t, 20>& mik,
+    uint64_t now_sec)
+{
+    mik_last_accept_[mik] = now_sec;
+    mik_peer_last_accept_[std::make_pair(mik, peer_id)] = now_sec;
 }
 
 void DNASampleRateLimiter::prune_locked(uint64_t now_sec) {
@@ -43,6 +86,27 @@ void DNASampleRateLimiter::prune_locked(uint64_t now_sec) {
     }
 }
 
+void DNASampleRateLimiter::prune_replay_locked(uint64_t now_sec) {
+    while (!replay_fifo_.empty() && replay_fifo_.front().first <= now_sec) {
+        replay_set_.erase(replay_fifo_.front().second);
+        replay_fifo_.pop_front();
+    }
+}
+
+std::array<uint8_t, 32> DNASampleRateLimiter::replay_key(
+    const std::array<uint8_t, 20>& mik,
+    uint64_t ts,
+    uint64_t nonce)
+{
+    uint8_t buf[20 + 8 + 8];
+    std::copy(mik.begin(), mik.end(), buf);
+    for (int i = 0; i < 8; ++i) buf[20 + i] = static_cast<uint8_t>((ts >> (8 * i)) & 0xFFu);
+    for (int i = 0; i < 8; ++i) buf[28 + i] = static_cast<uint8_t>((nonce >> (8 * i)) & 0xFFu);
+    std::array<uint8_t, 32> out;
+    SHA3_256(buf, sizeof(buf), out.data());
+    return out;
+}
+
 DNASampleRateLimiter::Reject DNASampleRateLimiter::allow_detail(
     int peer_id,
     const std::array<uint8_t, 20>& mik,
@@ -51,27 +115,17 @@ DNASampleRateLimiter::Reject DNASampleRateLimiter::allow_detail(
     std::lock_guard<std::mutex> lock(mu_);
     prune_locked(now_sec);
 
-    // Layer 1: per-peer token bucket.
-    auto& bucket = peer_buckets_[peer_id];
-    if (bucket.last_refill_sec == 0) {
-        // First observation of this peer: start at full burst.
-        bucket.tokens = PEER_BUCKET_BURST;
-        bucket.last_refill_sec = now_sec;
-    } else {
-        refill(bucket, now_sec);
-    }
+    auto& bucket = get_bucket_locked(peer_id, now_sec);
     if (bucket.tokens < 1.0) {
         return Reject::PEER_BUCKET;
     }
 
-    // Layer 2: per-MIK global interval.
     auto mik_it = mik_last_accept_.find(mik);
     if (mik_it != mik_last_accept_.end() &&
         now_sec < mik_it->second + MIK_GLOBAL_MIN_SEC) {
         return Reject::MIK_GLOBAL;
     }
 
-    // Layer 3: per-MIK-per-peer interval.
     auto pair_key = std::make_pair(mik, peer_id);
     auto mp_it = mik_peer_last_accept_.find(pair_key);
     if (mp_it != mik_peer_last_accept_.end() &&
@@ -92,11 +146,70 @@ bool DNASampleRateLimiter::allow(int peer_id,
     return allow_detail(peer_id, mik, now_sec) == Reject::OK;
 }
 
+// ---- Staged (Phase 1.5) ---------------------------------------------------
+
+bool DNASampleRateLimiter::consume_peer_bucket(int peer_id, uint64_t now_sec) {
+    std::lock_guard<std::mutex> lock(mu_);
+    prune_locked(now_sec);
+    auto& bucket = get_bucket_locked(peer_id, now_sec);
+    if (bucket.tokens < 1.0) return false;
+    bucket.tokens -= 1.0;
+    return true;
+}
+
+bool DNASampleRateLimiter::check_mik_limits(
+    int peer_id,
+    const std::array<uint8_t, 20>& mik,
+    uint64_t now_sec)
+{
+    std::lock_guard<std::mutex> lock(mu_);
+    return check_mik_locked(peer_id, mik, now_sec);
+}
+
+void DNASampleRateLimiter::commit_mik_limits(
+    int peer_id,
+    const std::array<uint8_t, 20>& mik,
+    uint64_t now_sec)
+{
+    std::lock_guard<std::mutex> lock(mu_);
+    commit_mik_locked(peer_id, mik, now_sec);
+}
+
+bool DNASampleRateLimiter::replay_seen(
+    const std::array<uint8_t, 20>& mik,
+    uint64_t ts,
+    uint64_t nonce)
+{
+    auto key = replay_key(mik, ts, nonce);
+    std::lock_guard<std::mutex> lock(mu_);
+    // Don't prune here — we want lookup to be idempotent. Staleness only
+    // matters at record time, where we prune before inserting.
+    return replay_set_.find(key) != replay_set_.end();
+}
+
+void DNASampleRateLimiter::replay_record(
+    const std::array<uint8_t, 20>& mik,
+    uint64_t ts,
+    uint64_t nonce,
+    uint64_t now_sec)
+{
+    auto key = replay_key(mik, ts, nonce);
+    std::lock_guard<std::mutex> lock(mu_);
+    prune_replay_locked(now_sec);
+    if (replay_set_.insert(key).second) {
+        replay_fifo_.emplace_back(now_sec + REPLAY_TTL_SEC, key);
+    }
+}
+
+// ---- Test helpers ---------------------------------------------------------
+
 void DNASampleRateLimiter::clear() {
     std::lock_guard<std::mutex> lock(mu_);
     peer_buckets_.clear();
     mik_last_accept_.clear();
     mik_peer_last_accept_.clear();
+    replay_fifo_.clear();
+    replay_set_.clear();
     last_prune_sec_ = 0;
 }
 
@@ -113,6 +226,11 @@ size_t DNASampleRateLimiter::mik_global_state_size() const {
 size_t DNASampleRateLimiter::mik_peer_state_size() const {
     std::lock_guard<std::mutex> lock(mu_);
     return mik_peer_last_accept_.size();
+}
+
+size_t DNASampleRateLimiter::replay_cache_size() const {
+    std::lock_guard<std::mutex> lock(mu_);
+    return replay_set_.size();
 }
 
 } // namespace digital_dna

--- a/src/digital_dna/sample_rate_limiter.h
+++ b/src/digital_dna/sample_rate_limiter.h
@@ -5,7 +5,7 @@
 #define DILITHION_DIGITAL_DNA_SAMPLE_RATE_LIMITER_H
 
 /**
- * DNA sample rate limiter (Phase 1 propagation fix).
+ * DNA sample rate limiter (Phase 1 propagation fix + Phase 1.5 split pipeline).
  *
  * Three layers applied in order. A sample is accepted only if all three pass.
  *
@@ -17,13 +17,25 @@
  * not here — it needs access to `g_mik_peer_map`, which lives in the node
  * binaries.
  *
+ * Two usage modes:
+ *   A) Atomic  (Phase 1 / 1.1 callers): `allow()` / `allow_detail()` check and
+ *      consume all three layers in one shot. State is only mutated on accept.
+ *   B) Staged  (Phase 1.5 signed pipeline): layer 1 is consumed BEFORE the
+ *      expensive signature verify via `consume_peer_bucket()`, and layers 2+3
+ *      are split into a check-without-commit (`check_mik_limits`) and a commit
+ *      step (`commit_mik_limits`) so receiver stages 4+5 can reject-without-
+ *      commit if the signature fails or the sample is a replay.
+ *
+ * Phase 1.5 also colocates the replay FIFO for signed samples here (rather
+ * than adding a third concurrency-protected class). The key is
+ * `SHA3-256(mik || ts_le || nonce_le)` and entries expire after 10 min.
+ *
  * Thread-safe. All state is protected by a single internal mutex. Callers may
- * invoke allow() from multiple receiver threads.
+ * invoke any public method from multiple receiver threads.
  *
  * Memory: state grows with unique (peer_id) and (mik) seen. A cheap lazy-prune
- * on each allow() call drops entries that haven't been touched in 1h. No
- * explicit eviction cap — bounded by the number of peers * active MIKs, which
- * in practice is small (hundreds, not millions).
+ * on each call drops entries that haven't been touched in 1h. Replay FIFO is
+ * bounded by the 10-min TTL (hundreds of entries at typical traffic).
  */
 
 #include <array>
@@ -31,6 +43,7 @@
 #include <deque>
 #include <map>
 #include <mutex>
+#include <set>
 #include <utility>
 
 namespace digital_dna {
@@ -50,8 +63,11 @@ public:
     static constexpr uint64_t MIK_GLOBAL_MIN_SEC     = 10 * 60;
     static constexpr uint64_t MIK_PEER_MIN_SEC       = 30 * 60;
     static constexpr uint64_t PRUNE_IDLE_SEC         = 60 * 60;
+    static constexpr uint64_t REPLAY_TTL_SEC         = 10 * 60;
 
     DNASampleRateLimiter() = default;
+
+    // ---- Atomic (Phase 1/1.1) --------------------------------------------
 
     // Returns true iff the sample is accepted. On accept, internal state is
     // updated to reflect the acceptance. On reject, state is unchanged.
@@ -64,6 +80,44 @@ public:
                         const std::array<uint8_t, 20>& mik,
                         uint64_t now_sec);
 
+    // ---- Staged (Phase 1.5) ----------------------------------------------
+
+    // Consume one token from the peer bucket. Used at receive pipeline stage 2,
+    // before signature verify, to cap verification work per peer regardless of
+    // MIK spread. Returns true iff a token was consumed. The bucket is the
+    // same state that `allow()` uses; a token spent here counts toward the
+    // per-peer burst limit.
+    bool consume_peer_bucket(int peer_id, uint64_t now_sec);
+
+    // Check MIK-global and MIK-per-peer intervals without mutating. Returns
+    // true iff both intervals would allow a new acceptance right now. Callers
+    // run this at stage 5 (after verify + skew + replay) and then call
+    // `commit_mik_limits()` before `append_sample`.
+    bool check_mik_limits(int peer_id,
+                          const std::array<uint8_t, 20>& mik,
+                          uint64_t now_sec);
+
+    // Commit MIK-global and MIK-per-peer acceptance records. Must be called
+    // only after `check_mik_limits()` returned true and stages 4/5 passed.
+    void commit_mik_limits(int peer_id,
+                           const std::array<uint8_t, 20>& mik,
+                           uint64_t now_sec);
+
+    // Replay cache — lookup without mutation. Returns true iff
+    // SHA3-256(mik || ts || nonce) is already in the 10-min FIFO.
+    bool replay_seen(const std::array<uint8_t, 20>& mik,
+                     uint64_t ts,
+                     uint64_t nonce);
+
+    // Replay cache — record the (mik, ts, nonce) triple. Should be called
+    // only once the sample is fully accepted (stage 6).
+    void replay_record(const std::array<uint8_t, 20>& mik,
+                       uint64_t ts,
+                       uint64_t nonce,
+                       uint64_t now_sec);
+
+    // ---- Test helpers ----------------------------------------------------
+
     // For tests: reset all state.
     void clear();
 
@@ -71,6 +125,7 @@ public:
     size_t peer_state_size() const;
     size_t mik_global_state_size() const;
     size_t mik_peer_state_size() const;
+    size_t replay_cache_size() const;
 
 private:
     struct TokenBucket {
@@ -81,14 +136,39 @@ private:
     // Refill the bucket to `now_sec` using PEER_BUCKET_REFILL_SEC / BURST.
     static void refill(TokenBucket& b, uint64_t now_sec);
 
-    // Drop entries not touched in > PRUNE_IDLE_SEC.
+    // Ensure `peer_buckets_[peer_id]` exists and is up-to-date.
+    // Returns a reference to the bucket (must be under lock).
+    TokenBucket& get_bucket_locked(int peer_id, uint64_t now_sec);
+
+    // Check/commit MIK layers — under lock.
+    bool check_mik_locked(int peer_id,
+                          const std::array<uint8_t, 20>& mik,
+                          uint64_t now_sec) const;
+    void commit_mik_locked(int peer_id,
+                           const std::array<uint8_t, 20>& mik,
+                           uint64_t now_sec);
+
+    // Compute the replay key = SHA3-256(mik || ts_le || nonce_le).
+    static std::array<uint8_t, 32> replay_key(
+        const std::array<uint8_t, 20>& mik,
+        uint64_t ts,
+        uint64_t nonce);
+
+    // Drop entries not touched in > PRUNE_IDLE_SEC (rate-limit layers).
     void prune_locked(uint64_t now_sec);
+
+    // Drop replay entries whose expiry <= now_sec.
+    void prune_replay_locked(uint64_t now_sec);
 
     mutable std::mutex mu_;
     std::map<int, TokenBucket> peer_buckets_;
     std::map<std::array<uint8_t, 20>, uint64_t> mik_last_accept_;
     std::map<std::pair<std::array<uint8_t, 20>, int>, uint64_t> mik_peer_last_accept_;
     uint64_t last_prune_sec_ = 0;
+
+    // Replay cache: FIFO deque of (expiry_sec, key) + set for O(log n) lookup.
+    std::deque<std::pair<uint64_t, std::array<uint8_t, 32>>> replay_fifo_;
+    std::set<std::array<uint8_t, 32>> replay_set_;
 };
 
 } // namespace digital_dna

--- a/src/net/net.cpp
+++ b/src/net/net.cpp
@@ -339,7 +339,7 @@ bool CNetMessageProcessor::ProcessMessage(int peer_id, const CNetMessage& messag
         {"dnabwtest",  {20, 1048596}},                 // nonce(8) + size(4) + send_wall_ms(8) + payload(0..1MB)
         {"dnabwres",   {24, 24}},                      // nonce(8) + upload(8) + download(8)
         {"dnaireq",    {20, 20}},                      // mik_identity(20)
-        {"dnaires",    {21, 4117}},                    // mik(20) + found(1) [+ data_len(2) + data(max ~4KB)]
+        {"dnaires",    {21, 8192}},                    // mik(20) + found(1) [+ data_len(2) + data(max 4096)] [+ SMP1 trailer: magic(4)+ts(8)+nonce(8)+sig_len(2)+sig(3309)=3331]
         // Phase 2: DNA Verification & Attestation
         {"dnavchall",  {92, 8192}},                    // Minimum challenge size 92 bytes
         {"dnavresp",   {70, 8192}},                    // Minimum response size 70 bytes
@@ -2666,8 +2666,36 @@ bool CNetMessageProcessor::ProcessDNAIdentResMessage(int peer_id, CDataStream& s
             stream.read(dna_data.data(), data_len);
         }
 
+        // Phase 1.5: parse optional SMP1 trailer. The trailer starts at the
+        // byte immediately after dna_data (or after the `found` byte if
+        // found==0). Trailer parse MUST NOT inspect bytes inside dna_data —
+        // the offset rule prevents dual-interpretation of DNA bytes.
+        std::vector<uint8_t> trailer_bytes;
+        if (stream.size() > 0) {
+            trailer_bytes.resize(stream.size());
+            stream.read(trailer_bytes.data(), trailer_bytes.size());
+        }
+
+        digital_dna::SampleEnvelope envelope;
+        auto parse_result = digital_dna::SampleEnvelope::TryParse(trailer_bytes, envelope);
+
+        // found=0 + SMP1 trailer is spec-violating (a sig without data is
+        // meaningless) — reject with misbehaviour.
+        if (parse_result == digital_dna::SampleEnvelope::ParseResult::SIGNED &&
+            found != 0x01) {
+            peer_manager.Misbehaving(peer_id, 10, MisbehaviorType::INVALID_MESSAGE_SIZE);
+            return false;
+        }
+        // MALFORMED SMP1 trailer — attacker or buggy sender. Penalise.
+        if (parse_result == digital_dna::SampleEnvelope::ParseResult::MALFORMED) {
+            peer_manager.Misbehaving(peer_id, 10, MisbehaviorType::INVALID_MESSAGE_SIZE);
+            return false;
+        }
+        // UNKNOWN_MAGIC or NONE — envelope stays empty/unsigned, no penalty.
+        // The handler routes unsigned messages through the merge-fill path.
+
         if (on_dna_ident_res) {
-            on_dna_ident_res(peer_id, mik, found == 0x01, dna_data);
+            on_dna_ident_res(peer_id, mik, found == 0x01, dna_data, envelope);
         }
         return true;
     } catch (...) {
@@ -2686,7 +2714,9 @@ CNetMessage CNetMessageProcessor::CreateDNAIdentReqMessage(const std::array<uint
 
 CNetMessage CNetMessageProcessor::CreateDNAIdentResMessage(
     const std::array<uint8_t, 20>& mik, bool found,
-    const std::vector<uint8_t>& dna_data)
+    const std::vector<uint8_t>& dna_data,
+    const digital_dna::SampleEnvelope* envelope,
+    int peer_version)
 {
     CDataStream stream;
     stream.write(mik.data(), 20);
@@ -2696,6 +2726,21 @@ CNetMessage CNetMessageProcessor::CreateDNAIdentResMessage(
         stream.WriteUint16(data_len);
         stream.write(dna_data.data(), data_len);
     }
+
+    // Phase 1.5: append SMP1 trailer iff (a) caller supplied a signed
+    // envelope AND (b) peer version meets the minimum. Sending a trailer to
+    // an older peer would trip the old {21, 4117} payload cap and trigger
+    // misbehaviour scoring on that peer. Silent fallback to unsigned keeps
+    // a single sender call-site safe across a mixed-version network.
+    if (envelope != nullptr &&
+        !envelope->signature.empty() &&
+        peer_version >= NetProtocol::DNA_SMP1_MIN_PROTOCOL_VERSION) {
+        auto trailer = envelope->ToWireBytes();
+        if (!trailer.empty()) {
+            stream.write(trailer.data(), trailer.size());
+        }
+    }
+
     g_network_stats.messages_sent++;
     g_network_stats.bytes_sent += 24 + stream.size();
     return CNetMessage("dnaires", stream.GetData());

--- a/src/net/net.h
+++ b/src/net/net.h
@@ -11,8 +11,10 @@
 #include <net/bandwidth_throttle.h>  // Network: Bandwidth throttling
 #include <net/partition_detector.h>  // Network: Partition detection
 #include <net/blockencodings.h>      // BIP 152: Compact blocks
+#include <digital_dna/sample_envelope.h>  // Phase 1.5: SMP1 trailer on dnaires
 #include <primitives/block.h>
 #include <primitives/transaction.h>
+#include <array>
 #include <string>
 #include <vector>
 #include <functional>
@@ -55,10 +57,13 @@ public:
         uint64_t nonce, uint64_t send_wall_ms)>;
     using DNABWResultHandler = std::function<void(int peer_id, uint64_t nonce,
         double upload_mbps, double download_mbps)>;
-    // DNA identity propagation: request/response for full DNA data
+    // DNA identity propagation: request/response for full DNA data.
+    // Phase 1.5: receiver handler also gets the parsed SMP1 trailer (envelope
+    // with populated `signature` if signed; empty signature = unsigned/no-trailer).
     using DNAIdentReqHandler = std::function<void(int peer_id, const std::array<uint8_t, 20>& mik)>;
     using DNAIdentResHandler = std::function<void(int peer_id, const std::array<uint8_t, 20>& mik,
-        bool found, const std::vector<uint8_t>& dna_data)>;
+        bool found, const std::vector<uint8_t>& dna_data,
+        const digital_dna::SampleEnvelope& envelope)>;
     // Phase 2: DNA Verification & Attestation handlers
     using DNAVerifyChallengeHandler = std::function<void(int peer_id, const std::vector<uint8_t>& data)>;
     using DNAVerifyResponseHandler = std::function<void(int peer_id, const std::vector<uint8_t>& data)>;
@@ -95,10 +100,18 @@ public:
                                           uint64_t nonce, bool is_response);
     CNetMessage CreateDNABWTestMessage(uint64_t nonce, uint32_t payload_size);
     CNetMessage CreateDNABWResultMessage(uint64_t nonce, double upload_mbps, double download_mbps);
-    // DNA identity propagation messages
+    // DNA identity propagation messages.
+    // Phase 1.5: `peer_version` selects whether to append an SMP1 trailer when
+    // `envelope` is signed. Pass `envelope=nullptr` for unsigned (pre-1.5)
+    // shape; pass a signed envelope + a peer version >= DNA_SMP1_MIN_PROTOCOL_VERSION
+    // to append the trailer. Mixed: signed envelope + too-old peer version
+    // falls back to unsigned silently so a single sender can broadcast to a
+    // mixed-version network without version-gating at every call site.
     CNetMessage CreateDNAIdentReqMessage(const std::array<uint8_t, 20>& mik);
     CNetMessage CreateDNAIdentResMessage(const std::array<uint8_t, 20>& mik, bool found,
-                                          const std::vector<uint8_t>& dna_data);
+                                          const std::vector<uint8_t>& dna_data,
+                                          const digital_dna::SampleEnvelope* envelope = nullptr,
+                                          int peer_version = 0);
     // Phase 2: DNA Verification messages
     CNetMessage CreateDNAVerifyChallengeMessage(const std::vector<uint8_t>& data);
     CNetMessage CreateDNAVerifyResponseMessage(const std::vector<uint8_t>& data);

--- a/src/net/protocol.h
+++ b/src/net/protocol.h
@@ -19,9 +19,15 @@ static const uint32_t REGTEST_MAGIC = 0xFABFB5DA;
 static const uint32_t DILV_MAGIC    = 0xD17FD100;  // DilV chain
 
 /** Protocol version */
-static const int PROTOCOL_VERSION = 70010;          // v4.0.0: DilV reset + DIL attestation
+static const int PROTOCOL_VERSION = 70011;          // v4.0.18: DNA Phase 1.5 signed sample envelope
 static const int MIN_PEER_PROTO_VERSION = 70005;    // DIL: Allow old nodes until attestation activates at 40,000
 static const int DILV_MIN_PEER_PROTO_VERSION = 70010; // DilV: Require v4.0.0 (new genesis)
+
+/** DNA Phase 1.5 (v4.0.18): minimum peer version that understands the SMP1
+ *  trailer on dnaires. Senders MUST NOT emit the trailer to peers reporting
+ *  a negotiated nVersion below this number — older receivers have a payload
+ *  cap that would treat the oversized message as misbehaviour. */
+static const int DNA_SMP1_MIN_PROTOCOL_VERSION = 70011;
 
 /** Default network port */
 static const uint16_t DEFAULT_PORT = 8444;

--- a/src/node/dilithion-node.cpp
+++ b/src/node/dilithion-node.cpp
@@ -326,21 +326,63 @@ static digital_dna::DNASampleRateLimiter g_dna_sample_limiter;
 // Helper: broadcast a DNA sample to all connected peers via dnaires.
 // Extracted from the initial-registration path so both that path and the
 // progressive-enrichment path can keep the network converged.
+//
+// Phase 1.5: if the wallet has a MIK whose identity matches the DNA's MIK,
+// the broadcast is signed with a fresh (timestamp, nonce) envelope. The
+// trailer is only emitted to peers at protocol version >=
+// DNA_SMP1_MIN_PROTOCOL_VERSION — older peers receive the pre-1.5 payload
+// shape to avoid tripping their smaller size gate.
 static void BroadcastDNASample(const digital_dna::DigitalDNA& dna) {
     if (!g_node_context.connman || !g_node_context.message_processor) return;
     if (dna.mik_identity == std::array<uint8_t, 20>{}) return;
     auto dna_data = dna.serialize();
-    auto msg = g_node_context.message_processor->CreateDNAIdentResMessage(
-        dna.mik_identity, true, dna_data);
-    auto nodes = g_node_context.connman->GetNodes();
-    int sent = 0;
-    for (auto* n : nodes) {
-        if (n && n->IsConnected()) {
-            g_node_context.connman->PushMessage(n->id, msg);
-            ++sent;
+
+    // Attempt to sign. Seeds with no wallet-managed MIK fall back to unsigned.
+    digital_dna::SampleEnvelope envelope;
+    bool have_signed = false;
+    if (g_node_context.wallet && g_node_context.wallet->HasMIK()) {
+        const auto* mik_key = g_node_context.wallet->GetMIKKeyPtr();
+        if (mik_key && mik_key->HasPrivateKey()) {
+            // Only sign if the wallet's MIK matches the DNA's MIK.
+            std::array<uint8_t, 20> wallet_mik{};
+            std::memcpy(wallet_mik.data(), mik_key->identity.data, 20);
+            if (wallet_mik == dna.mik_identity) {
+                envelope.timestamp_sec = static_cast<uint64_t>(
+                    std::chrono::duration_cast<std::chrono::seconds>(
+                        std::chrono::system_clock::now().time_since_epoch()).count());
+                std::random_device rd;
+                std::mt19937_64 gen(rd());
+                envelope.nonce = gen();
+                have_signed = digital_dna::SampleEnvelope::Sign(
+                    mik_key->privkey.data(), mik_key->privkey.size(),
+                    dna.mik_identity,
+                    envelope.timestamp_sec, envelope.nonce, dna_data,
+                    envelope.signature);
+            }
         }
     }
-    std::cout << "[DNA] Broadcast identity to " << sent << " peers" << std::endl;
+
+    auto nodes = g_node_context.connman->GetNodes();
+    int sent = 0;
+    int signed_sent = 0;
+    for (auto* n : nodes) {
+        if (!n || !n->IsConnected()) continue;
+        auto msg = g_node_context.message_processor->CreateDNAIdentResMessage(
+            dna.mik_identity, true, dna_data,
+            have_signed ? &envelope : nullptr,
+            n->nVersion);
+        g_node_context.connman->PushMessage(n->id, msg);
+        ++sent;
+        if (have_signed && n->nVersion >= NetProtocol::DNA_SMP1_MIN_PROTOCOL_VERSION) {
+            ++signed_sent;
+        }
+    }
+    std::cout << "[DNA] Broadcast identity to " << sent << " peers";
+    if (have_signed) {
+        std::cout << " (" << signed_sent << " signed, "
+                  << (sent - signed_sent) << " unsigned legacy)";
+    }
+    std::cout << std::endl;
 }
 
 // Phase 1.2: Global state now managed via NodeContext
@@ -2467,6 +2509,12 @@ int main(int argc, char* argv[]) {
         }
         std::cout << "  [OK] DFMP subsystem initialized" << std::endl;
 
+        // Phase 1.5: MIK pubkey cache. Reads through to DFMP::g_identityDb
+        // for missing keys; populated by block-connect callbacks for the
+        // hot path. Must be constructed after InitializeDFMP returns.
+        g_node_context.mik_pubkey_cache =
+            std::make_unique<digital_dna::MikPubkeyCache>(DFMP::g_identityDb);
+
         // P1-4 FIX: Initialize Write-Ahead Log for atomic reorganizations
         if (!g_chainstate.InitializeWAL(config.datadir)) {
             if (g_chainstate.RequiresReindex()) {
@@ -4353,33 +4401,53 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
             }
         });
 
-        // DNA identity response handler: store received DNA in registry
+        // DNA identity response handler: store received DNA in registry.
+        //
+        // Phase 1.5 staged 6-stage pipeline:
+        //   1. Structural parse — done in ProcessDNAIdentResMessage (net.cpp).
+        //      DNA deserialization + MIK match also happens here below.
+        //   2. Per-peer token bucket — consume before any crypto work.
+        //   3. Route by plausibility — mapped / signed-unmapped / unsigned-unmapped.
+        //   4. Signature verification (signed paths only).
+        //   5. MIK-scoped checks — timestamp skew, replay cache, MIK rate limits.
+        //   6. Accept — append_sample + commit replay + commit MIK limits.
+        //
+        // Silent drops on failure everywhere except stage 1 (structural),
+        // where misbehaviour is already assigned by the parser in net.cpp.
         message_processor.SetDNAIdentResHandler([](int peer_id,
             const std::array<uint8_t, 20>& mik, bool found,
-            const std::vector<uint8_t>& dna_data)
+            const std::vector<uint8_t>& dna_data,
+            const digital_dna::SampleEnvelope& envelope)
         {
             if (!g_node_context.dna_registry) return;
             if (!found || dna_data.empty()) return;
 
+            // Stage 1 continuation — DNA deserialize + MIK match.
             auto dna = digital_dna::DigitalDNA::deserialize(dna_data);
             if (!dna || !dna->is_valid) return;
             if (dna->mik_identity != mik) return;
 
-            // Check by MIK (not address) to match how discovery decides what to request
+            uint64_t now_sec = static_cast<uint64_t>(
+                std::chrono::duration_cast<std::chrono::seconds>(
+                    std::chrono::system_clock::now().time_since_epoch()).count());
+
+            // Check by MIK (not address) to match how discovery decides what to request.
             auto existing = g_node_context.dna_registry->get_identity_by_mik(mik);
             if (!existing) {
                 // First time seeing this MIK — accept without rate-limiting, as the
                 // miner's initial-registration broadcast establishes the peer_id→MIK
                 // mapping that subsequent samples rely on for plausibility.
+                //
+                // Signed trailer is intentionally ignored on first-registration:
+                // the pubkey may not be in our identity DB yet (if the chain hasn't
+                // processed the registration block) and we'd otherwise reject
+                // legitimate initial broadcasts. Later samples use the registered
+                // pubkey to verify the signed-full-replacement path.
                 auto result = g_node_context.dna_registry->register_identity(*dna);
                 const bool stored =
                     (result == digital_dna::IDNARegistry::RegisterResult::SUCCESS ||
                      result == digital_dna::IDNARegistry::RegisterResult::SYBIL_FLAGGED);
                 if (stored) {
-                    // Set mapping only on successful registration. Never set on
-                    // merge-fill or silent-drop paths below — doing so would let any
-                    // relay forwarding a benign dnaires become "mapped" for a MIK,
-                    // bypassing the skip-crypto trust gate on later full replacements.
                     std::lock_guard<std::mutex> lock(g_mik_peer_mutex);
                     g_mik_peer_map[mik] = peer_id;
                     char hex[9];
@@ -4388,70 +4456,115 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                               << peer_id << " (registry=" << g_node_context.dna_registry->count()
                               << ")" << std::endl;
                 }
-            } else {
-                // DNA Propagation Phase 1: accept enriched sample for already-registered MIK.
-                //   1. Plausibility — sender must be the currently-mapped peer for this MIK
-                //      (established by the initial registration broadcast).
-                //   2. Rate-limit — three layers (per-peer bucket, per-MIK global, per-MIK-per-peer).
-                //   3. append_sample — archives old canonical to history, writes new as canonical,
-                //      with 100-entry history cap and a dim-loss guard.
-                //   Dropped samples are silent (no misbehaviour score) so mixed-version and
-                //   proxy-relay scenarios don't get anyone banned.
-                bool mapped = false;
-                {
-                    std::lock_guard<std::mutex> lock(g_mik_peer_mutex);
-                    auto it = g_mik_peer_map.find(mik);
-                    mapped = (it != g_mik_peer_map.end() && it->second == peer_id);
-                }
-                uint64_t now_sec = static_cast<uint64_t>(
-                    std::chrono::duration_cast<std::chrono::seconds>(
-                        std::chrono::system_clock::now().time_since_epoch()).count());
-
-                if (mapped) {
-                    // Full-trust path (Phase 1): mapped peer can overwrite any field.
-                    if (g_dna_sample_limiter.allow(peer_id, mik, now_sec)) {
-                        auto result = g_node_context.dna_registry->append_sample(*dna);
-                        if (result == digital_dna::IDNARegistry::RegisterResult::UPDATED ||
-                            result == digital_dna::IDNARegistry::RegisterResult::DNA_CHANGED) {
-                            char hex[9];
-                            snprintf(hex, sizeof(hex), "%02x%02x%02x%02x",
-                                     mik[0], mik[1], mik[2], mik[3]);
-                            std::cout << "[DNA] Appended sample for MIK " << hex
-                                      << "... from peer " << peer_id << std::endl;
-                        }
-                        // INVALID_DNA (dim-loss) and DB_ERROR are silent — expected under
-                        // mixed-version propagation and transient storage issues.
-                    }
-                } else {
-                    // Phase 1.1 dim-fill path: unmapped peers can fill missing
-                    // dimensions but cannot overwrite existing values. Protects
-                    // data provenance from relay-peer pollution while unblocking
-                    // propagation for the common case (discovery response from a
-                    // peer that happens to have enriched DNA for this MIK).
-                    //
-                    // The mapping is NOT updated here. Unmapped merge-fill is a
-                    // weak-trust path; promoting its sender to mapped status would
-                    // let any relay gain full-replacement authority on subsequent
-                    // messages. The signed-envelope path (Phase 1.5) provides the
-                    // authenticated way for unmapped peers to push full updates.
-                    int filled = 0;
-                    auto merged = digital_dna::merge_fill_missing_dims(*existing, *dna, &filled);
-                    if (filled == 0) {
-                        // Nothing to add — unmapped peer has no new info. Silent drop.
-                    } else if (g_dna_sample_limiter.allow(peer_id, mik, now_sec)) {
-                        auto result = g_node_context.dna_registry->append_sample(merged);
-                        if (result == digital_dna::IDNARegistry::RegisterResult::UPDATED ||
-                            result == digital_dna::IDNARegistry::RegisterResult::DNA_CHANGED) {
-                            char hex[9];
-                            snprintf(hex, sizeof(hex), "%02x%02x%02x%02x",
-                                     mik[0], mik[1], mik[2], mik[3]);
-                            std::cout << "[DNA] Filled " << filled << " dim(s) for MIK "
-                                      << hex << "... from peer " << peer_id
-                                      << " (unmapped)" << std::endl;
-                        }
-                    }
-                }
+                return;
             }
+
+            // ----- Existing-MIK path: the staged 6-stage pipeline. -----
+
+            // Stage 2: per-peer token bucket. Caps verification work a single
+            // peer can force on us regardless of MIK spread. Silent drop.
+            if (!g_dna_sample_limiter.consume_peer_bucket(peer_id, now_sec)) {
+                return;
+            }
+
+            // Stage 3: route by plausibility.
+            bool mapped = false;
+            {
+                std::lock_guard<std::mutex> lock(g_mik_peer_mutex);
+                auto it = g_mik_peer_map.find(mik);
+                mapped = (it != g_mik_peer_map.end() && it->second == peer_id);
+            }
+            const bool signed_envelope = !envelope.signature.empty();
+
+            // Fast path: mapped + unsigned → full replacement, skip crypto.
+            // This preserves Phase 1 trust for the miner's own connection.
+            if (mapped && !signed_envelope) {
+                if (!g_dna_sample_limiter.check_mik_limits(peer_id, mik, now_sec)) return;
+                auto result = g_node_context.dna_registry->append_sample(*dna);
+                if (result == digital_dna::IDNARegistry::RegisterResult::UPDATED ||
+                    result == digital_dna::IDNARegistry::RegisterResult::DNA_CHANGED) {
+                    g_dna_sample_limiter.commit_mik_limits(peer_id, mik, now_sec);
+                    char hex[9];
+                    snprintf(hex, sizeof(hex), "%02x%02x%02x%02x",
+                             mik[0], mik[1], mik[2], mik[3]);
+                    std::cout << "[DNA] Appended sample for MIK " << hex
+                              << "... from peer " << peer_id << std::endl;
+                }
+                return;
+            }
+
+            // Merge-fill path: unmapped + unsigned → Phase 1.1 behaviour.
+            if (!mapped && !signed_envelope) {
+                int filled = 0;
+                auto merged = digital_dna::merge_fill_missing_dims(*existing, *dna, &filled);
+                if (filled == 0) return;  // Nothing to add — silent drop.
+                if (!g_dna_sample_limiter.check_mik_limits(peer_id, mik, now_sec)) return;
+                auto result = g_node_context.dna_registry->append_sample(merged);
+                if (result == digital_dna::IDNARegistry::RegisterResult::UPDATED ||
+                    result == digital_dna::IDNARegistry::RegisterResult::DNA_CHANGED) {
+                    g_dna_sample_limiter.commit_mik_limits(peer_id, mik, now_sec);
+                    char hex[9];
+                    snprintf(hex, sizeof(hex), "%02x%02x%02x%02x",
+                             mik[0], mik[1], mik[2], mik[3]);
+                    std::cout << "[DNA] Filled " << filled << " dim(s) for MIK "
+                              << hex << "... from peer " << peer_id
+                              << " (unmapped)" << std::endl;
+                }
+                return;
+            }
+
+            // Signed path: stage 4 — pubkey lookup + post-hit sanity check + verify.
+            if (!g_node_context.mik_pubkey_cache) return;
+
+            std::vector<uint8_t> pubkey;
+            if (!g_node_context.mik_pubkey_cache->Lookup(mik, pubkey)) {
+                return;  // Unknown MIK; peer may be ahead of our chain. Silent drop.
+            }
+            // Post-hit sanity check: DB must still know this MIK. If a reorg has
+            // dropped it, evict our stale cache entry and silent-drop.
+            if (!g_node_context.mik_pubkey_cache->DbStillHasMIK(mik)) {
+                g_node_context.mik_pubkey_cache->Evict(mik);
+                return;
+            }
+            if (!digital_dna::SampleEnvelope::Verify(
+                    pubkey, mik, envelope.timestamp_sec, envelope.nonce,
+                    dna_data, envelope.signature)) {
+                return;
+            }
+
+            // Stage 5: MIK-scoped checks — skew, replay, MIK rate limits.
+            // Timestamp skew (±600s relative to our wall clock).
+            constexpr uint64_t SKEW_BOUND_SEC = 600;
+            int64_t skew = static_cast<int64_t>(now_sec) -
+                           static_cast<int64_t>(envelope.timestamp_sec);
+            if (skew < -static_cast<int64_t>(SKEW_BOUND_SEC) ||
+                skew >  static_cast<int64_t>(SKEW_BOUND_SEC)) {
+                return;
+            }
+            if (g_dna_sample_limiter.replay_seen(mik, envelope.timestamp_sec, envelope.nonce)) {
+                return;
+            }
+            if (!g_dna_sample_limiter.check_mik_limits(peer_id, mik, now_sec)) {
+                return;
+            }
+
+            // Stage 6: accept — full replacement via append_sample, then commit.
+            auto result = g_node_context.dna_registry->append_sample(*dna);
+            if (result == digital_dna::IDNARegistry::RegisterResult::UPDATED ||
+                result == digital_dna::IDNARegistry::RegisterResult::DNA_CHANGED) {
+                g_dna_sample_limiter.commit_mik_limits(peer_id, mik, now_sec);
+                g_dna_sample_limiter.replay_record(
+                    mik, envelope.timestamp_sec, envelope.nonce, now_sec);
+                char hex[9];
+                snprintf(hex, sizeof(hex), "%02x%02x%02x%02x",
+                         mik[0], mik[1], mik[2], mik[3]);
+                std::cout << "[DNA] Signed accept for MIK " << hex
+                          << "... from peer " << peer_id
+                          << (mapped ? " (mapped)" : " (unmapped)")
+                          << std::endl;
+            }
+            // INVALID_DNA (dim-loss) and DB_ERROR are silent — expected under
+            // mixed-version propagation and transient storage issues.
         });
 
         // Phase 2: DNA Verification & Attestation P2P handlers
@@ -6185,6 +6298,34 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                                             }
                                         }
                                     }
+                                }
+                            }
+                        }
+                    }
+
+                    // Phase 1.5: periodic re-broadcast of our own DNA every 15
+                    // minutes, regardless of enrichment. Paired with the signed
+                    // envelope + version-gated send in BroadcastDNASample, this
+                    // keeps the network converged on our current sample without
+                    // requiring a dimension change to trigger broadcast.
+                    // Seeds without a wallet MIK still benefit — the unsigned
+                    // path still propagates via merge-fill on receivers.
+                    {
+                        static auto last_dna_push = std::chrono::steady_clock::now();
+                        auto now_push = std::chrono::steady_clock::now();
+                        auto push_elapsed = std::chrono::duration_cast<std::chrono::minutes>(
+                            now_push - last_dna_push).count();
+                        if (push_elapsed >= 15 &&
+                            g_node_context.dna_registry &&
+                            g_node_context.connman &&
+                            g_node_context.message_processor) {
+                            auto dna_coll_push = g_node_context.GetDNACollector();
+                            if (dna_coll_push) {
+                                auto dna_push = dna_coll_push->get_dna();
+                                if (dna_push &&
+                                    dna_push->mik_identity != std::array<uint8_t, 20>{}) {
+                                    last_dna_push = now_push;
+                                    BroadcastDNASample(*dna_push);
                                 }
                             }
                         }

--- a/src/node/dilv-node.cpp
+++ b/src/node/dilv-node.cpp
@@ -324,21 +324,57 @@ static digital_dna::DNASampleRateLimiter g_dna_sample_limiter;
 // Helper: broadcast a DNA sample to all connected peers via dnaires.
 // Extracted from the initial-registration path so both that path and the
 // progressive-enrichment path can keep the network converged.
+// Phase 1.5: see dilithion-node.cpp for the full doc. Signs with the wallet
+// MIK privkey when available; version-gates the trailer per peer.
 static void BroadcastDNASample(const digital_dna::DigitalDNA& dna) {
     if (!g_node_context.connman || !g_node_context.message_processor) return;
     if (dna.mik_identity == std::array<uint8_t, 20>{}) return;
     auto dna_data = dna.serialize();
-    auto msg = g_node_context.message_processor->CreateDNAIdentResMessage(
-        dna.mik_identity, true, dna_data);
-    auto nodes = g_node_context.connman->GetNodes();
-    int sent = 0;
-    for (auto* n : nodes) {
-        if (n && n->IsConnected()) {
-            g_node_context.connman->PushMessage(n->id, msg);
-            ++sent;
+
+    digital_dna::SampleEnvelope envelope;
+    bool have_signed = false;
+    if (g_node_context.wallet && g_node_context.wallet->HasMIK()) {
+        const auto* mik_key = g_node_context.wallet->GetMIKKeyPtr();
+        if (mik_key && mik_key->HasPrivateKey()) {
+            std::array<uint8_t, 20> wallet_mik{};
+            std::memcpy(wallet_mik.data(), mik_key->identity.data, 20);
+            if (wallet_mik == dna.mik_identity) {
+                envelope.timestamp_sec = static_cast<uint64_t>(
+                    std::chrono::duration_cast<std::chrono::seconds>(
+                        std::chrono::system_clock::now().time_since_epoch()).count());
+                std::random_device rd;
+                std::mt19937_64 gen(rd());
+                envelope.nonce = gen();
+                have_signed = digital_dna::SampleEnvelope::Sign(
+                    mik_key->privkey.data(), mik_key->privkey.size(),
+                    dna.mik_identity,
+                    envelope.timestamp_sec, envelope.nonce, dna_data,
+                    envelope.signature);
+            }
         }
     }
-    std::cout << "[DNA] Broadcast identity to " << sent << " peers" << std::endl;
+
+    auto nodes = g_node_context.connman->GetNodes();
+    int sent = 0;
+    int signed_sent = 0;
+    for (auto* n : nodes) {
+        if (!n || !n->IsConnected()) continue;
+        auto msg = g_node_context.message_processor->CreateDNAIdentResMessage(
+            dna.mik_identity, true, dna_data,
+            have_signed ? &envelope : nullptr,
+            n->nVersion);
+        g_node_context.connman->PushMessage(n->id, msg);
+        ++sent;
+        if (have_signed && n->nVersion >= NetProtocol::DNA_SMP1_MIN_PROTOCOL_VERSION) {
+            ++signed_sent;
+        }
+    }
+    std::cout << "[DNA] Broadcast identity to " << sent << " peers";
+    if (have_signed) {
+        std::cout << " (" << signed_sent << " signed, "
+                  << (sent - signed_sent) << " unsigned legacy)";
+    }
+    std::cout << std::endl;
 }
 
 // Phase 1.2: Global state now managed via NodeContext
@@ -2393,6 +2429,12 @@ int main(int argc, char* argv[]) {
         }
         std::cout << "  [OK] DFMP subsystem initialized" << std::endl;
 
+        // Phase 1.5: MIK pubkey cache. Reads through to DFMP::g_identityDb
+        // for missing keys; populated by block-connect callbacks for the
+        // hot path. Must be constructed after InitializeDFMP returns.
+        g_node_context.mik_pubkey_cache =
+            std::make_unique<digital_dna::MikPubkeyCache>(DFMP::g_identityDb);
+
         // P1-4 FIX: Initialize Write-Ahead Log for atomic reorganizations
         if (!g_chainstate.InitializeWAL(config.datadir)) {
             if (g_chainstate.RequiresReindex()) {
@@ -4229,10 +4271,12 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
             }
         });
 
-        // DNA identity response handler: store received DNA in registry
+        // DNA identity response handler: store received DNA in registry.
+        // See dilithion-node.cpp for the full stage-by-stage pipeline docs.
         message_processor.SetDNAIdentResHandler([](int peer_id,
             const std::array<uint8_t, 20>& mik, bool found,
-            const std::vector<uint8_t>& dna_data)
+            const std::vector<uint8_t>& dna_data,
+            const digital_dna::SampleEnvelope& envelope)
         {
             if (!g_node_context.dna_registry) return;
             if (!found || dna_data.empty()) return;
@@ -4241,21 +4285,17 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
             if (!dna || !dna->is_valid) return;
             if (dna->mik_identity != mik) return;
 
-            // Check by MIK (not address) to match how discovery decides what to request
+            uint64_t now_sec = static_cast<uint64_t>(
+                std::chrono::duration_cast<std::chrono::seconds>(
+                    std::chrono::system_clock::now().time_since_epoch()).count());
+
             auto existing = g_node_context.dna_registry->get_identity_by_mik(mik);
             if (!existing) {
-                // First time seeing this MIK — accept without rate-limiting, as the
-                // miner's initial-registration broadcast establishes the peer_id→MIK
-                // mapping that subsequent samples rely on for plausibility.
                 auto result = g_node_context.dna_registry->register_identity(*dna);
                 const bool stored =
                     (result == digital_dna::IDNARegistry::RegisterResult::SUCCESS ||
                      result == digital_dna::IDNARegistry::RegisterResult::SYBIL_FLAGGED);
                 if (stored) {
-                    // Set mapping only on successful registration. Never set on
-                    // merge-fill or silent-drop paths below — doing so would let any
-                    // relay forwarding a benign dnaires become "mapped" for a MIK,
-                    // bypassing the skip-crypto trust gate on later full replacements.
                     std::lock_guard<std::mutex> lock(g_mik_peer_mutex);
                     g_mik_peer_map[mik] = peer_id;
                     char hex[9];
@@ -4264,68 +4304,92 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                               << peer_id << " (registry=" << g_node_context.dna_registry->count()
                               << ")" << std::endl;
                 }
-            } else {
-                // DNA Propagation Phase 1: accept enriched sample for already-registered MIK.
-                //   1. Plausibility — sender must be the currently-mapped peer for this MIK.
-                //   2. Rate-limit — three layers (per-peer bucket, per-MIK global, per-MIK-per-peer).
-                //   3. append_sample — archives old canonical to history, writes new as canonical,
-                //      with 100-entry history cap and a dim-loss guard.
-                //   Dropped samples are silent (no misbehaviour score) so mixed-version and
-                //   proxy-relay scenarios don't get anyone banned.
-                bool mapped = false;
-                {
-                    std::lock_guard<std::mutex> lock(g_mik_peer_mutex);
-                    auto it = g_mik_peer_map.find(mik);
-                    mapped = (it != g_mik_peer_map.end() && it->second == peer_id);
-                }
-                uint64_t now_sec = static_cast<uint64_t>(
-                    std::chrono::duration_cast<std::chrono::seconds>(
-                        std::chrono::system_clock::now().time_since_epoch()).count());
+                return;
+            }
 
-                if (mapped) {
-                    // Full-trust path (Phase 1): mapped peer can overwrite any field.
-                    if (g_dna_sample_limiter.allow(peer_id, mik, now_sec)) {
-                        auto result = g_node_context.dna_registry->append_sample(*dna);
-                        if (result == digital_dna::IDNARegistry::RegisterResult::UPDATED ||
-                            result == digital_dna::IDNARegistry::RegisterResult::DNA_CHANGED) {
-                            char hex[9];
-                            snprintf(hex, sizeof(hex), "%02x%02x%02x%02x",
-                                     mik[0], mik[1], mik[2], mik[3]);
-                            std::cout << "[DNA] Appended sample for MIK " << hex
-                                      << "... from peer " << peer_id << std::endl;
-                        }
-                        // INVALID_DNA (dim-loss) and DB_ERROR are silent — expected under
-                        // mixed-version propagation and transient storage issues.
-                    }
-                } else {
-                    // Phase 1.1 dim-fill path: unmapped peers can fill missing
-                    // dimensions but cannot overwrite existing values. Protects
-                    // data provenance from relay-peer pollution while unblocking
-                    // propagation for the common case (discovery response from a
-                    // peer that happens to have enriched DNA for this MIK).
-                    //
-                    // The mapping is NOT updated here. Unmapped merge-fill is a
-                    // weak-trust path; promoting its sender to mapped status would
-                    // let any relay gain full-replacement authority on subsequent
-                    // messages. The signed-envelope path (Phase 1.5) provides the
-                    // authenticated way for unmapped peers to push full updates.
-                    int filled = 0;
-                    auto merged = digital_dna::merge_fill_missing_dims(*existing, *dna, &filled);
-                    if (filled == 0) {
-                        // Nothing to add — unmapped peer has no new info. Silent drop.
-                    } else if (g_dna_sample_limiter.allow(peer_id, mik, now_sec)) {
-                        auto result = g_node_context.dna_registry->append_sample(merged);
-                        if (result == digital_dna::IDNARegistry::RegisterResult::UPDATED ||
-                            result == digital_dna::IDNARegistry::RegisterResult::DNA_CHANGED) {
-                            char hex[9];
-                            snprintf(hex, sizeof(hex), "%02x%02x%02x%02x",
-                                     mik[0], mik[1], mik[2], mik[3]);
-                            std::cout << "[DNA] Filled " << filled << " dim(s) for MIK "
-                                      << hex << "... from peer " << peer_id
-                                      << " (unmapped)" << std::endl;
-                        }
-                    }
+            // Stage 2: per-peer bucket.
+            if (!g_dna_sample_limiter.consume_peer_bucket(peer_id, now_sec)) return;
+
+            // Stage 3: plausibility routing.
+            bool mapped = false;
+            {
+                std::lock_guard<std::mutex> lock(g_mik_peer_mutex);
+                auto it = g_mik_peer_map.find(mik);
+                mapped = (it != g_mik_peer_map.end() && it->second == peer_id);
+            }
+            const bool signed_envelope = !envelope.signature.empty();
+
+            if (mapped && !signed_envelope) {
+                if (!g_dna_sample_limiter.check_mik_limits(peer_id, mik, now_sec)) return;
+                auto result = g_node_context.dna_registry->append_sample(*dna);
+                if (result == digital_dna::IDNARegistry::RegisterResult::UPDATED ||
+                    result == digital_dna::IDNARegistry::RegisterResult::DNA_CHANGED) {
+                    g_dna_sample_limiter.commit_mik_limits(peer_id, mik, now_sec);
+                    char hex[9];
+                    snprintf(hex, sizeof(hex), "%02x%02x%02x%02x",
+                             mik[0], mik[1], mik[2], mik[3]);
+                    std::cout << "[DNA] Appended sample for MIK " << hex
+                              << "... from peer " << peer_id << std::endl;
                 }
+                return;
+            }
+
+            if (!mapped && !signed_envelope) {
+                int filled = 0;
+                auto merged = digital_dna::merge_fill_missing_dims(*existing, *dna, &filled);
+                if (filled == 0) return;
+                if (!g_dna_sample_limiter.check_mik_limits(peer_id, mik, now_sec)) return;
+                auto result = g_node_context.dna_registry->append_sample(merged);
+                if (result == digital_dna::IDNARegistry::RegisterResult::UPDATED ||
+                    result == digital_dna::IDNARegistry::RegisterResult::DNA_CHANGED) {
+                    g_dna_sample_limiter.commit_mik_limits(peer_id, mik, now_sec);
+                    char hex[9];
+                    snprintf(hex, sizeof(hex), "%02x%02x%02x%02x",
+                             mik[0], mik[1], mik[2], mik[3]);
+                    std::cout << "[DNA] Filled " << filled << " dim(s) for MIK "
+                              << hex << "... from peer " << peer_id
+                              << " (unmapped)" << std::endl;
+                }
+                return;
+            }
+
+            // Stage 4: pubkey lookup + post-hit sanity + Dilithium verify.
+            if (!g_node_context.mik_pubkey_cache) return;
+            std::vector<uint8_t> pubkey;
+            if (!g_node_context.mik_pubkey_cache->Lookup(mik, pubkey)) return;
+            if (!g_node_context.mik_pubkey_cache->DbStillHasMIK(mik)) {
+                g_node_context.mik_pubkey_cache->Evict(mik);
+                return;
+            }
+            if (!digital_dna::SampleEnvelope::Verify(
+                    pubkey, mik, envelope.timestamp_sec, envelope.nonce,
+                    dna_data, envelope.signature)) {
+                return;
+            }
+
+            // Stage 5: MIK-scoped checks.
+            constexpr uint64_t SKEW_BOUND_SEC = 600;
+            int64_t skew = static_cast<int64_t>(now_sec) -
+                           static_cast<int64_t>(envelope.timestamp_sec);
+            if (skew < -static_cast<int64_t>(SKEW_BOUND_SEC) ||
+                skew >  static_cast<int64_t>(SKEW_BOUND_SEC)) return;
+            if (g_dna_sample_limiter.replay_seen(mik, envelope.timestamp_sec, envelope.nonce)) return;
+            if (!g_dna_sample_limiter.check_mik_limits(peer_id, mik, now_sec)) return;
+
+            // Stage 6: accept + commit replay/limits.
+            auto result = g_node_context.dna_registry->append_sample(*dna);
+            if (result == digital_dna::IDNARegistry::RegisterResult::UPDATED ||
+                result == digital_dna::IDNARegistry::RegisterResult::DNA_CHANGED) {
+                g_dna_sample_limiter.commit_mik_limits(peer_id, mik, now_sec);
+                g_dna_sample_limiter.replay_record(
+                    mik, envelope.timestamp_sec, envelope.nonce, now_sec);
+                char hex[9];
+                snprintf(hex, sizeof(hex), "%02x%02x%02x%02x",
+                         mik[0], mik[1], mik[2], mik[3]);
+                std::cout << "[DNA] Signed accept for MIK " << hex
+                          << "... from peer " << peer_id
+                          << (mapped ? " (mapped)" : " (unmapped)")
+                          << std::endl;
             }
         });
 
@@ -6045,6 +6109,30 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                                             }
                                         }
                                     }
+                                }
+                            }
+                        }
+                    }
+
+                    // Phase 1.5: 15-min periodic push of our own DNA. See
+                    // dilithion-node.cpp for rationale. Signed via
+                    // BroadcastDNASample when wallet has a matching MIK.
+                    {
+                        static auto last_dna_push = std::chrono::steady_clock::now();
+                        auto now_push = std::chrono::steady_clock::now();
+                        auto push_elapsed = std::chrono::duration_cast<std::chrono::minutes>(
+                            now_push - last_dna_push).count();
+                        if (push_elapsed >= 15 &&
+                            g_node_context.dna_registry &&
+                            g_node_context.connman &&
+                            g_node_context.message_processor) {
+                            auto dna_coll_push = g_node_context.GetDNACollector();
+                            if (dna_coll_push) {
+                                auto dna_push = dna_coll_push->get_dna();
+                                if (dna_push &&
+                                    dna_push->mik_identity != std::array<uint8_t, 20>{}) {
+                                    last_dna_push = now_push;
+                                    BroadcastDNASample(*dna_push);
                                 }
                             }
                         }

--- a/src/test/dna_propagation_tests.cpp
+++ b/src/test/dna_propagation_tests.cpp
@@ -25,16 +25,26 @@
 
 #include <digital_dna/digital_dna.h>
 #include <digital_dna/dna_registry_db.h>
+#include <digital_dna/sample_envelope.h>
 #include <digital_dna/sample_rate_limiter.h>
+#include <dfmp/mik.h>  // MIK_PRIVKEY_SIZE, MIK_PUBKEY_SIZE, MIK_SIGNATURE_SIZE
 
 #include <array>
 #include <chrono>
 #include <cstdint>
+#include <cstring>
 #include <filesystem>
 #include <iostream>
 #include <stdexcept>
 #include <string>
 #include <vector>
+
+// Dilithium3 keypair — declared here because the test needs to fabricate
+// a real keypair for sign/verify round-trips (not available via the public
+// wallet path in a pure unit test).
+extern "C" {
+    int pqcrystals_dilithium3_ref_keypair(uint8_t *pk, uint8_t *sk);
+}
 
 #define RESET_  "\033[0m"
 #define GREEN_  "\033[32m"
@@ -533,11 +543,329 @@ TEST(dna_registry_db_get_all_miks_returns_stored_miks) {
 }
 
 // ---------------------------------------------------------------------------
+// Phase 1.5 — SampleEnvelope sign/verify, TryParse negatives,
+//             replay cache, staged rate-limiter APIs.
+// ---------------------------------------------------------------------------
+
+namespace p15 {
+
+struct Keypair {
+    std::vector<uint8_t> pubkey;
+    std::vector<uint8_t> privkey;
+};
+
+static Keypair make_keypair() {
+    Keypair k;
+    k.pubkey.resize(DFMP::MIK_PUBKEY_SIZE);
+    k.privkey.resize(DFMP::MIK_PRIVKEY_SIZE);
+    int rc = pqcrystals_dilithium3_ref_keypair(k.pubkey.data(), k.privkey.data());
+    if (rc != 0) throw std::runtime_error("keypair generation failed");
+    return k;
+}
+
+static std::array<uint8_t, 20> make_mik(uint8_t seed) {
+    std::array<uint8_t, 20> m{};
+    for (size_t i = 0; i < m.size(); ++i) m[i] = seed + static_cast<uint8_t>(i);
+    return m;
+}
+
+static std::vector<uint8_t> make_dna_bytes(uint8_t seed, size_t len = 256) {
+    std::vector<uint8_t> out(len);
+    for (size_t i = 0; i < len; ++i) out[i] = static_cast<uint8_t>(seed ^ (i * 31));
+    return out;
+}
+
+} // namespace p15
+
+using digital_dna::SampleEnvelope;
+
+TEST(envelope_sign_verify_roundtrip) {
+    auto kp = p15::make_keypair();
+    auto mik = p15::make_mik(0x01);
+    auto dna = p15::make_dna_bytes(0x42);
+    std::vector<uint8_t> sig;
+    bool ok = SampleEnvelope::Sign(
+        kp.privkey.data(), kp.privkey.size(), mik,
+        1700000000ULL, 0xdeadbeefULL, dna, sig);
+    ASSERT(ok, "Sign should succeed");
+    ASSERT_EQ(sig.size(), DFMP::MIK_SIGNATURE_SIZE, "signature length");
+    ASSERT(SampleEnvelope::Verify(
+               kp.pubkey, mik, 1700000000ULL, 0xdeadbeefULL, dna, sig),
+           "Verify of round-trip should pass");
+}
+
+TEST(envelope_verify_rejects_tampered_signature) {
+    auto kp = p15::make_keypair();
+    auto mik = p15::make_mik(0x02);
+    auto dna = p15::make_dna_bytes(0x77);
+    std::vector<uint8_t> sig;
+    ASSERT(SampleEnvelope::Sign(kp.privkey.data(), kp.privkey.size(),
+                                 mik, 1700000000ULL, 1ULL, dna, sig), "sign");
+    sig[42] ^= 0x01;  // flip one bit
+    ASSERT(!SampleEnvelope::Verify(kp.pubkey, mik, 1700000000ULL, 1ULL, dna, sig),
+           "tampered signature must fail verify");
+}
+
+TEST(envelope_verify_rejects_tampered_dna_data) {
+    auto kp = p15::make_keypair();
+    auto mik = p15::make_mik(0x03);
+    auto dna = p15::make_dna_bytes(0x11);
+    std::vector<uint8_t> sig;
+    ASSERT(SampleEnvelope::Sign(kp.privkey.data(), kp.privkey.size(),
+                                 mik, 1700000000ULL, 2ULL, dna, sig), "sign");
+    dna[7] ^= 0x01;
+    ASSERT(!SampleEnvelope::Verify(kp.pubkey, mik, 1700000000ULL, 2ULL, dna, sig),
+           "tampered dna_data must fail verify");
+}
+
+TEST(envelope_verify_rejects_wrong_mik) {
+    auto kp = p15::make_keypair();
+    auto mik1 = p15::make_mik(0x04);
+    auto mik2 = p15::make_mik(0x05);  // different
+    auto dna = p15::make_dna_bytes(0x22);
+    std::vector<uint8_t> sig;
+    ASSERT(SampleEnvelope::Sign(kp.privkey.data(), kp.privkey.size(),
+                                 mik1, 1700000000ULL, 3ULL, dna, sig), "sign");
+    ASSERT(!SampleEnvelope::Verify(kp.pubkey, mik2, 1700000000ULL, 3ULL, dna, sig),
+           "verify under different mik must fail");
+}
+
+TEST(envelope_tryparse_empty_returns_none) {
+    SampleEnvelope env;
+    auto r = SampleEnvelope::TryParse({}, env);
+    ASSERT(r == SampleEnvelope::ParseResult::NONE, "empty trailer = NONE");
+    ASSERT(env.signature.empty(), "signature empty on NONE");
+}
+
+TEST(envelope_tryparse_unknown_magic_is_silent_ignore) {
+    SampleEnvelope env;
+    // 4 bytes not matching "SMP1"
+    std::vector<uint8_t> t = {'X','X','X','X', 0,0,0,0, 0,0,0,0};
+    auto r = SampleEnvelope::TryParse(t, env);
+    ASSERT(r == SampleEnvelope::ParseResult::UNKNOWN_MAGIC,
+           "unknown magic must be UNKNOWN_MAGIC (forward-compat), not malformed");
+}
+
+TEST(envelope_tryparse_truncated_magic_is_malformed) {
+    SampleEnvelope env;
+    // Fewer than 4 bytes = can't determine magic => malformed
+    std::vector<uint8_t> t = {'S','M'};
+    auto r = SampleEnvelope::TryParse(t, env);
+    ASSERT(r == SampleEnvelope::ParseResult::MALFORMED, "truncated magic = MALFORMED");
+}
+
+TEST(envelope_tryparse_truncated_timestamp) {
+    SampleEnvelope env;
+    // SMP1 magic + 5 bytes of "timestamp" (truncated; need 8)
+    std::vector<uint8_t> t = {'S','M','P','1', 1,2,3,4,5};
+    auto r = SampleEnvelope::TryParse(t, env);
+    ASSERT(r == SampleEnvelope::ParseResult::MALFORMED, "truncated ts = MALFORMED");
+}
+
+TEST(envelope_tryparse_truncated_nonce) {
+    SampleEnvelope env;
+    // SMP1 + 8-byte ts + 3 bytes of nonce (truncated; need 8)
+    std::vector<uint8_t> t(4 + 8 + 3, 0);
+    t[0]='S'; t[1]='M'; t[2]='P'; t[3]='1';
+    auto r = SampleEnvelope::TryParse(t, env);
+    ASSERT(r == SampleEnvelope::ParseResult::MALFORMED, "truncated nonce = MALFORMED");
+}
+
+TEST(envelope_tryparse_truncated_sig_len) {
+    SampleEnvelope env;
+    // SMP1 + ts(8) + nonce(8) + 1 byte of sig_len (need 2)
+    std::vector<uint8_t> t(4 + 8 + 8 + 1, 0);
+    t[0]='S'; t[1]='M'; t[2]='P'; t[3]='1';
+    auto r = SampleEnvelope::TryParse(t, env);
+    ASSERT(r == SampleEnvelope::ParseResult::MALFORMED, "truncated sig_len = MALFORMED");
+}
+
+TEST(envelope_tryparse_siglen_zero_is_malformed) {
+    SampleEnvelope env;
+    std::vector<uint8_t> t(4 + 8 + 8 + 2, 0);
+    t[0]='S'; t[1]='M'; t[2]='P'; t[3]='1';
+    // sig_len = 0 (already zeroed), remaining = 0 — still malformed per spec
+    auto r = SampleEnvelope::TryParse(t, env);
+    ASSERT(r == SampleEnvelope::ParseResult::MALFORMED,
+           "sig_len=0 is meaningless with SMP1 — must be MALFORMED");
+}
+
+TEST(envelope_tryparse_wrong_sig_len) {
+    SampleEnvelope env;
+    // sig_len = 100 (not Dilithium3's 3309) but remaining matches to make sure
+    // the length check fires before the remaining-bytes check.
+    std::vector<uint8_t> t(4 + 8 + 8 + 2 + 100, 0);
+    t[0]='S'; t[1]='M'; t[2]='P'; t[3]='1';
+    t[4 + 8 + 8] = 100;  // sig_len LE low byte
+    t[4 + 8 + 8 + 1] = 0;
+    auto r = SampleEnvelope::TryParse(t, env);
+    ASSERT(r == SampleEnvelope::ParseResult::MALFORMED,
+           "sig_len != MIK_SIGNATURE_SIZE must be MALFORMED");
+}
+
+TEST(envelope_tryparse_sig_len_gt_remaining) {
+    SampleEnvelope env;
+    // sig_len = MIK_SIGNATURE_SIZE (3309) but only 10 bytes remain
+    std::vector<uint8_t> t(4 + 8 + 8 + 2 + 10, 0);
+    t[0]='S'; t[1]='M'; t[2]='P'; t[3]='1';
+    uint16_t sig_len = static_cast<uint16_t>(DFMP::MIK_SIGNATURE_SIZE);
+    t[4 + 8 + 8] = static_cast<uint8_t>(sig_len & 0xFF);
+    t[4 + 8 + 8 + 1] = static_cast<uint8_t>(sig_len >> 8);
+    auto r = SampleEnvelope::TryParse(t, env);
+    ASSERT(r == SampleEnvelope::ParseResult::MALFORMED,
+           "sig_len larger than remaining bytes = MALFORMED");
+}
+
+TEST(envelope_tryparse_trailing_bytes_after_sig) {
+    SampleEnvelope env;
+    // sig_len = MIK_SIGNATURE_SIZE, but trailer carries one extra byte after.
+    std::vector<uint8_t> t(4 + 8 + 8 + 2 + DFMP::MIK_SIGNATURE_SIZE + 1, 0);
+    t[0]='S'; t[1]='M'; t[2]='P'; t[3]='1';
+    uint16_t sig_len = static_cast<uint16_t>(DFMP::MIK_SIGNATURE_SIZE);
+    t[4 + 8 + 8] = static_cast<uint8_t>(sig_len & 0xFF);
+    t[4 + 8 + 8 + 1] = static_cast<uint8_t>(sig_len >> 8);
+    auto r = SampleEnvelope::TryParse(t, env);
+    ASSERT(r == SampleEnvelope::ParseResult::MALFORMED,
+           "extra bytes after declared signature must be MALFORMED (strict mode)");
+}
+
+TEST(envelope_tryparse_duplicate_magic) {
+    SampleEnvelope env;
+    // SMP1 header + a second SMP1 inside the signature region (place at an
+    // offset that collides with what would otherwise be a valid trailer).
+    std::vector<uint8_t> t(4 + 8 + 8 + 2 + DFMP::MIK_SIGNATURE_SIZE, 0);
+    t[0]='S'; t[1]='M'; t[2]='P'; t[3]='1';
+    uint16_t sig_len = static_cast<uint16_t>(DFMP::MIK_SIGNATURE_SIZE);
+    t[4 + 8 + 8] = static_cast<uint8_t>(sig_len & 0xFF);
+    t[4 + 8 + 8 + 1] = static_cast<uint8_t>(sig_len >> 8);
+    // Place a second SMP1 at offset 100 (well inside the signature region)
+    t[100]='S'; t[101]='M'; t[102]='P'; t[103]='1';
+    auto r = SampleEnvelope::TryParse(t, env);
+    ASSERT(r == SampleEnvelope::ParseResult::MALFORMED,
+           "duplicate SMP1 markers in trailer region must be MALFORMED");
+}
+
+TEST(envelope_tryparse_valid_roundtrip_via_towire) {
+    auto kp = p15::make_keypair();
+    auto mik = p15::make_mik(0x06);
+    auto dna = p15::make_dna_bytes(0x55);
+    SampleEnvelope in;
+    in.timestamp_sec = 1700000123ULL;
+    in.nonce = 0xcafebabe12345678ULL;
+    ASSERT(SampleEnvelope::Sign(kp.privkey.data(), kp.privkey.size(),
+                                 mik, in.timestamp_sec, in.nonce, dna, in.signature),
+           "sign roundtrip");
+
+    auto wire = in.ToWireBytes();
+    ASSERT(!wire.empty(), "wire bytes non-empty");
+
+    SampleEnvelope out;
+    auto r = SampleEnvelope::TryParse(wire, out);
+    ASSERT(r == SampleEnvelope::ParseResult::SIGNED,
+           "roundtrip via ToWireBytes -> TryParse must be SIGNED");
+    ASSERT_EQ(out.timestamp_sec, in.timestamp_sec, "ts roundtrip");
+    ASSERT_EQ(out.nonce, in.nonce, "nonce roundtrip");
+    ASSERT_EQ(out.signature.size(), in.signature.size(), "sig size roundtrip");
+    ASSERT(std::memcmp(out.signature.data(), in.signature.data(), in.signature.size()) == 0,
+           "sig bytes roundtrip");
+
+    // And the parsed envelope verifies against the original pubkey.
+    ASSERT(SampleEnvelope::Verify(kp.pubkey, mik, out.timestamp_sec, out.nonce,
+                                   dna, out.signature),
+           "parsed sig verifies");
+}
+
+// ---- Replay cache -------------------------------------------------------
+
+TEST(replay_cache_not_seen_before_record) {
+    DNASampleRateLimiter lim;
+    auto mik = p15::make_mik(0x10);
+    ASSERT(!lim.replay_seen(mik, 100, 1), "unseen (mik,ts,nonce) is not in cache");
+}
+
+TEST(replay_cache_seen_after_record) {
+    DNASampleRateLimiter lim;
+    auto mik = p15::make_mik(0x11);
+    lim.replay_record(mik, 100, 1, 1700000000ULL);
+    ASSERT(lim.replay_seen(mik, 100, 1), "recorded (mik,ts,nonce) must be seen");
+    ASSERT(!lim.replay_seen(mik, 100, 2), "different nonce not seen");
+    ASSERT(!lim.replay_seen(mik, 101, 1), "different ts not seen");
+}
+
+TEST(replay_cache_expires_after_ttl) {
+    DNASampleRateLimiter lim;
+    auto mik = p15::make_mik(0x12);
+    lim.replay_record(mik, 100, 42, 1700000000ULL);
+    ASSERT(lim.replay_seen(mik, 100, 42), "seen at record time");
+    // After record: entry expires at now_sec + REPLAY_TTL_SEC (1700000000 + 600)
+    // A later record at a time past that will prune the expired entry.
+    lim.replay_record(mik, 200, 99, 1700000000ULL + DNASampleRateLimiter::REPLAY_TTL_SEC + 1);
+    ASSERT(!lim.replay_seen(mik, 100, 42), "original entry pruned after TTL");
+    ASSERT(lim.replay_seen(mik, 200, 99), "new entry still present");
+}
+
+// ---- Staged rate-limiter APIs ------------------------------------------
+
+TEST(staged_consume_peer_bucket_caps_at_burst) {
+    DNASampleRateLimiter lim;
+    // Peer 1 starts at full burst = 5 tokens. Staged API caps at burst.
+    for (int i = 0; i < static_cast<int>(DNASampleRateLimiter::PEER_BUCKET_BURST); ++i) {
+        ASSERT(lim.consume_peer_bucket(1, 1000), "burst consume");
+    }
+    ASSERT(!lim.consume_peer_bucket(1, 1000), "6th consume in same second must fail");
+}
+
+TEST(staged_peer_bucket_refills_over_time) {
+    DNASampleRateLimiter lim;
+    // Drain all 5 tokens.
+    for (int i = 0; i < static_cast<int>(DNASampleRateLimiter::PEER_BUCKET_BURST); ++i) {
+        lim.consume_peer_bucket(1, 1000);
+    }
+    // One refill tick is PEER_BUCKET_REFILL_SEC.
+    ASSERT(lim.consume_peer_bucket(1, 1000 + DNASampleRateLimiter::PEER_BUCKET_REFILL_SEC),
+           "one refill after refill-sec should allow one consume");
+}
+
+TEST(staged_check_mik_limits_is_non_mutating) {
+    DNASampleRateLimiter lim;
+    auto mik = p15::make_mik(0x20);
+    // Fresh MIK — both layers pass. Call twice: idempotent / non-mutating.
+    ASSERT(lim.check_mik_limits(1, mik, 1000), "first check passes");
+    ASSERT(lim.check_mik_limits(1, mik, 1000), "second check still passes (non-mutating)");
+}
+
+TEST(staged_commit_mik_limits_persists) {
+    DNASampleRateLimiter lim;
+    auto mik = p15::make_mik(0x21);
+    ASSERT(lim.check_mik_limits(1, mik, 1000), "initial check passes");
+    lim.commit_mik_limits(1, mik, 1000);
+    // Immediately after commit, per-MIK global should deny for MIK_GLOBAL_MIN_SEC.
+    ASSERT(!lim.check_mik_limits(2, mik, 1001),
+           "different peer within MIK global window must fail");
+    ASSERT(!lim.check_mik_limits(1, mik, 1001),
+           "same peer within MIK-per-peer window must fail");
+    // After MIK_GLOBAL_MIN_SEC + 1, a different peer passes the global layer
+    // but still fails MIK-per-peer on peer 1; peer 2 sees fresh state.
+    uint64_t later = 1000 + DNASampleRateLimiter::MIK_GLOBAL_MIN_SEC + 1;
+    ASSERT(lim.check_mik_limits(2, mik, later),
+           "different peer after global min passes");
+}
+
+TEST(staged_allow_still_works_for_phase_1_callers) {
+    // Regression: the atomic allow() / allow_detail() path must still be intact
+    // after the split-API refactor so Phase 1.1 merge-fill callers don't break.
+    DNASampleRateLimiter lim;
+    auto mik = p15::make_mik(0x22);
+    ASSERT(lim.allow(1, mik, 1000), "first allow accepts");
+    ASSERT(!lim.allow(1, mik, 1001), "same peer within window rejects");
+}
+
+// ---------------------------------------------------------------------------
 // main
 // ---------------------------------------------------------------------------
 
 int main() {
-    std::cout << "\n" << YELLOW_ << "=== DNA Propagation Phase 1 + 1.1 Tests ===" << RESET_ << "\n" << std::endl;
+    std::cout << "\n" << YELLOW_ << "=== DNA Propagation Phase 1 + 1.1 + 1.5 Tests ===" << RESET_ << "\n" << std::endl;
 
     test_append_sample_unregistered_registers_wrapper();
     test_append_sample_enriches_and_archives_wrapper();
@@ -562,6 +890,37 @@ int main() {
     test_discovery_source_dil_empty_cooldown_tracker_returns_registry_miks_wrapper();
     test_discovery_source_union_dedupes_overlap_wrapper();
     test_dna_registry_db_get_all_miks_returns_stored_miks_wrapper();
+
+    // Phase 1.5 envelope tests
+    test_envelope_sign_verify_roundtrip_wrapper();
+    test_envelope_verify_rejects_tampered_signature_wrapper();
+    test_envelope_verify_rejects_tampered_dna_data_wrapper();
+    test_envelope_verify_rejects_wrong_mik_wrapper();
+
+    test_envelope_tryparse_empty_returns_none_wrapper();
+    test_envelope_tryparse_unknown_magic_is_silent_ignore_wrapper();
+    test_envelope_tryparse_truncated_magic_is_malformed_wrapper();
+    test_envelope_tryparse_truncated_timestamp_wrapper();
+    test_envelope_tryparse_truncated_nonce_wrapper();
+    test_envelope_tryparse_truncated_sig_len_wrapper();
+    test_envelope_tryparse_siglen_zero_is_malformed_wrapper();
+    test_envelope_tryparse_wrong_sig_len_wrapper();
+    test_envelope_tryparse_sig_len_gt_remaining_wrapper();
+    test_envelope_tryparse_trailing_bytes_after_sig_wrapper();
+    test_envelope_tryparse_duplicate_magic_wrapper();
+    test_envelope_tryparse_valid_roundtrip_via_towire_wrapper();
+
+    // Phase 1.5 replay cache tests
+    test_replay_cache_not_seen_before_record_wrapper();
+    test_replay_cache_seen_after_record_wrapper();
+    test_replay_cache_expires_after_ttl_wrapper();
+
+    // Phase 1.5 staged rate-limiter API tests
+    test_staged_consume_peer_bucket_caps_at_burst_wrapper();
+    test_staged_peer_bucket_refills_over_time_wrapper();
+    test_staged_check_mik_limits_is_non_mutating_wrapper();
+    test_staged_commit_mik_limits_persists_wrapper();
+    test_staged_allow_still_works_for_phase_1_callers_wrapper();
 
     std::cout << "\n" << YELLOW_ << "=== Results ===" << RESET_ << std::endl;
     std::cout << GREEN_ << "Passed: " << g_tests_passed << RESET_ << std::endl;


### PR DESCRIPTION
## Summary

Closes the last DNA propagation gap identified after Phase 1.1 deployment. Miners now cryptographically sign their DNA broadcasts so any peer with a valid signature can push **full-replacement** updates across the network — not just the dim-fill merge that Phase 1.1 allowed for unmapped peers.

Also adds a 15-minute periodic push so propagation stays live even when dimension values don't change.

Contract: `.claude/contracts/dna_phase_1_5.md` (locked after Cursor's 2026-04-23 technical review). All four Cursor findings are folded in:

1. **Version-gated send** — new `DNA_SMP1_MIN_PROTOCOL_VERSION = 70011`. The `SMP1` trailer is only emitted to peers at or above that version; older v4.0.17 peers receive the unchanged pre-1.5 payload shape, avoiding the smaller size-cap misbehaviour that would otherwise trip their parser.
2. **Split `DNASampleRateLimiter` APIs** — `consume_peer_bucket` / `check_mik_limits` / `commit_mik_limits` / `replay_seen` / `replay_record` enable the staged receive pipeline to reject-without-commit when stage 4 (signature verify) or stage 5 (skew / replay) fail.
3. **Post-hit `HasMIKPubKey` sanity check** — defends against stale pubkey cache entries that could otherwise outlive a reorg-driven DB eviction. One microsecond DB existence check before a 1–3ms Dilithium verify.
4. **Pre-requisite `g_mik_peer_map` fix** — shipped as the standalone PR #22, merged into main before this branch rebased onto it.

## What lands in this PR

Three commits on top of main (`f783d9b`):

- `661809a` **Foundation** — three new modules:
  - `src/digital_dna/sample_envelope.{h,cpp}` — Dilithium3 sign/verify with a domain-separated sign target: `"DNASMP1" || mik || ts_le || nonce_le || SHA3_256(dna_data)`, plus `TryParse`/`ToWireBytes` for the trailer. Takes raw privkey pointer + length so the wallet's SecureAllocator-backed key flows without copy.
  - `src/digital_dna/mik_pubkey_cache.{h,cpp}` — Option D cache, LRU-bounded at 10k, read-through fallback to `DFMP::g_identityDb`, `DbStillHasMIK` for the post-hit sanity check.
  - `src/digital_dna/sample_rate_limiter.{h,cpp}` — extended with the split APIs listed above, plus a 10-min replay FIFO keyed by `SHA3-256(mik || ts_le || nonce_le)`.
- `c6a2f24` **Wire format + receiver pipeline + miner signing**:
  - `SMP1` trailer on `dnaires`. Size gate raised `{21, 4117}` → `{21, 8192}`. `PROTOCOL_VERSION` bumped `70010` → `70011`. Parser enforces the trailer-offset invariant (no scanning inside `dna_data`) and all 8 parser-negative cases.
  - Full 6-stage receive pipeline in both node binaries: structural parse → per-peer bucket → plausibility route → signature verify → MIK-scoped checks → accept. Mapped-peer legacy fast path preserved. Unsigned unmapped falls to Phase 1.1 merge-fill.
  - Miner-side `BroadcastDNASample` signs via the wallet MIK when it matches the DNA's MIK; version-gates per peer. Seeds without a wallet MIK broadcast unsigned (initial-registration path preserved).
  - 15-minute periodic push in the main loop of both binaries.
- `4c3b7d6` **Unit tests** — 24 new tests in `dna_propagation_tests.cpp` covering envelope sign/verify, all 12 parser-negative and round-trip cases, replay cache TTL, and all 5 staged rate-limiter API behaviours. **42/42 tests green.**

## Compatibility matrix

| Sender (v4.0.18) | Receiver | Payload shape | Path |
| --- | --- | --- | --- |
| Signed + wallet MIK | v4.0.18 peer | `dnaires` + `SMP1` trailer | Stage 4 sig verify → full replacement |
| Signed + wallet MIK | v4.0.17 peer | `dnaires` unchanged (no trailer) | Phase 1 mapped / Phase 1.1 merge-fill |
| Unsigned (seed/no MIK) | v4.0.18 peer | `dnaires` unchanged | Phase 1 mapped / Phase 1.1 merge-fill |
| Unsigned | v4.0.17 peer | `dnaires` unchanged | Phase 1 mapped / Phase 1.1 merge-fill |

Old peers never see an oversized message, never misbehaviour-score. Mixed-version rollout is safe.

## DoS budget

- Stage 2 per-peer bucket (O(1)) runs before any Dilithium verify. One peer can force at most `PEER_BUCKET_BURST = 5` sig verifications per 30s window ≈ 15ms CPU per peer per 30s.
- Per-MIK rate limits (stage 5) gate acceptance after verify so legitimate signed updates aren't pre-throttled.
- Replay cache bounded by 10-min TTL × traffic. At typical 10-20 peer × 6 signed pushes/hour this is hundreds of entries max.

## Rollout plan (from the contract)

1. Deploy to NYC first (DIL only) — observe `[DNA] Signed accept` log lines within 1h.
2. 24h NYC observation window — advance to LDN/SGP/SYD only if all of: ≥10 Signed accept events, zero malformed-trailer parse errors, misbehaviour rate flat or lower, CPU < baseline + 5%, peer count ≥90% of pre-deploy.
3. Rollback triggers: sanitizer crash, parse-error rate > 5/min, verify CPU > baseline + 15%, misbehaviour rate > 2× baseline, peer count drop > 20%.
4. Cut v4.0.18 release binary. Discord #mining announcement. 7-day coverage observation.

## Test plan

- [x] MSYS2 clean build: `dilithion-node`, `dilv-node`, `dna_propagation_tests` all link cleanly. Pre-existing warnings only.
- [x] `dna_propagation_tests` 42/42 green (18 pre-existing + 24 new Phase 1.5).
- [ ] CI green (Linux, macOS, Windows workflows).
- [ ] Manual 2-node test on a dev pair exercising: mapped-peer full replacement (unsigned legacy), signed full replacement (unmapped), unsigned merge-fill (unmapped), replay rejection, timestamp skew rejection.
- [ ] Code review.

## Conflict note

Sister PR #23 (first-time miner registration) also touches `dilithion-node.cpp` and `dilv-node.cpp`. If #23 lands first, this PR rebases cleanly against the post-#23 main (small context shifts only, no semantic conflict — #23 touches handshake / registration scaffolding, this PR touches the DNA receiver handler and broadcast helper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)