### PR TITLE
fix(dna): Phase 1.5 follow-ups #2 — wallet wiring, encrypted-wallet signing, authoritative merge (live-tested)

### DIFF
--- a/src/digital_dna/digital_dna.h
+++ b/src/digital_dna/digital_dna.h
@@ -447,6 +447,56 @@ inline DigitalDNA merge_fill_missing_dims(const DigitalDNA& existing,
     return merged;
 }
 
+/**
+ * Phase 1.5: merge an authenticated (signed) sample with the existing
+ * canonical record, treating the signed sample as the source of truth for
+ * any dimension it asserts.
+ *
+ * Per dim:
+ *   - If incoming has the dim populated → use incoming's value (signed
+ *     assertion from the MIK holder is authoritative).
+ *   - Else → keep existing's value (preserves dims the MIK doesn't assert
+ *     this round, which may have been enriched from other peers).
+ *
+ * The merged result always has at least the dim count of `existing`, so the
+ * dim-loss guard in `append_sample` never trips for signed traffic. This
+ * lets a miner who currently collects only a subset of dims still publish
+ * authoritative updates for the ones they DO collect, without losing the
+ * network's accumulated knowledge of the dims they don't.
+ *
+ * Trust-model note: the MIK can update dims they assert, but cannot delete
+ * dims they don't assert. They could already publish wrong values for dims
+ * they assert (no defense against a dishonest MIK on its own data). The
+ * per-dim provenance refinement (which would, for example, defer to the
+ * receiver's own latency/bandwidth measurements over the MIK's claim) is
+ * deferred to a Phase 2 spec with explicit Cursor design review.
+ */
+inline DigitalDNA merge_authoritative_dims(const DigitalDNA& existing,
+                                           const DigitalDNA& incoming) {
+    // Start from incoming. Core dims (latency, timing, identity, address) are
+    // always present on a valid DigitalDNA, so they take incoming's values
+    // unconditionally — that's the "authoritative for what's asserted" rule.
+    DigitalDNA merged = incoming;
+
+    // Optional dims: if incoming didn't assert, fall back to existing.
+    if (!incoming.memory      && existing.memory)      merged.memory      = existing.memory;
+    if (!incoming.clock_drift && existing.clock_drift) merged.clock_drift = existing.clock_drift;
+    if (!incoming.bandwidth   && existing.bandwidth)   merged.bandwidth   = existing.bandwidth;
+    if (!incoming.thermal     && existing.thermal)     merged.thermal     = existing.thermal;
+    if (!incoming.behavioral  && existing.behavioral)  merged.behavioral  = existing.behavioral;
+
+    // Perspective: same predicate as merge_fill_missing_dims uses.
+    bool incoming_has_perspective = (incoming.perspective.total_unique_peers() > 0
+                                     || !incoming.perspective.snapshots.empty());
+    bool existing_has_perspective = (existing.perspective.total_unique_peers() > 0
+                                     || !existing.perspective.snapshots.empty());
+    if (!incoming_has_perspective && existing_has_perspective) {
+        merged.perspective = existing.perspective;
+    }
+
+    return merged;
+}
+
 } // namespace digital_dna
 
 #endif // DILITHION_DIGITAL_DNA_H

