### PR TITLE
rpc: port getindexinfo from Bitcoin Core v28.0

### DIFF
--- a/docs/TX-INDEX.md
+++ b/docs/TX-INDEX.md
@@ -334,6 +334,72 @@ Stop the node, `rm -rf <datadir>/indexes/txindex/`, restart with
 the next startup with `-txindex=1` the operator must pass `-reindex` to
 re-acknowledge the rebuild.
 
+### `getindexinfo` JSON-RPC
+
+Bitcoin Core port (`src/rpc/blockchain.cpp::getindexinfo` v28.0). Returns
+a JSON object keyed by index name, with each enabled index reporting its
+sync state. Indexes that are not enabled at runtime are omitted entirely
+-- a node started without `-txindex=1` returns `{}`.
+
+Currently Dilithion exposes only the `txindex` key; future ports
+(BIP 157/158 block filter index, coinstatsindex) will register here under
+the same schema.
+
+```bash
+curl -s --user rpc:rpc -H 'X-Dilithion-RPC: 1' -H 'content-type:application/json' \
+  --data-binary '{"jsonrpc":"2.0","id":1,"method":"getindexinfo","params":[]}' \
+  http://127.0.0.1:8332/
+```
+
+Response (txindex enabled and synced):
+
+```json
+{
+  "txindex": {
+    "synced": true,
+    "best_block_height": 152043
+  }
+}
+```
+
+Response (txindex enabled, still building):
+
+```json
+{
+  "txindex": {
+    "synced": false,
+    "best_block_height": 41200
+  }
+}
+```
+
+Response (txindex enabled, cold-start window — first row not yet written):
+
+```json
+{
+  "txindex": {
+    "synced": false,
+    "best_block_height": -1
+  }
+}
+```
+
+`best_block_height = -1` is the sentinel value emitted between
+`-txindex=1 -reindex` startup and the moment SyncLoop writes its first
+record. Consumers should treat `-1` as "no progress yet" rather than a
+sync error.
+
+Response (txindex not enabled):
+
+```json
+{}
+```
+
+Intended use: explorer/wallet/exchange health pages can poll
+`getindexinfo` on a short interval (seconds) and surface readiness to
+operators without tailing logs. The handler is read-only and lock-free
+-- it costs two atomic loads per call and returns immediately.
+
 ## Source references
 
 * `src/index/tx_index.h` -- `CTxIndex` declaration; thread/lock contract

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -261,6 +261,7 @@ CRPCServer::CRPCServer(uint16_t port)
     m_handlers["generatetoaddress"] = [this](const std::string& p) { return RPC_GenerateToAddress(p); };
     m_handlers["getrawtransaction"] = [this](const std::string& p) { return RPC_GetRawTransaction(p); };
     m_handlers["decoderawtransaction"] = [this](const std::string& p) { return RPC_DecodeRawTransaction(p); };
+    m_handlers["getindexinfo"] = [](const std::string& p) { return RPC_GetIndexInfo(p); };
     m_handlers["addnode"] = [this](const std::string& p) { return RPC_AddNode(p); };
 
     // x402 payment methods (DilV only)
