### PR TITLE
txindex: FA-HI-1 architectural fix (BaseIndex pattern) + hardening

### DIFF
--- a/docs/TX-INDEX-RUNBOOK.md
+++ b/docs/TX-INDEX-RUNBOOK.md
@@ -74,6 +74,32 @@ will refuse to start otherwise.
 5. **After "(sync complete)" appears, the index is ready.** RPC calls
    to `getrawtransaction` / `gettransaction` will hit the fast path.
 
+### Behavior during the initial reindex (PR-7G R1)
+
+While the reindex thread is catching up (i.e. between startup and the
+"(sync complete)" log line), live blocks arriving via P2P are **NOT
+immediately indexed**. The reindex thread's outer loop catches them on
+its next pass via tip-rebase: after walking up to the snapshotted tip,
+it re-reads the live tip; if the tip advanced during the walk, the
+outer loop walks the newly-visible range; only when the tip is stable
+does it set `IsSynced()` to `true`.
+
+What this means operationally:
+
+- Until `(sync complete)` fires, `getrawtransaction` calls for newly-
+  arrived (post-startup) txs may fall through to the legacy tip-walk
+  (slower but correct). This is the "default-OFF behavior" semantically:
+  the fast path simply isn't populated yet for those heights.
+- The outer loop does NOT race the live-callback writers; live
+  callbacks are gated on `IsSynced()`. This is the Bitcoin Core
+  BaseIndex pattern. It eliminates the "leapfrog" failure mode where
+  a live callback writing at the chain tip caused the reindex's
+  catchup writes to silently no-op via the C1 monotonicity guard
+  (TXINDEX-FA-HI-1).
+- If you see `(sync complete)` and then a flood of new-chain activity,
+  the live callbacks pick up immediately after the gate opens. There
+  is no second-pass reindex needed.
+
 ### Subsequent restarts
 
 After the first cold rebuild, restart the node with `--txindex` only —
@@ -97,12 +123,15 @@ Once the index is built, the next time a fast-path tx lookup happens you
 will see (operator-visible info log):
 
 ```
-[RPC] Found transaction <txid> at block <blockhash> [txindex]
+[RPC] Found transaction <txid> in block <blockhash> (height N, M confirmations) [txindex]
 ```
 
 The `[txindex]` suffix indicates the response came from the fast path
 instead of the legacy tip-walk. If you don't see the suffix on confirmed
 non-mempool tx lookups, the index isn't being consulted — see §Troubleshooting.
+
+(PR-7G L2: literal log text matches code emission verbatim. The runbook
+previously said "at block" but the code emits "in block".)
 
 To benchmark the speedup, time a `getrawtransaction` call against a tx
 deep in the chain (e.g., > 10000 blocks back). With the fast path the

--- a/docs/TX-INDEX.md
+++ b/docs/TX-INDEX.md
@@ -82,27 +82,35 @@ Dilithion stores blocks keyed by hash in leveldb, not in flat files --
 
 1. **Connect callback thread** (chain validator). Fires from
    `CChainState::ActivateBestChain` after each successful block connect.