--- a/src/node/dilithion-node.cpp
+++ b/src/node/dilithion-node.cpp
@@ -339,28 +339,21 @@ static void BroadcastDNASample(const digital_dna::DigitalDNA& dna) {
     auto dna_data = dna.serialize();
 
     // Attempt to sign. Seeds with no wallet-managed MIK fall back to unsigned.
+    // wallet->SignDNAEnvelope handles unencrypted + encrypted-and-unlocked
+    // wallets uniformly; the privkey is decrypted briefly inside wallet scope
+    // and wiped on return — never crosses module boundaries.
     digital_dna::SampleEnvelope envelope;
     bool have_signed = false;
     if (g_node_context.wallet && g_node_context.wallet->HasMIK()) {
-        const auto* mik_key = g_node_context.wallet->GetMIKKeyPtr();
-        if (mik_key && mik_key->HasPrivateKey()) {
-            // Only sign if the wallet's MIK matches the DNA's MIK.
-            std::array<uint8_t, 20> wallet_mik{};
-            std::memcpy(wallet_mik.data(), mik_key->identity.data, 20);
-            if (wallet_mik == dna.mik_identity) {
-                envelope.timestamp_sec = static_cast<uint64_t>(
-                    std::chrono::duration_cast<std::chrono::seconds>(
-                        std::chrono::system_clock::now().time_since_epoch()).count());
-                std::random_device rd;
-                std::mt19937_64 gen(rd());
-                envelope.nonce = gen();
-                have_signed = digital_dna::SampleEnvelope::Sign(
-                    mik_key->privkey.data(), mik_key->privkey.size(),
-                    dna.mik_identity,
-                    envelope.timestamp_sec, envelope.nonce, dna_data,
-                    envelope.signature);
-            }
-        }
+        envelope.timestamp_sec = static_cast<uint64_t>(
+            std::chrono::duration_cast<std::chrono::seconds>(
+                std::chrono::system_clock::now().time_since_epoch()).count());
+        std::random_device rd;
+        std::mt19937_64 gen(rd());
+        envelope.nonce = gen();
+        have_signed = g_node_context.wallet->SignDNAEnvelope(
+            dna.mik_identity, envelope.timestamp_sec, envelope.nonce,
+            dna_data, envelope.signature);
     }
 
     auto nodes = g_node_context.connman->GetNodes();
@@ -4306,23 +4299,49 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                 return;
             }
 
-            // Stage 6: accept — full replacement via append_sample, then commit.
-            auto result = g_node_context.dna_registry->append_sample(*dna);
+            // Stage 6: accept + commit replay/limits.
+            // Authoritative-merge with existing record: signed sample's
+            // populated dims overwrite (MIK is authoritative for what they
+            // assert), dims not asserted preserve the receiver's existing
+            // value (preserves network-enriched data the MIK didn't include
+            // in this broadcast). Without this, the dim-loss guard in
+            // append_sample silently rejects signed samples whenever the
+            // receiver has been enriched beyond what the MIK currently
+            // knows.
+            digital_dna::DigitalDNA to_store = digital_dna::merge_authoritative_dims(*existing, *dna);
+
+            // Log every signed-verify-pass with the registry outcome — gives
+            // operators end-to-end observability of the signed Phase 1.5 path
+            // even when the sample doesn't update the registry.
+            auto result = g_node_context.dna_registry->append_sample(to_store);
+            char hex[9];
+            snprintf(hex, sizeof(hex), "%02x%02x%02x%02x",
+                     mik[0], mik[1], mik[2], mik[3]);
+            const char* outcome = "OTHER";
+            switch (result) {
+                case digital_dna::IDNARegistry::RegisterResult::SUCCESS:        outcome = "SUCCESS"; break;
+                case digital_dna::IDNARegistry::RegisterResult::UPDATED:        outcome = "UPDATED"; break;
+                case digital_dna::IDNARegistry::RegisterResult::DNA_CHANGED:    outcome = "DNA_CHANGED"; break;
+                case digital_dna::IDNARegistry::RegisterResult::INVALID_DNA:    outcome = "INVALID_DNA (dim-loss guard)"; break;
+                case digital_dna::IDNARegistry::RegisterResult::ALREADY_REGISTERED: outcome = "ALREADY_REGISTERED"; break;
+                case digital_dna::IDNARegistry::RegisterResult::SYBIL_FLAGGED:  outcome = "SYBIL_FLAGGED"; break;
+                case digital_dna::IDNARegistry::RegisterResult::SYBIL_REJECTED: outcome = "SYBIL_REJECTED"; break;
+                case digital_dna::IDNARegistry::RegisterResult::DB_ERROR:       outcome = "DB_ERROR"; break;
+            }
+            std::cout << "[DNA] Signed accept for MIK " << hex
+                      << "... from peer " << peer_id
+                      << (mapped ? " (mapped)" : " (unmapped)")
+                      << " result=" << outcome
+                      << std::endl;
+            // Commit replay + MIK limits ONLY when the registry actually
+            // accepted the change. INVALID_DNA / DB_ERROR do not consume the
+            // per-MIK rate-limit budget so honest signed pushes can retry.
             if (result == digital_dna::IDNARegistry::RegisterResult::UPDATED ||
                 result == digital_dna::IDNARegistry::RegisterResult::DNA_CHANGED) {
                 g_dna_sample_limiter.commit_mik_limits(peer_id, mik, now_sec);
                 g_dna_sample_limiter.replay_record(
                     mik, envelope.timestamp_sec, envelope.nonce, now_sec);
-                char hex[9];
-                snprintf(hex, sizeof(hex), "%02x%02x%02x%02x",
-                         mik[0], mik[1], mik[2], mik[3]);
-                std::cout << "[DNA] Signed accept for MIK " << hex
-                          << "... from peer " << peer_id
-                          << (mapped ? " (mapped)" : " (unmapped)")
-                          << std::endl;
             }