@@ -5324,6 +5325,7 @@ std::string CRPCServer::RPC_Help(const std::string& params) {
     oss << "\"getblock - Get block by hash\",";
     oss << "\"getblockhash - Get block hash by height\",";
     oss << "\"gettxout - Get UTXO information\",";
+    oss << "\"getindexinfo - Get sync state of all enabled indexes (txindex, ...)\",";
     oss << "\"checkchain - Verify your chain matches official checkpoints (detect forks)\",";
     oss << "\"checkblockdb - Check for missing blocks in database (diagnostic)\",";
     oss << "\"repairblocks - Repair blocks stored under wrong hashes (Bug #243 fix)\",";
@@ -5424,6 +5426,56 @@ std::string CRPCServer::RPC_GetBestBlockHash(const std::string& params) {
     }
 
     return "\"" + hashBestBlock.GetHex() + "\"";
+}
+
+// Bitcoin Core port: src/rpc/blockchain.cpp::getindexinfo (v28.0).
+//
+// Returns a JSON object keyed by index name. Each enabled index reports
+// its sync state via {synced, best_block_height}. Indexes that are not
+// enabled at runtime are omitted entirely -- a stock node started without
+// any index flags returns "{}".
+//
+// Currently Dilithion exposes only the txindex (PR #32 + PR #33). Future
+// ports (BIP 157/158 block filter index, coinstatsindex) will register
+// here with the same schema. The "first" comma-handling pattern is a
+// no-op while there is only one index, but is retained for forward
+// compatibility -- when the second index lands, no structural change to
+// the loop body is needed.
+//
+// best_block_height = -1 is a valid response value when the txindex has
+// been enabled but has not yet written its first row (the cold-start
+// window after `-txindex=1 -reindex` startup, before SyncLoop begins
+// emitting rows). Consumers should treat -1 as "no progress yet" rather
+// than as a sync error.
+//
+// Race-safety: in the normal shutdown path, the RPC server stops
+// accepting new requests BEFORE `g_tx_index.reset()` runs (see node
+// shutdown sequence in dilithion-node.cpp / dilv-node.cpp), so
+// g_tx_index cannot be torn down concurrently with a live request. The
+// error-path catch handlers also call `g_tx_index.reset()`, but they
+// rely on the RPC server destructor running during stack unwind before
+// main() returns -- the same exposure already exists for the
+// connect/disconnect callback lambdas at dilithion-node.cpp:2945,2952.
+// The atomic loads (IsSynced, LastIndexedHeight) are inherently
+// race-free.
+std::string CRPCServer::RPC_GetIndexInfo(const std::string& params) {
+    (void)params;   // takes no arguments
+
+    std::ostringstream oss;
+    oss << "{";
+
+    bool first = true;
+    if (g_tx_index) {
+        if (!first) oss << ",";
+        oss << "\"txindex\":{"
+            << "\"synced\":" << (g_tx_index->IsSynced() ? "true" : "false") << ","
+            << "\"best_block_height\":" << g_tx_index->LastIndexedHeight()
+            << "}";
+        first = false;
+    }
+
+    oss << "}";
+    return oss.str();
 }
 
 std::string CRPCServer::RPC_GetChainTips(const std::string& params) {

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -628,6 +628,12 @@ public:
      * @return true if initialized successfully
      */
     bool InitializeWebSocket(uint16_t port = 0);
+
+    // Index introspection (Bitcoin Core port: getindexinfo, src/rpc/blockchain.cpp v28.0).
+    // Static because it is stateless w.r.t. CRPCServer instance state -- it reads only the
+    // process-wide `g_tx_index` global. Public + static lets tests exercise the formatter
+    // directly without standing up a full HTTP server (schema-lock-in coverage).
+    static std::string RPC_GetIndexInfo(const std::string& params);
 };
 
 #endif // DILITHION_RPC_SERVER_H

--- a/src/test/tx_index_tests.cpp
+++ b/src/test/tx_index_tests.cpp
@@ -4,6 +4,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include <index/tx_index.h>
+#include <rpc/server.h>
 
 #include <consensus/chain.h>
 #include <consensus/validation.h>
