### PR TITLE
harden: raise fd limit to 65536 in seed wrappers

### DIFF
--- a/run-dil-seed-relayonly.sh
+++ b/run-dil-seed-relayonly.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+# Raise fd limit from the default 1024 so the node can absorb connection
+# surges without hitting EMFILE. A 2026-04-21 SYN flood on port 8444 hit
+# the 1024 limit on NYC and stalled a user tx for 37 min because miners
+# couldn't connect to fetch it. 65536 matches the hard ulimit on the
+# droplets and the LimitNOFILE in the (currently unused) systemd units.
+ulimit -n 65536
+
 # Auto-restart wrapper for DIL relay-only seed nodes (LDN/SGP/SYD).
 #
 # NYC is different: NYC's DIL node loads the bridge wallet and runs WITHOUT

--- a/run-dilv-seed-relayonly.sh
+++ b/run-dilv-seed-relayonly.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+# Raise fd limit from the default 1024 so the node can absorb connection
+# surges without hitting EMFILE. A 2026-04-21 SYN flood on port 8444 hit
+# the 1024 limit on NYC and stalled a user tx for 37 min because miners
+# couldn't connect to fetch it. 65536 matches the hard ulimit on the
+# droplets and the LimitNOFILE in the (currently unused) systemd units.
+ulimit -n 65536
+
 # Auto-restart wrapper for DilV relay-only seed nodes (LDN/SGP/SYD).
 #
 # NYC is different: NYC's DilV node loads the bridge wallet and runs WITHOUT


### PR DESCRIPTION
## Summary

- Add `ulimit -n 65536` at the top of [run-dil-seed-relayonly.sh](run-dil-seed-relayonly.sh) and [run-dilv-seed-relayonly.sh](run-dilv-seed-relayonly.sh).
- Prevents the default 1024 soft fd limit from being inherited via `nohup ./wrapper &` launches over ssh.
- Locks in the in-place fix already applied across all 4 seeds on 2026-04-24 so a future `git pull` + deploy won't revert it.

## Background

A 4-minute SYN flood hit NYC port 8444 on 2026-04-21 03:27–03:30 UTC (peak ~10,000 accept()/sec). The 1024 fd soft limit was exhausted, producing ~1M `Accept failed: 24` log entries in one hour. During that window NYC could only send mempool INVs to peers already connected — a user's transaction sat 37 min before a miner that wasn't already peered could fetch it.

All 4 seeds were patched live on 2026-04-24 and verified at 65536 fd. This PR commits the same change to the versioned wrapper so future deploys preserve it.

Value 65536 matches:
- Droplet hard ulimit of 1,048,576 (well under)
- `LimitNOFILE=65536` in the (currently unused) systemd unit files at `/etc/systemd/system/dilithion-node.service` and `dilv-node.service`

NYC uses a separate custom wrapper (bridge host, no `--relay-only`) that is already patched in place — not affected by this PR.

## Test plan

- [ ] Verify diff shows `ulimit -n 65536` added as line 2 in both files (after shebang)
- [ ] Verify comments explaining the why are preserved
- [ ] After merge, the next deploy of `run-*-seed-relayonly.sh` to LDN/SGP/SYD should preserve the 65536 fd limit on the node process (`grep 'Max open files' /proc/\$(pgrep -f dilithion-node)/limits`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)