-            // INVALID_DNA (dim-loss) and DB_ERROR are silent — expected under
-            // mixed-version propagation and transient storage issues.
         });
 
         // Phase 2: DNA Verification & Attestation P2P handlers
@@ -4537,6 +4556,10 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
         // BUG #56 FIX: Full wallet persistence with Bitcoin Core pattern
         CWallet wallet;
         g_node_state.wallet = &wallet;
+        // Phase 1.5: also wire the wallet into NodeContext so BroadcastDNASample
+        // can find the MIK private key for signing. Without this, signed-DNA
+        // broadcasts are silently skipped and Phase 1.5 has no effect on the wire.
+        g_node_context.wallet = &wallet;
         std::string wallet_path = config.datadir + "/wallet.dat";
         bool wallet_loaded = false;
 

--- a/src/node/dilv-node.cpp
+++ b/src/node/dilv-node.cpp
@@ -335,24 +335,18 @@ static void BroadcastDNASample(const digital_dna::DigitalDNA& dna) {
     digital_dna::SampleEnvelope envelope;
     bool have_signed = false;
     if (g_node_context.wallet && g_node_context.wallet->HasMIK()) {
-        const auto* mik_key = g_node_context.wallet->GetMIKKeyPtr();
-        if (mik_key && mik_key->HasPrivateKey()) {
-            std::array<uint8_t, 20> wallet_mik{};
-            std::memcpy(wallet_mik.data(), mik_key->identity.data, 20);
-            if (wallet_mik == dna.mik_identity) {
-                envelope.timestamp_sec = static_cast<uint64_t>(
-                    std::chrono::duration_cast<std::chrono::seconds>(
-                        std::chrono::system_clock::now().time_since_epoch()).count());
-                std::random_device rd;
-                std::mt19937_64 gen(rd());
-                envelope.nonce = gen();
-                have_signed = digital_dna::SampleEnvelope::Sign(
-                    mik_key->privkey.data(), mik_key->privkey.size(),
-                    dna.mik_identity,
-                    envelope.timestamp_sec, envelope.nonce, dna_data,
-                    envelope.signature);
-            }
-        }
+        // Wallet does the privkey decrypt + sign atomically — privkey never
+        // leaves wallet scope. Mirrors the pattern of SignWithMIK. Works for
+        // both unencrypted wallets and encrypted+unlocked wallets.
+        envelope.timestamp_sec = static_cast<uint64_t>(
+            std::chrono::duration_cast<std::chrono::seconds>(
+                std::chrono::system_clock::now().time_since_epoch()).count());
+        std::random_device rd;
+        std::mt19937_64 gen(rd());
+        envelope.nonce = gen();
+        have_signed = g_node_context.wallet->SignDNAEnvelope(
+            dna.mik_identity, envelope.timestamp_sec, envelope.nonce,
+            dna_data, envelope.signature);
     }
 
     auto nodes = g_node_context.connman->GetNodes();
@@ -4163,19 +4157,47 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
             if (!g_dna_sample_limiter.check_mik_limits(peer_id, mik, now_sec)) return;
 
             // Stage 6: accept + commit replay/limits.
-            auto result = g_node_context.dna_registry->append_sample(*dna);
+            // Authoritative-merge with existing record: signed sample's
+            // populated dims overwrite (MIK is authoritative for what they
+            // assert), dims not asserted preserve the receiver's existing
+            // value (preserves network-enriched data the MIK didn't include
+            // in this broadcast). Without this, the dim-loss guard in
+            // append_sample silently rejects signed samples whenever the
+            // receiver has been enriched beyond what the MIK currently
+            // knows.
+            digital_dna::DigitalDNA to_store = digital_dna::merge_authoritative_dims(*existing, *dna);
+
+            // Log every signed-verify-pass with the registry outcome — gives
+            // operators end-to-end observability of the signed Phase 1.5 path
+            // even when the sample doesn't update the registry.
+            auto result = g_node_context.dna_registry->append_sample(to_store);
+            char hex[9];
+            snprintf(hex, sizeof(hex), "%02x%02x%02x%02x",
+                     mik[0], mik[1], mik[2], mik[3]);
+            const char* outcome = "OTHER";
+            switch (result) {
+                case digital_dna::IDNARegistry::RegisterResult::SUCCESS:        outcome = "SUCCESS"; break;
+                case digital_dna::IDNARegistry::RegisterResult::UPDATED:        outcome = "UPDATED"; break;
+                case digital_dna::IDNARegistry::RegisterResult::DNA_CHANGED:    outcome = "DNA_CHANGED"; break;
+                case digital_dna::IDNARegistry::RegisterResult::INVALID_DNA:    outcome = "INVALID_DNA (dim-loss guard)"; break;
+                case digital_dna::IDNARegistry::RegisterResult::ALREADY_REGISTERED: outcome = "ALREADY_REGISTERED"; break;
+                case digital_dna::IDNARegistry::RegisterResult::SYBIL_FLAGGED:  outcome = "SYBIL_FLAGGED"; break;
+                case digital_dna::IDNARegistry::RegisterResult::SYBIL_REJECTED: outcome = "SYBIL_REJECTED"; break;
+                case digital_dna::IDNARegistry::RegisterResult::DB_ERROR:       outcome = "DB_ERROR"; break;
+            }
+            std::cout << "[DNA] Signed accept for MIK " << hex
+                      << "... from peer " << peer_id
+                      << (mapped ? " (mapped)" : " (unmapped)")
+                      << " result=" << outcome
+                      << std::endl;
+            // Commit replay + MIK limits ONLY when the registry actually
+            // accepted the change. INVALID_DNA / DB_ERROR do not consume the
+            // per-MIK rate-limit budget so honest signed pushes can retry.
             if (result == digital_dna::IDNARegistry::RegisterResult::UPDATED ||
                 result == digital_dna::IDNARegistry::RegisterResult::DNA_CHANGED) {
                 g_dna_sample_limiter.commit_mik_limits(peer_id, mik, now_sec);
                 g_dna_sample_limiter.replay_record(
                     mik, envelope.timestamp_sec, envelope.nonce, now_sec);
-                char hex[9];
-                snprintf(hex, sizeof(hex), "%02x%02x%02x%02x",
-                         mik[0], mik[1], mik[2], mik[3]);
-                std::cout << "[DNA] Signed accept for MIK " << hex
-                          << "... from peer " << peer_id
-                          << (mapped ? " (mapped)" : " (unmapped)")
-                          << std::endl;
             }
         });
 