@@ -1679,6 +1680,65 @@ BOOST_AUTO_TEST_CASE(reindex_skips_height_with_no_main_chain) {
 
     // The walk bailed; m_synced stays false so operators detect.
     BOOST_CHECK(!idx.IsSynced());
+
+    g_chainstate.Cleanup();
+}
+
+// getindexinfo schema-lock-in test (red-team CONCERN #3 from the
+// getindexinfo PR diff audit). The handler is a pure formatter on the
+// already-tested CTxIndex APIs (IsSynced, LastIndexedHeight); this test
+// locks the JSON shape against accidental future drift -- the case that
+// would silently break Explorer/wallet/exchange health pages without
+// any compiler warning.
+//
+// Three response shapes covered:
+//   (a) g_tx_index == nullptr            -> "{}"
+//   (b) txindex enabled, mid-sync        -> {"txindex":{"synced":false,"best_block_height":-1}}
+//   (c) txindex enabled, synced+at-tip   -> {"txindex":{"synced":true,"best_block_height":N}}
+//
+// The handler is `static` precisely so this test can call it directly
+// without standing up an HTTP server.
+BOOST_AUTO_TEST_CASE(getindexinfo_schema_lock_in) {
+    // (a) No index registered.
+    BOOST_REQUIRE(g_tx_index == nullptr);
+    BOOST_CHECK_EQUAL(CRPCServer::RPC_GetIndexInfo(""), std::string("{}"));
+
+    TempDbScope scope_idx("getindexinfo_idx");
+    TempDbScope scope_chain("getindexinfo_chain");
+
+    CBlockchainDB chain_db;
+    BOOST_REQUIRE(chain_db.Open(scope_chain.path(), true));
+
+    constexpr int kN = 4;
+    ChainFixture fix;
+    fix.Build(kN, chain_db);
+
+    // Stand up g_tx_index as the global the handler reads.
+    g_tx_index = std::make_unique<CTxIndex>();
+    BOOST_REQUIRE(g_tx_index->Init(scope_idx.path(), &chain_db));
+
+    // (b) Cold-start: registered but no rows written yet.
+    BOOST_CHECK(!g_tx_index->IsSynced());
+    BOOST_CHECK_EQUAL(g_tx_index->LastIndexedHeight(), -1);
+    BOOST_CHECK_EQUAL(
+        CRPCServer::RPC_GetIndexInfo(""),
+        std::string("{\"txindex\":{\"synced\":false,\"best_block_height\":-1}}"));
+
+    // (c) Run the reindex to completion, then check the synced shape.
+    g_tx_index->StartBackgroundSync();
+    BOOST_REQUIRE(WaitForSync(*g_tx_index, std::chrono::seconds(5)));
+    BOOST_CHECK(g_tx_index->IsSynced());
+    BOOST_CHECK_EQUAL(g_tx_index->LastIndexedHeight(), kN - 1);
+    BOOST_CHECK_EQUAL(
+        CRPCServer::RPC_GetIndexInfo(""),
+        std::string("{\"txindex\":{\"synced\":true,\"best_block_height\":3}}"));
+
+    // Tear down: g_tx_index destruction joins the reindex thread.
+    g_tx_index->Stop();
+    g_tx_index.reset();
+
+    // Post-teardown: back to the {} shape.
+    BOOST_CHECK_EQUAL(CRPCServer::RPC_GetIndexInfo(""), std::string("{}"));
 
     g_chainstate.Cleanup();
 }


### PR DESCRIPTION
## Summary

Ports the `getindexinfo` JSON-RPC method from Bitcoin Core v28.0 (`src/rpc/blockchain.cpp::getindexinfo`). Returns a JSON object keyed by index name; each enabled index reports `{synced, best_block_height}`. Indexes that are not enabled at runtime are omitted entirely — a stock node returns `{}`.

Currently exposes only the `txindex` key. Future ports (BIP 157/158 block filter index, coinstatsindex) will register here under the same schema with no structural change to the formatter.

## Why

Explorer/wallet/exchange health pages currently have no clean way to surface txindex sync state — only log-tail or RPC-timing heuristics. This RPC closes that gap. Two atomic loads per call, lock-free, safe to poll on a short interval.

## Audit

Diff red-team verdict: **GO** with 3 CONCERNs, all addressed in the same commit per the no-defer principle:

- **C1** — documented the `best_block_height = -1` cold-start sentinel case in `docs/TX-INDEX.md` and the Explorer handoff doc (the case where txindex is enabled but `SyncLoop` hasn't written its first row yet).
- **C2** — softened the shutdown-race comment to honestly describe the normal-path guarantee (RPC server stops before `g_tx_index.reset()`) plus the error-path exposure (which already exists for the connect/disconnect callback lambdas).
- **C3** — refactored handler from instance-method to public `static` and added a schema-lock-in Boost test (`tx_index_tests/getindexinfo_schema_lock_in`) covering all three response shapes (no index, cold-start, synced).

## Test plan

- [x] Build clean: zero new warnings on touched files
- [x] 41 tx_index test cases pass (was 40 — schema-lock-in test added 1 case / 20 assertions)
- [x] 20040 assertions pass (was 20020)
- [x] Default-flag (`-txindex=0`) behavior preserved: handler returns `{}` when `g_tx_index == nullptr`
- [x] Schema matches Bitcoin Core v28.0 exactly (field names `synced`, `best_block_height`; empty state `{}` not `null`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)