-   Calls `g_tx_index->WriteBlock(block, height, hash)`. **Holds `cs_main`**
-   when the callback fires (verified at `src/consensus/chain.cpp:1289`,
-   contract reference line 1474). The recursive nature of `cs_main` means
-   the callback's thread already owns the lock; `WriteBlock` therefore must
-   not call any function that re-enters `CChainState`.
+   Calls `g_tx_index->WriteBlock(block, height, hash)` **only when
+   `IsSynced()` is true** (PR-7G R1: live callbacks are gated until the
+   reindex thread has caught up). **Holds `cs_main`** when the callback
+   fires (verified at the connect callback firing site in
+   `src/consensus/chain.cpp`'s `ConnectTip`). The recursive nature of
+   `cs_main` means the callback's thread already owns the lock;
+   `WriteBlock` therefore must not call any function that re-enters
+   `CChainState`.
 2. **Disconnect callback thread** (chain validator). Fires from
    `CChainState::DisconnectTip` after a successful disconnect. Calls
-   `g_tx_index->EraseBlock(block, height, hash)`. **Does NOT hold `cs_main`**
-   when the callback fires (verified at `src/consensus/chain.cpp:1465`,
-   contract reference line 1656; the in-tree comment at chain.cpp lines
-   1283-1285 and 1460-1462 claiming "We don't hold cs_main during callbacks"
-   is correct ONLY for the disconnect path).
+   `g_tx_index->EraseBlock(block, height, hash)` **only when
+   `IsSynced()` is true** (same PR-7G gate). **Does NOT hold `cs_main`**
+   when the callback fires (verified at the disconnect callback firing
+   site in `src/consensus/chain.cpp`'s `DisconnectTip`; the in-tree
+   comment claiming "We don't hold cs_main during callbacks" is correct
+   ONLY for the disconnect path).
 3. **Reindex thread** (owned by `CTxIndex::m_sync_thread`). Spawned by
-   `StartBackgroundSync()`; iterates heights from `last_indexed + 1` to
-   the tip-height snapshot taken once at thread entry, resolving each
-   height to a block hash via `g_chainstate.GetBlocksAtHeight(h)` (and
-   preferring the on-main-chain block via `IsOnMainChain()` when more
-   than one block exists at that height), reads each block from the
-   block store, and writes the corresponding tx records. Holds `m_mutex`
-   only inside `WriteBlock` (never while calling into `CChainState`).
-   Honors `m_interrupt` between blocks.
+   `StartBackgroundSync()`; runs `SyncLoop` which wraps an outer loop
+   around `WalkBlockRange`. The outer loop walks heights from
+   `m_last_height + 1` to a snapshotted tip, then re-reads
+   `g_chainstate.GetTip()->nHeight`. If the tip advanced during the
+   walk, the outer loop bumps `current_target` and walks again.
+   `m_synced` is set to `true` (release ordering) ONLY when the tip is
+   stable across a full walk pass. Inside `WalkBlockRange`: each height
+   is resolved to a block hash via `g_chainstate.GetBlocksAtHeight(h)`
+   (preferring the on-main-chain block via `IsOnMainChain()`); blocks
+   are read from `m_chain_db` and written via `WriteBlock`. Holds
+   `m_mutex` only inside `WriteBlock` (never while calling into
+   `CChainState`). Honors `m_interrupt` at every iteration.
 
 ### The `cs_main` asymmetry
 
@@ -125,14 +133,85 @@ within it:
   `CChainState`. The RPC caller takes any chain locks separately, after
   `FindTx` returns.
 
-### Live-vs-reindex gating
+### Live-vs-reindex gating (Bitcoin Core BaseIndex pattern)
 
-Without gating, the reindex thread and the live callback could race on the
-same block (reindex catching up while IBD progresses). The fix is in
-`CTxIndex::WriteBlock`: under `m_mutex`, it short-circuits if
-`height <= m_last_height`. Strict monotonic meta. This makes both writers
-safe regardless of arrival order and makes the operation idempotent under
-the legitimate retry case (e.g., disconnect-reconnect cycle).
+The reindex thread and live callbacks are temporally separated, not
+concurrently serialized. While the reindex thread is catching up
+(`m_synced=false`), the live connect/disconnect callback lambdas
+short-circuit:
+
+```cpp
+if (g_tx_index && g_tx_index->IsSynced() &&
+    !g_tx_index->WriteBlock(b, h, hh)) { ... }
+```
+
+This is the Bitcoin Core BaseIndex pattern. The reindex thread is the
+SOLE writer to the index until catchup completes. After that, the
+reindex thread has exited and only the live callbacks update the index.
+
+The C1 monotonicity guard in `WriteBlock` (`if (height <=
+m_last_height) return true`) is **preserved** as defense-in-depth. Under
+the new gating, it can only fire on legitimate same-height duplicates
+(e.g., an idempotent disconnect+reconnect at the same height). The
+"leapfrog" failure mode that the original "both writers race" strategy
+exposed (see plan §4 historical context) is closed by the gate, not by
+changing the C1 guard.
+
+#### Outer-loop tip rebase (R1)
+
+`SyncLoop` wraps an outer loop around `WalkBlockRange`. Each pass
+walks `[m_last_height+1, current_target]`, then re-reads
+`g_chainstate.GetTip()->nHeight`. If the tip advanced during the walk,
+the outer loop bumps `current_target` and walks the newly-visible
+range. `m_synced.store(true)` happens ONLY when the tip is stable
+across a full walk pass (no advancement during the most recent walk).
+
+This guarantees: if `IsSynced()` returns true, every block at heights
+`[0, current_target]` is in the index. The loop cannot be blindsided
+by a tip advance during its walk because it always re-reads after
+walking.
+
+#### Failure modes that leave `m_synced=false`
+
+Operators detect incomplete state by polling `IsSynced()`:
+
+- **R4 — WriteBlock failure during reindex.** Inside
+  `WalkBlockRange`, a `WriteBlock` failure (e.g. disk full) returns
+  false. SyncLoop returns without setting `m_synced=true`.
+- **R6 — contested-height with no main-chain block.** When
+  `GetBlocksAtHeight(h)` returns multiple candidates and NONE is on
+  the main chain (mid-reorg), `WalkBlockRange` returns false. Same
+  effect. After the reorg settles, a subsequent
+  `StartBackgroundSync` re-walks cleanly.
+- **EraseBlock failure (post-sync).** `EraseBlock` failure during
+  normal operation sets the sticky `m_corrupted` flag (R2). The RPC
+  fast-path checks `IsCorrupted()` before `FindTx` and falls through
+  to the legacy tip-walk if true. The flag is sticky until
+  `WipeIndex()` succeeds (the `--reindex` path) or process restart.
+
+#### Known limitation: single-candidate chain-recession during reindex
+
+R6's bail logic only fires on **multi-candidate** contested heights
+(`hashes.size() > 1 && !found_main`). The single-candidate non-main-
+chain case still falls through to `hashes.front()` because the
+genuine current tip block reads as `!IsOnMainChain()` (its `pnext`
+is null until something extends it) and the reindex must be able to
+write the tip.
+
+Edge case: if the chain RECEDES during a walk (a deep reorg drops
+the tip below `current_target`), heights between the new tip and
+`current_target` may have orphaned single-candidate blocks. The
+walker writes those records, and SyncLoop's tip-rebase
+(`if (tip_now <= current_target) m_synced=true`) then sets
+`m_synced=true` with the now-stale records on disk. The records
+will surface as `MismatchCount` increments at RPC paranoia-check
+time (L3), but they persist until the next `--reindex`.
+
+This is **pre-existing behavior** (not regressed by the FA-HI-1
+fix). Operators concerned about reorg-during-reindex correctness
+should re-run with `--reindex` after any deep reorg observed during
+the initial sync. Filed as `TXINDEX-FA-LO-4` for follow-up
+hardening.
 
 ## Lifecycle
 
@@ -270,9 +349,12 @@ re-acknowledge the rebuild.
 * `src/rpc/server.cpp` -- surgical fast-path branch in
   `RPC_GetRawTransaction` and `RPC_GetTransaction`: `FindTx`, `ReadBlock`,
   paranoia check, fall-through to legacy tip-walk on any anomaly.
-* `src/consensus/chain.cpp` -- callback hook sites at lines 1289 (connect)
-  and 1465 (disconnect); the `cs_main` asymmetry documented in the
-  Threading model section above.
+* `src/consensus/chain.cpp` -- the connect callback firing site
+  (`ConnectTip`) and the disconnect callback firing site
+  (`DisconnectTip`); the `cs_main` asymmetry documented in the
+  Threading model section above. Anchor strings rather than literal
+  line numbers (PR-7G L1) — line numbers drift when chain.cpp is
+  edited; greppable site names do not.
 * `src/test/tx_index_tests.cpp` -- 26 unit cases covering Init, schema
   versioning, monotonicity, reindex happy path, reindex resume across
   destruct, C7 wipe atomicity, stale-LOCK error path, stop-mid-walk

--- a/src/index/tx_index.cpp
+++ b/src/index/tx_index.cpp
@@ -26,14 +26,29 @@ std::unique_ptr<CTxIndex> g_tx_index;
 
 const std::string CTxIndex::META_KEY = std::string("\x00meta", 5);
 
-// Test-observability hook (U3, Cursor 2nd-pass): counts the number of
-// m_db->Write() calls issued by WipeIndex. Lives in a dedicated namespace
-// so production code never reads it. Cost in production: 8 bytes of static
-// storage and one relaxed atomic increment per wipe — wipes happen at most
-// once per startup on a corrupted index. The counter proves the wipe is
-// implemented as a SINGLE WriteBatch (criterion U3).
+// Test-observability hooks. Live in a dedicated namespace so production
+// code never reads them. Cost in production: a few bytes of static
+// storage and one relaxed atomic touch per gated event. All hooks are
+// inert (no behavior change) unless tests explicitly set the gating
+// atomic.
+//
+// - g_wipe_write_count (U3): counts the number of m_db->Write() calls
+//   issued by WipeIndex AFTER the leveldb status is OK (PR-7G A4). The
+//   counter proves the wipe is implemented as a SINGLE WriteBatch and
+//   measures committed writes, not attempts.
+//
+// - g_walk_iteration_count (PR-7G E.2): incremented each time
+//   WalkBlockRange enters a new height inside its inner loop. Tests can
+//   poll this counter to inject blocks mid-walk deterministically.
+//
+// - g_force_eraseblock_failure (PR-7G E.4): when set true by a test,
+//   makes EraseBlock skip the leveldb write and return false (as if the
+//   underlying leveldb write had failed). Drives the m_corrupted-on-
+//   failure path without filesystem fragility on Windows MSYS2.
 namespace tx_index_test_hooks {
 std::atomic<uint64_t> g_wipe_write_count{0};
+std::atomic<uint64_t> g_walk_iteration_count{0};
+std::atomic<bool>     g_force_eraseblock_failure{false};
 }
 
 CTxIndex::CTxIndex() = default;
@@ -101,8 +116,16 @@ bool CTxIndex::Init(const std::string& datadir, CBlockchainDB* chain_db) {
         // U4 (Cursor 2nd-pass): stale-LOCK path — when leveldb fails to open
         // because another process holds the LOCK file, surface the exact path
         // and remediation step. No retry, no crash, no infinite loop.
+        //
+        // PR-7G A2: prefer the typed predicate IsIOError() — leveldb returns
+        // an IOError status whenever it cannot acquire the LOCK file (see
+        // depends/leveldb/util/env_*.cc PosixEnv::LockFile / WindowsEnv).
+        // Substring fallback is retained for portability across leveldb
+        // versions whose error text we cannot inspect at compile time, but
+        // the typed predicate is the primary signal.
         const std::string status_str = status.ToString();
         const bool likely_lock =
+            status.IsIOError() ||
             status_str.find("lock") != std::string::npos ||
             status_str.find("LOCK") != std::string::npos ||
             status_str.find("Resource temporarily unavailable") != std::string::npos;
@@ -153,6 +176,32 @@ bool CTxIndex::Init(const std::string& datadir, CBlockchainDB* chain_db) {
 
     int32_t height = 0;
     std::memcpy(&height, &meta_value[1], 4);
+
+    // PR-7G R5: bound-check the meta height. The on-disk value is a signed
+    // 32-bit int; the only legitimate values are -1 (cold) or [0, tip].
+    // Anything outside [-1, kMaxReasonableHeight] is provable corruption
+    // (e.g. a forged INT_MAX would overflow `current = height + 1` in
+    // SyncLoop, wrapping to INT_MIN and producing a near-2^31-iteration
+    // hang). Wipe and treat as cold-start. The 100M cap is well above any
+    // plausible chain depth in this lifetime.
+    constexpr int32_t kMaxReasonableHeight = 100'000'000;
+    if (height < -1 || height > kMaxReasonableHeight) {
+        std::cerr << "[txindex] meta height " << height
+                  << " is out of bounds [-1, " << kMaxReasonableHeight
+                  << "] -- treating as corrupt and wiping" << std::endl;
+        lock.unlock();
+        const bool wiped = WipeIndex();
+        lock.lock();
+        if (!wiped) {
+            std::cerr << "[txindex] integrity wipe failed; closing index" << std::endl;
+            m_db.reset();
+            return false;
+        }
+        m_last_height.store(-1);
+        m_synced.store(false);
+        return true;
+    }
+
     m_last_height.store(height);
     m_synced.store(false);
 
@@ -273,12 +322,20 @@ bool CTxIndex::WipeIndex() {
     batch.Delete(leveldb::Slice(META_KEY.data(), META_KEY.size()));
 
     leveldb::Status status = m_db->Write(leveldb::WriteOptions(), &batch);
-    tx_index_test_hooks::g_wipe_write_count.fetch_add(1, std::memory_order_relaxed);
     if (!status.ok()) {
         std::cerr << "[txindex] WipeIndex write failed: "
                   << status.ToString() << std::endl;
         return false;
     }
+    // PR-7G A4: counter measures committed writes only (post-status.ok()),
+    // not attempts. Failed writes shouldn't bump the counter; otherwise
+    // U3's "exactly 1 db->Write call" assertion is inflated by failures.
+    tx_index_test_hooks::g_wipe_write_count.fetch_add(1, std::memory_order_relaxed);
+    // PR-7G R2 (CONCERN-B2): the only legitimate runtime reset for the
+    // sticky m_corrupted flag is a successful wipe (C7 / --reindex). The
+    // index has just been reduced to a clean cold-start state on disk;
+    // any prior staleness has been erased.
+    m_corrupted.store(false);
     return true;
 }
 
@@ -371,14 +428,38 @@ bool CTxIndex::EraseBlock(const CBlock& block, int height, const uint256& block_
         return false;
     }
 
-    leveldb::Status status = m_db->Write(leveldb::WriteOptions(), &batch);
+    // PR-7G R2: optimistic m_last_height decrement BEFORE issuing the
+    // leveldb write. Without this, a write failure leaves m_last_height==H
+    // while the (intended) on-disk state is height H-1; a subsequent
+    // connect-replacement at height H would hit the C1 monotonicity guard
+    // (`height <= m_last_height` is `H <= H` = true) and silently no-op,
+    // so the replacement block's tx records would never be written.
+    // Decrementing first allows the replacement WriteBlock to succeed
+    // (its height becomes > new_height); we then set the sticky m_corrupted
+    // flag to give RPC operators a signal that the on-disk index may
+    // contain stale records for the failed-erase block.
+    m_last_height.store(new_height);
+
+    // PR-7G E.4 test-hook seam: when set, simulate a leveldb write failure
+    // without touching the filesystem. Production cost is one relaxed
+    // atomic load on the EraseBlock path, fired only on real disconnects.
+    const bool force_fail =
+        tx_index_test_hooks::g_force_eraseblock_failure.load(std::memory_order_relaxed);
+
+    leveldb::Status status =
+        force_fail ? leveldb::Status::IOError("forced EraseBlock failure (test)")
+                   : m_db->Write(leveldb::WriteOptions(), &batch);
     if (!status.ok()) {
         std::cerr << "[txindex] EraseBlock failed at height " << height
                   << ": " << status.ToString() << std::endl;
+        // PR-7G R2: sticky flag — the on-disk records for `height` may be
+        // stale (the optimistic m_last_height already decremented but the
+        // delete-batch never landed). Operators see corruption via RPC
+        // mismatch counters and the IsCorrupted() getter; recovery is
+        // --reindex (which calls WipeIndex and clears the flag).
+        m_corrupted.store(true);
         return false;
     }
-
-    m_last_height.store(new_height);
     (void)block_hash;
     return true;
 }
@@ -425,6 +506,10 @@ bool CTxIndex::IsBuiltUpToHeight(int h) const {
 
 bool CTxIndex::IsSynced() const {
     return m_synced.load();
+}
+
+bool CTxIndex::IsCorrupted() const {
+    return m_corrupted.load();
 }
 
 void CTxIndex::StartBackgroundSync() {
@@ -475,20 +560,36 @@ void CTxIndex::StartBackgroundSync() {
     m_starting.store(false);        // thread is now joinable; gate released
 }
 
-void CTxIndex::SyncLoop(int snapshotted_tip_height) {
-    // R3 (Cursor 2nd-pass) — load-bearing comment, NOT decoration:
-    // Chain reads (`g_chainstate.GetTip()`, `g_chainstate.GetBlockIndex(hash)`)
-    // acquire `cs_main` internally. `m_mutex` MUST NOT be held across these
-    // calls. The callback path only enters CTxIndex through `WriteBlock` /
-    // `EraseBlock`, which acquire `m_mutex` themselves; the reindex thread
-    // acquires `m_mutex` only via the same `WriteBlock` call site.
-
-    int current = m_last_height.load() + 1;
-    int blocks_indexed_this_run = 0;
-    while (current <= snapshotted_tip_height) {
+// R3 (Cursor 2nd-pass) — load-bearing comment, NOT decoration:
+// Chain reads (`g_chainstate.GetTip()`, `g_chainstate.GetBlockIndex(hash)`)
+// acquire `cs_main` internally. `m_mutex` MUST NOT be held across these
+// calls. The callback path only enters CTxIndex through `WriteBlock` /
+// `EraseBlock`, which acquire `m_mutex` themselves; the reindex thread
+// acquires `m_mutex` only via the same `WriteBlock` call site.
+//
+// PR-7G R1 (Bitcoin Core BaseIndex pattern):
+//   SyncLoop wraps an outer loop around WalkBlockRange. After each inner
+//   walk completes, it re-reads `g_chainstate.GetTip()->nHeight` and, if
+//   the tip advanced during the walk, walks the newly-visible range.
+//   m_synced is set to true ONLY when the tip is stable across a full
+//   walk pass. Live callbacks short-circuit at the lambda site while
+//   `!IsSynced()` (see dilithion-node.cpp / dilv-node.cpp), so the
+//   reindex thread is the SOLE writer to the index until catchup
+//   completes — closing the FA-HI-1 leapfrog vector by separating
+//   reindex and live writers temporally rather than relying on the C1
+//   monotonicity guard alone.
+bool CTxIndex::WalkBlockRange(int start, int end) {
+    int current = start;
+    while (current <= end) {
         if (m_interrupt.load()) {
-            break;
+            return false;
         }
+
+        // PR-7G E.2 test-hook seam: tests can poll this counter to inject
+        // blocks mid-walk deterministically. Production cost: one relaxed
+        // atomic increment per height, on the rare reindex path only.
+        tx_index_test_hooks::g_walk_iteration_count.fetch_add(
+            1, std::memory_order_relaxed);
 
         // Resolve current height -> block hash via g_chainstate. We do NOT
         // hold m_mutex across this call (R1).
@@ -496,10 +597,23 @@ void CTxIndex::SyncLoop(int snapshotted_tip_height) {
         if (hashes.empty()) {
             std::cerr << "[txindex] reindex: no block index entry at height "
                       << current << "; aborting reindex" << std::endl;
-            break;
+            return false;
         }
 
-        // Prefer the on-main-chain block at this height; fall back to any.
+        // Prefer the on-main-chain block at this height. PR-7G R6: when
+        // MULTIPLE blocks exist at this height and NONE is on main chain
+        // (e.g. mid-reorg where DisconnectTip cleared pnext on the old
+        // block but the new ConnectTip hasn't fired yet), do NOT fall
+        // back to hashes.front(). hashes.front() is non-deterministic
+        // (mapBlockIndex ordering) and can land on a stale side-chain
+        // block whose tx records would then persist forever (FA-MD-5).
+        // Skip the height with a log line and rely on the outer-loop
+        // tip-rebase to revisit it once the reorg settles.
+        //
+        // The hashes.size()==1 single-block case still falls through to
+        // hashes.front() — this is the normal "current tip" case where
+        // pnext is null for the genuine tip block. There is no ambiguity
+        // when there's only one candidate.
         uint256 block_hash;
         bool found_main = false;
         for (const uint256& h : hashes) {
@@ -511,6 +625,20 @@ void CTxIndex::SyncLoop(int snapshotted_tip_height) {
             }
         }
         if (!found_main) {
+            if (hashes.size() > 1) {
+                // PR-7G R6: stop the walk here. m_last_height is NOT
+                // advanced past the contested height; the reindex is
+                // not yet complete. SyncLoop's outer loop will return
+                // without setting m_synced=true, so operators detect
+                // via IsSynced()==false. After the reorg settles, a
+                // subsequent StartBackgroundSync will re-walk from
+                // m_last_height+1 and find a single main-chain block.
+                std::cerr << "[txindex] reindex: no main-chain block at height "
+                          << current << " (mid-reorg, " << hashes.size()
+                          << " candidates) -- bailing walk; outer loop will "
+                          << "revisit when the reorg settles" << std::endl;
+                return false;
+            }
             block_hash = hashes.front();
         }
 
@@ -525,27 +653,72 @@ void CTxIndex::SyncLoop(int snapshotted_tip_height) {
 
         // WriteBlock acquires m_mutex internally. The reindex thread does
         // NOT hold m_mutex across this call.
+        //
+        // PR-7G R4: a WriteBlock failure during reindex is unrecoverable
+        // for THIS walk pass — the local meta is now inconsistent with
+        // the writer's intent. Break and signal failure to the outer
+        // loop; the outer loop will return without setting m_synced=true
+        // so operators detect via `IsSynced()` polling that the index is
+        // not fully built. (Under the new gating, C1 same-height no-op
+        // is impossible during reindex because live callbacks are gated
+        // off — so a `false` return here is always a real disk error.)
         if (!WriteBlock(block, current, block_hash)) {
-            // WriteBlock already logged the cause. C1 monotonicity means a
-            // racing live-callback WriteBlock at the same height returns
-            // true (no-op); a real error here is rare.
+            std::cerr << "[txindex] reindex: WriteBlock failed at height "
+                      << current << "; aborting walk (m_synced stays false)"
+                      << std::endl;
+            return false;
         }
 
-        ++blocks_indexed_this_run;
         if ((current % 1000) == 0) {
             std::cout << "[txindex] indexed " << current
-                      << "/" << snapshotted_tip_height << " blocks" << std::endl;
+                      << "/" << end << " blocks" << std::endl;
         }
         ++current;
     }
 
-    if (!m_interrupt.load() && current > snapshotted_tip_height) {
-        std::cout << "[txindex] indexed " << snapshotted_tip_height
-                  << "/" << snapshotted_tip_height << " blocks (sync complete)"
-                  << std::endl;
-        m_synced.store(true);
+    return true;
+}
+
+void CTxIndex::SyncLoop(int initial_snapshotted_tip) {
+    int current_target = initial_snapshotted_tip;
+
+    while (!m_interrupt.load()) {
+        // PR-7G R1: each iteration walks `[m_last_height+1, current_target]`,
+        // then re-reads the live tip. If the tip advanced during the walk,
+        // bump current_target and walk again. Only when the tip is stable
+        // across a full walk pass do we set m_synced=true.
+        const int walk_start = m_last_height.load() + 1;
+        if (walk_start > current_target) {
+            // Either we resumed already at-or-past the target (warm-stale
+            // resume case), or the previous iteration completed up to
+            // current_target. Fall through to the tip re-read below.
+        } else {
+            const bool walk_completed = WalkBlockRange(walk_start, current_target);
+            if (m_interrupt.load() || !walk_completed) {
+                // Bail without setting m_synced=true. Operators detect the
+                // incomplete state via IsSynced()==false. R4 path.
+                return;
+            }
+        }
+
+        // Re-read the chain tip. If it advanced during the walk, continue;
+        // otherwise we're synced.
+        CBlockIndex* tip = g_chainstate.GetTip();
+        if (tip == nullptr) {
+            // Chainstate vanished mid-walk (shutdown in progress?) — bail
+            // without setting m_synced.
+            return;
+        }
+        const int tip_now = tip->nHeight;
+        if (tip_now <= current_target) {
+            std::cout << "[txindex] indexed " << current_target
+                      << "/" << current_target << " blocks (sync complete)"
+                      << std::endl;
+            m_synced.store(true);
+            return;
+        }
+        current_target = tip_now;
     }
-    (void)blocks_indexed_this_run;
 }
 
 void CTxIndex::Interrupt() {

--- a/src/index/tx_index.h
+++ b/src/index/tx_index.h
@@ -36,6 +36,13 @@ public:
     bool IsBuiltUpToHeight(int h) const;
     bool IsSynced() const;
 
+    // PR-7G R2: sticky corruption flag set on EraseBlock leveldb-write
+    // failure. Never auto-cleared at runtime; reset to false only by
+    // (a) WipeIndex() succeeding (i.e. C7 / --reindex path), or
+    // (b) destruction (process restart with a fresh g_tx_index). The
+    // flag is intentionally sticky to give the operator a clear signal.
+    bool IsCorrupted() const;
+
     // PR-4 will fill in actual thread bodies.
     void StartBackgroundSync();
     void Interrupt();
@@ -62,6 +69,9 @@ private:
     std::atomic<bool>     m_interrupt{false};
     std::atomic<uint64_t> m_mismatches_observed{0};
 
+    // PR-7G R2: sticky corruption flag (see IsCorrupted() above).
+    std::atomic<bool>     m_corrupted{false};
+
     // SEC-MD-1: gates the spawn-vs-stop race. Set under m_mutex inside
     // StartBackgroundSync before m_mutex is released for the chainstate
     // query. Cleared after m_sync_thread has been assigned. Stop() waits
@@ -82,7 +92,31 @@ private:
     // Reindex thread body. Spawned by StartBackgroundSync; reads g_chainstate
     // and m_chain_db without holding m_mutex (m_mutex is acquired only inside
     // WriteBlock). Honors m_interrupt between blocks.
-    void SyncLoop(int snapshotted_tip_height);
+    //
+    // PR-7G R1: SyncLoop now wraps an outer loop around WalkBlockRange.
+    // After each inner walk completes, the loop re-reads g_chainstate's
+    // tip height and, if the tip advanced during the walk, walks the
+    // newly-visible range. m_synced is set to true ONLY when the tip is
+    // stable across a full walk pass (i.e. no advancement during the
+    // most recent walk). This is the Bitcoin Core BaseIndex pattern.
+    void SyncLoop(int initial_snapshotted_tip);
+
+    // PR-7G R1: extracted inner-walk helper. Walks heights [start, end]
+    // inclusive, calling WriteBlock for each main-chain block. Returns
+    // true on clean completion; false on m_interrupt OR an unrecoverable
+    // WriteBlock failure (R4) -- caller must NOT set m_synced=true if false.
+    //
+    // R6 contested-height behavior: when MULTIPLE candidates exist at a
+    // height and NONE is on the main chain (mid-reorg), the walk BAILS
+    // by returning false and m_last_height is NOT advanced past the
+    // contested height. SyncLoop's outer loop will return without setting
+    // m_synced=true, and the next StartBackgroundSync will re-walk from
+    // m_last_height+1 once the reorg settles. Single-candidate non-main-
+    // chain heights (the normal "current tip" case where pnext==nullptr
+    // because nothing extends the tip yet) still fall through to
+    // hashes.front() -- there is no ambiguity when only one candidate
+    // exists.
+    bool WalkBlockRange(int start, int end);
 };
 
 extern std::unique_ptr<CTxIndex> g_tx_index;

--- a/src/node/dilithion-node.cpp
+++ b/src/node/dilithion-node.cpp
@@ -2930,9 +2930,18 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                           << " (chain tip " << tip << ", gap=" << (tip - last)
                           << " blocks)" << std::endl;
             }
+            // PR-7G R1: live connect/disconnect callbacks are GATED on
+            // IsSynced(). While the reindex thread is catching up
+            // (m_synced=false), incoming chain blocks are NOT written by
+            // these lambdas — the reindex thread's outer loop in SyncLoop
+            // catches them via tip-rebase. This is the Bitcoin Core
+            // BaseIndex pattern; it closes the FA-HI-1 leapfrog vector
+            // by separating reindex and live writers temporally rather
+            // than relying on the C1 monotonicity guard alone.
             g_chainstate.RegisterBlockConnectCallback(
                 [](const CBlock& b, int h, const uint256& hh) {
-                    if (g_tx_index && !g_tx_index->WriteBlock(b, h, hh)) {
+                    if (g_tx_index && g_tx_index->IsSynced() &&
+                        !g_tx_index->WriteBlock(b, h, hh)) {
                         std::cerr << "[txindex] WriteBlock failed at height " << h
                                   << " (hash " << hh.GetHex().substr(0, 16) << "...) "
                                   << "-- index now lagging chain" << std::endl;
@@ -2940,7 +2949,8 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                 });
             g_chainstate.RegisterBlockDisconnectCallback(
                 [](const CBlock& b, int h, const uint256& hh) {
-                    if (g_tx_index && !g_tx_index->EraseBlock(b, h, hh)) {
+                    if (g_tx_index && g_tx_index->IsSynced() &&
+                        !g_tx_index->EraseBlock(b, h, hh)) {
                         std::cerr << "[txindex] EraseBlock failed at height " << h
                                   << " (hash " << hh.GetHex().substr(0, 16) << "...) "
                                   << "-- index may contain stale entries" << std::endl;
@@ -7772,6 +7782,13 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
         #endif
         std::cerr << "===========================================================" << std::endl;
 
+        // PR-7G R3: release tx_index before chainParams cleanup so the
+        // reindex thread (which reads g_chainstate.GetBlocksAtHeight /
+        // GetBlockIndex) is joined before any global it depends on can
+        // be torn down by the static destructor sequence. Mirrors the
+        // normal-shutdown ordering at line 7725.
+        g_tx_index.reset();
+
         // Cleanup on error (P0-5 FIX: use load/store for atomic)
         auto* relay_mgr = g_tx_relay_manager.load();
         if (relay_mgr) {
@@ -7822,6 +7839,10 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
         }
         #endif
         std::cerr << "===========================================================" << std::endl;
+
+        // PR-7G R3: release tx_index before chainParams cleanup. See the
+        // matching note in the std::exception catch above.
+        g_tx_index.reset();
 
         // Cleanup on error (P0-5 FIX: use load/store for atomic)
         auto* relay_mgr = g_tx_relay_manager.load();

--- a/src/node/dilv-node.cpp
+++ b/src/node/dilv-node.cpp
@@ -2811,9 +2811,18 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                           << " (chain tip " << tip << ", gap=" << (tip - last)
                           << " blocks)" << std::endl;
             }
+            // PR-7G R1: live connect/disconnect callbacks are GATED on
+            // IsSynced(). While the reindex thread is catching up
+            // (m_synced=false), incoming chain blocks are NOT written by
+            // these lambdas — the reindex thread's outer loop in SyncLoop
+            // catches them via tip-rebase. This is the Bitcoin Core
+            // BaseIndex pattern; it closes the FA-HI-1 leapfrog vector
+            // by separating reindex and live writers temporally rather
+            // than relying on the C1 monotonicity guard alone.
             g_chainstate.RegisterBlockConnectCallback(
                 [](const CBlock& b, int h, const uint256& hh) {
-                    if (g_tx_index && !g_tx_index->WriteBlock(b, h, hh)) {
+                    if (g_tx_index && g_tx_index->IsSynced() &&
+                        !g_tx_index->WriteBlock(b, h, hh)) {
                         std::cerr << "[txindex] WriteBlock failed at height " << h
                                   << " (hash " << hh.GetHex().substr(0, 16) << "...) "
                                   << "-- index now lagging chain" << std::endl;
@@ -2821,7 +2830,8 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                 });
             g_chainstate.RegisterBlockDisconnectCallback(
                 [](const CBlock& b, int h, const uint256& hh) {
-                    if (g_tx_index && !g_tx_index->EraseBlock(b, h, hh)) {
+                    if (g_tx_index && g_tx_index->IsSynced() &&
+                        !g_tx_index->EraseBlock(b, h, hh)) {
                         std::cerr << "[txindex] EraseBlock failed at height " << h
                                   << " (hash " << hh.GetHex().substr(0, 16) << "...) "
                                   << "-- index may contain stale entries" << std::endl;
@@ -7415,6 +7425,13 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
         #endif
         std::cerr << "===========================================================" << std::endl;
 
+        // PR-7G R3: release tx_index before chainParams cleanup so the
+        // reindex thread (which reads g_chainstate.GetBlocksAtHeight /
+        // GetBlockIndex) is joined before any global it depends on can
+        // be torn down by the static destructor sequence. Mirrors the
+        // normal-shutdown ordering at line 7368.
+        g_tx_index.reset();
+
         // Cleanup on error (P0-5 FIX: use load/store for atomic)
         auto* relay_mgr = g_tx_relay_manager.load();
         if (relay_mgr) {
@@ -7465,6 +7482,10 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
         }
         #endif
         std::cerr << "===========================================================" << std::endl;
+
+        // PR-7G R3: release tx_index before chainParams cleanup. See the
+        // matching note in the std::exception catch above.
+        g_tx_index.reset();
 
         // Cleanup on error (P0-5 FIX: use load/store for atomic)
         auto* relay_mgr = g_tx_relay_manager.load();

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -2908,7 +2908,13 @@ std::string CRPCServer::RPC_GetTransaction(const std::string& params) {
     // PR-5: txindex fast-path. Same semantics as the RPC_GetRawTransaction
     // wiring — verified hit returns immediately, paranoia mismatch logs and
     // falls through to the legacy tip-walk below.
-    if (g_tx_index) {
+    //
+    // PR-7G R2: an EraseBlock failure leaves the index in a known-stale
+    // state until the operator runs --reindex. Skip the fast-path entirely
+    // when m_corrupted is set — the legacy tip-walk produces the correct
+    // answer for every txid and avoids serving orphaned-block records.
+    // Cheap atomic load before the leveldb lookup; rare path in practice.
+    if (g_tx_index && !g_tx_index->IsCorrupted()) {
         uint256 indexedBlockHash;
         uint32_t txPos = 0;
         if (g_tx_index->FindTx(txid, indexedBlockHash, txPos)) {
@@ -2917,18 +2923,19 @@ std::string CRPCServer::RPC_GetTransaction(const std::string& params) {
                 std::vector<CTransactionRef> txs;
                 std::string err;
                 CBlockValidator validator;
-                if (validator.DeserializeBlockTransactions(block, txs, err)
+                CBlockIndex* pIdx = m_chainstate->GetBlockIndex(indexedBlockHash);
+                if (pIdx != nullptr
+                    && validator.DeserializeBlockTransactions(block, txs, err)
                     && txPos < txs.size()
                     && txs[txPos]->GetHash() == txid) {
-                    CBlockIndex* pIdx = m_chainstate->GetBlockIndex(indexedBlockHash);
                     // SEC-MD-1: bound confirmations to >=0. pIdx is a free-form
                     // mapBlockIndex lookup, not a pprev walk from pTip — under
                     // reorg the indexed block may sit at a height above the
                     // post-reorg tip, which would produce a negative result.
-                    int conf = (pIdx && pIdx->nHeight <= pTip->nHeight)
+                    int conf = (pIdx->nHeight <= pTip->nHeight)
                                ? (pTip->nHeight - pIdx->nHeight + 1)
                                : 0;
-                    int height = pIdx ? pIdx->nHeight : 0;
+                    int height = pIdx->nHeight;
 
                     std::cout << "[RPC] Found transaction " << txid.GetHex()
                               << " in block " << indexedBlockHash.GetHex()
@@ -2937,6 +2944,12 @@ std::string CRPCServer::RPC_GetTransaction(const std::string& params) {
 
                     return buildTxJSON(txs[txPos], indexedBlockHash, height, conf);
                 }
+                // PR-7G L3: pIdx == nullptr is treated as a paranoia
+                // mismatch (defense in depth — mapBlockIndex never
+                // removes entries today, but an indexed hash that
+                // chainstate doesn't know would silently report
+                // height=0/conf=0 in the prior code; surface and fall
+                // through instead).
                 std::cerr << "[txindex] WARN paranoia mismatch txid=" << txid.GetHex().substr(0,16)
                           << " indexed_block=" << indexedBlockHash.GetHex().substr(0,16)
                           << " -- falling through to scan" << std::endl;
@@ -4700,7 +4713,7 @@ std::string CRPCServer::RPC_StartMining(const std::string& params) {
                 if (wait_sec % 30 == 0) {
                     auto status = mgr->GetStatusForUI();
                     std::cout << "[RPC] Waiting for registration (" << status.phase
-                              << " — " << status.message << ")" << std::endl;
+                              << " -- " << status.message << ")" << std::endl;
                 }
                 std::this_thread::sleep_for(std::chrono::seconds(1));
                 wait_sec++;
@@ -5591,7 +5604,10 @@ std::string CRPCServer::RPC_GetRawTransaction(const std::string& params) {
     // verified hit. On any failure (paranoia guard, block read, deserialize),
     // log a WARN, increment the mismatch counter, and fall through to the
     // existing tip-walk so behavior is bounded by the legacy scan.
-    if (g_tx_index) {
+    //
+    // PR-7G R2: m_corrupted check before FindTx — see the matching note in
+    // RPC_GetTransaction above.
+    if (g_tx_index && !g_tx_index->IsCorrupted()) {
         uint256 indexedBlockHash;
         uint32_t txPos = 0;
         if (g_tx_index->FindTx(txid, indexedBlockHash, txPos)) {
@@ -5600,23 +5616,26 @@ std::string CRPCServer::RPC_GetRawTransaction(const std::string& params) {
                 std::vector<CTransactionRef> txs;
                 std::string err;
                 CBlockValidator validator;
-                if (validator.DeserializeBlockTransactions(block, txs, err)
+                CBlockIndex* pIdx = m_chainstate->GetBlockIndex(indexedBlockHash);
+                if (pIdx != nullptr
+                    && validator.DeserializeBlockTransactions(block, txs, err)
                     && txPos < txs.size()
                     && txs[txPos]->GetHash() == txid) {
-                    CBlockIndex* pIdx = m_chainstate->GetBlockIndex(indexedBlockHash);
                     // SEC-MD-1: bound confirmations to >=0. pIdx is a free-form
                     // mapBlockIndex lookup, not a pprev walk from pTip — under
                     // reorg the indexed block may sit at a height above the
                     // post-reorg tip, which would produce a negative result.
-                    int conf = (pIdx && pIdx->nHeight <= pTip->nHeight)
+                    int conf = (pIdx->nHeight <= pTip->nHeight)
                                ? (pTip->nHeight - pIdx->nHeight + 1)
                                : 0;
                     if (!verbose) {
                         return "\"" + HexStr(txs[txPos]->Serialize()) + "\"";
                     }
                     return txToJSON(txs[txPos], indexedBlockHash.GetHex(),
-                                    pIdx ? pIdx->nHeight : 0, conf);
+                                    pIdx->nHeight, conf);
                 }
+                // PR-7G L3: pIdx == nullptr is treated as a paranoia
+                // mismatch (see matching note in RPC_GetTransaction).
                 std::cerr << "[txindex] WARN paranoia mismatch txid=" << txid.GetHex().substr(0,16)
                           << " indexed_block=" << indexedBlockHash.GetHex().substr(0,16)
                           << " -- falling through to scan" << std::endl;

--- a/src/test/tx_index_integration_tests.cpp
+++ b/src/test/tx_index_integration_tests.cpp
@@ -967,4 +967,103 @@ BOOST_AUTO_TEST_CASE(tc7_mempool_first_ordering) {
     }
 }
 
+// PR-7G E.7 / L3: pIdx == nullptr in the RPC fast-path is treated as a
+// paranoia mismatch — log WARN, IncrementMismatches, and fall through to
+// the legacy tip-walk. Pre-fix, the code silently reported height=0 /
+// conf=0 (genesis), a valid-looking-but-wrong response.
+//
+// Test mechanism (no chainstate-side seam needed): plant an indexed
+// record whose block_hash is an arbitrary value NOT in chainstate's
+// mapBlockIndex. Then `FindTx(txid) -> (block_hash_unknown, ...)` and
+// `GetBlockIndex(block_hash_unknown) -> nullptr`. The fast-path branch
+// fires WARN + IncrementMismatches + falls through to legacy walk,
+// which either finds the genuine tx (if forged for a real txid) or
+// surfaces a not-found error.
+BOOST_AUTO_TEST_CASE(pidx_null_treated_as_paranoia_mismatch) {
+    IntegrationFixture fix("e7");
+    constexpr int kN = 3;
+    fix.BuildChain(kN);
+
+    g_tx_index = std::make_unique<CTxIndex>();
+    BOOST_REQUIRE(g_tx_index->Init(fix.idx_scope.path(), &fix.chain_db));
+    g_tx_index->StartBackgroundSync();
+    BOOST_REQUIRE(WaitForSync(*g_tx_index, std::chrono::seconds(5)));
+    g_tx_index->Stop();
+
+    // Drop the index so leveldb releases its lock for direct mutation.
+    g_tx_index.reset();
+
+    // Construction: take the genuine tx from block 2 (the regular tx at
+    // vtx[1], NOT the coinbase at vtx[0]). Plant block 2's full content
+    // into chain_db at an alternate key `unknown_block_hash` that we
+    // never add to chainstate's mapBlockIndex. Then plant an index
+    // record that maps the genuine txid -> (unknown_block_hash, 1).
+    //
+    // RPC fast-path for `getrawtransaction(genuine_txid)`:
+    //   FindTx -> (unknown_block_hash, 1)            [success]
+    //   ReadBlock(unknown_block_hash) -> block 2 data [success]
+    //   DeserializeBlockTransactions -> [coinbase, genuine_tx]
+    //   txPos=1 < 2 [ok]
+    //   txs[1]->GetHash() == genuine_txid [matches]
+    //   GetBlockIndex(unknown_block_hash) -> nullptr  [L3 trigger]
+    //
+    // PR-7G L3: pIdx==nullptr fires WARN + IncrementMismatches + falls
+    // through. Pre-fix, the code returned a synthetic height=0/conf=0
+    // response despite tx hash matching — silently wrong.
+    const uint256& genuine_txid = fix.per_height_tx[2]->GetHash();   // vtx[1]
+    uint256 unknown_block_hash;
+    std::memset(unknown_block_hash.data, 0xC9, 32);
+
+    // Plant block 2's data at the unknown_block_hash key.
+    {
+        CBlock block2_copy;
+        BOOST_REQUIRE(fix.chain_db.ReadBlock(fix.per_height_hash[2], block2_copy));
+        BOOST_REQUIRE(fix.chain_db.WriteBlock(unknown_block_hash, block2_copy));
+    }
+
+    {
+        leveldb::DB* raw = nullptr;
+        leveldb::Options opts;
+        opts.create_if_missing = false;
+        BOOST_REQUIRE(leveldb::DB::Open(opts, fix.idx_scope.path(), &raw).ok());
+        std::unique_ptr<leveldb::DB> raw_db(raw);
+
+        std::string key;
+        key.push_back('t');
+        key.append(reinterpret_cast<const char*>(genuine_txid.data), 32);
+        char value[40];
+        std::memset(value, 0, 40);
+        value[0] = 0x01;
+        std::memcpy(&value[1], unknown_block_hash.data, 32);
+        uint32_t pos = 1;        // genuine_txid lives at vtx[1] in block 2
+        std::memcpy(&value[33], &pos, 4);
+        BOOST_REQUIRE(raw_db->Put(leveldb::WriteOptions(),
+                                  leveldb::Slice(key.data(), key.size()),
+                                  leveldb::Slice(value, 40)).ok());
+    }
+
+    g_tx_index = std::make_unique<CTxIndex>();
+    BOOST_REQUIRE(g_tx_index->Init(fix.idx_scope.path(), &fix.chain_db));
+    const uint64_t pre_mismatch = g_tx_index->MismatchCount();
+
+    CerrCapture cap;
+    std::string env = SendRPCRequest(fix.port, "getrawtransaction",
+                                     TxidParams(genuine_txid, true));
+    std::string captured = cap.str();
+
+    // (a) the L3 WARN log fired (pIdx==nullptr was treated as paranoia
+    // mismatch, NOT silently substituted with height=0)
+    BOOST_CHECK_NE(captured.find("[txindex] WARN paranoia mismatch txid="),
+                   std::string::npos);
+    // (b) MismatchCount incremented
+    BOOST_CHECK_EQUAL(g_tx_index->MismatchCount() - pre_mismatch, 1u);
+    // (c) the legacy tip-walk found the genuine tx in block 2; response
+    // contains the genuine txid hex AND the real block-2 hash — NOT the
+    // forged unknown hash.
+    BOOST_CHECK_NE(env.find("\"result\""), std::string::npos);
+    BOOST_CHECK_NE(env.find(genuine_txid.GetHex()), std::string::npos);
+    BOOST_CHECK_NE(env.find(fix.per_height_hash[2].GetHex()), std::string::npos);
+    BOOST_CHECK_EQUAL(env.find(unknown_block_hash.GetHex()), std::string::npos);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/tx_index_tests.cpp
+++ b/src/test/tx_index_tests.cpp
@@ -22,6 +22,7 @@
 #include <chrono>
 #include <cstring>
 #include <filesystem>
+#include <limits>
 #include <memory>
 #include <random>
 #include <string>
@@ -33,6 +34,8 @@ extern CChainState g_chainstate;
 
 namespace tx_index_test_hooks {
 extern std::atomic<uint64_t> g_wipe_write_count;
+extern std::atomic<uint64_t> g_walk_iteration_count;
+extern std::atomic<bool>     g_force_eraseblock_failure;
 }
 
 BOOST_AUTO_TEST_SUITE(tx_index_tests)
@@ -798,6 +801,12 @@ BOOST_AUTO_TEST_CASE(reindex_resume_across_destruct) {
 
 // C7 wipe atomicity: meta says height=4 with mismatched truncated hash;
 // chainstate has a different real hash at height 4. Init must wipe + reset.
+//
+// PR-7G A1: kN bumped from 5 to 10. With kN=5 the forged meta height (4)
+// equaled the chain tip's height, which masked an earlier off-by-one when
+// validating the wipe path; raising kN to 10 forges meta at a height
+// strictly below tip, exercising the more interesting "indexed too far"
+// shape. The U3 counter assertion (`post - pre == 1`) is unaffected.
 BOOST_AUTO_TEST_CASE(c7_wipe_on_mismatch_resets_to_minus_one) {
     TempDbScope scope_idx("c7_wipe_idx");
     TempDbScope scope_chain("c7_wipe_chain");
@@ -805,7 +814,7 @@ BOOST_AUTO_TEST_CASE(c7_wipe_on_mismatch_resets_to_minus_one) {
     CBlockchainDB chain_db;
     BOOST_REQUIRE(chain_db.Open(scope_chain.path(), true));
 
-    constexpr int kN = 5;
+    constexpr int kN = 10;
     ChainFixture fix;
     fix.Build(kN, chain_db);
 
@@ -1009,10 +1018,10 @@ BOOST_AUTO_TEST_CASE(stop_mid_walk_completes_promptly) {
     BOOST_CHECK_LT(elapsed.count(), 5000);
 
     // Non-vacuity: prove the thread was actually mid-walk, not done. With
-    // kN=10000 synthesized blocks each requiring a chain_db ReadBlock plus
+    // kN=5000 synthesized blocks each requiring a chain_db ReadBlock plus
     // deserialize plus leveldb write, the loop cannot complete in the 50ms
     // sleep window above on any reasonable hardware (empirically: ~tens of
-    // microseconds per block; 10000 blocks ~> hundreds of ms minimum). If
+    // microseconds per block; 5000 blocks ~> hundreds of ms minimum). If
     // Stop() were a no-op or Interrupt() were broken, the thread would run
     // to natural completion and this assertion would fire.
     BOOST_CHECK_LT(idx.LastIndexedHeight(), kN - 1);
@@ -1173,6 +1182,504 @@ BOOST_AUTO_TEST_CASE(concurrent_start_no_double_spawn) {
     BOOST_CHECK_EQUAL(idx.LastIndexedHeight(), kN - 1);
 
     idx.Stop();
+    g_chainstate.Cleanup();
+}
+
+// ===========================================================================
+// PR-7G: BaseIndex-pattern tests (R1) and defensive-fix tests (R2-R6, L3).
+// ===========================================================================
+
+// PR-7G E.1: live connect callback gated on IsSynced. With m_synced=false,
+// firing a connect callback for height H must NOT write the index. The
+// callback path is deliberately mimicked here (the lambda body is small
+// and lives in dilithion-node.cpp / dilv-node.cpp). Without the IsSynced
+// gate, FindTx(txid_in_H) would return true after the simulated callback.
+BOOST_AUTO_TEST_CASE(live_callback_gated_until_synced) {
+    TempDbScope scope_idx("e1_idx");
+    TempDbScope scope_chain("e1_chain");
+
+    CBlockchainDB chain_db;
+    BOOST_REQUIRE(chain_db.Open(scope_chain.path(), true));
+
+    constexpr int kN = 5;
+    ChainFixture fix;
+    fix.Build(kN, chain_db);
+
+    CTxIndex idx;
+    BOOST_REQUIRE(idx.Init(scope_idx.path(), &chain_db));
+
+    // m_synced is false at Init time; verify the gate.
+    BOOST_REQUIRE_EQUAL(idx.IsSynced(), false);
+
+    // Simulate the live connect callback for height 0. The lambda's body
+    // (see dilithion-node.cpp PR-7G R1 callback) is:
+    //     if (g_tx_index && g_tx_index->IsSynced() &&
+    //         !g_tx_index->WriteBlock(b, h, hh)) { ... }
+    // We mimic the gate at the test boundary so the test exercises the
+    // semantic, not the lambda's literal text.
+    const int h_gated = 0;
+    CBlock blk0 = MakeBlock({fix.per_height_tx[h_gated]});
+    blk0.hashPrevBlock = uint256();
+    if (idx.IsSynced()) {
+        BOOST_REQUIRE(idx.WriteBlock(blk0, h_gated, fix.per_height_hash[h_gated]));
+    }
+    // After the gated callback, FindTx must return false — the index has
+    // not yet seen this tx.
+    {
+        uint256 fb;
+        uint32_t fp = 0;
+        BOOST_CHECK(!idx.FindTx(fix.per_height_tx[h_gated]->GetHash(), fb, fp));
+    }
+
+    // Now run the reindex thread to completion so m_synced flips to true.
+    idx.StartBackgroundSync();
+    BOOST_REQUIRE(WaitForSync(idx, std::chrono::seconds(5)));
+    BOOST_REQUIRE(idx.IsSynced());
+    BOOST_REQUIRE_EQUAL(idx.LastIndexedHeight(), kN - 1);
+
+    // Synthesize a NEW block at height kN and fire the (now ungated)
+    // callback. The gate should now be open; FindTx must succeed.
+    auto tx_kN = MakeUniqueTx(0xAB, 0xCD);
+    CBlock blk_kN = MakeBlock({tx_kN});
+    blk_kN.hashPrevBlock = fix.per_height_hash[kN - 1];
+    uint256 hash_kN = HashForHeight(kN);
+
+    if (idx.IsSynced()) {
+        BOOST_REQUIRE(idx.WriteBlock(blk_kN, kN, hash_kN));
+    }
+    {
+        uint256 fb;
+        uint32_t fp = 0;
+        BOOST_CHECK(idx.FindTx(tx_kN->GetHash(), fb, fp));
+        BOOST_CHECK(fb == hash_kN);
+    }
+
+    idx.Stop();
+    g_chainstate.Cleanup();
+}
+
+// PR-7G E.2: outer loop catches a tip advance during the inner walk.
+// Use the g_walk_iteration_count test seam to detect when the walk has
+// started; inject M new blocks at that point; assert all N+M blocks end
+// up in the index. Without R1's outer loop, the second batch would be
+// missed because the inner walk would never re-read the tip.
+BOOST_AUTO_TEST_CASE(reindex_outer_loop_catches_tip_advance) {
+    TempDbScope scope_idx("e2_idx");
+    TempDbScope scope_chain("e2_chain");
+
+    CBlockchainDB chain_db;
+    BOOST_REQUIRE(chain_db.Open(scope_chain.path(), true));
+
+    // Use enough blocks that the inner walk takes long enough for the
+    // test thread to inject more blocks BEFORE the walk completes. On
+    // fast hardware (~tens of microseconds per block via leveldb +
+    // deserialize), kN_initial=2000 yields ~tens of ms of walk work,
+    // ample for the test to extend chainstate mid-walk. The exact
+    // threshold doesn't matter as long as the determinism mechanism
+    // (inject after walk_count advances, before walk completes)
+    // succeeds — the load-bearing assertion is that all N+M txs are
+    // findable, NOT that the injection landed at any specific count.
+    constexpr int kN_initial = 2000;
+    constexpr int kM_extra   = 50;
+    ChainFixture fix;
+    fix.Build(kN_initial, chain_db);
+
+    CTxIndex idx;
+    BOOST_REQUIRE(idx.Init(scope_idx.path(), &chain_db));
+
+    const uint64_t pre_walk_count =
+        tx_index_test_hooks::g_walk_iteration_count.load();
+    idx.StartBackgroundSync();
+
+    // Wait for the inner walk to start (counter advances). Then extend the
+    // chain. The outer loop must re-read the tip after the inner walk
+    // completes and walk the newly-visible range.
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (tx_index_test_hooks::g_walk_iteration_count.load() > pre_walk_count + 5) {
+            // Walk is well underway; inject new blocks now.
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    BOOST_REQUIRE(tx_index_test_hooks::g_walk_iteration_count.load()
+                  > pre_walk_count + 5);
+
+    // Extend chainstate by kM_extra blocks. ChainFixture::Build wipes prior
+    // state, so we manually append below — preserving the tx_index's
+    // already-running thread state.
+    {
+        // Find current tip pointer.
+        CBlockIndex* prev_idx =
+            g_chainstate.GetBlockIndex(fix.per_height_hash[kN_initial - 1]);
+        BOOST_REQUIRE(prev_idx != nullptr);
+
+        for (int h = kN_initial; h < kN_initial + kM_extra; ++h) {
+            uint256 block_hash = HashForHeight(h);
+            fix.per_height_hash.push_back(block_hash);
+            auto tx = MakeUniqueTx(static_cast<uint8_t>(h & 0xFF),
+                                   static_cast<uint8_t>((h >> 8) & 0xFF));
+            fix.per_height_tx.push_back(tx);
+
+            CBlock block = MakeBlock({tx});
+            block.hashPrevBlock = fix.per_height_hash[h - 1];
+            BOOST_REQUIRE(chain_db.WriteBlock(block_hash, block));
+
+            auto pidx = std::make_unique<CBlockIndex>();
+            pidx->nHeight = h;
+            pidx->phashBlock = block_hash;
+            pidx->pprev = prev_idx;
+            pidx->nStatus = CBlockIndex::BLOCK_VALID_HEADER |
+                            CBlockIndex::BLOCK_HAVE_DATA;
+            CBlockIndex* raw = pidx.get();
+            BOOST_REQUIRE(g_chainstate.AddBlockIndex(block_hash, std::move(pidx)));
+            prev_idx->pnext = raw;
+            prev_idx = raw;
+        }
+        g_chainstate.SetTipForTest(prev_idx);
+    }
+
+    // The outer loop must catch the tip advance. Wait for IsSynced.
+    BOOST_REQUIRE(WaitForSync(idx, std::chrono::seconds(10)));
+    BOOST_CHECK_EQUAL(idx.LastIndexedHeight(), kN_initial + kM_extra - 1);
+
+    // All N+M blocks' txs must be findable.
+    for (int h = 0; h < kN_initial + kM_extra; ++h) {
+        uint256 fb;
+        uint32_t fp = 0;
+        BOOST_REQUIRE_MESSAGE(idx.FindTx(fix.per_height_tx[h]->GetHash(), fb, fp),
+                              "missing tx at height " << h);
+        BOOST_CHECK(fb == fix.per_height_hash[h]);
+    }
+
+    idx.Stop();
+    g_chainstate.Cleanup();
+}
+
+// PR-7G E.3: meta-height resume invariant. Verifies that a reindex
+// thread spawned with m_last_height already at a non-zero seed value
+// (from prior on-disk meta) walks from m_last_height+1 to tip without
+// re-walking blocks below the seed.
+//
+// Naming history (PR-7G C3 rename): originally posed as a "leapfrog
+// regression" test, but the red-team correctly noted that THIS test
+// does not actually exercise the FA-HI-1 racing-callback vector --
+// the non-vacuous proof of R1 is E.2 (`reindex_outer_loop_catches_
+// tip_advance`), which DOES exercise the racing-tip-advance path via
+// the g_walk_iteration_count test seam. This test asserts a different
+// (also valuable) invariant: meta-height resume correctness. The
+// docstring no longer claims "would fail without R1" because the
+// scenario here would pass under both pre- and post-fix code -- the
+// pre-fix bug was the racing callback, not meta resume.
+BOOST_AUTO_TEST_CASE(reindex_resumes_from_meta_height_after_high_seed) {
+    TempDbScope scope_idx("e3_idx");
+    TempDbScope scope_chain("e3_chain");
+
+    CBlockchainDB chain_db;
+    BOOST_REQUIRE(chain_db.Open(scope_chain.path(), true));
+
+    constexpr int kN = 20;
+    constexpr int kLeapfrogHeight = 15;
+    ChainFixture fix;
+    fix.Build(kN, chain_db);
+
+    // Step 1: open the index, force-write the high-height block via
+    // direct WriteBlock to push m_last_height to 15 and persist that
+    // value in the on-disk meta. This sets up a "seeded" index whose
+    // next reindex must resume from height 16 (m_last_height + 1) and
+    // walk to tip, without re-walking heights 0..15.
+    {
+        CTxIndex idx;
+        BOOST_REQUIRE(idx.Init(scope_idx.path(), &chain_db));
+
+        CBlock blk_leap;
+        BOOST_REQUIRE(chain_db.ReadBlock(fix.per_height_hash[kLeapfrogHeight], blk_leap));
+        BOOST_REQUIRE(idx.WriteBlock(blk_leap, kLeapfrogHeight,
+                                     fix.per_height_hash[kLeapfrogHeight]));
+        BOOST_REQUIRE_EQUAL(idx.LastIndexedHeight(), kLeapfrogHeight);
+        // No Stop() needed — destructor closes leveldb.
+    }
+
+    // Step 2: re-open and run the reindex thread. SyncLoop must:
+    //   (a) read the persisted m_last_height (=15) from on-disk meta
+    //   (b) start the inner walk at m_last_height + 1 = 16
+    //   (c) write heights 16..tip via WalkBlockRange
+    //   (d) NOT re-walk heights 0..15 (already-indexed range)
+    //   (e) reach m_synced=true once tip is stable across a full pass
+    //
+    // Heights 0..14 are deliberately absent from the index in this
+    // test. In production the only way to reach this state is via the
+    // C7 startup integrity wipe (which would zero m_last_height) -- the
+    // gap is recoverable, not silently persistent. This test asserts
+    // the resume-mechanic, not the gap-handling policy.
+    {
+        CTxIndex idx;
+        BOOST_REQUIRE(idx.Init(scope_idx.path(), &chain_db));
+        BOOST_REQUIRE_EQUAL(idx.LastIndexedHeight(), kLeapfrogHeight);
+
+        idx.StartBackgroundSync();
+        BOOST_REQUIRE(WaitForSync(idx, std::chrono::seconds(5)));
+        BOOST_REQUIRE_EQUAL(idx.LastIndexedHeight(), kN - 1);
+
+        // Heights 16..kN-1 must be findable (walked by the reindex).
+        for (int h = kLeapfrogHeight + 1; h < kN; ++h) {
+            uint256 fb;
+            uint32_t fp = 0;
+            BOOST_REQUIRE_MESSAGE(
+                idx.FindTx(fix.per_height_tx[h]->GetHash(), fb, fp),
+                "post-resume tx missing at height " << h);
+        }
+
+        // The seed block itself (15) is findable -- we wrote it directly.
+        {
+            uint256 fb;
+            uint32_t fp = 0;
+            BOOST_CHECK(idx.FindTx(fix.per_height_tx[kLeapfrogHeight]->GetHash(),
+                                   fb, fp));
+        }
+
+        idx.Stop();
+    }
+    g_chainstate.Cleanup();
+}
+
+// PR-7G E.4: EraseBlock failure sets the sticky m_corrupted flag.
+// Uses the g_force_eraseblock_failure test-hook seam to inject a
+// leveldb write failure without filesystem fragility. Asserts:
+//   (a) IsCorrupted() flips to true after the failure;
+//   (b) IsCorrupted() is sticky across subsequent successful operations;
+//   (c) WipeIndex() (the C7 / --reindex path) clears the flag.
+BOOST_AUTO_TEST_CASE(eraseblock_failure_sets_corrupted_flag) {
+    TempDbScope scope_idx("e4_idx");
+    TempDbScope scope_chain("e4_chain");
+
+    CBlockchainDB chain_db;
+    BOOST_REQUIRE(chain_db.Open(scope_chain.path(), true));
+
+    constexpr int kN = 3;
+    ChainFixture fix;
+    fix.Build(kN, chain_db);
+
+    {
+        CTxIndex idx;
+        BOOST_REQUIRE(idx.Init(scope_idx.path(), &chain_db));
+
+        // Write block at height 0 so EraseBlock has something to undo.
+        CBlock blk0 = MakeBlock({fix.per_height_tx[0]});
+        blk0.hashPrevBlock = uint256();
+        BOOST_REQUIRE(idx.WriteBlock(blk0, 0, fix.per_height_hash[0]));
+        BOOST_REQUIRE(!idx.IsCorrupted());
+
+        // Inject leveldb-failure into EraseBlock.
+        tx_index_test_hooks::g_force_eraseblock_failure.store(true);
+        const bool erased = idx.EraseBlock(blk0, 0, fix.per_height_hash[0]);
+        tx_index_test_hooks::g_force_eraseblock_failure.store(false);
+
+        BOOST_CHECK(!erased);          // EraseBlock surfaced the leveldb failure
+        BOOST_CHECK(idx.IsCorrupted()); // sticky flag is set
+
+        // Stickiness: subsequent successful WriteBlock at height 1 does NOT
+        // clear the flag. (The flag is intentionally sticky; only WipeIndex
+        // or process restart clears it.)
+        CBlock blk1 = MakeBlock({fix.per_height_tx[1]});
+        blk1.hashPrevBlock = fix.per_height_hash[0];
+        (void)idx.WriteBlock(blk1, 1, fix.per_height_hash[1]);
+        BOOST_CHECK(idx.IsCorrupted());
+
+        idx.Stop();
+        // idx destructs at scope exit, releasing the leveldb LOCK file
+        // so the raw-DB::Open below can acquire it.
+    }
+
+    // PR-7G C2: extend the test to actually exercise the C7 wipe path.
+    // The pre-fix docstring promised "WipeIndex() clears the flag" but
+    // the body never exercised it. Now we forge a deliberately-wrong
+    // truncated hash so the C7 startup integrity check
+    // (tx_index.cpp:208-296) detects mismatch on Init re-open and
+    // invokes WipeIndex(). The forged height (0) matches the chain's
+    // genesis height -- C7 only fires when chainstate has a block at
+    // the recorded height (otherwise it leaves the index untouched).
+    {
+        leveldb::DB* raw = nullptr;
+        leveldb::Options opts;
+        opts.create_if_missing = false;
+        BOOST_REQUIRE(leveldb::DB::Open(opts, scope_idx.path(), &raw).ok());
+        std::unique_ptr<leveldb::DB> raw_db(raw);
+
+        std::string meta_key("\x00meta", 5);
+        char value[13];
+        std::memset(value, 0, 13);
+        value[0] = 0x01;       // SCHEMA_VERSION
+        int32_t h = 0;
+        std::memcpy(&value[1], &h, 4);
+        std::memset(&value[5], 0xCC, 8);   // wrong truncated hash
+        BOOST_REQUIRE(raw_db->Put(leveldb::WriteOptions(),
+                                  leveldb::Slice(meta_key.data(), meta_key.size()),
+                                  leveldb::Slice(value, 13)).ok());
+    }
+
+    // Re-open via a fresh CTxIndex. Init() reads forged meta, runs C7,
+    // detects truncated-hash mismatch against chainstate, calls
+    // WipeIndex() which (per R2) sets m_corrupted=false on success.
+    // Observable proof that WipeIndex actually ran: LastIndexedHeight is
+    // reset to -1 (Init line 287). The flag-clears claim is the
+    // post-condition `!idx2.IsCorrupted()` -- on a fresh instance the
+    // flag starts false, but a buggy WipeIndex that mistakenly raised
+    // the flag (or a regression that skipped the store(false) line)
+    // would surface here.
+    {
+        CTxIndex idx2;
+        BOOST_REQUIRE(idx2.Init(scope_idx.path(), &chain_db));
+        BOOST_CHECK_EQUAL(idx2.LastIndexedHeight(), -1);
+        BOOST_CHECK(!idx2.IsCorrupted());
+        idx2.Stop();
+    }
+
+    g_chainstate.Cleanup();
+}
+
+// PR-7G E.5: Init rejects pathological INT_MAX meta height. Without the
+// R5 bound check, SyncLoop's `current = m_last_height + 1` overflows and
+// wraps to INT_MIN, causing a near-2^31-iteration hang. The R5 fix
+// detects the out-of-bounds value, wipes, and treats as cold-start.
+BOOST_AUTO_TEST_CASE(init_rejects_int_max_meta) {
+    TempDbScope scope_idx("e5_idx");
+    TempDbScope scope_chain("e5_chain");
+
+    CBlockchainDB chain_db;
+    BOOST_REQUIRE(chain_db.Open(scope_chain.path(), true));
+
+    constexpr int kN = 3;
+    ChainFixture fix;
+    fix.Build(kN, chain_db);
+
+    // Open the leveldb directly and forge a meta with last_indexed=INT_MAX.
+    {
+        leveldb::DB* raw = nullptr;
+        leveldb::Options opts;
+        opts.create_if_missing = true;
+        BOOST_REQUIRE(leveldb::DB::Open(opts, scope_idx.path(), &raw).ok());
+        std::unique_ptr<leveldb::DB> raw_db(raw);
+
+        std::string meta_key("\x00meta", 5);
+        char value[13];
+        std::memset(value, 0, 13);
+        value[0] = 0x01;
+        int32_t h = std::numeric_limits<int32_t>::max();
+        std::memcpy(&value[1], &h, 4);
+        std::memset(&value[5], 0xAB, 8);
+        BOOST_REQUIRE(raw_db->Put(leveldb::WriteOptions(),
+                                  leveldb::Slice(meta_key.data(), meta_key.size()),
+                                  leveldb::Slice(value, 13)).ok());
+    }
+
+    // Re-open via CTxIndex::Init. R5 must detect, wipe, and reset to -1.
+    {
+        CTxIndex idx;
+        BOOST_REQUIRE(idx.Init(scope_idx.path(), &chain_db));
+        BOOST_CHECK_EQUAL(idx.LastIndexedHeight(), -1);
+
+        // Run a brief reindex pass to confirm SyncLoop does not overflow
+        // / hang. With the bound check, walk_start = -1 + 1 = 0, which
+        // matches the expected cold-start path; without the check, the
+        // overflow would make the loop run for billions of iterations
+        // and the test harness would time out at 5s.
+        idx.StartBackgroundSync();
+        BOOST_REQUIRE(WaitForSync(idx, std::chrono::seconds(5)));
+        BOOST_CHECK_EQUAL(idx.LastIndexedHeight(), kN - 1);
+        idx.Stop();
+    }
+    g_chainstate.Cleanup();
+}
+
+// PR-7G E.6: WalkBlockRange skips heights with TWO competing blocks
+// where NEITHER is on main chain. Build a 3-block fixture (heights 0..2),
+// then inject a SECOND block at height 1 (alongside the existing main-
+// chain block at height 1), and clear pnext on the original height-1
+// block so neither competitor advertises IsOnMainChain. The walker
+// must encounter hashes.size()==2 at height 1 with !found_main and
+// skip rather than write the wrong block (FA-MD-5 simulation).
+BOOST_AUTO_TEST_CASE(reindex_skips_height_with_no_main_chain) {
+    TempDbScope scope_idx("e6_idx");
+    TempDbScope scope_chain("e6_chain");
+
+    CBlockchainDB chain_db;
+    BOOST_REQUIRE(chain_db.Open(scope_chain.path(), true));
+
+    constexpr int kN = 3;       // heights 0, 1, 2
+    ChainFixture fix;
+    fix.Build(kN, chain_db);
+
+    constexpr int kContested = 1;
+    CBlockIndex* prev_idx = g_chainstate.GetBlockIndex(fix.per_height_hash[0]);
+    CBlockIndex* main_at_contested =
+        g_chainstate.GetBlockIndex(fix.per_height_hash[kContested]);
+    BOOST_REQUIRE(prev_idx != nullptr);
+    BOOST_REQUIRE(main_at_contested != nullptr);
+
+    // Inject a second competing block at the contested height.
+    auto tx_competitor = MakeUniqueTx(0xA1, 0x10);
+    CBlock blk_competitor = MakeBlock({tx_competitor});
+    blk_competitor.hashPrevBlock = fix.per_height_hash[0];
+
+    uint256 hash_competitor = MakeBlockHash(0x71);
+    BOOST_REQUIRE(chain_db.WriteBlock(hash_competitor, blk_competitor));
+
+    auto pidx_competitor = std::make_unique<CBlockIndex>();
+    pidx_competitor->nHeight = kContested;
+    pidx_competitor->phashBlock = hash_competitor;
+    pidx_competitor->pprev = prev_idx;
+    pidx_competitor->pnext = nullptr;       // !IsOnMainChain
+    pidx_competitor->nStatus = CBlockIndex::BLOCK_VALID_HEADER |
+                               CBlockIndex::BLOCK_HAVE_DATA;
+    BOOST_REQUIRE(g_chainstate.AddBlockIndex(hash_competitor,
+                                              std::move(pidx_competitor)));
+
+    // Clear pnext on the original height-1 block so it ALSO reports
+    // !IsOnMainChain. Now both blocks at height 1 have pnext=nullptr.
+    main_at_contested->pnext = nullptr;
+
+    // Tip is still the height-2 block (its pnext is null naturally).
+    g_chainstate.SetTipForTest(
+        g_chainstate.GetBlockIndex(fix.per_height_hash[kN - 1]));
+
+    // Run the reindex. WalkBlockRange will:
+    //   - height 0: single hash, write it (m_last_height = 0)
+    //   - height 1: TWO hashes (main + competitor), neither has pnext;
+    //               !found_main && hashes.size() > 1 → bail walk
+    // The walk returns false; SyncLoop returns without setting m_synced.
+    // m_last_height stays at 0 (NOT advanced past contested height).
+    CTxIndex idx;
+    BOOST_REQUIRE(idx.Init(scope_idx.path(), &chain_db));
+    idx.StartBackgroundSync();
+
+    // Wait briefly for the walk to bail. Without success there is no
+    // m_synced=true to wait for; we just need the thread to complete.
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    idx.Stop();
+
+    // The contested-height records (both candidates) must NOT be found.
+    {
+        uint256 fb;
+        uint32_t fp = 0;
+        BOOST_CHECK(!idx.FindTx(tx_competitor->GetHash(), fb, fp));
+        BOOST_CHECK(!idx.FindTx(fix.per_height_tx[kContested]->GetHash(),
+                                fb, fp));
+    }
+
+    // Height 0 IS findable (it was unambiguous and walked first).
+    {
+        uint256 fb;
+        uint32_t fp = 0;
+        BOOST_CHECK(idx.FindTx(fix.per_height_tx[0]->GetHash(), fb, fp));
+    }
+
+    // m_last_height was NOT advanced past the contested height.
+    BOOST_CHECK_LT(idx.LastIndexedHeight(), kContested);
+
+    // The walk bailed; m_synced stays false so operators detect.
+    BOOST_CHECK(!idx.IsSynced());
+
     g_chainstate.Cleanup();
 }
 


### PR DESCRIPTION
## Summary

Closes the FA-HI-1 leapfrog HIGH bug missed by PR #32 (already merged) by porting Bitcoin Core's BaseIndex pattern: live `BlockConnect`/`BlockDisconnect` callbacks are gated on `IsSynced()`, and `SyncLoop` gains an outer loop that re-reads the chain tip after each inner walk and continues catchup until the tip is stable before setting `m_synced=true`. The leapfrog vector is closed by *temporal separation* of reindex and live writers, not by changing the C1 monotonicity guard (which is preserved unchanged).

Also bundles 5 MEDIUM defensive fixes (R2-R6), 4 LOW polish items, 3 LOW doc/RPC items, and 1 drive-by hygiene fix surfaced during the PR-7G audit chain. See commit body for the full breakdown.

This PR has gone through a full multi-agent audit cycle on the rebased branch:
- **Hacken-stance security audit:** GO (no defects)
- **Diff red-team:** initially FIX FIRST (1 BLOCKER + 4 CONCERNs); all addressed in this commit (B1 commit-subject overrun fixed; C1 header doc, C2 vacuous test docstring, C3 misleading test name, C4 edge-case documentation all reconciled per the no-defer principle)

## Why architectural change instead of point-fix

The original PR-7G plan (Rev 2) tried to make both writers race using just the C1 monotonicity guard. Red-team caught FA-HI-1: a live callback firing mid-reindex with a high tip height could push `m_last_height` past the reindex's walk position, causing the inner walk's `if (height <= m_last_height) return true;` to silently no-op all subsequent reindex writes. The fundamental flaw: `m_last_height` was conflating two meanings (reindex progress vs live tip).

Option A (BaseIndex pattern) collapses the conflation by separating the modes temporally — reindex first, then live — which matches Bitcoin Core upstream's 2018+ mainnet-tested approach. Aligns with KISS (one writer at a time), Bulletproof (no race window remains), and Dilithion-idiom (port-from-Bitcoin-Core principle).

## Test plan

- [x] Build clean: `make -j4 dilithion-node dilv-node test_dilithion` (zero new warnings on touched files)
- [x] All 40 tx_index test cases pass: `test_dilithion --run_test=tx_index_tests,tx_index_integration_tests` → 20020 assertions
- [x] E.2 `reindex_outer_loop_catches_tip_advance` — non-vacuous proof of R1 via `g_walk_iteration_count` test seam (would fail without the outer loop; passes with it)
- [x] E.3 `reindex_resumes_from_meta_height_after_high_seed` — meta-resume invariant
- [x] E.4 `eraseblock_failure_sets_corrupted_flag` — sticky `m_corrupted` + WipeIndex-clears-flag via C7 path
- [x] E.5 `init_rejects_int_max_meta` — R5 bound check + cold-start recovery
- [x] E.6 `reindex_skips_height_with_no_main_chain` — R6 contested-height bail
- [x] Default-flag (`-txindex=0`): zero behavior change verified by inspection (lambda gates and RPC fast-path both short-circuit on `g_tx_index &&`)
- [x] Lock-order discipline preserved: every `g_chainstate` query in `WalkBlockRange` and `SyncLoop` is OUTSIDE `m_mutex` scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)