### PR TITLE
chore: rename bootstrap output from 'mainnet' to 'dil' for chain-name symmetry

### DIFF
--- a/package-bootstrap.sh
+++ b/package-bootstrap.sh
@@ -6,19 +6,27 @@
 #  Bootstrap lets new users skip IBD (Initial Block Download).
 #
 #  Usage:
-#    ./package-bootstrap.sh              # mainnet (default)
-#    ./package-bootstrap.sh mainnet      # mainnet
-#    ./package-bootstrap.sh testnet      # testnet
+#    ./package-bootstrap.sh              # DIL mainnet (default)
+#    ./package-bootstrap.sh dil          # DIL mainnet (preferred)
+#    ./package-bootstrap.sh mainnet      # DIL mainnet (backward-compat alias)
+#    ./package-bootstrap.sh testnet      # DIL testnet
 #    ./package-bootstrap.sh dilv         # DilV chain
+#
+#  Output naming (both chains are mainnet; we identify by chain name):
+#    bootstrap-dil-<height>.tar.gz   (DIL chain)
+#    bootstrap-dilv-<height>.tar.gz  (DilV chain)
+#  Pre-v4.0.18 releases used `bootstrap-mainnet-<height>.tar.gz` for DIL;
+#  inconsistent with `bootstrap-dilv-*` since both chains are mainnet.
+#  Renamed to `dil` for symmetry starting v4.0.18.
 ################################################################
 
-NETWORK="${1:-mainnet}"
+NETWORK="${1:-dil}"
 
 case "$NETWORK" in
-    mainnet|main)
+    mainnet|main|dil)
         DATA_DIR="${HOME}/.dilithion"
         RPC_PORT=8332
-        NETWORK_LABEL="mainnet"
+        NETWORK_LABEL="dil"
         ;;
     testnet|test)
         DATA_DIR="${HOME}/.dilithion-testnet"
@@ -31,7 +39,7 @@ case "$NETWORK" in
         NETWORK_LABEL="dilv"
         ;;
     *)
-        echo "Usage: $0 [mainnet|testnet|dilv]"
+        echo "Usage: $0 [dil|mainnet|testnet|dilv]"
         exit 1
         ;;
 esac


### PR DESCRIPTION
## Summary

The bootstrap archive naming has been asymmetric since bootstraps were introduced:

- `bootstrap-mainnet-<height>.tar.gz` (DIL chain)
- `bootstrap-dilv-<height>.tar.gz` (DilV chain)

Both DIL and DilV are mainnet chains. `"mainnet"` is a network type, not a chain identifier, so the name was ambiguous about which chain the archive was for. This PR aligns DIL's name with the DilV pattern: **identify by chain name**.

New naming:
- `bootstrap-dil-<height>.tar.gz` (DIL chain — new)
- `bootstrap-dilv-<height>.tar.gz` (DilV chain — unchanged)

## Script behavior

- Default arg changes from `mainnet` to `dil`
- `mainnet` and `main` are still accepted as aliases for back-compat (any existing scripts/docs calling `./package-bootstrap.sh mainnet` keep working; the output filename uses `dil` regardless)
- `NETWORK_LABEL` (baked into the output filename) is always `dil` for the DIL chain

## Retroactive rename

The v4.0.18 DIL bootstrap asset already uploaded as `bootstrap-mainnet-46001.tar.gz` has been renamed on GitHub via API to `bootstrap-dil-46001.tar.gz` — the release is already consistent with the new convention. The `.claude/skills/release/SKILL.md` (gitignored) was also updated locally to match.

## Test plan

- [ ] Next release cycle uses the new name natively (no manual rename step)
- [x] Back-compat: `./package-bootstrap.sh mainnet` still works (outputs `bootstrap-dil-<h>.tar.gz`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)