### PR TITLE
fix(dna): rename SampleEnvelope::DOMAIN → SMP1_DOMAIN (macOS <math.h> clash, v4.0.18 release blocker)

### DIFF
--- a/src/digital_dna/sample_envelope.cpp
+++ b/src/digital_dna/sample_envelope.cpp
@@ -40,12 +40,12 @@ std::vector<uint8_t> SampleEnvelope::BuildSignTarget(
 {
     // Total: 7 (domain) + 20 (mik) + 8 (ts) + 8 (nonce) + 32 (SHA3-256) = 75 bytes
     std::vector<uint8_t> msg;
-    msg.reserve(DOMAIN_LEN + mik.size() + 8 + 8 + 32);
+    msg.reserve(SMP1_DOMAIN_LEN + mik.size() + 8 + 8 + 32);
 
     // Domain separator (raw ASCII, no terminator)
     msg.insert(msg.end(),
-               reinterpret_cast<const uint8_t*>(DOMAIN),
-               reinterpret_cast<const uint8_t*>(DOMAIN) + DOMAIN_LEN);
+               reinterpret_cast<const uint8_t*>(SMP1_DOMAIN),
+               reinterpret_cast<const uint8_t*>(SMP1_DOMAIN) + SMP1_DOMAIN_LEN);
 
     // MIK
     msg.insert(msg.end(), mik.begin(), mik.end());

--- a/src/digital_dna/sample_envelope.h
+++ b/src/digital_dna/sample_envelope.h
@@ -43,8 +43,13 @@ struct SampleEnvelope {
 
     /// 7-byte domain separator inside the signed bytes.
     /// Prevents cross-protocol reuse against MIK block signatures.
-    static constexpr char DOMAIN[] = "DNASMP1";
-    static constexpr size_t DOMAIN_LEN = 7;  // strlen("DNASMP1")
+    /// NOTE: named with the SMP1_ prefix (rather than the shorter DOMAIN)
+    /// because macOS's <math.h> defines `DOMAIN` as a preprocessor macro
+    /// (`#define DOMAIN 1`) which clashes with any identifier named DOMAIN
+    /// when sample_envelope.h is transitively included in a TU that also
+    /// includes <math.h>. Linux/Windows do not have this macro.
+    static constexpr char SMP1_DOMAIN[] = "DNASMP1";
+    static constexpr size_t SMP1_DOMAIN_LEN = 7;  // strlen("DNASMP1")
 
     /// Result of TryParse — distinguishes unsigned/no-trailer from malformed.
     enum class ParseResult {
@@ -67,7 +72,7 @@ struct SampleEnvelope {
     std::vector<uint8_t> signature;  // empty = unsigned
 
     /// Build the exact byte string that gets signed/verified.
-    /// sig_msg = DOMAIN || mik(20) || ts_le(8) || nonce_le(8) || SHA3_256(dna_data)
+    /// sig_msg = SMP1_DOMAIN || mik(20) || ts_le(8) || nonce_le(8) || SHA3_256(dna_data)
     static std::vector<uint8_t> BuildSignTarget(
         const std::array<uint8_t, 20>& mik,
         uint64_t timestamp,


### PR DESCRIPTION
## Summary

**Release blocker for v4.0.18.** macOS CI failed on the `v4.0.18` tag push with:

```
src/digital_dna/sample_envelope.h:46:27: error: expected member name or ';' after declaration specifiers
   46 |     static constexpr char DOMAIN[] = "DNASMP1";
      |     ~~~~~~~~~~~~~~~~~~~~~ ^
/Applications/Xcode_16.4.app/.../MacOSX.sdk/usr/include/math.h:755:17: note: expanded from macro 'DOMAIN'
  755 | #define DOMAIN          1
```

macOS's `<math.h>` defines `DOMAIN` as a preprocessor macro, which collides with `SampleEnvelope::DOMAIN` wherever `sample_envelope.h` is transitively included alongside `<math.h>`. Linux + Windows headers don't have this — which is why local Windows builds and Linux CI are clean.

## Fix

Rename `DOMAIN` → `SMP1_DOMAIN` and `DOMAIN_LEN` → `SMP1_DOMAIN_LEN`. No semantic change — the 7-byte ASCII sign-target prefix `"DNASMP1"` is unchanged, so signed samples produced by seeds already running on Linux/Windows will verify identically under the renamed binary.

## Impact

- **Binary compatibility: preserved.** The on-the-wire sign target bytes are unchanged (`"DNASMP1" || mik || ts || nonce || sha3(dna)`). A seed running the v4.0.18 code built from Linux/Windows can interop with a macOS-built v4.0.18 binary seamlessly.
- **No tag retag needed yet.** v4.0.18 tag was pushed before this fix. After this PR merges, I'll delete the existing v4.0.18 tag on origin and retag at the new HEAD so CI runs cleanly and all 3 platforms produce binaries.

## Test plan

- [x] Local build (MSYS2/Windows) clean after rename
- [x] 49/49 `dna_propagation_tests` green — signature round-trip tests verify the rename didn't break the sign-target byte sequence
- [ ] CI clean on Linux, macOS, Windows after merge + retag

🤖 Generated with [Claude Code](https://claude.com/claude-code)