@@ -4573,6 +4595,10 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
         // BUG #56 FIX: Full wallet persistence with Bitcoin Core pattern
         CWallet wallet;
         g_node_state.wallet = &wallet;
+        // Phase 1.5: also wire the wallet into NodeContext so BroadcastDNASample
+        // can find the MIK private key for signing. Without this, signed-DNA
+        // broadcasts are silently skipped and Phase 1.5 has no effect on the wire.
+        g_node_context.wallet = &wallet;
         std::string wallet_path = config.datadir + "/wallet.dat";
         bool wallet_loaded = false;
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -7,6 +7,7 @@
 #include <wallet/wal_recovery.h>  // PERSIST-008 FIX
 #include <crypto/sha3.h>
 #include <crypto/hmac_sha3.h>  // FIX-011: For file integrity HMAC
+#include <digital_dna/sample_envelope.h>  // Phase 1.5: SignDNAEnvelope
 #include <rpc/auth.h>  // FIX-011/FIX-012: For SecureCompare
 #include <util/base58.h>
 #include <node/utxo_set.h>
@@ -5236,6 +5237,41 @@ bool CWallet::SignWithMIK(const uint256& prevHash, int height, uint32_t timestam
 
         return m_mik->Sign(prevHash, height, timestamp, signature);
     }
