### PR TITLE
Incident recovery: v4.0.19 + v4.0.20 + v4.0.21 (DilV chain split fix)

### DIFF
--- a/src/consensus/chain.cpp
+++ b/src/consensus/chain.cpp
@@ -295,6 +295,25 @@ bool CChainState::ActivateBestChain(CBlockIndex* pindexNew, const CBlock& block,
         if (g_verbose.load(std::memory_order_relaxed))
             std::cout << "[Chain] VDF DISTRIBUTION REPLACEMENT -- 1-block reorg" << std::endl;
 
+        // v4.0.21 — Patch B: Capture the old tip's block data BEFORE disconnect so
+        // we can roll back if ConnectTip(pindexNew) fails.
+        //
+        // Pre-fix bug (incident 2026-04-25): if ConnectTip below failed, undo data
+        // for oldTip was already deleted by DisconnectTip → UndoBlock → batch.Delete(undoKey).
+        // The function then returned false, leaving "block-is-tip-but-undo-missing".
+        // Any subsequent reorg attempt would deterministically fail trying to disconnect
+        // that block, looping forever. Fix B: re-apply old tip on failure.
+        CBlockIndex* pindexOldTip = pindexTip;
+        CBlock oldTipBlock;
+        bool oldTipBlockLoaded = false;
+        if (pdb != nullptr && pindexOldTip != nullptr) {
+            oldTipBlockLoaded = pdb->ReadBlock(pindexOldTip->GetBlockHash(), oldTipBlock);
+            if (!oldTipBlockLoaded) {
+                std::cerr << "[Chain] WARN: Could not pre-load old tip block for Case 2.5 rollback safety; "
+                          << "proceeding without rollback capability for height " << pindexOldTip->nHeight << std::endl;
+            }
+        }
+
         // Disconnect current tip
         if (!DisconnectTip(pindexTip)) {
             std::cerr << "[Chain] ERROR: Failed to disconnect tip for VDF replacement" << std::endl;
@@ -304,9 +323,26 @@ bool CChainState::ActivateBestChain(CBlockIndex* pindexNew, const CBlock& block,
         // Connect new block (shares same parent as old tip)
         if (!ConnectTip(pindexNew, block)) {
             std::cerr << "[Chain] CRITICAL: Failed to connect VDF replacement block" << std::endl;
-            std::cerr << "[Chain] Chain is in intermediate state (tip disconnected)." << std::endl;
-            // NOTE: This is the same failure mode as any reorg ConnectTip failure
-            // in Case 3. The chain is in an inconsistent state and will need a restart.
+
+            // v4.0.21 — Patch B: roll back to old tip to restore undo data.
+            if (oldTipBlockLoaded && pindexOldTip != nullptr) {
+                std::cerr << "[Chain] Case 2.5 rollback: re-applying old tip "
+                          << pindexOldTip->GetBlockHash().GetHex().substr(0, 16)
+                          << " at height " << pindexOldTip->nHeight << std::endl;
+                if (!ConnectTip(pindexOldTip, oldTipBlock)) {
+                    std::cerr << "[CRITICAL] Case 2.5 rollback FAILED — chain state inconsistent at height "
+                              << pindexOldTip->nHeight << ". Triggering auto_rebuild." << std::endl;
+                    m_chain_needs_rebuild.store(true);
+                    return false;
+                }
+                pindexTip = pindexOldTip;
+                m_cachedHeight.store(pindexOldTip->nHeight, std::memory_order_release);
+                std::cerr << "[Chain] Case 2.5 rollback succeeded; old tip restored." << std::endl;
+            } else {
+                std::cerr << "[CRITICAL] Case 2.5 ConnectTip failed and old tip block was unreadable. "
+                          << "Cannot roll back. Triggering auto_rebuild." << std::endl;
+                m_chain_needs_rebuild.store(true);
+            }
             return false;
         }
 
@@ -1321,16 +1357,24 @@ bool CChainState::DisconnectTip(CBlockIndex* pindex, bool force_skip_utxo) {
         // Step 2: Undo UTXO set changes (CS-004)
         // BUG #159 FIX: Allow skipping UTXO undo during IBD fork recovery when undo data is missing
         // BUG #271 FIX: Pass block index hash to UndoBlock for consistent undo data lookup
+        // v4.0.19: Track persistent UndoBlock failures so a stuck node can self-recover
+        // via auto_rebuild instead of looping forever (incident 2026-04-25).
         if (pUTXOSet != nullptr && block_loaded) {
             if (!pUTXOSet->UndoBlock(block, pindex->GetBlockHash())) {
                 if (!force_skip_utxo) {
                     std::cerr << "[Chain] ERROR: Failed to undo block from UTXO set at height "
                               << pindex->nHeight << std::endl;
+                    RecordUndoFailure(pindex->GetBlockHash(), pindex->nHeight);
                     return false;
                 } else {
                     std::cout << "[Chain] WARNING: Failed to undo UTXO at height "
                               << pindex->nHeight << " (force_skip_utxo=true, continuing anyway)" << std::endl;
+                    // Don't track in force_skip_utxo path — caller has explicitly opted into
+                    // continuing past undo failure (IBD fork recovery).
                 }
+            } else {
+                // UndoBlock succeeded — clear any prior failure tracking.
+                ResetUndoFailureCounter();
             }
         } else if (force_skip_utxo) {
             std::cout << "[Chain] Skipping UTXO undo for height " << pindex->nHeight
@@ -1715,4 +1759,107 @@ void CChainState::RegisterBlockConnectCallback(BlockConnectCallback callback) {
 void CChainState::RegisterBlockDisconnectCallback(BlockDisconnectCallback callback) {
     std::lock_guard<std::recursive_mutex> lock(cs_main);
     m_blockDisconnectCallbacks.push_back(callback);
+}
+
+// ============================================================================
+// v4.0.19: Persistent UndoBlock failure tracking
+// ============================================================================
+// Mirrors the BUG #277 UTXO-failure pattern but for the disconnect path. When
+// DisconnectTip's UndoBlock returns false repeatedly on the SAME block hash,
+// the chain is stuck — the node cannot reorg forward without manual recovery.
+// At kPersistentUndoFailureThreshold, sets m_chain_needs_rebuild so the IBD
+// coordinator can write the auto_rebuild marker and trigger graceful shutdown.
+
+void CChainState::RecordUndoFailure(const uint256& blockHash, int height) {
+    int failures;
+    {
+        std::lock_guard<std::mutex> lock(m_undo_failure_mutex);
+        if (blockHash == m_last_undo_failure_hash) {
+            failures = ++m_consecutive_undo_failures;
+        } else {
+            // Different block hash — reset to 1 (this is the first failure on this hash).
+            // Persistent failures only count when on the SAME block; a sequence of failures
+            // on different blocks is a different failure mode.
+            m_last_undo_failure_hash = blockHash;
+            m_consecutive_undo_failures.store(1);
+            failures = 1;
+        }
+    }
+
+    std::cerr << "[Chain] UndoBlock failure #" << failures << " at height " << height
+              << " hash=" << blockHash.GetHex().substr(0, 16) << "..."
+              << " (threshold=" << kPersistentUndoFailureThreshold << ")" << std::endl;
+
+    if (failures >= kPersistentUndoFailureThreshold) {
+        std::cerr << "[CRITICAL] DisconnectTip: persistent UndoBlock failure"
+                  << " hash=" << blockHash.GetHex()
+                  << " height=" << height
+                  << " consecutive=" << failures
+                  << ". Triggering auto_rebuild." << std::endl;
+        m_chain_needs_rebuild.store(true);
+    }
+}
+
+void CChainState::ResetUndoFailureCounter() {
+    std::lock_guard<std::mutex> lock(m_undo_failure_mutex);
+    m_consecutive_undo_failures.store(0);
+    m_last_undo_failure_hash = uint256();  // default-constructed = zeroed (no SetNull on this type)
+}
+
+void CChainState::ClearChainRebuildFlag() {
+    m_chain_needs_rebuild.store(false);
+    ResetUndoFailureCounter();
+}
+
+uint256 CChainState::GetLastUndoFailureHash() const {
+    std::lock_guard<std::mutex> lock(m_undo_failure_mutex);
+    return m_last_undo_failure_hash;
+}
+
+// ============================================================================
+// v4.0.19: VerifyRecentUndoIntegrity — Fix B startup-time integrity check
+// ============================================================================
+// Walks back from the current tip up to probeDepth blocks, confirming each
+// block has a corresponding undo_<hash> entry in the UTXO LevelDB. Used at
+// startup to detect the missing-undo-data state BEFORE reorg attempts begin.
+// On detection, the caller writes auto_rebuild and exits, instead of letting
+// the node loop forever like NYC + LDN did 2026-04-25.
+
+bool CChainState::VerifyRecentUndoIntegrity(int probeDepth,
+                                            uint256& outMissingHash,
+                                            int& outMissingHeight) const {
+    if (pUTXOSet == nullptr) {
+        // No UTXO set wired — nothing to verify against. Treat as pass.
+        return true;
+    }
+
+    std::lock_guard<std::recursive_mutex> lock(cs_main);
+
+    if (pindexTip == nullptr || probeDepth <= 0) {
+        return true;  // Empty chain or zero depth — nothing to check.
+    }
+
+    CBlockIndex* pwalker = pindexTip;
+    int probed = 0;
+    while (pwalker != nullptr && probed < probeDepth) {
+        // Stop walking at genesis — we don't need to reorg past it, so verifying
+        // its undo entry adds no operational value. (ApplyBlock does write an
+        // undo_<hash> record for every connected block including genesis when
+        // the genesis path runs through it; we just don't need to assert that
+        // here. Per Cursor review 2026-04-25.)
+        if (pwalker->pprev == nullptr) {
+            break;
+        }
+
+        const uint256 hash = pwalker->GetBlockHash();
+        if (!pUTXOSet->HasUndoData(hash)) {
+            outMissingHash = hash;
+            outMissingHeight = pwalker->nHeight;
+            return false;
+        }
+
+        pwalker = pwalker->pprev;
+        ++probed;
+    }
+    return true;
 }

--- a/src/consensus/chain.h
+++ b/src/consensus/chain.h
@@ -70,6 +70,21 @@ private:
     std::atomic<bool> m_utxo_needs_rebuild{false};
     static constexpr int MAX_UTXO_FAILURES_BEFORE_REBUILD = 3;
 
+    // v4.0.19: Persistent UndoBlock failure detection (parallel to BUG #277).
+    // Catches the failure mode where DisconnectTip's UndoBlock returns false
+    // repeatedly on the same block hash because undo data is missing on disk.
+    // Without this, the node loops forever attempting reorgs it cannot complete
+    // (incident 2026-04-25, NYC + LDN DilV seeds).
+    // Counter is incremented on UndoBlock failure for the same hash, reset to 1
+    // when the failing hash changes, and reset to 0 on any successful disconnect.
+    // m_last_undo_failure_hash is uint256 (not trivially atomic) — protected by
+    // m_undo_failure_mutex which is held only briefly to update both fields.
+    std::atomic<int> m_consecutive_undo_failures{0};
+    std::atomic<bool> m_chain_needs_rebuild{false};
+    uint256 m_last_undo_failure_hash;
+    mutable std::mutex m_undo_failure_mutex;
+    static constexpr int kPersistentUndoFailureThreshold = 3;
+
     // Bug #40 fix: Callback mechanism for tip updates
     // Allows HeadersManager and other components to be notified when chain tip changes
     using TipUpdateCallback = std::function<void(const CBlockIndex*)>;
@@ -139,6 +154,62 @@ public:
      * BUG #277: Clear the UTXO rebuild flag (after recovery is initiated)
      */
     void ClearUTXORebuildFlag() { m_utxo_needs_rebuild.store(false); m_consecutive_utxo_failures.store(0); }
+
+    /**
+     * v4.0.19: Check if persistent UndoBlock failure was detected and the chain
+     * needs a full resync. Polled by IBDCoordinator::Tick alongside NeedsUTXORebuild.
+     * @return true if chain undo state is unrecoverable and a rebuild is needed
+     */
+    bool NeedsChainRebuild() const { return m_chain_needs_rebuild.load(); }
+
+    /**
+     * v4.0.19: Clear the chain rebuild flag (after recovery is initiated).
+     * Resets the consecutive failure counter and the last-failure hash.
+     */
+    void ClearChainRebuildFlag();
+
+    /**
+     * v4.0.19: Get the hash that triggered the most recent persistent undo failure.
+     * Used by IBDCoordinator to write a useful reason into the auto_rebuild marker.
+     * Returns null hash if no failure has been recorded.
+     */
+    uint256 GetLastUndoFailureHash() const;
+
+    /**
+     * v4.0.19: Record an UndoBlock failure for a specific block.
+     * Increments counter if same hash as last failure, resets to 1 if different.
+     * Sets m_chain_needs_rebuild when threshold reached.
+     * Internal — called from DisconnectTip on UndoBlock failure path.
+     */
+    void RecordUndoFailure(const uint256& blockHash, int height);
+
+    /**
+     * v4.0.19: Reset undo failure tracking after a successful disconnect.
+     * Called whenever DisconnectTip succeeds.
+     */
+    void ResetUndoFailureCounter();
+
+    /**
+     * v4.0.19: Startup-time integrity check for undo data on the active chain.
+     *
+     * Walks back up to probeDepth blocks from the current tip and confirms that
+     * each block has a corresponding undo_<hash> entry in the UTXO LevelDB.
+     * Catches the missing-undo-data corruption mode that causes reorg loops
+     * (incident 2026-04-25). The check is cheap — one LevelDB Get per block,
+     * called once at startup.
+     *
+     * If any probed block is missing its undo entry, fills the out parameters
+     * with the FIRST missing block (closest to tip) and returns false.
+     *
+     * @param probeDepth Maximum number of blocks to walk back from tip
+     * @param outMissingHash Receives the hash of the first missing-undo block
+     * @param outMissingHeight Receives that block's height
+     * @return true if all probed blocks have undo data (or chain is empty);
+     *         false if any block is missing undo (out params populated)
+     */
+    bool VerifyRecentUndoIntegrity(int probeDepth,
+                                   uint256& outMissingHash,
+                                   int& outMissingHeight) const;
 
     /**
      * Get current chain tip (most work)

--- a/src/consensus/vdf_validation.cpp
+++ b/src/consensus/vdf_validation.cpp
@@ -300,8 +300,34 @@ bool CheckConsecutiveMiner(
     // Force recalc at this height to avoid stale cache (Cursor review finding #2).
     tracker.IsInCooldown(currentMik, pindex->nHeight);
     int activeMiners = tracker.GetActiveMiners();
-    if (activeMiners <= 1)
-        return true;
+
+    // v4.0.21 — Patch C: tighten solo-miner exemption with deterministic
+    // lifetime gate. Pre-fix bug (incident 2026-04-25): if the active sliding
+    // window happened to contain mostly one MIK's blocks (Vector 3
+    // self-reinforcing dominance), activeMiners reports 1, solo exemption
+    // fires, that MIK keeps mining freely. New rule: solo exemption only
+    // applies if BOTH activeMiners <= 1 AND the chain has had <= bootstrap
+    // threshold (5) distinct MIKs in its entire history. Once the chain has
+    // seen more miners, "solo" is no longer a legitimate state — it's a
+    // concentration symptom and the consecutive-miner cap applies.
+    int soloLifetimeGateHeight = Dilithion::g_chainParams ?
+        Dilithion::g_chainParams->soloExemptionLifetimeGateHeight : 999999999;
+    constexpr int kBootstrapMinerThreshold = 5;
+    if (activeMiners <= 1) {
+        if (pindex->nHeight < soloLifetimeGateHeight) {
+            // Pre-activation: original solo exemption applies (no lifetime gate).
+            return true;
+        }
+        // Post-activation: solo exemption gated on lifetime miner count.
+        int lifetimeMiners = tracker.GetLifetimeMinerCount();
+        if (lifetimeMiners <= kBootstrapMinerThreshold) {
+            return true;  // genuine bootstrap network, allow solo
+        }
+        // Otherwise: even though activeMiners is 1 right now, the chain has
+        // seen many distinct MIKs over its history — fall through to consecutive
+        // check. The rule will reject 4+ same-MIK in a row even with reported
+        // activeMiners=1. Network self-heals as other miners come back online.
+    }
 
     // Walk back through parent chain, counting consecutive same-miner blocks
     int consecutiveCount = 0;
@@ -324,29 +350,37 @@ bool CheckConsecutiveMiner(
     }
 
     if (consecutiveCount >= MAX_CONSECUTIVE_SAME_MINER) {
-        // Stall exemption: if no block has been produced for a long time,
-        // allow the same miner past the consecutive limit to keep the chain
-        // alive.  Without this, a chain where only one miner is active (but
-        // many MIKs are registered) deadlocks permanently — the sole miner
-        // hits the consecutive cap and nobody else produces blocks.
-        //
-        // 3600s threshold (raised from 600s): at 600s, a solo miner produced
-        // ~18 blocks/hour, fast enough to outpace legitimate chains. At 3600s,
-        // a solo miner produces ~3 blocks/hour — too slow to exploit but
-        // keeps chain alive when genuinely only one miner is online.
-        static constexpr int64_t CONSECUTIVE_STALL_THRESHOLD_SECS = 3600;
+        // v4.0.21 — Patch A: retire stall exemption above activation height.
+        // The 1-hour stall exemption was an attack surface during the 2026-04-25
+        // incident. With 50+ active miners, a 1-hour stall is not a real failure
+        // mode; if it does happen, operator action (forcerebuild RPC, manual
+        // intervention) is the right response, not a quiet rule bypass.
+        // For activation see consecutiveMinerStallExemptionRetiredHeight (DilV: 44600).
+        // For pre-activation history we keep the original behaviour so this
+        // change is forward-only and does not invalidate existing chain history.
+        int stallRetiredHeight = Dilithion::g_chainParams ?
+            Dilithion::g_chainParams->consecutiveMinerStallExemptionRetiredHeight : 999999999;
 
-        if (pindex->pprev) {
-            int64_t gap = static_cast<int64_t>(block.nTime) -
-                          static_cast<int64_t>(pindex->pprev->nTime);
-            if (gap >= CONSECUTIVE_STALL_THRESHOLD_SECS) {
-                std::cout << "[Chain] CheckConsecutiveMiner: stall exemption at height "
-                          << pindex->nHeight << " (gap=" << gap
-                          << "s >= " << CONSECUTIVE_STALL_THRESHOLD_SECS << "s, "
-                          << (consecutiveCount + 1) << " consecutive)" << std::endl;
-                return true;
+        if (pindex->nHeight < stallRetiredHeight) {
+            // Pre-activation: original stall exemption applies.
+            // Stall exemption: if no block has been produced for a long time,
+            // allow the same miner past the consecutive limit to keep the chain
+            // alive. 3600s threshold = ~3 blocks/hour for a solo miner.
+            static constexpr int64_t CONSECUTIVE_STALL_THRESHOLD_SECS = 3600;
+
+            if (pindex->pprev) {
+                int64_t gap = static_cast<int64_t>(block.nTime) -
+                              static_cast<int64_t>(pindex->pprev->nTime);
+                if (gap >= CONSECUTIVE_STALL_THRESHOLD_SECS) {
+                    std::cout << "[Chain] CheckConsecutiveMiner: stall exemption at height "
+                              << pindex->nHeight << " (gap=" << gap
+                              << "s >= " << CONSECUTIVE_STALL_THRESHOLD_SECS << "s, "
+                              << (consecutiveCount + 1) << " consecutive)" << std::endl;
+                    return true;
+                }
             }
         }
+        // Post-activation OR no stall exemption matched: fall through to error below.
 
         std::ostringstream oss;
         oss << "CheckConsecutiveMiner: MIK ";
@@ -929,12 +963,20 @@ bool CheckVDFReplacementPreflight(
             }
 
             if (consecutiveCount >= MAX_CONSECUTIVE_SAME_MINER) {
-                static constexpr int64_t CONSECUTIVE_STALL_THRESHOLD_SECS = 3600;
+                // v4.0.21 — Patch A: retire stall exemption above activation height.
+                // Mirror of the change in CheckConsecutiveMiner (line ~326).
+                // Both call sites updated in lockstep so a block rejected by the
+                // authoritative connect path is also rejected by preflight.
+                int stallRetiredHeight = Dilithion::g_chainParams ?
+                    Dilithion::g_chainParams->consecutiveMinerStallExemptionRetiredHeight : 999999999;
                 bool stallExempt = false;
-                if (pindexNew && pindexNew->pprev) {
-                    int64_t gap = static_cast<int64_t>(block.nTime) -
-                                  static_cast<int64_t>(pindexNew->pprev->nTime);
-                    if (gap >= CONSECUTIVE_STALL_THRESHOLD_SECS) stallExempt = true;
+                if (height < stallRetiredHeight) {
+                    static constexpr int64_t CONSECUTIVE_STALL_THRESHOLD_SECS = 3600;
+                    if (pindexNew && pindexNew->pprev) {
+                        int64_t gap = static_cast<int64_t>(block.nTime) -
+                                      static_cast<int64_t>(pindexNew->pprev->nTime);
+                        if (gap >= CONSECUTIVE_STALL_THRESHOLD_SECS) stallExempt = true;
+                    }
                 }
                 if (!stallExempt) {
                     error = "CheckVDFReplacementPreflight: consecutive-miner preflight failed";

--- a/src/core/chainparams.cpp
+++ b/src/core/chainparams.cpp
@@ -122,6 +122,8 @@ ChainParams ChainParams::Mainnet() {
     params.dfmpCooldownConsensusHeight = 999999999; // Disabled (VDF not active on mainnet)
     params.stallExemptionV2Height = 999999999;     // Disabled (VDF not active on mainnet)
     params.consecutiveMinerCheckHeight = 999999999; // Disabled (VDF not active on mainnet)
+    params.consecutiveMinerStallExemptionRetiredHeight = 999999999;  // v4.0.21 Patch A: disabled on DIL (no VDF)
+    params.soloExemptionLifetimeGateHeight = 999999999;              // v4.0.21 Patch C: disabled on DIL (no VDF)
     params.vdfCooldownShortWindow = 0;               // Disabled (VDF not active on mainnet)
     params.stabilizationForkHeight = 999999999;      // Disabled (VDF not active on mainnet)
     params.mikWindowCapWindow = 0;                   // Disabled (VDF not active on mainnet)
@@ -310,6 +312,8 @@ ChainParams ChainParams::Testnet() {
     params.dfmpCooldownConsensusHeight = 0;    // Consensus-enforced cooldown from genesis
     params.stallExemptionV2Height = 0;         // Tightened stall exemption from genesis
     params.consecutiveMinerCheckHeight = 0;    // Reject >3 consecutive from genesis
+    params.consecutiveMinerStallExemptionRetiredHeight = 0;  // v4.0.21 Patch A: testnet retires stall exemption from genesis
+    params.soloExemptionLifetimeGateHeight = 0;              // v4.0.21 Patch C: testnet activates lifetime gate from genesis
     params.vdfCooldownShortWindow = 0;         // Disabled — avoids MIN_COOLDOWN bypass
     params.stabilizationForkHeight = 0;        // Dual-window + time expiry from genesis
     params.mikWindowCapWindow = 480;           // 480 blocks = ~6h at 45s/block (MVP)
@@ -448,6 +452,14 @@ ChainParams ChainParams::DilV() {
     params.dfmpCooldownConsensusHeight = 0;    // Consensus-enforced cooldown from genesis
     params.stallExemptionV2Height = 0;         // Tightened stall exemption from genesis
     params.consecutiveMinerCheckHeight = 0;    // Reject >3 consecutive blocks from same miner from genesis
+    // v4.0.21 — Patch A: retire 1-hour stall exemption in CheckConsecutiveMiner +
+    // CheckVDFReplacementPreflight. Activation = 44600 (forward-only, ~150 blocks
+    // above current network tip ~44400 to give miners ~110 minutes to upgrade).
+    // Existing chain history below 44600 retains the prior rule.
+    params.consecutiveMinerStallExemptionRetiredHeight = 44600;
+    // v4.0.21 — Patch C: tighten solo-miner exemption with deterministic lifetime
+    // gate. Same activation height as Patch A.
+    params.soloExemptionLifetimeGateHeight = 44600;
     params.vdfCooldownShortWindow = 0;         // Disabled at genesis — avoids short-window MIN_COOLDOWN bypass
     params.stabilizationForkHeight = 0;        // Dual-window cooldown + time-based expiry from genesis
 

--- a/src/core/chainparams.h
+++ b/src/core/chainparams.h
@@ -190,6 +190,26 @@ public:
     // 999999999 = disabled
     int consecutiveMinerCheckHeight;
 
+    // v4.0.21 — Patch A: After this height, the 1-hour stall exemption in
+    // CheckConsecutiveMiner and CheckVDFReplacementPreflight is RETIRED.
+    // The exemption was an attack surface during the 2026-04-25 incident:
+    // chain stalls during fork churn allowed consecutive-miner bypass which
+    // compounded with cooldown self-reinforcement. With 50+ active miners
+    // on mainnet, a 1-hour gap is not a real failure mode; if it does happen,
+    // operator action (forcerebuild RPC) is the right response, not a quiet
+    // rule bypass. Set to a future height (DilV mainnet = 44600) so v4.0.21
+    // is forward-only and existing chain history retains the prior rule.
+    // 999999999 = disabled
+    int consecutiveMinerStallExemptionRetiredHeight;
+
+    // v4.0.21 — Patch C: After this height, the solo-miner exemption in
+    // CheckConsecutiveMiner only applies if BOTH activeMiners <= 1 AND the
+    // chain has had <= kBootstrapMinerThreshold (5) distinct MIKs in its
+    // entire history. Prevents the "active window dominated → activeMiners
+    // reports 1 → solo exemption fires" self-reinforcing exploit.
+    // 999999999 = disabled
+    int soloExemptionLifetimeGateHeight;
+
     // VDF cooldown short window (blocks) for dual-window cooldown.
     // After stabilizationForkHeight, effective cooldown = min(longCooldown, shortCooldown).
     // Short window tracks recent participation; long window prevents gaming.

--- a/src/dfmp/mik.cpp
+++ b/src/dfmp/mik.cpp
@@ -231,7 +231,7 @@ std::vector<uint8_t> BuildMIKSignatureMessage(
     return message;
 }
 
-bool VerifyMIKSignature(
+bool VerifyMIKSignatureExact(
     const std::vector<uint8_t>& pubkey,
     const std::vector<uint8_t>& signature,
     const uint256& prevHash,
@@ -264,6 +264,52 @@ bool VerifyMIKSignature(
     );
 
     return result == 0;
+}
+
+bool VerifyMIKSignature(
+    const std::vector<uint8_t>& pubkey,
+    const std::vector<uint8_t>& signature,
+    const uint256& prevHash,
+    int height,
+    uint32_t timestamp,
+    const Identity& identity) {
+    // First try the supplied timestamp directly. In the common case (signature
+    // was created over block.nTime exactly, e.g. for blocks produced by miners
+    // running the post-v4.1.0 fixed signing path), this single check passes
+    // and we return immediately — no perceptible cost added vs. v4.0.19.
+    if (VerifyMIKSignatureExact(pubkey, signature, prevHash, height, timestamp, identity)) {
+        return true;
+    }
+
+    // Fast-path validation: skip brute-force if obviously malformed.
+    // (These all fail quickly inside Exact too, but checking here avoids the
+    // 180-iteration loop on garbage input.)
+    if (pubkey.size() != MIK_PUBKEY_SIZE || signature.size() != MIK_SIGNATURE_SIZE) {
+        return false;
+    }
+    Identity derivedIdentity = DeriveIdentityFromMIK(pubkey);
+    if (derivedIdentity != identity) {
+        return false;
+    }
+
+    // v4.0.20 backward-window brute force.
+    // The signing happens at wall-clock T1 (in RPC), the block's final nTime
+    // is set at T3 (after VDF + grace period in vdf_miner.cpp). For DilV
+    // mainnet, T3 - T1 can be up to ~90s. We scan back kMIKVerifyBackwardWindowSeconds
+    // (180s) for safety margin. Stop at first match.
+    //
+    // Underflow guard: don't wrap below the genesis timestamp on chains
+    // with very early blocks.
+    constexpr uint32_t kFloor = 1;
+    for (uint32_t k = 1; k <= kMIKVerifyBackwardWindowSeconds; ++k) {
+        if (timestamp <= k) break;            // Don't subtract past 0
+        const uint32_t earlier = timestamp - k;
+        if (earlier < kFloor) break;
+        if (VerifyMIKSignatureExact(pubkey, signature, prevHash, height, earlier, identity)) {
+            return true;
+        }
+    }
+    return false;
 }
 
 Identity DeriveIdentityFromMIK(const std::vector<uint8_t>& pubkey) {

--- a/src/dfmp/mik.h
+++ b/src/dfmp/mik.h
@@ -213,17 +213,72 @@ std::vector<uint8_t> BuildMIKSignatureMessage(
     const Identity& identity);
 
 /**
- * Verify a MIK signature
+ * v4.0.20: Backward-time-window for MIK signature verification.
+ *
+ * The current signing path has a race: signing happens in the RPC handler at
+ * wall-clock T1, but the block's final nTime is set later — once after
+ * CreateBlockTemplate (T2 ≈ T1), and again inside vdf_miner.cpp after the VDF
+ * computation + grace period (T3, can be 45+ seconds after T1 on DilV).
+ * Verification at fork-time uses block.nTime (T3), which doesn't match the
+ * signed-with timestamp (T1). Result: every v4.0.18/4.0.19 block from a
+ * v4.0.18+ miner fails fork-validation. This caused the 2026-04-25 mainnet
+ * chain split between v4.0.17 and v4.0.18+ nodes.
+ *
+ * Until the signing path is moved to AFTER the final nTime is set
+ * (planned for v4.1.0 — see roadmap below), v4.0.20 verifiers brute-force a
+ * backward window from block.nTime, trying each candidate signing-time. The
+ * window is sized to cover VDF (45s) + grace period (45s) + clock skew (90s
+ * margin) = 180s.
+ *
+ * Roadmap to v4.1.0 (Option B from the v4.0.20 design discussion):
+ *   - Move signing to immediately before block submission so it commits to
+ *     the FINAL block.nTime — fixes the race at the source.
+ *   - Once all miners are on v4.1.0+, the brute-force loop in this file is
+ *     dead code and can be removed.
+ *   - Activation: hard-fork height where verifiers REJECT signatures that
+ *     don't match block.nTime exactly. Drop the backward window.
+ *
+ * Cost: in the worst case 181 Dilithium3 verifies (~1 ms each on x86_64).
+ * For the common case (signature was made over block.nTime exactly), the
+ * very first attempt succeeds and the window is never iterated.
+ */
+constexpr uint32_t kMIKVerifyBackwardWindowSeconds = 180;
+
+/**
+ * Verify a MIK signature.
+ *
+ * v4.0.20: First tries verification with the supplied timestamp; on failure,
+ * scans backward up to kMIKVerifyBackwardWindowSeconds seconds to catch
+ * blocks signed by v4.0.18/4.0.19 miners whose signing time predated
+ * block.nTime by up to that window.
  *
  * @param pubkey Public key (1,952 bytes)
  * @param signature Signature to verify (3,309 bytes)
  * @param prevHash Previous block hash
  * @param height Block height
- * @param timestamp Block timestamp
+ * @param timestamp Block timestamp (typically block.nTime); also the upper
+ *                  bound of the backward search window
  * @param identity Expected identity (must match SHA3-256(pubkey)[:20])
- * @return true if signature is valid
+ * @return true if signature is valid for some timestamp in
+ *         [timestamp - kMIKVerifyBackwardWindowSeconds, timestamp]
  */
 bool VerifyMIKSignature(
+    const std::vector<uint8_t>& pubkey,
+    const std::vector<uint8_t>& signature,
+    const uint256& prevHash,
+    int height,
+    uint32_t timestamp,
+    const Identity& identity);
+
+/**
+ * Verify a MIK signature with EXACT timestamp match (no backward-window).
+ *
+ * Internal helper used by VerifyMIKSignature for each candidate timestamp.
+ * Exposed for tests and for code paths that need strict matching (e.g. the
+ * post-v4.1.0 strict verifier path once the timestamp race is fixed at the
+ * signer side).
+ */
+bool VerifyMIKSignatureExact(
     const std::vector<uint8_t>& pubkey,
     const std::vector<uint8_t>& signature,
     const uint256& prevHash,

--- a/src/net/block_fetcher.cpp
+++ b/src/net/block_fetcher.cpp
@@ -142,6 +142,22 @@ bool CBlockFetcher::RequestBlockFromPeer(NodeId peer_id, int height, const uint2
         return false;
     }
 
+    // v4.0.21 — Patch D: enforce scheduler-level per-peer cap.
+    // CBlockTracker::AddBlock has its own MAX_PER_PEER (128) ceiling, but the
+    // IBD coordinator gates new requests on MAX_BLOCKS_IN_TRANSIT_PER_PEER (32)
+    // and reports HangCause::PEERS_AT_CAPACITY when the live in-flight count
+    // is >= that limit. Parent-fetch and other direct callers of this function
+    // bypassed the 32-cap and could push in-flight to 33-128. Once that
+    // happened, the coordinator's capacity gate stayed closed until timeout
+    // requeue (120s) drained the surplus — the operator-visible "sync peer
+    // stuck at capacity" symptom from the 2026-04-25 incident.
+    // Reject early so the scheduler stays consistent with the in-flight count
+    // it later reads back via GetPeerBlocksInFlight().
+    int in_flight = g_node_context.block_tracker->GetPeerInFlightCount(peer_id);
+    if (in_flight >= MAX_BLOCKS_IN_TRANSIT_PER_PEER) {
+        return false;
+    }
+
     // AddBlock handles capacity checks and duplicate detection
     return g_node_context.block_tracker->AddBlock(height, hash, peer_id);
 }

--- a/src/node/dilithion-node.cpp
+++ b/src/node/dilithion-node.cpp
@@ -2748,6 +2748,37 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                     }
                 }
 
+                // v4.0.19 Fix B: Startup undo-presence integrity check.
+                // Catches the missing-undo-data corruption mode (incident 2026-04-25)
+                // BEFORE the node starts trying to reorg and loops forever. If any
+                // recent block lacks its undo entry, write auto_rebuild marker and exit.
+                {
+                    constexpr int kStartupUndoIntegrityProbeDepth = 100;
+                    uint256 missingHash;
+                    int missingHeight = 0;
+                    if (!g_chainstate.VerifyRecentUndoIntegrity(kStartupUndoIntegrityProbeDepth,
+                                                                missingHash, missingHeight)) {
+                        std::cerr << "\n==========================================================" << std::endl;
+                        std::cerr << "[CRITICAL] Startup integrity check failed: undo data missing"
+                                  << " for block at height " << missingHeight
+                                  << " hash=" << missingHash.GetHex() << std::endl;
+                        std::cerr << "This node cannot perform reorgs without manual recovery."
+                                  << " Writing auto_rebuild marker — node will wipe and resync"
+                                  << " on next launch." << std::endl;
+                        std::cerr << "==========================================================" << std::endl;
+
+                        const std::string reason =
+                            "Startup integrity: undo missing at height " + std::to_string(missingHeight)
+                            + " hash=" + missingHash.GetHex();
+                        Dilithion::WriteAutoRebuildMarker(config.datadir, reason);
+
+                        delete Dilithion::g_chainParams;
+                        return 2;  // Distinguishable exit code; wrapper restarts and wipes
+                    }
+                    std::cout << "  [OK] Startup undo integrity check passed (probed last "
+                              << kStartupUndoIntegrityProbeDepth << " blocks)" << std::endl;
+                }
+
                 std::cout << "  [OK] Loaded chain state: " << chainHashes.size() + 1 << " blocks (height "
                           << pindexTip->nHeight << ")" << std::endl;
             } else {

--- a/src/node/dilv-node.cpp
+++ b/src/node/dilv-node.cpp
@@ -2630,6 +2630,40 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                     }
                 }
 
+                // v4.0.19 Fix B: Startup undo-presence integrity check.
+                // Catches the missing-undo-data corruption mode (incident 2026-04-25)
+                // BEFORE the node starts trying to reorg and loops forever. If any
+                // recent block lacks its undo entry, write auto_rebuild marker and exit.
+                // Probes only the most recent k blocks because (a) corruption typically
+                // affects the tip region, (b) cost scales with k, (c) deep history
+                // is protected by checkpoints. 100 blocks ~ 75 minutes of DilV history.
+                {
+                    constexpr int kStartupUndoIntegrityProbeDepth = 100;
+                    uint256 missingHash;
+                    int missingHeight = 0;
+                    if (!g_chainstate.VerifyRecentUndoIntegrity(kStartupUndoIntegrityProbeDepth,
+                                                                missingHash, missingHeight)) {
+                        std::cerr << "\n==========================================================" << std::endl;
+                        std::cerr << "[CRITICAL] Startup integrity check failed: undo data missing"
+                                  << " for block at height " << missingHeight
+                                  << " hash=" << missingHash.GetHex() << std::endl;
+                        std::cerr << "This node cannot perform reorgs without manual recovery."
+                                  << " Writing auto_rebuild marker — node will wipe and resync"
+                                  << " on next launch." << std::endl;
+                        std::cerr << "==========================================================" << std::endl;
+
+                        const std::string reason =
+                            "Startup integrity: undo missing at height " + std::to_string(missingHeight)
+                            + " hash=" + missingHash.GetHex();
+                        Dilithion::WriteAutoRebuildMarker(config.datadir, reason);
+
+                        delete Dilithion::g_chainParams;
+                        return 2;  // Distinguishable exit code; wrapper restarts and wipes
+                    }
+                    std::cout << "  [OK] Startup undo integrity check passed (probed last "
+                              << kStartupUndoIntegrityProbeDepth << " blocks)" << std::endl;
+                }
+
                 std::cout << "  [OK] Loaded chain state: " << chainHashes.size() + 1 << " blocks (height "
                           << pindexTip->nHeight << ")" << std::endl;
             } else {
@@ -4346,14 +4380,23 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
         if (g_node_context.cooldown_tracker != nullptr) {
             CBlockIndex* pindexTip = g_chainstate.GetTip();
             if (pindexTip != nullptr && pindexTip->nHeight > 0) {
-                const int windowSize = cooldown_tracker.GetActiveWindow();
-                int startHeight = std::max(vdf_activation, pindexTip->nHeight - windowSize + 1);
+                // v4.0.21 — Patch C: walk from VDF activation (effectively
+                // genesis on DilV) so m_lifetimeBlockCount is deterministic and
+                // covers the full chain history. Active-window state still ends
+                // up correct because OnBlockConnected auto-evicts entries
+                // outside the active window. The lifetime count needs every
+                // block's MIK observed at least once, so a full-chain walk
+                // is required for determinism across nodes with different
+                // restart histories. Cost: O(chain_length) block reads at
+                // startup (~tens of seconds for 44k blocks). Acceptable.
+                int startHeight = std::max(vdf_activation, 1);
 
                 // Only attempt population if we're past VDF activation
                 if (pindexTip->nHeight >= vdf_activation) {
-                    std::cout << "Populating VDF cooldown tracker from existing chain..." << std::endl;
+                    std::cout << "Populating VDF cooldown tracker from existing chain "
+                              << "(full-history scan for v4.0.21 lifetime determinism)..." << std::endl;
 
-                    // Walk back from tip to startHeight
+                    // Walk back from tip to startHeight (typically VDF activation height = 0 on DilV)
                     std::vector<CBlockIndex*> recentBlocks;
                     CBlockIndex* pindex = pindexTip;
                     while (pindex != nullptr && pindex->nHeight >= startHeight) {

--- a/src/node/ibd_coordinator.cpp
+++ b/src/node/ibd_coordinator.cpp
@@ -23,6 +23,7 @@
 #include <net/peers.h>
 #include <net/protocol.h>
 #include <node/block_validation_queue.h>  // Phase 2: Async block validation
+#include <util/chain_reset.h>  // v4.0.19: WriteAutoRebuildMarker
 #include <node/fork_manager.h>  // Validate-before-disconnect fork handling
 #include <net/orphan_manager.h>  // IBD STUCK FIX #3: Periodic orphan scan
 #include <node/block_processing.h>  // BUG #260: ProcessNewBlock for orphan re-processing
@@ -114,40 +115,55 @@ void CIbdCoordinator::Tick() {
     }
 
     // =========================================================================
-    // BUG #277: Auto-recovery from UTXO corruption
+    // BUG #277 + v4.0.19: Auto-recovery from chain corruption
     // =========================================================================
-    // When ConnectTip fails repeatedly due to UTXO lookup errors (e.g., after
-    // OOM crash), the chain state signals that a rebuild is needed. We write
-    // a marker file and trigger graceful shutdown. On next restart, the node
-    // detects the marker and auto-wipes blocks+chainstate for a clean resync.
-    if (m_chainstate.NeedsUTXORebuild()) {
-        static bool recovery_triggered = false;
-        if (!recovery_triggered) {
-            recovery_triggered = true;
-            std::cerr << "\n==========================================================" << std::endl;
-            std::cerr << "CRITICAL: UTXO corruption detected! Auto-recovery initiated." << std::endl;
-            std::cerr << "The node will shut down and rebuild on next restart." << std::endl;
-            std::cerr << "==========================================================" << std::endl;
-
-            // Write marker file so startup code knows to wipe and resync
-            std::string datadir;
-            if (Dilithion::g_chainParams) {
-                datadir = Dilithion::g_chainParams->dataDir;
-            }
-            if (!datadir.empty()) {
-                std::string markerPath = datadir + "/auto_rebuild";
-                std::ofstream marker(markerPath);
-                if (marker.is_open()) {
-                    marker << "UTXO corruption detected at height " << m_chainstate.GetHeight() << std::endl;
-                    marker.close();
-                    std::cerr << "[Recovery] Wrote auto_rebuild marker to " << markerPath << std::endl;
+    // Two failure modes feed into one recovery path:
+    //   - NeedsUTXORebuild()  : ConnectTip's ApplyBlock fails repeatedly (BUG #277)
+    //   - NeedsChainRebuild() : DisconnectTip's UndoBlock fails repeatedly on the
+    //                           same hash (v4.0.19, incident 2026-04-25)
+    // In either case we write the auto_rebuild marker file with a reason describing
+    // which signal fired, then trigger graceful shutdown.
+    {
+        const bool utxo_rebuild = m_chainstate.NeedsUTXORebuild();
+        const bool chain_rebuild = m_chainstate.NeedsChainRebuild();
+        if (utxo_rebuild || chain_rebuild) {
+            static bool recovery_triggered = false;
+            if (!recovery_triggered) {
+                recovery_triggered = true;
+                std::cerr << "\n==========================================================" << std::endl;
+                if (utxo_rebuild) {
+                    std::cerr << "CRITICAL: UTXO corruption detected! Auto-recovery initiated." << std::endl;
+                } else {
+                    std::cerr << "CRITICAL: Persistent UndoBlock failure detected! Auto-recovery initiated." << std::endl;
                 }
-            }
+                std::cerr << "The node will shut down and rebuild on next restart." << std::endl;
+                std::cerr << "==========================================================" << std::endl;
 
-            // Trigger graceful shutdown
-            g_node_state.running = false;
+                std::string datadir;
+                if (Dilithion::g_chainParams) {
+                    datadir = Dilithion::g_chainParams->dataDir;
+                }
+                // Build combined reason when BOTH signals fire so operators see the
+                // full picture in auto_rebuild (Cursor review feedback, 2026-04-25).
+                std::string reason;
+                const std::string heightStr = std::to_string(m_chainstate.GetHeight());
+                if (utxo_rebuild && chain_rebuild) {
+                    uint256 failing = m_chainstate.GetLastUndoFailureHash();
+                    reason = "UTXO corruption AND persistent UndoBlock failure at height "
+                             + heightStr + " hash=" + failing.GetHex();
+                } else if (utxo_rebuild) {
+                    reason = "UTXO corruption detected at height " + heightStr;
+                } else {
+                    uint256 failing = m_chainstate.GetLastUndoFailureHash();
+                    reason = "Persistent UndoBlock failure at height "
+                             + heightStr + " hash=" + failing.GetHex();
+                }
+                Dilithion::WriteAutoRebuildMarker(datadir, reason);
+
+                g_node_state.running = false;
+            }
+            return;
         }
-        return;
     }
 
     int header_height = m_node_context.headers_manager->GetBestHeight();
@@ -829,7 +845,7 @@ void CIbdCoordinator::DownloadBlocks(int header_height, int chain_height,
         switch (m_last_hang_cause) {
             case HangCause::VALIDATION_QUEUE_FULL: cause_str = "validation queue full"; break;
             case HangCause::NO_PEERS_AVAILABLE: cause_str = "no peers available"; break;
-            case HangCause::PEERS_AT_CAPACITY: cause_str = "all peers at capacity"; break;
+            case HangCause::PEERS_AT_CAPACITY: cause_str = "sync peer at capacity"; break;
             case HangCause::WAITING_ON_PARENT_VALIDATION: cause_str = "parent block awaiting validation"; break;
             case HangCause::NONE: cause_str = "no suitable peers"; break;
         }

--- a/src/node/utxo_set.cpp
+++ b/src/node/utxo_set.cpp
@@ -1141,3 +1141,25 @@ bool CUTXOSet::Clear() {
 
     return true;
 }
+
+// ============================================================================
+// v4.0.19: HasUndoData — cheap existence probe for undo_<blockhash> entry
+// ============================================================================
+// Used at startup by CChainState::VerifyRecentUndoIntegrity to detect the
+// missing-undo-data corruption mode (incident 2026-04-25). Symmetric with the
+// undo key construction in ApplyBlock (line ~562) and UndoBlock (line ~606):
+// key format is "undo_" + 32 bytes of blockHash.data.
+
+bool CUTXOSet::HasUndoData(const uint256& blockHash) const {
+    if (!IsOpen()) {
+        return false;
+    }
+    std::lock_guard<std::recursive_mutex> lock(cs_utxo);
+
+    std::string undoKey = "undo_";
+    undoKey.append(reinterpret_cast<const char*>(blockHash.data), 32);
+
+    std::string undoValue;
+    leveldb::Status status = db->Get(leveldb::ReadOptions(), undoKey, &undoValue);
+    return status.ok();
+}

--- a/src/node/utxo_set.h
+++ b/src/node/utxo_set.h
@@ -171,6 +171,18 @@ public:
     bool UndoBlock(const CBlock& block, const uint256& blockHash);
 
     /**
+     * v4.0.19: Cheap probe for whether undo data exists for a given block hash.
+     * Reads the value from LevelDB to confirm presence (no atomicity guarantees
+     * against concurrent writes, but used at startup before block processing
+     * begins, so concurrency is not a concern).
+     * Used by CChainState::VerifyRecentUndoIntegrity during startup to detect
+     * the missing-undo-data corruption mode (incident 2026-04-25).
+     * @param blockHash The block hash to probe
+     * @return true if an undo_<blockhash> entry exists in LevelDB
+     */
+    bool HasUndoData(const uint256& blockHash) const;
+
+    /**
      * Flush all pending changes to disk
      * This writes all cached additions/deletions to LevelDB
      * @return true if successful

--- a/src/rpc/permissions.cpp
+++ b/src/rpc/permissions.cpp
@@ -131,6 +131,9 @@ void CRPCPermissions::InitializeMethodPermissions() {
     uint32_t adminServer = static_cast<uint32_t>(RPCPermission::ADMIN_SERVER);
 
     m_methodPermissions["stop"]               = adminServer;
+    // v4.0.19: forcerebuild writes auto_rebuild marker and shuts down. Treated
+    // as an admin-server operation alongside `stop` because it triggers shutdown.
+    m_methodPermissions["forcerebuild"]       = adminServer;
 
     // ========================================================================
     // Public Methods (no permission required)

--- a/src/rpc/ratelimiter.cpp
+++ b/src/rpc/ratelimiter.cpp
@@ -37,6 +37,8 @@ const std::map<std::string, CRateLimiter::MethodRateLimit> CRateLimiter::METHOD_
     {"exportmnemonic",         {20.0, 0.333, 1.0}},  // 20/min - sensitive data export
     {"dumpprivkey",            {5.0,  0.083, 1.0}},  // 5/min - sensitive key export
     {"importprivkey",          {5.0,  0.083, 1.0}},  // 5/min - wallet key import
+    // v4.0.19: forcerebuild triggers wipe + IBD; 1/min is intentionally conservative.
+    {"forcerebuild",           {1.0,  0.0167, 1.0}}, // 1/min - destructive operator action
 
     // === HIGH: Mining Control (20/min) ===
     {"startmining",            {20.0, 0.333, 1.0}},  // 20/min - resource intensive

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -36,6 +36,7 @@
 #include <dfmp/identity_db.h>  // DFMP v2.0: Identity database
 #include <digital_dna/dna_verification.h>  // DFMP v3.4: Verification-aware free tier
 #include <core/chainparams.h>  // For Dilithion::g_chainParams
+#include <util/chain_reset.h>   // v4.0.19: WriteAutoRebuildMarker
 #include <script/htlc.h>        // HTLC script templates
 #include <script/script.h>      // CScript, opcodes
 #include <script/atomic_swap.h> // Atomic swap state machine
@@ -227,6 +228,7 @@ CRPCServer::CRPCServer(uint16_t port)
     m_handlers["exportmnemonic"] = [this](const std::string& p) { return RPC_ExportMnemonic(p); };
     m_handlers["dumpprivkey"] = [this](const std::string& p) { return RPC_DumpPrivKey(p); };
     m_handlers["importprivkey"] = [this](const std::string& p) { return RPC_ImportPrivKey(p); };
+    m_handlers["forcerebuild"] = [this](const std::string& p) { return RPC_ForceRebuild(p); };
     m_handlers["gethdwalletinfo"] = [this](const std::string& p) { return RPC_GetHDWalletInfo(p); };
     m_handlers["listhdaddresses"] = [this](const std::string& p) { return RPC_ListHDAddresses(p); };
     m_handlers["rescanwallet"] = [this](const std::string& p) { return RPC_RescanWallet(p); };
@@ -1469,7 +1471,7 @@ void CRPCServer::HandleClient(int clientSocket) {
     } else if (rpcReq.method == "sendtoaddress" || rpcReq.method == "encryptwallet" ||
                rpcReq.method == "walletpassphrase" || rpcReq.method == "exportmnemonic" ||
                rpcReq.method == "dumpprivkey" || rpcReq.method == "importprivkey" ||
-               rpcReq.method == "stop") {
+               rpcReq.method == "stop" || rpcReq.method == "forcerebuild") {
         // Log sensitive operations
         std::cout << "[RPC-AUDIT] " << clientIP << " called " << rpcReq.method
                   << " - SUCCESS" << std::endl;
@@ -4196,6 +4198,83 @@ std::string CRPCServer::RPC_ImportPrivKey(const std::string& params) {
         << "\"success\":true"
         << "}";
 
+    return oss.str();
+}
+
+// ============================================================================
+// v4.0.19: forcerebuild — operator escape hatch for stuck-chain recovery
+// ============================================================================
+// Writes the auto_rebuild marker file with operator-supplied reason and triggers
+// graceful shutdown. On restart, the wrapper sees the marker and the startup
+// code wipes blocks/chainstate for a clean resync. Used when an operator
+// already knows a node is stuck (e.g. NYC/LDN incident 2026-04-25) and doesn't
+// want to wait for the in-process detection threshold (Fix A) to fire.
+//
+// Auth: ADMIN_SERVER (registered in permissions.cpp). Rate limit: 1/min.
+// Hidden from public help — operators learn it from runbooks.
+//
+// Params (object): {"reason": "<string, max 256 chars, alnum/space/._-:>"}
+std::string CRPCServer::RPC_ForceRebuild(const std::string& params) {
+    constexpr size_t kMaxReasonLen = 256;
+
+    std::string reason;
+    if (!params.empty()) {
+        try {
+            auto j = nlohmann::json::parse(params);
+            if (j.is_object() && j.contains("reason")) {
+                reason = j["reason"].get<std::string>();
+            }
+        } catch (...) {}
+    }
+
+    if (reason.empty()) {
+        throw std::runtime_error("Missing required parameter: reason (string)");
+    }
+    if (reason.size() > kMaxReasonLen) {
+        throw std::runtime_error("Parameter 'reason' too long (max "
+                                 + std::to_string(kMaxReasonLen) + " chars)");
+    }
+    // Sanitise: alphanumeric + space, underscore, hyphen, dot, colon. No quotes,
+    // newlines, or shell metachars — keeps the marker file safe to grep, log,
+    // and embed in operator alerts.
+    for (char c : reason) {
+        const bool ok = std::isalnum(static_cast<unsigned char>(c))
+                     || c == ' ' || c == '_' || c == '-' || c == '.' || c == ':';
+        if (!ok) {
+            throw std::runtime_error("Parameter 'reason' contains disallowed characters; "
+                                     "allowed: alphanumeric, space, _-.:");
+        }
+    }
+
+    std::string datadir;
+    if (Dilithion::g_chainParams) {
+        datadir = Dilithion::g_chainParams->dataDir;
+    }
+    if (datadir.empty()) {
+        throw std::runtime_error("ChainParams not initialised — refusing to write marker");
+    }
+
+    const std::string fullReason = "operator_forcerebuild: " + reason;
+    if (!Dilithion::WriteAutoRebuildMarker(datadir, fullReason)) {
+        throw std::runtime_error("Failed to write auto_rebuild marker");
+    }
+
+    std::cerr << "[CRITICAL] forcerebuild: operator-initiated rebuild scheduled. Shutting down."
+              << std::endl;
+
+    // Trigger graceful shutdown after a brief delay so the response can be sent.
+    std::thread([]() {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        g_node_state.running = false;
+    }).detach();
+
+    const std::string markerPath = datadir + "/auto_rebuild";
+    std::ostringstream oss;
+    oss << "{"
+        << "\"status\":\"shutdown_initiated\","
+        << "\"marker_path\":\"" << EscapeJSON(markerPath) << "\","
+        << "\"reason\":\"" << EscapeJSON(fullReason) << "\""
+        << "}";
     return oss.str();
 }
 

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -336,6 +336,10 @@ private:
     std::string RPC_ExportMnemonic(const std::string& params);
     std::string RPC_DumpPrivKey(const std::string& params);
     std::string RPC_ImportPrivKey(const std::string& params);
+
+    // v4.0.19: Operator escape hatch — write auto_rebuild marker and shut down.
+    // Admin-gated (ADMIN_SERVER), rate-limited 1/min, hidden from public help.
+    std::string RPC_ForceRebuild(const std::string& params);
     std::string RPC_GetHDWalletInfo(const std::string& params);
     std::string RPC_ListHDAddresses(const std::string& params);
     std::string RPC_RescanWallet(const std::string& params);

--- a/src/util/chain_reset.cpp
+++ b/src/util/chain_reset.cpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <filesystem>
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <system_error>
@@ -99,6 +100,33 @@ ChainResetReport ResetChainState(const std::string& datadir) {
     }
 
     return report;
+}
+
+bool WriteAutoRebuildMarker(const std::string& datadir, const std::string& reason) {
+    if (datadir.empty()) {
+        std::cerr << "[Recovery] WriteAutoRebuildMarker: empty datadir, refusing to write marker"
+                  << std::endl;
+        return false;
+    }
+    std::filesystem::path markerPath = std::filesystem::path(datadir) / "auto_rebuild";
+    std::ofstream marker(markerPath);
+    if (!marker.is_open()) {
+        std::cerr << "[Recovery] WriteAutoRebuildMarker: failed to open " << markerPath.string()
+                  << " for write" << std::endl;
+        return false;
+    }
+    // Single-line reason. The startup handler reads this and logs it; some operators
+    // also tail the file directly. Keep newline-terminated for log readability.
+    marker << reason << std::endl;
+    marker.close();
+    if (marker.fail()) {
+        std::cerr << "[Recovery] WriteAutoRebuildMarker: write to " << markerPath.string()
+                  << " failed (stream error)" << std::endl;
+        return false;
+    }
+    std::cerr << "[Recovery] Wrote auto_rebuild marker to " << markerPath.string()
+              << " (reason: " << reason << ")" << std::endl;
+    return true;
 }
 
 bool ConfirmChainReset(const std::string& datadir, bool yesFlag) {

--- a/src/util/chain_reset.h
+++ b/src/util/chain_reset.h
@@ -40,6 +40,21 @@ ChainResetReport ResetChainState(const std::string& datadir);
  */
 bool ConfirmChainReset(const std::string& datadir, bool yesFlag);
 
+/**
+ * v4.0.19: Write the auto_rebuild marker file. Used by:
+ *   - IBDCoordinator on persistent UTXO/UndoBlock failure (BUG #277, v4.0.19)
+ *   - Startup integrity check on missing undo data (Fix B, v4.0.19)
+ *   - forcerebuild RPC on operator demand (Fix C, v4.0.19)
+ *
+ * The marker is a single text file at <datadir>/auto_rebuild containing the
+ * reason. Existence triggers the startup wipe path on next launch.
+ *
+ * @param datadir Data directory (creates marker as <datadir>/auto_rebuild)
+ * @param reason Human-readable reason — written to the file as a single line
+ * @return true on success, false if the write failed (logs to stderr on failure)
+ */
+bool WriteAutoRebuildMarker(const std::string& datadir, const std::string& reason);
+
 } // namespace Dilithion
 
 #endif // DILITHION_UTIL_CHAIN_RESET_H

--- a/src/vdf/cooldown_tracker.cpp
+++ b/src/vdf/cooldown_tracker.cpp
@@ -262,6 +262,10 @@ void CCooldownTracker::OnBlockConnected(int height, const Address& winner, int64
     m_lastWinHeight[winner] = height;
     m_heightToWinner[height] = winner;
 
+    // v4.0.21 — Patch C: increment lifetime block count for this winner.
+    // Deterministic: pure function of canonical chain state.
+    m_lifetimeBlockCount[winner]++;
+
     // Store timestamp for time-based expiry
     if (blockTimestamp > 0) {
         m_lastWinTimestamp[winner] = blockTimestamp;
@@ -301,6 +305,16 @@ void CCooldownTracker::OnBlockDisconnected(int height)
     m_heightToTimestamp.erase(height);
     m_heightToRegistration.erase(height);  // Layer 3: undo registration tracking
 
+    // v4.0.21 — Patch C: decrement lifetime block count. Remove the entry
+    // entirely if it reaches zero so GetLifetimeMinerCount() returns the
+    // accurate count of MIKs with at least one block on the active chain.
+    auto lifeIt = m_lifetimeBlockCount.find(winner);
+    if (lifeIt != m_lifetimeBlockCount.end()) {
+        if (--lifeIt->second <= 0) {
+            m_lifetimeBlockCount.erase(lifeIt);
+        }
+    }
+
     // Recompute the address's last win height from remaining entries.
     // Scan backwards from the end of m_heightToWinner.
     int lastWin = -1;
@@ -338,10 +352,22 @@ void CCooldownTracker::Clear()
     m_lastWinTimestamp.clear();
     m_heightToTimestamp.clear();
     m_heightToRegistration.clear();
+    m_lifetimeBlockCount.clear();  // v4.0.21 — Patch C
     m_cachedActiveMinersMut = 0;
     m_cachedAtHeightMut = -1;
     m_cachedShortActiveMinersMut = 0;
     m_cachedShortAtHeightMut = -1;
+}
+
+// v4.0.21 — Patch C: lifetime distinct-miner count. Deterministic across nodes
+// with the same canonical chain because populated only via connect/disconnect
+// callbacks, which fire deterministically per-block. On startup, the populator
+// at dilithion-node.cpp:~4515 calls OnBlockConnected for every block from
+// genesis to tip in order, rebuilding this map identically on every node.
+int CCooldownTracker::GetLifetimeMinerCount() const
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return static_cast<int>(m_lifetimeBlockCount.size());
 }
 
 void CCooldownTracker::RecalcActiveMiners(int height) const

--- a/src/vdf/cooldown_tracker.h
+++ b/src/vdf/cooldown_tracker.h
@@ -95,6 +95,14 @@ public:
     /** Number of unique miners seen in the short window. */
     int GetShortActiveMiners() const;
 
+    /** v4.0.21 — Patch C: Number of distinct MIKs with at least one block on
+     *  the active chain (lifetime, not a sliding window). Used by the
+     *  consecutive-miner consensus rule's solo-exemption gate. Deterministic:
+     *  a function purely of canonical chain state, not of node restart history.
+     *  See OnBlockConnected/OnBlockDisconnected for the per-MIK count maintenance.
+     *  Reloaded by replaying connect events from genesis on startup. */
+    int GetLifetimeMinerCount() const;
+
     /** All MIK addresses that have ever mined (for DNA discovery). */
     std::vector<Address> GetKnownAddresses() const;
 
@@ -169,6 +177,15 @@ private:
 
     // Layer 3: height → MIK identity (only for registration blocks, for rate limiting)
     std::map<int, Address> m_heightToRegistration;
+
+    // v4.0.21 — Patch C: per-MIK count of blocks currently contributing to the
+    // active chain. Updated in OnBlockConnected (++) and OnBlockDisconnected (--).
+    // A MIK is "lifetime active" iff its count > 0. Lifetime miner count =
+    // m_lifetimeBlockCount.size().
+    // Deterministic: the count is a function purely of canonical chain state,
+    // not of node restart history. Reloaded by replaying connect events from
+    // genesis on startup (NOT from sliding window).
+    std::map<Address, int> m_lifetimeBlockCount;
 
     /** Recount active miners up to `height` (long window).  Caller must hold m_mutex. */
     void RecalcActiveMiners(int height) const;


### PR DESCRIPTION
## Summary

Three-version incident response to the 2026-04-25 DilV mainnet chain split. All three versions are stacked on this branch.

- **v4.0.19** (`90a505c` + `194ef1a`): defensive recovery — Fix A persistent UndoBlock failure detection, Fix B startup undo-presence integrity check, Fix C `forcerebuild` operator RPC. Caught the corruption that started the cascade.
- **v4.0.20** (`455c6ae`): tolerant MIK signature verification (backward-window brute force) for the Phase 1.5 timestamp race that fragmented the network across version-mismatched peers.
- **v4.0.21** (`ae2687c`): cooldown hardening — Patches A+B+C close the design vulnerability that allowed cascade overflow. Patch B (Case 2.5 VDF replacement crash-safety) is the smoking-gun fix for the chainstate corruption. Activation height 44600 is forward-only; existing chain history retained.

## Key changes by file

- `src/consensus/chain.cpp` — Patch B Case 2.5 rollback path (Cursor-identified smoking gun)
- `src/consensus/vdf_validation.cpp` — Patch A retire stall exemption + Patch C tighten solo-miner exemption (both call sites updated)
- `src/vdf/cooldown_tracker.{h,cpp}` — Patch C `m_lifetimeBlockCount` deterministic tracking
- `src/core/chainparams.{h,cpp}` — new activation fields `consecutiveMinerStallExemptionRetiredHeight` (DilV: 44600) and `soloExemptionLifetimeGateHeight` (DilV: 44600)
- `src/node/dilv-node.cpp` — startup populator now walks full chain (genesis to tip) for deterministic lifetime-count repopulation
- `src/dfmp/mik.{h,cpp}` — v4.0.20 backward-window MIK signature verification
- `src/util/chain_reset.{h,cpp}` — shared `WriteAutoRebuildMarker` helper
- `src/rpc/server.{h,cpp}` + `permissions.cpp` + `ratelimiter.cpp` — `forcerebuild` admin RPC

## Test plan

- [ ] Confirm clean build on Linux (NYC) + Windows (MSYS2) + macOS (CI)
- [ ] Regression: existing unit tests pass
- [ ] Production: all 4 mainnet seeds running v4.0.21, converging on rules-respecting chain post-incident
- [ ] Bridge wallet preserved on NYC across the recovery (verified — 534,173 DilV)

## Reviewers

- Cursor: independent reviews on root cause analysis (Case 2.5 identification), spec correctness (consensus determinism for Patch C), and final implementation
- Explore agent: parallel root-cause hunt + Patch C deterministic-state design

## Production state

- v4.0.21 deployed to all 4 mainnet DilV seeds (NYC/LDN/SGP/SYD). Currently re-IBDing onto rules-respecting chain.
- Branch contains the v4.0.19 + v4.0.20 commits because the recovery was iterative; merging to main releases all three together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)