+}
+
+bool CWallet::SignDNAEnvelope(const std::array<uint8_t, 20>& mik,
+                              uint64_t timestamp_sec,
+                              uint64_t nonce,
+                              const std::vector<uint8_t>& dna_data,
+                              std::vector<uint8_t>& signature_out) {
+    std::lock_guard<std::mutex> lock(cs_wallet);
+    signature_out.clear();
+
+    if (!fHasMIK) return false;
+
+    // Verify the requested MIK matches our wallet's MIK identity. Reject
+    // attempts to sign for a different MIK (would always fail crypto verify
+    // anyway, but reject early to avoid leaking the privkey to a no-op).
+    if (std::memcmp(mik.data(), m_mikIdentity.data, 20) != 0) return false;
+
+    // Encrypted wallet: decrypt privkey, sign, wipe on scope exit.
+    if (masterKey.IsValid()) {
+        if (!fWalletUnlocked) return false;  // locked — cannot decrypt
+
+        std::vector<uint8_t, SecureAllocator<uint8_t>> privkey;
+        if (!DecryptMIKPrivKey(privkey)) return false;
+        bool ok = digital_dna::SampleEnvelope::Sign(
+            privkey.data(), privkey.size(),
+            mik, timestamp_sec, nonce, dna_data, signature_out);
+        // privkey wiped by SecureAllocator destructor here.
+        return ok;
+    }
+
+    // Unencrypted wallet: privkey already in m_mik->privkey.
+    if (!m_mik || !m_mik->HasPrivateKey()) return false;
+    return digital_dna::SampleEnvelope::Sign(
+        m_mik->privkey.data(), m_mik->privkey.size(),
+        mik, timestamp_sec, nonce, dna_data, signature_out);
 }
 
 bool CWallet::IsMIKRegistered() const {

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -998,8 +998,35 @@ public:
      * Get raw pointer to MIK key (for DNA verification signing)
      *
      * @return Pointer to CMiningIdentityKey, or nullptr if no MIK
+     *
+     * NOTE: returns nullptr for ENCRYPTED wallets even when fHasMIK is true,
+     * because the underlying CMiningIdentityKey is not constructed at load
+     * time — only the public identity hash is. For signing, prefer
+     * GetMIKPrivKey() below, which handles encrypted+unlocked wallets via
+     * decrypt-on-demand (mirrors the SignWithMIK pattern).
      */
     const DFMP::CMiningIdentityKey* GetMIKKeyPtr() const { return m_mik.get(); }
+
+    /**
+     * Sign a DNA sample envelope (Phase 1.5) with the wallet's MIK private
+     * key. Mirrors the SignWithMIK pattern: privkey is decrypted briefly
+     * into a SecureAllocator-backed temporary, used for one signing op,
+     * and wiped on scope exit. The privkey never leaves wallet scope.
+     *
+     * Handles both unencrypted and encrypted+unlocked wallets.
+     *
+     * @param mik           The MIK identity being signed for (must match wallet's MIK)
+     * @param timestamp_sec Wall-clock timestamp embedded in the sign target
+     * @param nonce         Random per-sample nonce for replay defense
+     * @param dna_data      The exact dna_data wire bytes being committed to
+     * @param[out] signature_out  Dilithium3 signature (MIK_SIGNATURE_SIZE bytes on success)
+     * @return true on success, false if: no MIK / wallet locked / mik mismatch / Dilithium failure
+     */
+    bool SignDNAEnvelope(const std::array<uint8_t, 20>& mik,
+                         uint64_t timestamp_sec,
+                         uint64_t nonce,
+                         const std::vector<uint8_t>& dna_data,
+                         std::vector<uint8_t>& signature_out);
 
     // ============================================================================
     // Persistence


### PR DESCRIPTION
## Summary

End-to-end live testing of Phase 1.5 against the Sydney mainnet seed surfaced three bugs that prevented signed propagation from working in the field. All three are fixed here, and the full pipeline has been **confirmed working end-to-end on real mainnet** before opening this PR.

### The three bugs (in order of discovery)

**#1 — `g_node_context.wallet` was never assigned (sender-side)**
`BroadcastDNASample` checks `g_node_context.wallet` to find the MIK private key. But the wallet pointer is wired to a different global (`g_node_state.wallet`). Result: `g_node_context.wallet` is always null, signing is silently skipped, and every broadcast goes out unsigned despite a fully loaded mining wallet. **Fix:** also assign `g_node_context.wallet` next to `g_node_state.wallet` in both node binaries.

**#2 — encrypted wallets don't populate `m_mik` (sender-side)**
On wallet load with an encrypted wallet, the underlying `CMiningIdentityKey` object is intentionally left null — only the public identity hash (`m_mikIdentity`) and pubkey are loaded. `m_mik` is reconstructed lazily on unlock. `BroadcastDNASample`'s path of `GetMIKKeyPtr() → HasPrivateKey()` fails because `m_mik` is null even when the wallet is unlocked. **Mining works** because `SignWithMIK` uses a decrypt-on-demand pattern: pulls the encrypted privkey, builds a temporary `CMiningIdentityKey`, signs, lets the `SecureAllocator` destructor wipe the privkey on scope exit. **Fix:** added `CWallet::SignDNAEnvelope()` mirroring this exact pattern — privkey is decrypted briefly inside wallet scope and never crosses the wallet/digital_dna module boundary. Receiver-side `BroadcastDNASample` reduced to a single call into the wallet helper.

**#3 — dim-loss guard silently rejects authoritative signed samples (receiver-side)**
Pre-fix flow: MIK with `timing+latency` signs and broadcasts; receiver's stored copy has `timing+latency+memory+bandwidth` from prior enrichment by other peers; `append_sample` sees the incoming has fewer dims and rejects with `INVALID_DNA`. Silent drop, no log, signed feature looks broken from outside even though the crypto works. **Fix:** added `merge_authoritative_dims` helper — for each dim, signed sample's value wins if asserted, else preserves receiver's existing value. Result always has ≥ existing's dim count so the dim-loss guard never trips on signed traffic. Receiver pipeline calls this merge before `append_sample`, mirroring how the Phase 1.1 unsigned path already uses `merge_fill_missing_dims`.

### Observability improvement

Receiver now logs **every signed-verify-pass** with the registry outcome, e.g.
```
[DNA] Signed accept for MIK abcd1234... from peer 113 (unmapped) result=DNA_CHANGED
```
Previously the log only fired on `UPDATED`/`DNA_CHANGED`, so operators saw nothing when accepts went silently merged-and-no-changed. Outcomes that don't update the registry (`INVALID_DNA`, `DB_ERROR`) do not consume the per-MIK rate-limit budget so honest signed pushes can retry.

### Live test results (Sydney mainnet, 2026-04-24)

Tested by deploying this branch to Sydney's DilV seed (134.199.159.83), pairing with my local v4.0.18 DilV miner (encrypted wallet). After ~15 min wait for the periodic-push cycle:

```
2026-04-24 06:54:40 [DNA] Signed accept for MIK 81b4c50e... from peer 113 (unmapped) result=DNA_CHANGED
```

| Signal | Result |
|---|---|
| Local broadcasts signed | ✅ `Broadcast identity to 4 peers (1 signed, 3 unsigned legacy)` |
| Sydney parses trailer | ✅ 0 `Malformed SMP1` events |
| Sydney looks up MIK pubkey | ✅ (cache warmed via block-connect during IBD) |
| Signature verifies | ✅ |
| Skew + replay + MIK limits pass | ✅ |
| Authoritative-merge with existing | ✅ `result=DNA_CHANGED` (real registry update) |
| Mixed-version peers handled | ✅ trailer suppressed for v4.0.17 peers via version gate |
| No misbehavior penalty | ✅ `misbehavior=0` |

### Bonus discovery during live test

Sydney's pre-existing DilV LevelDB had unexplained corruption (10 missing `.ldb` files) that was masked by the running v4.0.17 process holding open file handles. Discovered when v4.0.18 restarted and refused to open the database. **Not a v4.0.18 regression** — no storage-layer code changed between v4.0.17 and v4.0.18. Sydney recovered via full IBD on v4.0.18, which doubled as the highest-stress test of the validation path the new code can get (43k blocks processed via the new block-connect MikPubkeyCache wiring without issue).

### Contract update

`.claude/contracts/dna_phase_1_5.md` Section E updated to reflect the authoritative-merge semantic (replacing the original "full replacement" wording for the signed path). The decision to defer per-dim provenance and self-vs-network discrepancy detection to a Phase 2 spec with explicit Cursor design review is documented inline.

## Test plan

- [x] MSYS2 clean build, both `dilithion-node` and `dilv-node` link cleanly
- [x] 49/49 `dna_propagation_tests` green
- [x] **Live test on Sydney mainnet**: signed broadcast from local v4.0.18 miner produces `[DNA] Signed accept for MIK 81b4c50e... result=DNA_CHANGED` on Sydney ✅
- [x] Backward compat: 4 v4.0.17 peers receive unsigned (version-gated) without misbehavior
- [x] Encrypted wallet path: SignDNAEnvelope's decrypt-on-demand pattern verified working
- [ ] CI green
- [ ] Code review

After this lands and Sydney redeploys from main, we're clear to tag v4.0.18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)