### PR TITLE
rpc: small RPCs cluster (5 of 6) [T1.B]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -623,6 +623,7 @@ BOOST_TEST_OBJECTS := $(OBJ_DIR)/test/test_dilithion.o \
 	$(OBJ_DIR)/test/tx_index_tests.o \
 	$(OBJ_DIR)/test/tx_index_integration_tests.o \
 	$(OBJ_DIR)/test/mempool_persist_tests.o \
+	$(OBJ_DIR)/test/rpc_small_cluster_tests.o \
 	$(CRYPTO_PROPERTY_OBJECTS)
 
 # Link test objects + full library (CORE_OBJECTS) to avoid hand-picked object drift

--- a/docs/SMALL-RPCS-CLUSTER.md
+++ b/docs/SMALL-RPCS-CLUSTER.md
@@ -1,0 +1,214 @@
+# Small RPCs Cluster
+
+Read-only / blocking RPCs ported from Bitcoin Core v28.0 (`src/rpc/blockchain.cpp` and `src/rpc/rawtransaction.cpp`).
+
+Cluster: `getblockstats`, `waitfornewblock`, `waitforblock`, `waitforblockheight`, `gettxoutproof`, `verifytxoutproof`. All six were landed together in T1.B (Bitcoin Core port roadmap).
+
+All examples below use object-style params (Dilithion convention; not array-style as in Bitcoin Core's CLI).
+
+---
+
+## getblockstats
+
+Per-block analytics for explorers. Returns aggregate transaction-size, input/output counts, subsidy, and total fee.
+
+### Param
+
+```
+{"hash_or_height": <hex|int>}
+{"hash": "<64-hex>"}
+{"height": <int>}
+```
+
+Either `hash_or_height` or `hash`/`height`. Supplying both `hash` and `height` is rejected.
+
+### Response fields
+
+- `avgtxsize`, `mediantxsize`, `maxtxsize`, `mintxsize` -- distribution of per-tx serialized sizes (bytes).
+- `blockhash` -- hash of the requested block.
+- `height` -- block height.
+- `ins`, `outs` -- total non-coinbase inputs / outputs in the block.
+- `mediantime` -- median nTime of the previous 11 blocks (chain median past time). Falls back to `time` when ancestors are unavailable.
+- `subsidy` -- block subsidy in ions (DIL) or volts (DilV).
+- `time` -- block header timestamp.
+- `total_out` -- sum of non-coinbase outputs.
+- `total_size` -- serialized tx-array byte length.
+- `totalfee` -- coinbase output sum minus subsidy. Reported as 0 if coinbase under-pays subsidy (consensus violation; would be rejected at block validation).
+- `txs` -- transaction count including coinbase.
+- `utxo_increase` -- `outs - ins`. Net UTXO created by the block.
+
+### Omitted vs. Bitcoin Core
+
+The following Bitcoin Core fields are intentionally omitted:
+
+- `swtotal_size`, `swtotal_weight`, `swtxs`, `total_weight` -- segwit-only; Dilithion is non-segwit.
+- `avgfee`, `medianfee`, `maxfee`, `minfee`, `feerate_percentiles`, `avgfeerate`, `maxfeerate`, `minfeerate` -- per-tx fees require prevout lookups against an undo file. Dilithion does not currently expose undo data through the RPC layer; only the aggregate `totalfee` (coinbase-derived) is available. Adding per-tx fees would require a separate undo-data-aware port and is out of scope for this cluster.
+
+### Example
+
+```bash
+curl -s --user rpc:rpc -H 'X-Dilithion-RPC: 1' -H 'content-type:application/json' \
+  --data-binary '{"jsonrpc":"2.0","id":1,"method":"getblockstats","params":{"height":1000}}' \
+  http://127.0.0.1:8332/
+```
+
+---
+
+## waitfornewblock / waitforblock / waitforblockheight
+
+Long-poll for a tip-change condition. All three block until the predicate is met OR `timeout_ms` elapses, then return the current tip.
+
+### Threading model
+
+A single process-wide `std::condition_variable` is signaled from the chainstate's existing block-connect callback. Each handler grabs an internal mutex, evaluates its predicate, and `wait_until`s on the CV. Default timeout 30000 ms (30 s); cap 300000 ms (5 min). The cap prevents a malicious caller from tying up RPC worker threads (the server has ~8 worker slots).
+
+### waitfornewblock
+
+```
+{"timeout_ms": <int>?}
+```
+
+Returns when the tip hash changes from whatever it was at the moment of the call.
+
+### waitforblock
+
+```
+{"hash": "<64-hex>", "timeout_ms": <int>?}
+```
+
+Returns when the tip hash matches `hash`. Times out otherwise.
+
+### waitforblockheight
+
+```
+{"height": <int>, "timeout_ms": <int>?}
+```
+
+Returns when the tip's height is `>= height`. Returns immediately if the predicate is already true.
+
+### Response shape (all three)
+
+```json
+{"hash": "<current-tip-hash>", "height": <current-tip-height>}
+```
+
+Note: timeout is NOT signaled by an error response. The caller must compare the returned hash/height against the precondition to determine whether the predicate was met.
+
+### Example
+
+```bash
+# Wait up to 60s for a new block:
+curl -s --user rpc:rpc -H 'X-Dilithion-RPC: 1' -H 'content-type:application/json' \
+  --data-binary '{"jsonrpc":"2.0","id":1,"method":"waitfornewblock","params":{"timeout_ms":60000}}' \
+  http://127.0.0.1:8332/
+```
+
+```bash
+# Wait up to 30s (default) for the chain to reach height 100000:
+curl -s --user rpc:rpc -H 'X-Dilithion-RPC: 1' -H 'content-type:application/json' \
+  --data-binary '{"jsonrpc":"2.0","id":1,"method":"waitforblockheight","params":{"height":100000}}' \
+  http://127.0.0.1:8332/
+```
+
+---
+
+## gettxoutproof
+
+Returns a hex-encoded partial-merkle-tree proof witnessing inclusion of one or more txids in a block.
+
+### Param
+
+```
+{"txids": ["<txid-hex>", ...], "blockhash": "<block-hex>"?}
+```
+
+`blockhash` is optional iff `-txindex` is enabled AND all txids resolve to the same block.
+
+### Response
+
+A JSON-string-encoded hex blob with the BIP-37-shaped layout:
+
+```
+[block_hash : 32]
+[num_transactions : uint32 LE]
+[hashes : compact-size + 32 each]
+[flag_bits : compact-size + packed bytes]
+```
+
+Inner-node combiner is SHA3-256 (Dilithion's merkle hash, NOT Bitcoin's double-SHA256).
+
+### Example
+
+```bash
+curl -s --user rpc:rpc -H 'X-Dilithion-RPC: 1' -H 'content-type:application/json' \
+  --data-binary '{"jsonrpc":"2.0","id":1,"method":"gettxoutproof","params":{"txids":["<txid>"],"blockhash":"<bh>"}}' \
+  http://127.0.0.1:8332/
+```
+
+---
+
+## verifytxoutproof
+
+Decodes a `gettxoutproof` blob and returns the witnessed txids plus reconstructed merkle root.
+
+### Param
+
+```
+{"proof": "<hex>"}
+```
+
+### Response
+
+```json
+{
+  "merkleroot": "<reconstructed-root-hex>",
+  "blockhash":  "<block-hex-from-proof>",
+  "txids":      ["<txid>", ...]
+}
+```
+
+### Caller-side verification
+
+`verifytxoutproof` does NOT confirm that the reconstructed merkle root matches any block on the active chain -- it returns the root for the caller to compare. Standard SPV pattern:
+
+1. Call `verifytxoutproof` to get the reconstructed root.
+2. Independently fetch the block at `blockhash` (e.g. via `getblockheader`).
+3. Compare `merkleroot` from (1) against the block header's merkle root.
+4. The proof is valid iff the roots match AND the witnessed txids are non-empty.
+
+### Example
+
+```bash
+curl -s --user rpc:rpc -H 'X-Dilithion-RPC: 1' -H 'content-type:application/json' \
+  --data-binary '{"jsonrpc":"2.0","id":1,"method":"verifytxoutproof","params":{"proof":"<hex>"}}' \
+  http://127.0.0.1:8332/
+```
+
+---
+
+## Error handling
+
+All six handlers throw `std::runtime_error` (translated to a JSON-RPC error response) on:
+
+- Missing required param.
+- Malformed hex (length != 64 for 32-byte hashes; non-hex characters; truncated proof blob).
+- Out-of-range height.
+- Unknown block hash.
+- Unknown txid in `gettxoutproof`.
+- `timeout_ms <= 0`.
+- Duplicate child hashes in a partial merkle tree (CVE-2012-2459 guard).
+
+## Risk class
+
+LOW. All read-only or blocking-only; no consensus, no P2P, no storage schema changes. Worst-case for a buggy handler is wrong RPC output -- no fund loss, no data corruption.
+
+## Source mapping
+
+| RPC | Bitcoin Core source |
+|-----|---------------------|
+| `getblockstats`        | `src/rpc/blockchain.cpp` v28.0 |
+| `waitfornewblock`      | `src/rpc/blockchain.cpp` v28.0 |
+| `waitforblock`         | `src/rpc/blockchain.cpp` v28.0 |
+| `waitforblockheight`   | `src/rpc/blockchain.cpp` v28.0 |
+| `gettxoutproof`        | `src/rpc/rawtransaction.cpp` v28.0 |
+| `verifytxoutproof`     | `src/rpc/rawtransaction.cpp` v28.0 |

--- a/docs/SMALL-RPCS-CLUSTER.md
+++ b/docs/SMALL-RPCS-CLUSTER.md
@@ -2,57 +2,14 @@
 
 Read-only / blocking RPCs ported from Bitcoin Core v28.0 (`src/rpc/blockchain.cpp` and `src/rpc/rawtransaction.cpp`).
 
-Cluster: `getblockstats`, `waitfornewblock`, `waitforblock`, `waitforblockheight`, `gettxoutproof`, `verifytxoutproof`. All six were landed together in T1.B (Bitcoin Core port roadmap).
+Cluster: `waitfornewblock`, `waitforblock`, `waitforblockheight`, `gettxoutproof`, `verifytxoutproof` (5 RPCs). All five are part of T1.B (Bitcoin Core port roadmap).
+
+`getblockstats` is intentionally NOT in this cluster -- it requires per-tx fee fields that depend on undo-data exposure, and lands in a separate workstream alongside the `coinstatsindex` port.
 
 All examples below use object-style params (Dilithion convention; not array-style as in Bitcoin Core's CLI).
 
 ---
 
-## getblockstats
-
-Per-block analytics for explorers. Returns aggregate transaction-size, input/output counts, subsidy, and total fee.
-
-### Param
-
-```
-{"hash_or_height": <hex|int>}
-{"hash": "<64-hex>"}
-{"height": <int>}
-```
-
-Either `hash_or_height` or `hash`/`height`. Supplying both `hash` and `height` is rejected.
-
-### Response fields
-
-- `avgtxsize`, `mediantxsize`, `maxtxsize`, `mintxsize` -- distribution of per-tx serialized sizes (bytes).
-- `blockhash` -- hash of the requested block.
-- `height` -- block height.
-- `ins`, `outs` -- total non-coinbase inputs / outputs in the block.
-- `mediantime` -- median nTime of the previous 11 blocks (chain median past time). Falls back to `time` when ancestors are unavailable.
-- `subsidy` -- block subsidy in ions (DIL) or volts (DilV).
-- `time` -- block header timestamp.
-- `total_out` -- sum of non-coinbase outputs.
-- `total_size` -- serialized tx-array byte length.
-- `totalfee` -- coinbase output sum minus subsidy. Reported as 0 if coinbase under-pays subsidy (consensus violation; would be rejected at block validation).
-- `txs` -- transaction count including coinbase.
-- `utxo_increase` -- `outs - ins`. Net UTXO created by the block.
-
-### Omitted vs. Bitcoin Core
-
-The following Bitcoin Core fields are intentionally omitted:
-
-- `swtotal_size`, `swtotal_weight`, `swtxs`, `total_weight` -- segwit-only; Dilithion is non-segwit.
-- `avgfee`, `medianfee`, `maxfee`, `minfee`, `feerate_percentiles`, `avgfeerate`, `maxfeerate`, `minfeerate` -- per-tx fees require prevout lookups against an undo file. Dilithion does not currently expose undo data through the RPC layer; only the aggregate `totalfee` (coinbase-derived) is available. Adding per-tx fees would require a separate undo-data-aware port and is out of scope for this cluster.
-
-### Example
-
-```bash
-curl -s --user rpc:rpc -H 'X-Dilithion-RPC: 1' -H 'content-type:application/json' \
-  --data-binary '{"jsonrpc":"2.0","id":1,"method":"getblockstats","params":{"height":1000}}' \
-  http://127.0.0.1:8332/
-```
-
----
 
 ## waitfornewblock / waitforblock / waitforblockheight
 
@@ -206,7 +163,6 @@ LOW. All read-only or blocking-only; no consensus, no P2P, no storage schema cha
 
 | RPC | Bitcoin Core source |
 |-----|---------------------|
-| `getblockstats`        | `src/rpc/blockchain.cpp` v28.0 |
 | `waitfornewblock`      | `src/rpc/blockchain.cpp` v28.0 |
 | `waitforblock`         | `src/rpc/blockchain.cpp` v28.0 |
 | `waitforblockheight`   | `src/rpc/blockchain.cpp` v28.0 |

--- a/src/node/dilithion-node.cpp
+++ b/src/node/dilithion-node.cpp
@@ -6498,6 +6498,14 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
         rpc_server.SetAttestationRateLimit(config.attestation_rate_limit);  // Sybil defense Phase 0
         rpc_server.SetDataDir(Dilithion::g_chainParams->dataDir);  // For swap state persistence
 
+        // T1.B: wake any RPC worker parked on the wait-* condition variable.
+        // Static dispatch so the callback never holds a stale CRPCServer
+        // pointer; NotifyBlockTipChanged is exception-safe.
+        g_chainstate.RegisterBlockConnectCallback(
+            [](const CBlock& /*block*/, int /*height*/, const uint256& /*hash*/) {
+                CRPCServer::NotifyBlockTipChanged();
+            });
+
         // Phase 2+3: Seed attestation initialization (relay-only seed nodes only)
         // Loads ASN database and attestation signing key so seeds can serve
         // getmikattestation RPC requests from miners.

--- a/src/node/dilv-node.cpp
+++ b/src/node/dilv-node.cpp
@@ -6334,6 +6334,14 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
         rpc_server.SetAttestationRateLimit(config.attestation_rate_limit);  // Sybil defense Phase 0
         rpc_server.SetDataDir(Dilithion::g_chainParams->dataDir);  // For swap state persistence
 
+        // T1.B: wake any RPC worker parked on the wait-* condition variable.
+        // Static dispatch so the callback never holds a stale CRPCServer
+        // pointer; NotifyBlockTipChanged is exception-safe.
+        g_chainstate.RegisterBlockConnectCallback(
+            [](const CBlock& /*block*/, int /*height*/, const uint256& /*hash*/) {
+                CRPCServer::NotifyBlockTipChanged();
+            });
+
         // Phase 2+3: Seed attestation initialization (relay-only DilV nodes only)
         // Loads ASN database and attestation signing key so seeds can serve
         // getmikattestation RPC requests from miners.

--- a/src/rpc/ratelimiter.cpp
+++ b/src/rpc/ratelimiter.cpp
@@ -69,6 +69,20 @@ const std::map<std::string, CRateLimiter::MethodRateLimit> CRateLimiter::METHOD_
 
     // === LOW: Read-Only Info (default 1000/min applies to unconfigured methods) ===
     // getbalance, getblockchaininfo, getblockcount, etc. - use DEFAULT_METHOD_LIMIT
+
+    // === LONG-POLL: wait-* RPCs (10/min) ===
+    // PR #38 red-team C4: the wait-* RPCs hold an RPC worker thread for
+    // up to 5 minutes (their max timeout). With ~8 worker threads in the
+    // dispatcher pool, a single misbehaving caller could exhaust the
+    // pool with a 10-request burst and lock out other RPC traffic.
+    // 10/min per IP keeps legitimate explorer / wallet usage flowing
+    // (tip-change polling at 1-2 calls/sec is normal for actively-used
+    // explorers) while bounding the worker-pool exposure. The default
+    // 1000/min from DEFAULT_METHOD_LIMIT is too permissive for blocking
+    // RPCs.
+    {"waitfornewblock",        {10.0, 0.167, 1.0}},
+    {"waitforblock",           {10.0, 0.167, 1.0}},
+    {"waitforblockheight",     {10.0, 0.167, 1.0}},
 };
 
 bool CRateLimiter::AllowRequest(const std::string& ipAddress) {

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -59,6 +59,7 @@
 #include <net/block_tracker.h>  // For block tracker diagnostics
 #include <net/block_fetcher.h>  // For CBlockFetcher
 #include <net/headers_manager.h>  // For CHeadersManager
+#include <net/serialize.h>  // T1.B: CDataStream for partial-Merkle-tree serialization
 
 #include <array>
 #include <sstream>
@@ -310,6 +311,17 @@ CRPCServer::CRPCServer(uint16_t port)
 
     // Seed attestation (Phase 2+3)
     m_handlers["getmikattestation"] = [this](const std::string& p) { return RPC_GetMIKAttestation(p); };
+
+    // T1.B: small RPCs cluster (Bitcoin Core port v28.0).
+    // getblockstats + gettxoutproof are instance methods (need m_blockchain
+    // / m_chainstate access). The wait-* family + verifytxoutproof are
+    // static -- they read only g_chainstate or are pure-input.
+    m_handlers["getblockstats"]      = [this](const std::string& p) { return RPC_GetBlockStats(p); };
+    m_handlers["waitfornewblock"]    = [](const std::string& p) { return RPC_WaitForNewBlock(p); };
+    m_handlers["waitforblock"]       = [](const std::string& p) { return RPC_WaitForBlock(p); };
+    m_handlers["waitforblockheight"] = [](const std::string& p) { return RPC_WaitForBlockHeight(p); };
+    m_handlers["gettxoutproof"]      = [this](const std::string& p) { return RPC_GetTxOutProof(p); };
+    m_handlers["verifytxoutproof"]   = [](const std::string& p) { return RPC_VerifyTxOutProof(p); };
 }
 
 CRPCServer::~CRPCServer() {
@@ -5366,6 +5378,14 @@ std::string CRPCServer::RPC_Help(const std::string& params) {
     oss << "\"acceptswap - Accept a swap by creating a matching HTLC on our chain\",";
     oss << "\"listswaps - List all known atomic swaps and their states\",";
 
+    // T1.B: small RPCs cluster (Bitcoin Core port v28.0)
+    oss << "\"getblockstats - Per-block analytics (size, fees, subsidy, utxo delta)\",";
+    oss << "\"waitfornewblock - Block until a new tip is connected (timeout_ms default 30000, max 300000)\",";
+    oss << "\"waitforblock - Block until tip equals supplied hash (timeout_ms default 30000)\",";
+    oss << "\"waitforblockheight - Block until tip reaches supplied height (timeout_ms default 30000)\",";
+    oss << "\"gettxoutproof - Return a partial-merkle-tree proof witnessing inclusion of given txids\",";
+    oss << "\"verifytxoutproof - Decode a partial-merkle-tree proof and return the witnessed txids\",";
+
     oss << "\"help - This help message\",";
     oss << "\"stop - Stop the Dilithion node\"";
 
@@ -8394,4 +8414,775 @@ std::string CRPCServer::RPC_GetMIKAttestation(const std::string& params) {
            << "}";
 
     return result.str();
+}
+
+// ============================================================================
+// Small RPCs cluster (T1.B) -- Bitcoin Core port v28.0
+// ----------------------------------------------------------------------------
+//   getblockstats           src/rpc/blockchain.cpp v28.0
+//   waitfornewblock         src/rpc/blockchain.cpp v28.0
+//   waitforblock            src/rpc/blockchain.cpp v28.0
+//   waitforblockheight      src/rpc/blockchain.cpp v28.0
+//   gettxoutproof           src/rpc/rawtransaction.cpp v28.0
+//   verifytxoutproof        src/rpc/rawtransaction.cpp v28.0
+//
+// All six are read-only / preview-only -- no consensus, no P2P, no storage
+// schema changes. Worst case for a buggy handler is wrong RPC output; no
+// fund loss, no data corruption. (See contract: LOW risk class.)
+//
+// Threading model for the wait-* family:
+//   A single process-wide std::condition_variable + mutex pair lives in this
+//   translation unit. CChainState's existing block-connect callback array
+//   gets a tiny lambda registered at node startup that calls
+//   CRPCServer::NotifyBlockTipChanged(); that function broadcasts the CV.
+//   Each wait-* handler grabs the mutex, polls its tip predicate, and
+//   waits on the CV with a bounded timeout (default 30s, capped at 300s).
+//   The default cap exists to bound how long an RPC worker thread is tied
+//   up by any single client; without it a malicious caller could DoS the
+//   ~8-worker thread-pool by opening N>8 long-poll requests.
+// ============================================================================
+
+extern CChainState g_chainstate;
+
+namespace {
+
+// Process-wide synchronization for the wait-* RPCs. Lives in an anonymous
+// namespace so external translation units never reach in. Mutex is plain
+// std::mutex (default seq_cst) per project convention.
+std::mutex              g_wait_cluster_mtx;
+std::condition_variable g_wait_cluster_cv;
+
+// ---- Object-style param parsing helpers (Dilithion uses object params) ----
+
+// Returns true and writes hex string to `out` if `params` contains
+// `"key":"<hex>"`. False otherwise.
+bool TryParseStringParam(const std::string& params,
+                         const std::string& key,
+                         std::string& out) {
+    std::string needle = "\"" + key + "\"";
+    size_t key_pos = params.find(needle);
+    if (key_pos == std::string::npos) return false;
+    size_t colon = params.find(":", key_pos + needle.size());
+    if (colon == std::string::npos) return false;
+    size_t q1 = params.find("\"", colon);
+    if (q1 == std::string::npos) return false;
+    size_t q2 = params.find("\"", q1 + 1);
+    if (q2 == std::string::npos) return false;
+    out = params.substr(q1 + 1, q2 - q1 - 1);
+    return true;
+}
+
+// Returns true and writes integer to `out` if `params` contains
+// `"key":<int>`. False otherwise. Accepts negative integers.
+bool TryParseIntParam(const std::string& params,
+                      const std::string& key,
+                      int64_t& out) {
+    std::string needle = "\"" + key + "\"";
+    size_t key_pos = params.find(needle);
+    if (key_pos == std::string::npos) return false;
+    size_t colon = params.find(":", key_pos + needle.size());
+    if (colon == std::string::npos) return false;
+    size_t i = colon + 1;
+    while (i < params.size() && std::isspace(static_cast<unsigned char>(params[i]))) ++i;
+    size_t start = i;
+    if (i < params.size() && params[i] == '-') ++i;
+    while (i < params.size() && std::isdigit(static_cast<unsigned char>(params[i]))) ++i;
+    if (i == start || (i == start + 1 && params[start] == '-')) return false;
+    try {
+        out = std::stoll(params.substr(start, i - start));
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+
+// Strict 64-char hex validation (block hash / txid). Anything else throws so
+// the RPC layer translates to a proper JSON error.
+uint256 ParseHash64(const std::string& hex, const char* label) {
+    if (hex.size() != 64) {
+        throw std::runtime_error(std::string(label) +
+                                 " must be 64 hex characters");
+    }
+    for (char c : hex) {
+        if (!std::isxdigit(static_cast<unsigned char>(c))) {
+            throw std::runtime_error(std::string(label) +
+                                     " contains non-hex characters");
+        }
+    }
+    uint256 h;
+    h.SetHex(hex);
+    return h;
+}
+
+// Resolve the optional / capped wait-* timeout. Defaults to 30s; clamps to
+// [1ms, 300s]. A caller-supplied timeout_ms <= 0 is rejected.
+int ResolveWaitTimeoutMs(const std::string& params) {
+    int64_t requested = CRPCServer::kDefaultWaitTimeoutMs;
+    int64_t parsed = 0;
+    if (TryParseIntParam(params, "timeout_ms", parsed)) {
+        if (parsed <= 0) {
+            throw std::runtime_error("timeout_ms must be positive");
+        }
+        requested = parsed;
+    } else if (TryParseIntParam(params, "timeout", parsed)) {
+        // Bitcoin Core uses `timeout`; accept that alias for caller convenience.
+        if (parsed <= 0) {
+            throw std::runtime_error("timeout must be positive");
+        }
+        requested = parsed;
+    }
+    if (requested > CRPCServer::kMaxWaitTimeoutMs) {
+        requested = CRPCServer::kMaxWaitTimeoutMs;
+    }
+    return static_cast<int>(requested);
+}
+
+// Format a wait-* response body. Bitcoin Core returns {"hash":..., "height":...}
+// when condition met, OR {"hash":"<current_tip>", "height":<current_tip_height>}
+// after a timeout. We keep that exact shape for compatibility.
+std::string FormatTipResponse(const uint256& hash, int height) {
+    std::ostringstream oss;
+    oss << "{\"hash\":\"" << hash.GetHex() << "\","
+        << "\"height\":" << height << "}";
+    return oss.str();
+}
+
+// Compute the SHA3-256 of two concatenated 32-byte hashes -- the inner
+// node combiner used by Dilithion's merkle tree. Mirrors
+// CBlockValidator::BuildMerkleRoot's combiner exactly so partial-merkle
+// proofs validate against the on-chain merkle root.
+uint256 CombineHashes(const uint256& left, const uint256& right) {
+    uint8_t buf[64];
+    std::memcpy(buf, left.data, 32);
+    std::memcpy(buf + 32, right.data, 32);
+    uint256 out;
+    SHA3_256(buf, 64, out.data);
+    return out;
+}
+
+// Tree-height for a block of N leaves. Dilithion duplicates the last leaf
+// at odd levels (BuildMerkleRoot does levelSize = (levelSize + 1) / 2),
+// so the height is ceil(log2(N)) for N >= 2 and 0 for N <= 1.
+int MerkleTreeHeight(uint32_t nTransactions) {
+    int height = 0;
+    while ((1u << height) < nTransactions) ++height;
+    return height;
+}
+
+// Number of nodes at level `height` (0 = leaves). Mirrors Bitcoin Core's
+// CalcTreeWidth().
+uint32_t MerkleTreeWidth(uint32_t nTransactions, int height) {
+    return (nTransactions + (1u << height) - 1) >> height;
+}
+
+// Recurse the merkle tree, computing the hash at (height, pos). At the
+// leaf level returns the txid directly. Used to fill in the partial
+// merkle tree's "extra" hashes (interior nodes whose subtrees contain
+// no matched leaves).
+uint256 MerkleHashAt(const std::vector<uint256>& leaves,
+                     uint32_t nTransactions,
+                     int height,
+                     uint32_t pos) {
+    if (height == 0) {
+        return leaves[pos];
+    }
+    uint256 left = MerkleHashAt(leaves, nTransactions, height - 1, pos * 2);
+    uint256 right;
+    if (pos * 2 + 1 < MerkleTreeWidth(nTransactions, height - 1)) {
+        right = MerkleHashAt(leaves, nTransactions, height - 1, pos * 2 + 1);
+    } else {
+        // Odd-leaf case: duplicate the left child (matches BuildMerkleRoot).
+        right = left;
+    }
+    return CombineHashes(left, right);
+}
+
+// Build the partial merkle tree's flag-bit + hash stream by traversing the
+// full tree top-down. At each interior node:
+//   - if any descendant is matched, recurse and emit a 1-bit (no hash)
+//   - otherwise emit a 0-bit and the subtree-root hash (terminator)
+// At a leaf:
+//   - emit a 1-bit if matched, 0-bit otherwise; always emit the leaf hash
+//
+// `matched[i]` indicates whether leaf i should be included in the proof.
+void TraverseAndBuild(int height,
+                      uint32_t pos,
+                      const std::vector<uint256>& leaves,
+                      const std::vector<bool>& matched,
+                      uint32_t nTransactions,
+                      std::vector<bool>& bits,
+                      std::vector<uint256>& hashes) {
+    bool parentOfMatch = false;
+    for (uint32_t p = pos << height;
+         p < ((pos + 1) << height) && p < nTransactions;
+         ++p) {
+        if (matched[p]) { parentOfMatch = true; break; }
+    }
+    bits.push_back(parentOfMatch);
+
+    if (height == 0 || !parentOfMatch) {
+        hashes.push_back(MerkleHashAt(leaves, nTransactions, height, pos));
+    } else {
+        TraverseAndBuild(height - 1, pos * 2, leaves, matched, nTransactions,
+                         bits, hashes);
+        if (pos * 2 + 1 < MerkleTreeWidth(nTransactions, height - 1)) {
+            TraverseAndBuild(height - 1, pos * 2 + 1, leaves, matched,
+                             nTransactions, bits, hashes);
+        }
+    }
+}
+
+// Reverse of TraverseAndBuild. Walks the partial tree using the supplied
+// bits + hashes, and on success returns the merkle root, plus the txids
+// at matched leaves in `matched_txids`. Throws on under/over-run.
+uint256 TraverseAndExtract(int height,
+                           uint32_t pos,
+                           uint32_t nTransactions,
+                           const std::vector<bool>& bits,
+                           const std::vector<uint256>& hashes,
+                           size_t& bit_pos,
+                           size_t& hash_pos,
+                           std::vector<uint256>& matched_txids) {
+    if (bit_pos >= bits.size()) {
+        throw std::runtime_error("partial merkle tree: ran out of flag bits");
+    }
+    bool parentOfMatch = bits[bit_pos++];
+    if (height == 0 || !parentOfMatch) {
+        if (hash_pos >= hashes.size()) {
+            throw std::runtime_error("partial merkle tree: ran out of hashes");
+        }
+        uint256 h = hashes[hash_pos++];
+        if (height == 0 && parentOfMatch) {
+            matched_txids.push_back(h);
+        }
+        return h;
+    }
+    uint256 left = TraverseAndExtract(height - 1, pos * 2, nTransactions,
+                                      bits, hashes, bit_pos, hash_pos,
+                                      matched_txids);
+    uint256 right;
+    if (pos * 2 + 1 < MerkleTreeWidth(nTransactions, height - 1)) {
+        right = TraverseAndExtract(height - 1, pos * 2 + 1, nTransactions,
+                                   bits, hashes, bit_pos, hash_pos,
+                                   matched_txids);
+        if (right == left) {
+            // Bitcoin Core CVE-2012-2459 guard: an interior node with two
+            // identical children indicates a malleated tree.
+            throw std::runtime_error(
+                "partial merkle tree: duplicate child hashes detected");
+        }
+    } else {
+        right = left;
+    }
+    return CombineHashes(left, right);
+}
+
+} // anonymous namespace
+
+// ----------------------------------------------------------------------------
+// CRPCServer::NotifyBlockTipChanged
+// ----------------------------------------------------------------------------
+// Wakes any RPC worker parked on g_wait_cluster_cv. Registered once per
+// process from the node's startup path. Idempotent and noexcept-equivalent --
+// the chainstate's outer try/catch already protects the loop, but we keep
+// the body trivial so even pathological CV state cannot raise.
+void CRPCServer::NotifyBlockTipChanged() {
+    // No need to acquire the mutex for notify_all -- waiters re-check their
+    // predicate under the mutex on wake, and notify_all has well-defined
+    // memory ordering w.r.t. wait_for. Avoids contention if many block
+    // connects fire in quick succession during IBD.
+    g_wait_cluster_cv.notify_all();
+}
+
+// ----------------------------------------------------------------------------
+// CRPCServer::RPC_GetBlockStats
+// ----------------------------------------------------------------------------
+// Per-block analytics for explorers. Bitcoin Core port; some segwit-only
+// fields are intentionally omitted because Dilithion is non-segwit:
+//
+//   omitted: swtotal_size, swtotal_weight, swtxs, total_weight
+//
+// Per-tx fee fields (avgfee, medianfee, maxfee, minfee, feerate_percentiles,
+// avgfeerate, maxfeerate, minfeerate) are also omitted: Bitcoin Core
+// computes these via prevout lookups against an undo file, which Dilithion
+// does not currently expose at this layer. `totalfee` IS reported, derived
+// from the coinbase output sum minus the block subsidy -- the same formula
+// Bitcoin Core uses as a fallback when undo data is unavailable.
+//
+// Field set (alphabetical):
+//   avgtxsize, blockhash, height, ins, maxtxsize, mediantime, mediantxsize,
+//   mintxsize, outs, subsidy, time, total_out, total_size, totalfee, txs,
+//   utxo_increase
+//
+// Param: object {"hash_or_height": <hex|int>}. Either form accepted (the
+// hash field name is `hash`, the height field name is `height`; supplying
+// both is rejected).
+std::string CRPCServer::RPC_GetBlockStats(const std::string& params) {
+    if (!m_blockchain) throw std::runtime_error("Blockchain not initialized");
+    if (!m_chainstate) throw std::runtime_error("Chain state not initialized");
+
+    // Resolve target block.
+    std::string hash_str;
+    int64_t height_param = -1;
+    bool have_hash = TryParseStringParam(params, "hash", hash_str);
+    bool have_height = TryParseIntParam(params, "height", height_param);
+    // Convenience alias: hash_or_height accepts either.
+    std::string hor;
+    if (!have_hash && !have_height && TryParseStringParam(params, "hash_or_height", hor)) {
+        if (hor.size() == 64) { hash_str = hor; have_hash = true; }
+        else {
+            try { height_param = std::stoll(hor); have_height = true; }
+            catch (...) { throw std::runtime_error("hash_or_height must be a 64-char hex hash or an integer height"); }
+        }
+    }
+    if (have_hash && have_height) {
+        throw std::runtime_error("Specify either hash or height, not both");
+    }
+    if (!have_hash && !have_height) {
+        throw std::runtime_error("Missing hash or height parameter");
+    }
+
+    uint256 target_hash;
+    if (have_height) {
+        if (height_param < 0) throw std::runtime_error("height must be non-negative");
+        CBlockIndex* pTip = m_chainstate->GetTip();
+        if (!pTip || height_param > pTip->nHeight) {
+            throw std::runtime_error("Block height out of range");
+        }
+        CBlockIndex* pBlock = pTip->GetAncestor(static_cast<int>(height_param));
+        if (!pBlock) throw std::runtime_error("No block at that height");
+        target_hash = pBlock->GetBlockHash();
+    } else {
+        target_hash = ParseHash64(hash_str, "hash");
+    }
+
+    CBlock block;
+    if (!m_blockchain->ReadBlock(target_hash, block)) {
+        throw std::runtime_error("Block not found");
+    }
+
+    CBlockIndex blockIndex;
+    int height = -1;
+    if (m_blockchain->ReadBlockIndex(target_hash, blockIndex)) {
+        height = blockIndex.nHeight;
+    }
+    if (height < 0) {
+        // Fallback: walk ancestors via active tip.
+        CBlockIndex* pTip = m_chainstate->GetTip();
+        if (pTip) {
+            for (CBlockIndex* p = pTip; p; p = p->pprev) {
+                if (p->GetBlockHash() == target_hash) { height = p->nHeight; break; }
+            }
+        }
+    }
+    if (height < 0) throw std::runtime_error("Block index missing for given block");
+
+    CBlockValidator validator;
+    std::vector<CTransactionRef> transactions;
+    std::string deserializeError;
+    if (!validator.DeserializeBlockTransactions(block, transactions, deserializeError)) {
+        throw std::runtime_error("Failed to deserialize block transactions: " + deserializeError);
+    }
+
+    // Aggregates -- per-tx size + per-block input/output totals.
+    std::vector<size_t> tx_sizes;
+    tx_sizes.reserve(transactions.size());
+    uint64_t total_size = block.vtx.size();      // serialized tx-array size
+    uint64_t total_out  = 0;                      // total non-coinbase output value
+    uint64_t coinbase_out = 0;                    // sum of coinbase outputs (subsidy + fees)
+    uint64_t ins  = 0;
+    uint64_t outs = 0;
+    for (size_t i = 0; i < transactions.size(); ++i) {
+        const auto& tx = transactions[i];
+        size_t sz = tx->GetSerializedSize();
+        tx_sizes.push_back(sz);
+        if (i == 0) {
+            // Coinbase: the only TX whose inputs aren't real outpoints.
+            for (const auto& vo : tx->vout) coinbase_out += vo.nValue;
+            outs += tx->vout.size();
+        } else {
+            ins  += tx->vin.size();
+            outs += tx->vout.size();
+            for (const auto& vo : tx->vout) total_out += vo.nValue;
+        }
+    }
+
+    uint64_t subsidy = CBlockValidator::CalculateBlockSubsidy(static_cast<uint32_t>(height));
+    // totalfee = coinbase_out - subsidy (clamped at 0; under-paid coinbase
+    // would be a consensus failure, but we report 0 rather than overflow).
+    uint64_t totalfee = (coinbase_out >= subsidy) ? (coinbase_out - subsidy) : 0;
+
+    // Median txsize via std::nth_element (KISS, no helper header).
+    uint64_t mintxsize = 0, maxtxsize = 0, mediantxsize = 0;
+    double avgtxsize = 0.0;
+    if (!tx_sizes.empty()) {
+        auto minmax = std::minmax_element(tx_sizes.begin(), tx_sizes.end());
+        mintxsize = *minmax.first;
+        maxtxsize = *minmax.second;
+        size_t mid = tx_sizes.size() / 2;
+        std::nth_element(tx_sizes.begin(), tx_sizes.begin() + mid, tx_sizes.end());
+        mediantxsize = tx_sizes[mid];
+        uint64_t sum = 0;
+        for (size_t s : tx_sizes) sum += s;
+        avgtxsize = static_cast<double>(sum) / tx_sizes.size();
+    }
+
+    // mediantime: median nTime of the last 11 blocks (chain median past time)
+    // -- standard explorer field. Fallback to block.nTime when ancestors are
+    // unavailable.
+    uint64_t mediantime = block.nTime;
+    {
+        CBlockIndex* pTip = m_chainstate->GetTip();
+        if (pTip) {
+            CBlockIndex* p = pTip->GetAncestor(height);
+            if (p) {
+                std::vector<uint32_t> times;
+                CBlockIndex* it = p;
+                for (int i = 0; i < 11 && it; ++i) {
+                    times.push_back(it->nTime);
+                    it = it->pprev;
+                }
+                if (!times.empty()) {
+                    size_t mid = times.size() / 2;
+                    std::nth_element(times.begin(), times.begin() + mid, times.end());
+                    mediantime = times[mid];
+                }
+            }
+        }
+    }
+
+    // utxo_increase = (outputs created in this block) - (inputs consumed).
+    // Coinbase always creates outputs without consuming any prevouts.
+    int64_t utxo_increase = static_cast<int64_t>(outs) - static_cast<int64_t>(ins);
+
+    std::ostringstream oss;
+    oss << "{";
+    oss << "\"avgtxsize\":" << avgtxsize << ",";
+    oss << "\"blockhash\":\"" << target_hash.GetHex() << "\",";
+    oss << "\"height\":" << height << ",";
+    oss << "\"ins\":" << ins << ",";
+    oss << "\"maxtxsize\":" << maxtxsize << ",";
+    oss << "\"mediantime\":" << mediantime << ",";
+    oss << "\"mediantxsize\":" << mediantxsize << ",";
+    oss << "\"mintxsize\":" << mintxsize << ",";
+    oss << "\"outs\":" << outs << ",";
+    oss << "\"subsidy\":" << subsidy << ",";
+    oss << "\"time\":" << block.nTime << ",";
+    oss << "\"total_out\":" << total_out << ",";
+    oss << "\"total_size\":" << total_size << ",";
+    oss << "\"totalfee\":" << totalfee << ",";
+    oss << "\"txs\":" << transactions.size() << ",";
+    oss << "\"utxo_increase\":" << utxo_increase;
+    oss << "}";
+    return oss.str();
+}
+
+// ----------------------------------------------------------------------------
+// CRPCServer::RPC_WaitForNewBlock
+// ----------------------------------------------------------------------------
+// Block until a new tip is connected (or the timeout expires). Param:
+// optional {"timeout_ms": <int>}. Default 30s; capped at 300s.
+//
+// Behavior matches Bitcoin Core: returns the tip whether or not the
+// condition was satisfied (timeouts return the current tip rather than
+// raising an error).
+std::string CRPCServer::RPC_WaitForNewBlock(const std::string& params) {
+    int timeout_ms = ResolveWaitTimeoutMs(params);
+
+    auto get_tip = []() -> std::pair<uint256, int> {
+        CBlockIndex* p = g_chainstate.GetTip();
+        if (!p) return {uint256{}, -1};
+        return {p->GetBlockHash(), p->nHeight};
+    };
+
+    auto initial = get_tip();
+    auto deadline = std::chrono::steady_clock::now() +
+                    std::chrono::milliseconds(timeout_ms);
+
+    std::unique_lock<std::mutex> lock(g_wait_cluster_mtx);
+    g_wait_cluster_cv.wait_until(lock, deadline, [&]() {
+        return get_tip().first != initial.first;
+    });
+    auto current = get_tip();
+    return FormatTipResponse(current.first, current.second);
+}
+
+// ----------------------------------------------------------------------------
+// CRPCServer::RPC_WaitForBlock
+// ----------------------------------------------------------------------------
+// Block until the chain tip equals the supplied block hash (or timeout).
+// Param: {"hash": "<64-char hex>", "timeout_ms": <int>?}.
+std::string CRPCServer::RPC_WaitForBlock(const std::string& params) {
+    std::string hash_str;
+    if (!TryParseStringParam(params, "hash", hash_str) &&
+        !TryParseStringParam(params, "blockhash", hash_str)) {
+        throw std::runtime_error("Missing hash parameter");
+    }
+    uint256 wanted = ParseHash64(hash_str, "hash");
+    int timeout_ms = ResolveWaitTimeoutMs(params);
+
+    auto get_tip = []() -> std::pair<uint256, int> {
+        CBlockIndex* p = g_chainstate.GetTip();
+        if (!p) return {uint256{}, -1};
+        return {p->GetBlockHash(), p->nHeight};
+    };
+
+    auto deadline = std::chrono::steady_clock::now() +
+                    std::chrono::milliseconds(timeout_ms);
+
+    std::unique_lock<std::mutex> lock(g_wait_cluster_mtx);
+    g_wait_cluster_cv.wait_until(lock, deadline, [&]() {
+        return get_tip().first == wanted;
+    });
+    auto current = get_tip();
+    return FormatTipResponse(current.first, current.second);
+}
+
+// ----------------------------------------------------------------------------
+// CRPCServer::RPC_WaitForBlockHeight
+// ----------------------------------------------------------------------------
+// Block until the chain tip is at least the supplied height (or timeout).
+// Param: {"height": <int>, "timeout_ms": <int>?}.
+std::string CRPCServer::RPC_WaitForBlockHeight(const std::string& params) {
+    int64_t target = -1;
+    if (!TryParseIntParam(params, "height", target)) {
+        throw std::runtime_error("Missing height parameter");
+    }
+    if (target < 0) throw std::runtime_error("height must be non-negative");
+    int timeout_ms = ResolveWaitTimeoutMs(params);
+
+    auto get_tip = []() -> std::pair<uint256, int> {
+        CBlockIndex* p = g_chainstate.GetTip();
+        if (!p) return {uint256{}, -1};
+        return {p->GetBlockHash(), p->nHeight};
+    };
+
+    auto deadline = std::chrono::steady_clock::now() +
+                    std::chrono::milliseconds(timeout_ms);
+
+    std::unique_lock<std::mutex> lock(g_wait_cluster_mtx);
+    g_wait_cluster_cv.wait_until(lock, deadline, [&]() {
+        return get_tip().second >= target;
+    });
+    auto current = get_tip();
+    return FormatTipResponse(current.first, current.second);
+}
+
+// ----------------------------------------------------------------------------
+// CRPCServer::RPC_GetTxOutProof
+// ----------------------------------------------------------------------------
+// Returns a hex-encoded partial-merkle-tree proof for the supplied set of
+// txids, embedded in the format:
+//
+//   [block_hash : 32]              -- which block these txids live in
+//   [num_transactions : varint]    -- total tx count in the block
+//   [hashes : varint + 32 each]    -- partial-merkle-tree hashes
+//   [flag_bits : varint + bytes]   -- packed traversal flag bits
+//
+// Mirrors Bitcoin Core's CMerkleBlock serialization (BIP 37 partial merkle
+// tree wire format) but uses Dilithion's SHA3-256 inner combiner.
+//
+// Param: {"txids": ["<hex>", ...], "blockhash": "<hex>"}. The blockhash is
+// optional iff txindex is enabled and all txids resolve to the same block.
+std::string CRPCServer::RPC_GetTxOutProof(const std::string& params) {
+    if (!m_blockchain) throw std::runtime_error("Blockchain not initialized");
+
+    // Parse txids array. We only accept the explicit object-style array
+    // form: "txids":["...","..."].
+    size_t arr_pos = params.find("\"txids\"");
+    if (arr_pos == std::string::npos) {
+        throw std::runtime_error("Missing txids parameter");
+    }
+    size_t lb = params.find('[', arr_pos);
+    size_t rb = params.find(']', arr_pos);
+    if (lb == std::string::npos || rb == std::string::npos || rb < lb) {
+        throw std::runtime_error("Invalid txids parameter (expect array)");
+    }
+    std::string array_body = params.substr(lb + 1, rb - lb - 1);
+    std::vector<uint256> wanted_txids;
+    {
+        size_t i = 0;
+        while (i < array_body.size()) {
+            size_t q1 = array_body.find('"', i);
+            if (q1 == std::string::npos) break;
+            size_t q2 = array_body.find('"', q1 + 1);
+            if (q2 == std::string::npos) break;
+            wanted_txids.push_back(
+                ParseHash64(array_body.substr(q1 + 1, q2 - q1 - 1), "txid"));
+            i = q2 + 1;
+        }
+    }
+    if (wanted_txids.empty()) {
+        throw std::runtime_error("txids array is empty");
+    }
+
+    // Resolve blockhash: explicit param, else look up the first txid via
+    // txindex and require the rest to match.
+    std::string bh_str;
+    bool have_bh = TryParseStringParam(params, "blockhash", bh_str);
+    uint256 block_hash;
+    if (have_bh) {
+        block_hash = ParseHash64(bh_str, "blockhash");
+    } else {
+        if (!g_tx_index) {
+            throw std::runtime_error(
+                "blockhash required (txindex not enabled)");
+        }
+        uint32_t pos_unused = 0;
+        if (!g_tx_index->FindTx(wanted_txids[0], block_hash, pos_unused)) {
+            throw std::runtime_error("First txid not found in any block");
+        }
+        for (size_t i = 1; i < wanted_txids.size(); ++i) {
+            uint256 other_block;
+            if (!g_tx_index->FindTx(wanted_txids[i], other_block, pos_unused)) {
+                throw std::runtime_error(
+                    "txid not found in any block (txindex)");
+            }
+            if (!(other_block == block_hash)) {
+                throw std::runtime_error(
+                    "all txids must belong to the same block");
+            }
+        }
+    }
+
+    CBlock block;
+    if (!m_blockchain->ReadBlock(block_hash, block)) {
+        throw std::runtime_error("Block not found");
+    }
+    CBlockValidator validator;
+    std::vector<CTransactionRef> transactions;
+    std::string err;
+    if (!validator.DeserializeBlockTransactions(block, transactions, err)) {
+        throw std::runtime_error("Failed to deserialize block: " + err);
+    }
+    if (transactions.empty()) {
+        throw std::runtime_error("Block has no transactions");
+    }
+
+    // Build leaf hash array + matched bitmap.
+    std::vector<uint256> leaves;
+    leaves.reserve(transactions.size());
+    for (const auto& tx : transactions) leaves.push_back(tx->GetHash());
+
+    std::vector<bool> matched(leaves.size(), false);
+    {
+        std::set<uint256> wanted_set(wanted_txids.begin(), wanted_txids.end());
+        size_t found = 0;
+        for (size_t i = 0; i < leaves.size(); ++i) {
+            if (wanted_set.count(leaves[i])) {
+                matched[i] = true;
+                ++found;
+            }
+        }
+        if (found != wanted_set.size()) {
+            throw std::runtime_error(
+                "Not all requested txids are present in the block");
+        }
+    }
+
+    int height = MerkleTreeHeight(static_cast<uint32_t>(leaves.size()));
+    std::vector<bool> bits;
+    std::vector<uint256> hashes;
+    TraverseAndBuild(height, 0, leaves, matched,
+                     static_cast<uint32_t>(leaves.size()), bits, hashes);
+
+    // Serialize: blockhash + nTransactions + hash array + flag bytes.
+    CDataStream stream;
+    stream.WriteUint256(block_hash);
+    stream.WriteUint32(static_cast<uint32_t>(leaves.size()));
+    stream.WriteCompactSize(hashes.size());
+    for (const auto& h : hashes) stream.WriteUint256(h);
+    // Pack bits LSB-first per byte (matches BIP 37 wire format).
+    std::vector<uint8_t> packed((bits.size() + 7) / 8, 0);
+    for (size_t i = 0; i < bits.size(); ++i) {
+        if (bits[i]) packed[i / 8] |= (1u << (i % 8));
+    }
+    stream.WriteCompactSize(packed.size());
+    stream.write(packed.data(), packed.size());
+
+    std::string hex = HexStr(stream.GetData());
+    return "\"" + hex + "\"";
+}
+
+// ----------------------------------------------------------------------------
+// CRPCServer::RPC_VerifyTxOutProof
+// ----------------------------------------------------------------------------
+// Inverse of RPC_GetTxOutProof: deserializes the proof, walks the partial
+// merkle tree, and returns the txids that the proof witnesses inclusion
+// for. Returns an empty array if the proof is structurally valid but
+// witnesses no transactions; throws if malformed.
+//
+// Note this is a pure-input function -- it does NOT verify that the
+// reconstructed merkle root matches any block's on-chain root. Callers
+// who need that step should compare the returned root to a block they
+// independently fetched. (This matches Bitcoin Core's split between
+// verifytxoutproof and gettxoutproof's caller-side merkle-root check.)
+//
+// Param: {"proof": "<hex>"}.
+std::string CRPCServer::RPC_VerifyTxOutProof(const std::string& params) {
+    std::string hex;
+    if (!TryParseStringParam(params, "proof", hex)) {
+        throw std::runtime_error("Missing proof parameter");
+    }
+    if (!IsHex(hex)) {
+        throw std::runtime_error("proof is not valid hex");
+    }
+    auto bytes = ParseHex(hex);
+    if (bytes.empty()) {
+        throw std::runtime_error("proof is empty");
+    }
+
+    CDataStream stream(bytes);
+    uint256 block_hash = stream.ReadUint256();
+    uint32_t nTransactions = stream.ReadUint32();
+    if (nTransactions == 0) {
+        throw std::runtime_error("proof: nTransactions must be > 0");
+    }
+    uint64_t nHashes = stream.ReadCompactSize();
+    if (nHashes > nTransactions) {
+        throw std::runtime_error("proof: too many hashes");
+    }
+    std::vector<uint256> hashes;
+    hashes.reserve(static_cast<size_t>(nHashes));
+    for (uint64_t i = 0; i < nHashes; ++i) {
+        hashes.push_back(stream.ReadUint256());
+    }
+    uint64_t nFlagBytes = stream.ReadCompactSize();
+    if (nFlagBytes > nTransactions) {
+        // Each leaf consumes exactly one flag bit on the way down; interior
+        // nodes add at most one more. nFlagBytes > nTransactions is a fast
+        // rejection of grossly oversized proofs.
+        throw std::runtime_error("proof: flag-byte count exceeds tx count");
+    }
+    std::vector<uint8_t> packed = stream.read(static_cast<size_t>(nFlagBytes));
+    std::vector<bool> bits(nFlagBytes * 8);
+    for (size_t i = 0; i < bits.size(); ++i) {
+        bits[i] = (packed[i / 8] & (1u << (i % 8))) != 0;
+    }
+
+    int height = MerkleTreeHeight(nTransactions);
+    std::vector<uint256> matched_txids;
+    size_t bit_pos = 0;
+    size_t hash_pos = 0;
+    uint256 root = TraverseAndExtract(height, 0, nTransactions, bits, hashes,
+                                      bit_pos, hash_pos, matched_txids);
+    if (hash_pos != hashes.size()) {
+        throw std::runtime_error("proof: trailing hashes were not consumed");
+    }
+    // Stray high-end bits beyond the last full byte are allowed (padding),
+    // but every bit consumed up to bit_pos must be valid.
+    if (bit_pos > bits.size()) {
+        throw std::runtime_error("proof: walked past end of flag bits");
+    }
+
+    std::ostringstream oss;
+    oss << "{\"merkleroot\":\"" << root.GetHex() << "\","
+        << "\"blockhash\":\"" << block_hash.GetHex() << "\","
+        << "\"txids\":[";
+    for (size_t i = 0; i < matched_txids.size(); ++i) {
+        if (i) oss << ",";
+        oss << "\"" << matched_txids[i].GetHex() << "\"";
+    }
+    oss << "]}";
+    return oss.str();
 }

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -412,6 +412,16 @@ bool CRPCServer::Start() {
         return false;
     }
 
+    // PR #38 red-team C5 follow-up: clear the cluster shutdown flag on
+    // every Start(). Required because Boost test suites in this binary
+    // run sequentially; a prior test's Stop() sets the flag, and without
+    // a reset subsequent server starts would not properly handle
+    // wait-* RPC traffic. Production also benefits: restarting an RPC
+    // server (e.g. after re-init) returns to a clean wait-state.
+    // (Reuses the test-only reset method since the operation is
+    // identical.)
+    ResetClusterStateForTests();
+
 #ifdef _WIN32
     WSADATA wsaData;
     if (WSAStartup(MAKEWORD(2, 2), &wsaData) != 0) {
@@ -8786,6 +8796,16 @@ void CRPCServer::NotifyBlockTipChanged() {
 void CRPCServer::NotifyClusterShutdown() {
     g_wait_cluster_shutdown.store(true, std::memory_order_relaxed);
     g_wait_cluster_cv.notify_all();
+}
+
+// Test-only reset: Boost test suites in this binary run sequentially and
+// share process-wide state. A prior test that called CRPCServer::Stop()
+// leaves g_wait_cluster_shutdown=true, which would short-circuit
+// wait-* RPC predicates in subsequent tests. Test fixtures call this
+// at setup to get a clean slate. Production paths reset implicitly
+// via Start().
+void CRPCServer::ResetClusterStateForTests() {
+    g_wait_cluster_shutdown.store(false, std::memory_order_relaxed);
 }
 
 

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -508,6 +508,14 @@ void CRPCServer::Stop() {
 
     m_running = false;
 
+    // PR #38 red-team C5: wake any RPC worker parked in a wait-* long-poll
+    // (waitfornewblock / waitforblock / waitforblockheight). Without this,
+    // Ctrl+C would hang the node up to 5 minutes per outstanding wait
+    // because the workers only wake on a real chain advancement. Done
+    // before any other shutdown step so the workers can drain their
+    // responses while the rest of teardown proceeds in parallel.
+    NotifyClusterShutdown();
+
     // Phase 4: Stop WebSocket server
     if (m_websocket_server) {
         m_websocket_server->Stop();
@@ -8507,6 +8515,14 @@ namespace {
 std::mutex              g_wait_cluster_mtx;
 std::condition_variable g_wait_cluster_cv;
 
+// PR #38 red-team C5: shutdown flag. CRPCServer::Stop() sets this and
+// notify_all()s the CV (via WakeWaitClusterForShutdown) so any worker
+// thread parked in wait_until on a long-poll wait-* RPC wakes immediately
+// (otherwise Ctrl+C hangs the node up to 5 minutes per outstanding
+// wait). Predicates check this flag and return the current tip
+// (timeout-equivalent path) on shutdown.
+std::atomic<bool>       g_wait_cluster_shutdown{false};
+
 // ---- Object-style param parsing helpers (Dilithion uses object params) ----
 
 // Returns true and writes hex string to `out` if `params` contains
@@ -8618,9 +8634,22 @@ uint256 CombineHashes(const uint256& left, const uint256& right) {
 // Tree-height for a block of N leaves. Dilithion duplicates the last leaf
 // at odd levels (BuildMerkleRoot does levelSize = (levelSize + 1) / 2),
 // so the height is ceil(log2(N)) for N >= 2 and 0 for N <= 1.
+//
+// Hardened post-redteam (PR #38 BLOCKER B1):
+// - Loop counter is `unsigned int` and the shift uses 1ULL to avoid
+//   undefined behaviour at height >= 32 (`1u << 32` is UB; on x86_64
+//   gcc/clang/MSVC the shift count is masked to 5 bits and `1u << 32`
+//   evaluates to 1, so the loop never terminates -- an authenticated
+//   RPC caller submitting nTransactions = 0xFFFFFFFF would spin a worker
+//   thread forever, DoSing the 8-thread RPC pool with 8 crafted requests.
+// - Loop is upper-bounded at 32 iterations: nTransactions is uint32_t,
+//   so ceil(log2(N)) <= 32 always. The bound is defensive against
+//   miscompilation or future signedness changes.
+// - Caller MUST validate nTransactions against a sane block-tx count
+//   before calling (e.g. RPC_VerifyTxOutProof caps at MAX_BLOCK_TXS).
 int MerkleTreeHeight(uint32_t nTransactions) {
     int height = 0;
-    while ((1u << height) < nTransactions) ++height;
+    while (height < 32 && (1ULL << height) < nTransactions) ++height;
     return height;
 }
 
@@ -8749,6 +8778,16 @@ void CRPCServer::NotifyBlockTipChanged() {
     g_wait_cluster_cv.notify_all();
 }
 
+// PR #38 red-team C5: shutdown wake-up for the wait-* cluster.
+// CRPCServer::Stop() calls this so any worker parked in wait_until wakes
+// promptly. Setting the shutdown flag + notify_all is sufficient; the
+// wait predicates check the flag and return the current tip without
+// waiting for a real chain advancement.
+void CRPCServer::NotifyClusterShutdown() {
+    g_wait_cluster_shutdown.store(true, std::memory_order_relaxed);
+    g_wait_cluster_cv.notify_all();
+}
+
 
 // ----------------------------------------------------------------------------
 // CRPCServer::RPC_WaitForNewBlock
@@ -8774,7 +8813,8 @@ std::string CRPCServer::RPC_WaitForNewBlock(const std::string& params) {
 
     std::unique_lock<std::mutex> lock(g_wait_cluster_mtx);
     g_wait_cluster_cv.wait_until(lock, deadline, [&]() {
-        return get_tip().first != initial.first;
+        return g_wait_cluster_shutdown.load(std::memory_order_relaxed) ||
+               get_tip().first != initial.first;
     });
     auto current = get_tip();
     return FormatTipResponse(current.first, current.second);
@@ -8805,7 +8845,8 @@ std::string CRPCServer::RPC_WaitForBlock(const std::string& params) {
 
     std::unique_lock<std::mutex> lock(g_wait_cluster_mtx);
     g_wait_cluster_cv.wait_until(lock, deadline, [&]() {
-        return get_tip().first == wanted;
+        return g_wait_cluster_shutdown.load(std::memory_order_relaxed) ||
+               get_tip().first == wanted;
     });
     auto current = get_tip();
     return FormatTipResponse(current.first, current.second);
@@ -8835,7 +8876,8 @@ std::string CRPCServer::RPC_WaitForBlockHeight(const std::string& params) {
 
     std::unique_lock<std::mutex> lock(g_wait_cluster_mtx);
     g_wait_cluster_cv.wait_until(lock, deadline, [&]() {
-        return get_tip().second >= target;
+        return g_wait_cluster_shutdown.load(std::memory_order_relaxed) ||
+               get_tip().second >= target;
     });
     auto current = get_tip();
     return FormatTipResponse(current.first, current.second);
@@ -9010,6 +9052,27 @@ std::string CRPCServer::RPC_VerifyTxOutProof(const std::string& params) {
     uint32_t nTransactions = stream.ReadUint32();
     if (nTransactions == 0) {
         throw std::runtime_error("proof: nTransactions must be > 0");
+    }
+    // Red-team B1+C1: cap nTransactions at a sane block-tx upper bound.
+    // Without this:
+    //   B1: MerkleTreeHeight(0xFFFFFFFF) hits the 32-iteration loop bound
+    //       defensively, but only after the bound was added; an attacker
+    //       could otherwise drive a worker thread into infinite spin via
+    //       UB on `1u << 32`.
+    //   C1: hashes.reserve(nHashes) with nHashes <= nTransactions =
+    //       4'000'000'000 requests ~128 GB before any hash bytes are
+    //       read. bad_alloc is uncaught at this RPC entrypoint and
+    //       would propagate to the worker, killing it.
+    // Bitcoin Core caps via MAX_BLOCK_WEIGHT/MIN_TRANSACTION_WEIGHT
+    // (~250k). Dilithion's Consensus::MAX_TX_PER_BLOCK is the right
+    // analog. Pick a generous defensive bound that still rejects the
+    // pathological cases above; tighter than MAX_BLOCK_WEIGHT but well
+    // above any plausible legitimate block.
+    static constexpr uint32_t kVerifyTxOutProofMaxTxs = 1'000'000;
+    if (nTransactions > kVerifyTxOutProofMaxTxs) {
+        throw std::runtime_error(
+            "proof: nTransactions exceeds maximum (" +
+            std::to_string(kVerifyTxOutProofMaxTxs) + ")");
     }
     uint64_t nHashes = stream.ReadCompactSize();
     if (nHashes > nTransactions) {

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -313,10 +313,16 @@ CRPCServer::CRPCServer(uint16_t port)
     m_handlers["getmikattestation"] = [this](const std::string& p) { return RPC_GetMIKAttestation(p); };
 
     // T1.B: small RPCs cluster (Bitcoin Core port v28.0).
-    // getblockstats + gettxoutproof are instance methods (need m_blockchain
-    // / m_chainstate access). The wait-* family + verifytxoutproof are
-    // static -- they read only g_chainstate or are pure-input.
-    m_handlers["getblockstats"]      = [this](const std::string& p) { return RPC_GetBlockStats(p); };
+    // gettxoutproof is an instance method (needs m_blockchain access). The
+    // wait-* family + verifytxoutproof are static -- they read only
+    // g_chainstate or are pure-input.
+    //
+    // getblockstats is intentionally omitted from this cluster: shipping
+    // without per-tx fee fields (avgfee/medianfee/feerate_percentiles/...)
+    // would violate the project's "do not defer" + "world-class port from
+    // Bitcoin Core" principles. It lands in the dedicated block-analytics
+    // PR alongside undo-data exposure (T1.G coinstatsindex bundle) so the
+    // full BC schema ships in one shot.
     m_handlers["waitfornewblock"]    = [](const std::string& p) { return RPC_WaitForNewBlock(p); };
     m_handlers["waitforblock"]       = [](const std::string& p) { return RPC_WaitForBlock(p); };
     m_handlers["waitforblockheight"] = [](const std::string& p) { return RPC_WaitForBlockHeight(p); };
@@ -5379,7 +5385,6 @@ std::string CRPCServer::RPC_Help(const std::string& params) {
     oss << "\"listswaps - List all known atomic swaps and their states\",";
 
     // T1.B: small RPCs cluster (Bitcoin Core port v28.0)
-    oss << "\"getblockstats - Per-block analytics (size, fees, subsidy, utxo delta)\",";
     oss << "\"waitfornewblock - Block until a new tip is connected (timeout_ms default 30000, max 300000)\",";
     oss << "\"waitforblock - Block until tip equals supplied hash (timeout_ms default 30000)\",";
     oss << "\"waitforblockheight - Block until tip reaches supplied height (timeout_ms default 30000)\",";
@@ -8419,7 +8424,6 @@ std::string CRPCServer::RPC_GetMIKAttestation(const std::string& params) {
 // ============================================================================
 // Small RPCs cluster (T1.B) -- Bitcoin Core port v28.0
 // ----------------------------------------------------------------------------
-//   getblockstats           src/rpc/blockchain.cpp v28.0
 //   waitfornewblock         src/rpc/blockchain.cpp v28.0
 //   waitforblock            src/rpc/blockchain.cpp v28.0
 //   waitforblockheight      src/rpc/blockchain.cpp v28.0
@@ -8694,188 +8698,6 @@ void CRPCServer::NotifyBlockTipChanged() {
     g_wait_cluster_cv.notify_all();
 }
 
-// ----------------------------------------------------------------------------
-// CRPCServer::RPC_GetBlockStats
-// ----------------------------------------------------------------------------
-// Per-block analytics for explorers. Bitcoin Core port; some segwit-only
-// fields are intentionally omitted because Dilithion is non-segwit:
-//
-//   omitted: swtotal_size, swtotal_weight, swtxs, total_weight
-//
-// Per-tx fee fields (avgfee, medianfee, maxfee, minfee, feerate_percentiles,
-// avgfeerate, maxfeerate, minfeerate) are also omitted: Bitcoin Core
-// computes these via prevout lookups against an undo file, which Dilithion
-// does not currently expose at this layer. `totalfee` IS reported, derived
-// from the coinbase output sum minus the block subsidy -- the same formula
-// Bitcoin Core uses as a fallback when undo data is unavailable.
-//
-// Field set (alphabetical):
-//   avgtxsize, blockhash, height, ins, maxtxsize, mediantime, mediantxsize,
-//   mintxsize, outs, subsidy, time, total_out, total_size, totalfee, txs,
-//   utxo_increase
-//
-// Param: object {"hash_or_height": <hex|int>}. Either form accepted (the
-// hash field name is `hash`, the height field name is `height`; supplying
-// both is rejected).
-std::string CRPCServer::RPC_GetBlockStats(const std::string& params) {
-    if (!m_blockchain) throw std::runtime_error("Blockchain not initialized");
-    if (!m_chainstate) throw std::runtime_error("Chain state not initialized");
-
-    // Resolve target block.
-    std::string hash_str;
-    int64_t height_param = -1;
-    bool have_hash = TryParseStringParam(params, "hash", hash_str);
-    bool have_height = TryParseIntParam(params, "height", height_param);
-    // Convenience alias: hash_or_height accepts either.
-    std::string hor;
-    if (!have_hash && !have_height && TryParseStringParam(params, "hash_or_height", hor)) {
-        if (hor.size() == 64) { hash_str = hor; have_hash = true; }
-        else {
-            try { height_param = std::stoll(hor); have_height = true; }
-            catch (...) { throw std::runtime_error("hash_or_height must be a 64-char hex hash or an integer height"); }
-        }
-    }
-    if (have_hash && have_height) {
-        throw std::runtime_error("Specify either hash or height, not both");
-    }
-    if (!have_hash && !have_height) {
-        throw std::runtime_error("Missing hash or height parameter");
-    }
-
-    uint256 target_hash;
-    if (have_height) {
-        if (height_param < 0) throw std::runtime_error("height must be non-negative");
-        CBlockIndex* pTip = m_chainstate->GetTip();
-        if (!pTip || height_param > pTip->nHeight) {
-            throw std::runtime_error("Block height out of range");
-        }
-        CBlockIndex* pBlock = pTip->GetAncestor(static_cast<int>(height_param));
-        if (!pBlock) throw std::runtime_error("No block at that height");
-        target_hash = pBlock->GetBlockHash();
-    } else {
-        target_hash = ParseHash64(hash_str, "hash");
-    }
-
-    CBlock block;
-    if (!m_blockchain->ReadBlock(target_hash, block)) {
-        throw std::runtime_error("Block not found");
-    }
-
-    CBlockIndex blockIndex;
-    int height = -1;
-    if (m_blockchain->ReadBlockIndex(target_hash, blockIndex)) {
-        height = blockIndex.nHeight;
-    }
-    if (height < 0) {
-        // Fallback: walk ancestors via active tip.
-        CBlockIndex* pTip = m_chainstate->GetTip();
-        if (pTip) {
-            for (CBlockIndex* p = pTip; p; p = p->pprev) {
-                if (p->GetBlockHash() == target_hash) { height = p->nHeight; break; }
-            }
-        }
-    }
-    if (height < 0) throw std::runtime_error("Block index missing for given block");
-
-    CBlockValidator validator;
-    std::vector<CTransactionRef> transactions;
-    std::string deserializeError;
-    if (!validator.DeserializeBlockTransactions(block, transactions, deserializeError)) {
-        throw std::runtime_error("Failed to deserialize block transactions: " + deserializeError);
-    }
-
-    // Aggregates -- per-tx size + per-block input/output totals.
-    std::vector<size_t> tx_sizes;
-    tx_sizes.reserve(transactions.size());
-    uint64_t total_size = block.vtx.size();      // serialized tx-array size
-    uint64_t total_out  = 0;                      // total non-coinbase output value
-    uint64_t coinbase_out = 0;                    // sum of coinbase outputs (subsidy + fees)
-    uint64_t ins  = 0;
-    uint64_t outs = 0;
-    for (size_t i = 0; i < transactions.size(); ++i) {
-        const auto& tx = transactions[i];
-        size_t sz = tx->GetSerializedSize();
-        tx_sizes.push_back(sz);
-        if (i == 0) {
-            // Coinbase: the only TX whose inputs aren't real outpoints.
-            for (const auto& vo : tx->vout) coinbase_out += vo.nValue;
-            outs += tx->vout.size();
-        } else {
-            ins  += tx->vin.size();
-            outs += tx->vout.size();
-            for (const auto& vo : tx->vout) total_out += vo.nValue;
-        }
-    }
-
-    uint64_t subsidy = CBlockValidator::CalculateBlockSubsidy(static_cast<uint32_t>(height));
-    // totalfee = coinbase_out - subsidy (clamped at 0; under-paid coinbase
-    // would be a consensus failure, but we report 0 rather than overflow).
-    uint64_t totalfee = (coinbase_out >= subsidy) ? (coinbase_out - subsidy) : 0;
-
-    // Median txsize via std::nth_element (KISS, no helper header).
-    uint64_t mintxsize = 0, maxtxsize = 0, mediantxsize = 0;
-    double avgtxsize = 0.0;
-    if (!tx_sizes.empty()) {
-        auto minmax = std::minmax_element(tx_sizes.begin(), tx_sizes.end());
-        mintxsize = *minmax.first;
-        maxtxsize = *minmax.second;
-        size_t mid = tx_sizes.size() / 2;
-        std::nth_element(tx_sizes.begin(), tx_sizes.begin() + mid, tx_sizes.end());
-        mediantxsize = tx_sizes[mid];
-        uint64_t sum = 0;
-        for (size_t s : tx_sizes) sum += s;
-        avgtxsize = static_cast<double>(sum) / tx_sizes.size();
-    }
-
-    // mediantime: median nTime of the last 11 blocks (chain median past time)
-    // -- standard explorer field. Fallback to block.nTime when ancestors are
-    // unavailable.
-    uint64_t mediantime = block.nTime;
-    {
-        CBlockIndex* pTip = m_chainstate->GetTip();
-        if (pTip) {
-            CBlockIndex* p = pTip->GetAncestor(height);
-            if (p) {
-                std::vector<uint32_t> times;
-                CBlockIndex* it = p;
-                for (int i = 0; i < 11 && it; ++i) {
-                    times.push_back(it->nTime);
-                    it = it->pprev;
-                }
-                if (!times.empty()) {
-                    size_t mid = times.size() / 2;
-                    std::nth_element(times.begin(), times.begin() + mid, times.end());
-                    mediantime = times[mid];
-                }
-            }
-        }
-    }
-
-    // utxo_increase = (outputs created in this block) - (inputs consumed).
-    // Coinbase always creates outputs without consuming any prevouts.
-    int64_t utxo_increase = static_cast<int64_t>(outs) - static_cast<int64_t>(ins);
-
-    std::ostringstream oss;
-    oss << "{";
-    oss << "\"avgtxsize\":" << avgtxsize << ",";
-    oss << "\"blockhash\":\"" << target_hash.GetHex() << "\",";
-    oss << "\"height\":" << height << ",";
-    oss << "\"ins\":" << ins << ",";
-    oss << "\"maxtxsize\":" << maxtxsize << ",";
-    oss << "\"mediantime\":" << mediantime << ",";
-    oss << "\"mediantxsize\":" << mediantxsize << ",";
-    oss << "\"mintxsize\":" << mintxsize << ",";
-    oss << "\"outs\":" << outs << ",";
-    oss << "\"subsidy\":" << subsidy << ",";
-    oss << "\"time\":" << block.nTime << ",";
-    oss << "\"total_out\":" << total_out << ",";
-    oss << "\"total_size\":" << total_size << ",";
-    oss << "\"totalfee\":" << totalfee << ",";
-    oss << "\"txs\":" << transactions.size() << ",";
-    oss << "\"utxo_increase\":" << utxo_increase;
-    oss << "}";
-    return oss.str();
-}
 
 // ----------------------------------------------------------------------------
 // CRPCServer::RPC_WaitForNewBlock

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -678,6 +678,12 @@ public:
     // wait-* call.
     static void NotifyClusterShutdown();
 
+    // Test-only: clear the cluster shutdown flag so wait-* RPCs called
+    // after a prior test's Stop() don't short-circuit. Called from
+    // test fixtures, NOT from production code paths. Production
+    // resets the flag implicitly via Start() instead.
+    static void ResetClusterStateForTests();
+
     // Default and maximum wait-* timeouts in milliseconds. Exposed for tests.
     static constexpr int kDefaultWaitTimeoutMs = 30000;   // 30 seconds
     static constexpr int kMaxWaitTimeoutMs     = 300000;  // 5 minutes

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -635,6 +635,41 @@ public:
     // process-wide `g_tx_index` global. Public + static lets tests exercise the formatter
     // directly without standing up a full HTTP server (schema-lock-in coverage).
     static std::string RPC_GetIndexInfo(const std::string& params);
+
+    // ------------------------------------------------------------------------
+    // Small RPCs cluster (T1.B) -- Bitcoin Core port v28.0.
+    //
+    // The wait-* RPCs and `verifytxoutproof` are STATIC + PUBLIC for the
+    // same reason as RPC_GetIndexInfo: they read only process-wide
+    // globals (g_chainstate / cluster condition variable) or operate on
+    // pure-input hex, neither of which is CRPCServer instance state.
+    // Static exposure also keeps them callable from unit tests without
+    // standing up an HTTP server.
+    //
+    // `getblockstats` and `gettxoutproof` are instance methods because
+    // they need to reach into m_blockchain / m_utxo_set / m_chainstate.
+    //
+    // Default timeout 30s, cap 300s (DoS guard -- worker threads in the
+    // RPC thread-pool would otherwise be tied up by an unbounded number
+    // of long-poll clients).
+    std::string RPC_GetBlockStats(const std::string& params);
+    static std::string RPC_WaitForNewBlock(const std::string& params);
+    static std::string RPC_WaitForBlock(const std::string& params);
+    static std::string RPC_WaitForBlockHeight(const std::string& params);
+    std::string RPC_GetTxOutProof(const std::string& params);
+    static std::string RPC_VerifyTxOutProof(const std::string& params);
+
+    // Hook for the chainstate block-connect callback to wake any RPC worker
+    // currently parked on the cluster's condition variable. Registered once
+    // from each node's startup path (dilithion-node.cpp / dilv-node.cpp)
+    // alongside the existing wallet / index callbacks. Idempotent and
+    // exception-safe so a callback storm never trips the chainstate's
+    // outer try/catch loop.
+    static void NotifyBlockTipChanged();
+
+    // Default and maximum wait-* timeouts in milliseconds. Exposed for tests.
+    static constexpr int kDefaultWaitTimeoutMs = 30000;   // 30 seconds
+    static constexpr int kMaxWaitTimeoutMs     = 300000;  // 5 minutes
 };
 
 #endif // DILITHION_RPC_SERVER_H

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -646,13 +646,16 @@ public:
     // Static exposure also keeps them callable from unit tests without
     // standing up an HTTP server.
     //
-    // `getblockstats` and `gettxoutproof` are instance methods because
-    // they need to reach into m_blockchain / m_utxo_set / m_chainstate.
+    // `gettxoutproof` is an instance method because it needs to reach
+    // into m_blockchain / m_utxo_set / m_chainstate.
     //
     // Default timeout 30s, cap 300s (DoS guard -- worker threads in the
     // RPC thread-pool would otherwise be tied up by an unbounded number
     // of long-poll clients).
-    std::string RPC_GetBlockStats(const std::string& params);
+    //
+    // getblockstats is intentionally not in this cluster: it requires
+    // per-tx fee fields that depend on undo-data exposure (separate
+    // workstream alongside coinstatsindex).
     static std::string RPC_WaitForNewBlock(const std::string& params);
     static std::string RPC_WaitForBlock(const std::string& params);
     static std::string RPC_WaitForBlockHeight(const std::string& params);

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -670,6 +670,14 @@ public:
     // outer try/catch loop.
     static void NotifyBlockTipChanged();
 
+    // PR #38 red-team C5: called from Stop() to release any worker thread
+    // parked in a wait-* RPC. Sets a shutdown flag and notify_all()s the
+    // cluster CV; the wait predicates check the flag and return the
+    // current tip immediately (timeout-equivalent fast path). Without
+    // this, Ctrl+C would hang the node up to 5 minutes per outstanding
+    // wait-* call.
+    static void NotifyClusterShutdown();
+
     // Default and maximum wait-* timeouts in milliseconds. Exposed for tests.
     static constexpr int kDefaultWaitTimeoutMs = 30000;   // 30 seconds
     static constexpr int kMaxWaitTimeoutMs     = 300000;  // 5 minutes

--- a/src/test/rpc_small_cluster_tests.cpp
+++ b/src/test/rpc_small_cluster_tests.cpp
@@ -3,22 +3,24 @@
 
 // Boost unit tests for the small-RPCs cluster ported from Bitcoin Core
 // v28.0 (T1.B). Coverage:
-//   getblockstats          -- happy path (returns expected schema for a
-//                             synthesized block) + height-out-of-range
-//                             negative case.
 //   waitfornewblock        -- short-timeout returns the current tip.
 //   waitforblock           -- short-timeout returns the current tip.
 //   waitforblockheight     -- already-met height returns immediately.
+//   waitforblockheight     -- notify wakes a waiter early.
 //   gettxoutproof          -- happy path (proof is constructed and
 //                             verifytxoutproof recovers the txids)
 //                             plus non-existent-txid negative case.
 //   verifytxoutproof       -- corrupted-hex negative case.
 //
+// getblockstats is intentionally not in this cluster: it requires
+// per-tx fee fields that depend on undo-data exposure (separate
+// workstream alongside coinstatsindex).
+//
 // These exercise CRPCServer's public surface directly; they do NOT
 // stand up the HTTP server. Static handlers run as plain function
-// calls, and the two instance-method handlers (getblockstats /
-// gettxoutproof) run against a CRPCServer constructed with a non-
-// production port (no Listen() ever called).
+// calls, and the instance-method handler (gettxoutproof) runs against
+// a CRPCServer constructed with a non-production port (no Listen()
+// ever called).
 
 #include <boost/test/unit_test.hpp>
 
@@ -26,6 +28,7 @@
 
 #include <consensus/chain.h>
 #include <consensus/validation.h>
+#include <core/chainparams.h>
 #include <node/block_index.h>
 #include <node/blockchain_storage.h>
 #include <primitives/block.h>
@@ -108,8 +111,7 @@ CTransactionRef MakeUniqueTx(uint8_t seed_a, uint8_t seed_b) {
 
 // Coinbase: vin[0].prevout is null. Output value = subsidy + fee. We use
 // 50 DIL = 5'000'000'000 ions (matches CalculateBlockSubsidy at height 0
-// for the default chain params); test exclusion-from-fee path is checked
-// indirectly via getblockstats's totalfee field.
+// for the default chain params).
 CTransactionRef MakeCoinbaseTx(uint64_t value, uint8_t scriptsig_seed) {
     CTransaction tx;
     tx.nVersion = 1;
@@ -138,9 +140,9 @@ CBlock MakeBlock(const std::vector<CTransactionRef>& txs) {
     }
     block.vtx = std::move(vtx_data);
 
-    // Build merkle root so the block is internally consistent (some
-    // RPC paths verify it; getblockstats does not, but
-    // verifytxoutproof does compare reconstructed roots).
+    // Build merkle root so the block is internally consistent
+    // (verifytxoutproof compares reconstructed roots against the
+    // block header's hashMerkleRoot).
     CBlockValidator validator;
     block.hashMerkleRoot = validator.BuildMerkleRoot(txs);
     return block;
@@ -171,6 +173,21 @@ struct ClusterChainFixture {
         per_height_block.reserve(n_blocks);
 
         g_chainstate.Cleanup();
+
+        // Ensure chain params are initialized before any subsidy/difficulty
+        // computation. CalculateBlockSubsidy reads halvingInterval from
+        // g_chainParams; if g_chainParams is zero-initialized (default-
+        // constructed via `new ChainParams()`), halvingInterval==0 causes
+        // an integer divide-by-zero. The local agent's tests passed only
+        // because some prior test in the suite happened to leave a valid
+        // g_chainParams behind; on fresh CI, the divide-by-zero crashes
+        // test execution. Set up Mainnet defaults here for determinism.
+        if (Dilithion::g_chainParams == nullptr ||
+            Dilithion::g_chainParams->halvingInterval == 0) {
+            static Dilithion::ChainParams cluster_test_params =
+                Dilithion::ChainParams::Mainnet();
+            Dilithion::g_chainParams = &cluster_test_params;
+        }
 
         CBlockIndex* prev_idx = nullptr;
         uint64_t subsidy = CBlockValidator::CalculateBlockSubsidy(0);
@@ -255,7 +272,7 @@ bool ExtractScalar(const std::string& body,
 
 // ---- Help-text and registration smoke test ----
 
-BOOST_AUTO_TEST_CASE(help_text_lists_all_six_rpcs) {
+BOOST_AUTO_TEST_CASE(help_text_lists_all_five_rpcs) {
     CRPCServer srv(0);  // port 0; never starts the listener
     // RPC_Help is private but exposed via the "help" handler. We don't
     // call the full request path here; instead we just confirm that the
@@ -423,78 +440,6 @@ BOOST_AUTO_TEST_CASE(wait_timeout_zero_rejected) {
     BOOST_CHECK_THROW(
         CRPCServer::RPC_WaitForNewBlock("{\"timeout_ms\":0}"),
         std::runtime_error);
-}
-
-// ---- getblockstats: happy path + negative case ----
-
-BOOST_AUTO_TEST_CASE(getblockstats_happy_path) {
-    TempDbScope scope_chain("getblockstats_chain");
-    CBlockchainDB chain_db;
-    BOOST_REQUIRE(chain_db.Open(scope_chain.path(), true));
-    ClusterChainFixture fix;
-    fix.Build(3, chain_db);
-
-    CRPCServer srv(0);
-    srv.RegisterBlockchain(&chain_db);
-    srv.RegisterChainState(&g_chainstate);
-
-    std::string params = "{\"height\":1}";
-    std::string body = srv.RPC_GetBlockStats(params);
-
-    // Schema: every documented field present.
-    BOOST_CHECK(body.find("\"avgtxsize\":")     != std::string::npos);
-    BOOST_CHECK(body.find("\"blockhash\":\"")   != std::string::npos);
-    BOOST_CHECK(body.find("\"height\":1")       != std::string::npos);
-    BOOST_CHECK(body.find("\"ins\":")           != std::string::npos);
-    BOOST_CHECK(body.find("\"maxtxsize\":")     != std::string::npos);
-    BOOST_CHECK(body.find("\"mediantime\":")    != std::string::npos);
-    BOOST_CHECK(body.find("\"mediantxsize\":")  != std::string::npos);
-    BOOST_CHECK(body.find("\"mintxsize\":")     != std::string::npos);
-    BOOST_CHECK(body.find("\"outs\":")          != std::string::npos);
-    BOOST_CHECK(body.find("\"subsidy\":")       != std::string::npos);
-    BOOST_CHECK(body.find("\"time\":")          != std::string::npos);
-    BOOST_CHECK(body.find("\"total_out\":")     != std::string::npos);
-    BOOST_CHECK(body.find("\"total_size\":")    != std::string::npos);
-    BOOST_CHECK(body.find("\"totalfee\":")      != std::string::npos);
-    BOOST_CHECK(body.find("\"txs\":2")          != std::string::npos);
-    BOOST_CHECK(body.find("\"utxo_increase\":") != std::string::npos);
-
-    // totalfee = coinbase_out - subsidy = 0 (we built coinbase paying
-    // exactly the subsidy with no fee top-up).
-    std::string fee;
-    BOOST_REQUIRE(ExtractScalar(body, "totalfee", fee));
-    BOOST_CHECK_EQUAL(fee, "0");
-
-    // Hash matches what we built.
-    std::string returned_hash;
-    BOOST_REQUIRE(ExtractScalar(body, "blockhash", returned_hash));
-    BOOST_CHECK_EQUAL(returned_hash, fix.per_height_hash[1].GetHex());
-
-    g_chainstate.Cleanup();
-}
-
-BOOST_AUTO_TEST_CASE(getblockstats_height_out_of_range_rejected) {
-    TempDbScope scope_chain("getblockstats_oor");
-    CBlockchainDB chain_db;
-    BOOST_REQUIRE(chain_db.Open(scope_chain.path(), true));
-    ClusterChainFixture fix;
-    fix.Build(2, chain_db);
-
-    CRPCServer srv(0);
-    srv.RegisterBlockchain(&chain_db);
-    srv.RegisterChainState(&g_chainstate);
-
-    BOOST_CHECK_THROW(
-        srv.RPC_GetBlockStats("{\"height\":99}"),
-        std::runtime_error);
-    BOOST_CHECK_THROW(
-        srv.RPC_GetBlockStats("{\"height\":-5}"),
-        std::runtime_error);
-    BOOST_CHECK_THROW(
-        srv.RPC_GetBlockStats("{}"),
-        std::runtime_error);
-
-    g_chainstate.Cleanup();
 }
 
 // ---- gettxoutproof + verifytxoutproof: round-trip ----

--- a/src/test/rpc_small_cluster_tests.cpp
+++ b/src/test/rpc_small_cluster_tests.cpp
@@ -1,0 +1,588 @@
+// Copyright (c) 2026 The Dilithion Core developers
+// Distributed under the MIT software license
+
+// Boost unit tests for the small-RPCs cluster ported from Bitcoin Core
+// v28.0 (T1.B). Coverage:
+//   getblockstats          -- happy path (returns expected schema for a
+//                             synthesized block) + height-out-of-range
+//                             negative case.
+//   waitfornewblock        -- short-timeout returns the current tip.
+//   waitforblock           -- short-timeout returns the current tip.
+//   waitforblockheight     -- already-met height returns immediately.
+//   gettxoutproof          -- happy path (proof is constructed and
+//                             verifytxoutproof recovers the txids)
+//                             plus non-existent-txid negative case.
+//   verifytxoutproof       -- corrupted-hex negative case.
+//
+// These exercise CRPCServer's public surface directly; they do NOT
+// stand up the HTTP server. Static handlers run as plain function
+// calls, and the two instance-method handlers (getblockstats /
+// gettxoutproof) run against a CRPCServer constructed with a non-
+// production port (no Listen() ever called).
+
+#include <boost/test/unit_test.hpp>
+
+#include <rpc/server.h>
+
+#include <consensus/chain.h>
+#include <consensus/validation.h>
+#include <node/block_index.h>
+#include <node/blockchain_storage.h>
+#include <primitives/block.h>
+#include <primitives/transaction.h>
+
+#include <chrono>
+#include <cstring>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <system_error>
+#include <thread>
+#include <vector>
+
+extern CChainState g_chainstate;
+
+BOOST_AUTO_TEST_SUITE(rpc_small_cluster_tests)
+
+namespace {
+
+// ---- Test scaffolding (mirrors patterns from tx_index_tests.cpp) ----
+
+std::string MakeTempDir(const std::string& tag) {
+    auto base = std::filesystem::temp_directory_path();
+    auto path = base / ("rpc_small_cluster_" + tag + "_" +
+        std::to_string(static_cast<long long>(
+            std::chrono::steady_clock::now().time_since_epoch().count())));
+    std::filesystem::create_directories(path);
+    return path.string();
+}
+
+void CleanupTempDir(const std::string& path) {
+    std::error_code ec;
+    std::filesystem::remove_all(path, ec);
+}
+
+class TempDbScope {
+public:
+    explicit TempDbScope(const std::string& tag) : m_path(MakeTempDir(tag)) {}
+    ~TempDbScope() { CleanupTempDir(m_path); }
+    const std::string& path() const { return m_path; }
+    TempDbScope(const TempDbScope&) = delete;
+    TempDbScope& operator=(const TempDbScope&) = delete;
+private:
+    std::string m_path;
+};
+
+void WriteCompactSize(std::vector<uint8_t>& data, uint64_t size) {
+    if (size < 253) {
+        data.push_back(static_cast<uint8_t>(size));
+    } else if (size <= 0xFFFF) {
+        data.push_back(253);
+        data.push_back(static_cast<uint8_t>(size & 0xFF));
+        data.push_back(static_cast<uint8_t>((size >> 8) & 0xFF));
+    } else if (size <= 0xFFFFFFFF) {
+        data.push_back(254);
+        for (int i = 0; i < 4; ++i) {
+            data.push_back(static_cast<uint8_t>((size >> (i * 8)) & 0xFF));
+        }
+    } else {
+        data.push_back(255);
+        for (int i = 0; i < 8; ++i) {
+            data.push_back(static_cast<uint8_t>((size >> (i * 8)) & 0xFF));
+        }
+    }
+}
+
+CTransactionRef MakeUniqueTx(uint8_t seed_a, uint8_t seed_b) {
+    CTransaction tx;
+    tx.nVersion = 1;
+    tx.nLockTime = 0;
+    uint256 prev;
+    std::memset(prev.data, seed_a, 32);
+    std::vector<uint8_t> sig{seed_a, seed_b, 0xAA};
+    tx.vin.push_back(CTxIn(prev, seed_b, sig, CTxIn::SEQUENCE_FINAL));
+    std::vector<uint8_t> spk{0x76, 0xa9, 0x14, seed_a, seed_b};
+    tx.vout.push_back(CTxOut(1000ULL + seed_a, spk));
+    return MakeTransactionRef(tx);
+}
+
+// Coinbase: vin[0].prevout is null. Output value = subsidy + fee. We use
+// 50 DIL = 5'000'000'000 ions (matches CalculateBlockSubsidy at height 0
+// for the default chain params); test exclusion-from-fee path is checked
+// indirectly via getblockstats's totalfee field.
+CTransactionRef MakeCoinbaseTx(uint64_t value, uint8_t scriptsig_seed) {
+    CTransaction tx;
+    tx.nVersion = 1;
+    tx.nLockTime = 0;
+    CTxIn vin;
+    vin.prevout.SetNull();
+    vin.scriptSig = std::vector<uint8_t>{scriptsig_seed, 0x01, 0x02};
+    vin.nSequence = CTxIn::SEQUENCE_FINAL;
+    tx.vin.push_back(vin);
+    std::vector<uint8_t> spk{0x76, 0xa9, 0x14, scriptsig_seed, 0xCB};
+    tx.vout.push_back(CTxOut(value, spk));
+    return MakeTransactionRef(tx);
+}
+
+CBlock MakeBlock(const std::vector<CTransactionRef>& txs) {
+    CBlock block;
+    block.nVersion = 1;
+    block.nTime = 1700000000;
+    block.nBits = 0x1d00ffff;
+    block.nNonce = 0;
+    std::vector<uint8_t> vtx_data;
+    WriteCompactSize(vtx_data, txs.size());
+    for (const auto& tx : txs) {
+        auto data = tx->Serialize();
+        vtx_data.insert(vtx_data.end(), data.begin(), data.end());
+    }
+    block.vtx = std::move(vtx_data);
+
+    // Build merkle root so the block is internally consistent (some
+    // RPC paths verify it; getblockstats does not, but
+    // verifytxoutproof does compare reconstructed roots).
+    CBlockValidator validator;
+    block.hashMerkleRoot = validator.BuildMerkleRoot(txs);
+    return block;
+}
+
+uint256 SyntheticBlockHash(uint8_t seed) {
+    uint256 h;
+    std::memset(h.data, 0, 32);
+    h.data[0] = seed;
+    h.data[31] = 0xAB;
+    return h;
+}
+
+// Stand up a small chain (n blocks, each with one coinbase + one regular
+// tx), persisted to a CBlockchainDB so RPC handlers can ReadBlock /
+// ReadBlockIndex against it. Cleans up g_chainstate before building.
+struct ClusterChainFixture {
+    std::vector<uint256>                             per_height_hash;
+    std::vector<std::vector<CTransactionRef>>        per_height_txs;
+    std::vector<CBlock>                              per_height_block;
+
+    void Build(int n_blocks, CBlockchainDB& chain_db) {
+        per_height_hash.clear();
+        per_height_txs.clear();
+        per_height_block.clear();
+        per_height_hash.reserve(n_blocks);
+        per_height_txs.reserve(n_blocks);
+        per_height_block.reserve(n_blocks);
+
+        g_chainstate.Cleanup();
+
+        CBlockIndex* prev_idx = nullptr;
+        uint64_t subsidy = CBlockValidator::CalculateBlockSubsidy(0);
+
+        for (int h = 0; h < n_blocks; ++h) {
+            uint256 block_hash = SyntheticBlockHash(static_cast<uint8_t>(h + 1));
+            per_height_hash.push_back(block_hash);
+
+            // Coinbase pays subsidy exactly (no fees), then one user tx.
+            auto cb  = MakeCoinbaseTx(subsidy,
+                                      static_cast<uint8_t>(0xC0 | h));
+            auto utx = MakeUniqueTx(static_cast<uint8_t>(h + 0x10),
+                                    static_cast<uint8_t>(h + 0x20));
+            std::vector<CTransactionRef> txs{cb, utx};
+            per_height_txs.push_back(txs);
+
+            CBlock block = MakeBlock(txs);
+            block.nTime = 1700000000 + static_cast<uint32_t>(h * 60);
+            if (h == 0) {
+                block.hashPrevBlock = uint256();
+            } else {
+                block.hashPrevBlock = per_height_hash[h - 1];
+            }
+            BOOST_REQUIRE(chain_db.WriteBlock(block_hash, block));
+            {
+                CBlockIndex idx_persist;
+                idx_persist.nHeight = h;
+                idx_persist.phashBlock = block_hash;
+                idx_persist.nTime = block.nTime;
+                idx_persist.nVersion = block.nVersion;
+                idx_persist.header.hashMerkleRoot = block.hashMerkleRoot;
+                idx_persist.header.hashPrevBlock = block.hashPrevBlock;
+                idx_persist.nBits = block.nBits;
+                idx_persist.nNonce = block.nNonce;
+                idx_persist.nStatus = CBlockIndex::BLOCK_VALID_HEADER |
+                                      CBlockIndex::BLOCK_HAVE_DATA;
+                BOOST_REQUIRE(chain_db.WriteBlockIndex(block_hash, idx_persist));
+            }
+            per_height_block.push_back(block);
+
+            auto pidx = std::make_unique<CBlockIndex>();
+            pidx->nHeight = h;
+            pidx->phashBlock = block_hash;
+            pidx->pprev = prev_idx;
+            pidx->nTime = block.nTime;
+            pidx->nStatus = CBlockIndex::BLOCK_VALID_HEADER |
+                            CBlockIndex::BLOCK_HAVE_DATA;
+
+            CBlockIndex* raw = pidx.get();
+            BOOST_REQUIRE(g_chainstate.AddBlockIndex(block_hash,
+                                                     std::move(pidx)));
+            if (prev_idx != nullptr) prev_idx->pnext = raw;
+            prev_idx = raw;
+        }
+        if (prev_idx != nullptr) g_chainstate.SetTipForTest(prev_idx);
+    }
+};
+
+// Strip the "<key>": prefix off a JSON-string value embedded in our
+// hand-rolled JSON. Returns true if found; on success `value` is the
+// raw substring (no quotes for strings, raw token for ints).
+bool ExtractScalar(const std::string& body,
+                   const std::string& key,
+                   std::string& value) {
+    std::string needle = "\"" + key + "\":";
+    auto p = body.find(needle);
+    if (p == std::string::npos) return false;
+    p += needle.size();
+    if (p < body.size() && body[p] == '"') {
+        auto q = body.find('"', p + 1);
+        if (q == std::string::npos) return false;
+        value = body.substr(p + 1, q - p - 1);
+        return true;
+    }
+    auto end = body.find_first_of(",}", p);
+    if (end == std::string::npos) return false;
+    value = body.substr(p, end - p);
+    return true;
+}
+
+} // namespace
+
+// ---- Help-text and registration smoke test ----
+
+BOOST_AUTO_TEST_CASE(help_text_lists_all_six_rpcs) {
+    CRPCServer srv(0);  // port 0; never starts the listener
+    // RPC_Help is private but exposed via the "help" handler. We don't
+    // call the full request path here; instead we just confirm that the
+    // help-text addition compiles + that the handlers map is populated
+    // by introspecting NotifyBlockTipChanged (no-op) and the new
+    // statics being callable.
+    BOOST_CHECK_NO_THROW(CRPCServer::NotifyBlockTipChanged());
+}
+
+// ---- waitforblockheight: already-met case returns immediately ----
+
+BOOST_AUTO_TEST_CASE(waitforblockheight_already_met_returns_immediately) {
+    TempDbScope scope_chain("wait_height_chain");
+    CBlockchainDB chain_db;
+    BOOST_REQUIRE(chain_db.Open(scope_chain.path(), true));
+    ClusterChainFixture fix;
+    fix.Build(3, chain_db);
+
+    // Tip is at height 2. Asking for height 0 should return nearly
+    // instantly because the predicate is already true.
+    auto t0 = std::chrono::steady_clock::now();
+    std::string result = CRPCServer::RPC_WaitForBlockHeight(
+        "{\"height\":0,\"timeout_ms\":5000}");
+    auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - t0).count();
+    BOOST_CHECK_LT(elapsed, 1000);  // must not have actually waited
+
+    std::string height_str;
+    BOOST_REQUIRE(ExtractScalar(result, "height", height_str));
+    BOOST_CHECK_EQUAL(height_str, "2");
+
+    g_chainstate.Cleanup();
+}
+
+// ---- waitfornewblock + waitforblock: timeout returns current tip ----
+
+BOOST_AUTO_TEST_CASE(waitfornewblock_short_timeout_returns_tip) {
+    TempDbScope scope_chain("wait_new_chain");
+    CBlockchainDB chain_db;
+    BOOST_REQUIRE(chain_db.Open(scope_chain.path(), true));
+    ClusterChainFixture fix;
+    fix.Build(2, chain_db);  // tip at height 1
+
+    auto t0 = std::chrono::steady_clock::now();
+    std::string result = CRPCServer::RPC_WaitForNewBlock(
+        "{\"timeout_ms\":150}");
+    auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - t0).count();
+    BOOST_CHECK_GE(elapsed, 100);  // honored the timeout floor
+    BOOST_CHECK_LT(elapsed, 5000); // didn't wait forever
+
+    // Returned tip should be height 1 (no new block was connected).
+    std::string height_str;
+    BOOST_REQUIRE(ExtractScalar(result, "height", height_str));
+    BOOST_CHECK_EQUAL(height_str, "1");
+
+    g_chainstate.Cleanup();
+}
+
+BOOST_AUTO_TEST_CASE(waitforblock_short_timeout_returns_current_tip) {
+    TempDbScope scope_chain("wait_block_chain");
+    CBlockchainDB chain_db;
+    BOOST_REQUIRE(chain_db.Open(scope_chain.path(), true));
+    ClusterChainFixture fix;
+    fix.Build(1, chain_db);  // tip at height 0
+
+    // Wait for a hash that will never arrive.
+    uint256 ghost = SyntheticBlockHash(0xFE);
+    std::string params = std::string("{\"hash\":\"") + ghost.GetHex() +
+                         "\",\"timeout_ms\":120}";
+    auto t0 = std::chrono::steady_clock::now();
+    std::string result = CRPCServer::RPC_WaitForBlock(params);
+    auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - t0).count();
+    BOOST_CHECK_GE(elapsed, 80);
+
+    std::string height_str;
+    BOOST_REQUIRE(ExtractScalar(result, "height", height_str));
+    BOOST_CHECK_EQUAL(height_str, "0");
+
+    g_chainstate.Cleanup();
+}
+
+// ---- waitforblockheight: notify wakes a waiter early ----
+
+BOOST_AUTO_TEST_CASE(waitforblockheight_wakes_on_notify) {
+    TempDbScope scope_chain("wait_notify_chain");
+    CBlockchainDB chain_db;
+    BOOST_REQUIRE(chain_db.Open(scope_chain.path(), true));
+    ClusterChainFixture fix;
+    fix.Build(2, chain_db);  // tip at height 1
+
+    // Spawn a thread that, after a short delay, advances the tip and
+    // pings NotifyBlockTipChanged() the way the chainstate callback
+    // would in production.
+    std::thread bumper([&]() {
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        // Append a third block so tip advances to height 2.
+        uint256 block_hash = SyntheticBlockHash(0xF1);
+        auto cb  = MakeCoinbaseTx(
+            CBlockValidator::CalculateBlockSubsidy(0), 0xC9);
+        CBlock block = MakeBlock({cb});
+        block.nTime = 1700000999;
+        block.hashPrevBlock = fix.per_height_hash.back();
+        chain_db.WriteBlock(block_hash, block);
+        {
+            CBlockIndex idx_persist;
+            idx_persist.nHeight = 2;
+            idx_persist.phashBlock = block_hash;
+            idx_persist.nTime = block.nTime;
+            idx_persist.nVersion = block.nVersion;
+            idx_persist.header.hashMerkleRoot = block.hashMerkleRoot;
+            idx_persist.header.hashPrevBlock = block.hashPrevBlock;
+            idx_persist.nBits = block.nBits;
+            idx_persist.nNonce = block.nNonce;
+            idx_persist.nStatus = CBlockIndex::BLOCK_VALID_HEADER |
+                                  CBlockIndex::BLOCK_HAVE_DATA;
+            chain_db.WriteBlockIndex(block_hash, idx_persist);
+        }
+
+        auto pidx = std::make_unique<CBlockIndex>();
+        pidx->nHeight = 2;
+        pidx->phashBlock = block_hash;
+        pidx->pprev = g_chainstate.GetTip();
+        pidx->nTime = block.nTime;
+        pidx->nStatus = CBlockIndex::BLOCK_VALID_HEADER |
+                        CBlockIndex::BLOCK_HAVE_DATA;
+        CBlockIndex* raw = pidx.get();
+        g_chainstate.AddBlockIndex(block_hash, std::move(pidx));
+        if (auto* prev = g_chainstate.GetTip()) prev->pnext = raw;
+        g_chainstate.SetTipForTest(raw);
+        CRPCServer::NotifyBlockTipChanged();
+    });
+
+    auto t0 = std::chrono::steady_clock::now();
+    std::string result = CRPCServer::RPC_WaitForBlockHeight(
+        "{\"height\":2,\"timeout_ms\":5000}");
+    auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - t0).count();
+    bumper.join();
+
+    BOOST_CHECK_LT(elapsed, 4000);  // woke well before the 5s ceiling
+    std::string height_str;
+    BOOST_REQUIRE(ExtractScalar(result, "height", height_str));
+    BOOST_CHECK_EQUAL(height_str, "2");
+
+    g_chainstate.Cleanup();
+}
+
+// ---- waitforblock: bad hash rejected ----
+
+BOOST_AUTO_TEST_CASE(waitforblock_short_hex_rejected) {
+    BOOST_CHECK_THROW(
+        CRPCServer::RPC_WaitForBlock("{\"hash\":\"deadbeef\"}"),
+        std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(waitforblockheight_negative_rejected) {
+    BOOST_CHECK_THROW(
+        CRPCServer::RPC_WaitForBlockHeight("{\"height\":-1}"),
+        std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(wait_timeout_zero_rejected) {
+    BOOST_CHECK_THROW(
+        CRPCServer::RPC_WaitForNewBlock("{\"timeout_ms\":0}"),
+        std::runtime_error);
+}
+
+// ---- getblockstats: happy path + negative case ----
+
+BOOST_AUTO_TEST_CASE(getblockstats_happy_path) {
+    TempDbScope scope_chain("getblockstats_chain");
+    CBlockchainDB chain_db;
+    BOOST_REQUIRE(chain_db.Open(scope_chain.path(), true));
+    ClusterChainFixture fix;
+    fix.Build(3, chain_db);
+
+    CRPCServer srv(0);
+    srv.RegisterBlockchain(&chain_db);
+    srv.RegisterChainState(&g_chainstate);
+
+    std::string params = "{\"height\":1}";
+    std::string body = srv.RPC_GetBlockStats(params);
+
+    // Schema: every documented field present.
+    BOOST_CHECK(body.find("\"avgtxsize\":")     != std::string::npos);
+    BOOST_CHECK(body.find("\"blockhash\":\"")   != std::string::npos);
+    BOOST_CHECK(body.find("\"height\":1")       != std::string::npos);
+    BOOST_CHECK(body.find("\"ins\":")           != std::string::npos);
+    BOOST_CHECK(body.find("\"maxtxsize\":")     != std::string::npos);
+    BOOST_CHECK(body.find("\"mediantime\":")    != std::string::npos);
+    BOOST_CHECK(body.find("\"mediantxsize\":")  != std::string::npos);
+    BOOST_CHECK(body.find("\"mintxsize\":")     != std::string::npos);
+    BOOST_CHECK(body.find("\"outs\":")          != std::string::npos);
+    BOOST_CHECK(body.find("\"subsidy\":")       != std::string::npos);
+    BOOST_CHECK(body.find("\"time\":")          != std::string::npos);
+    BOOST_CHECK(body.find("\"total_out\":")     != std::string::npos);
+    BOOST_CHECK(body.find("\"total_size\":")    != std::string::npos);
+    BOOST_CHECK(body.find("\"totalfee\":")      != std::string::npos);
+    BOOST_CHECK(body.find("\"txs\":2")          != std::string::npos);
+    BOOST_CHECK(body.find("\"utxo_increase\":") != std::string::npos);
+
+    // totalfee = coinbase_out - subsidy = 0 (we built coinbase paying
+    // exactly the subsidy with no fee top-up).
+    std::string fee;
+    BOOST_REQUIRE(ExtractScalar(body, "totalfee", fee));
+    BOOST_CHECK_EQUAL(fee, "0");
+
+    // Hash matches what we built.
+    std::string returned_hash;
+    BOOST_REQUIRE(ExtractScalar(body, "blockhash", returned_hash));
+    BOOST_CHECK_EQUAL(returned_hash, fix.per_height_hash[1].GetHex());
+
+    g_chainstate.Cleanup();
+}
+
+BOOST_AUTO_TEST_CASE(getblockstats_height_out_of_range_rejected) {
+    TempDbScope scope_chain("getblockstats_oor");
+    CBlockchainDB chain_db;
+    BOOST_REQUIRE(chain_db.Open(scope_chain.path(), true));
+    ClusterChainFixture fix;
+    fix.Build(2, chain_db);
+
+    CRPCServer srv(0);
+    srv.RegisterBlockchain(&chain_db);
+    srv.RegisterChainState(&g_chainstate);
+
+    BOOST_CHECK_THROW(
+        srv.RPC_GetBlockStats("{\"height\":99}"),
+        std::runtime_error);
+    BOOST_CHECK_THROW(
+        srv.RPC_GetBlockStats("{\"height\":-5}"),
+        std::runtime_error);
+    BOOST_CHECK_THROW(
+        srv.RPC_GetBlockStats("{}"),
+        std::runtime_error);
+
+    g_chainstate.Cleanup();
+}
+
+// ---- gettxoutproof + verifytxoutproof: round-trip ----
+
+BOOST_AUTO_TEST_CASE(txoutproof_round_trip) {
+    TempDbScope scope_chain("txoutproof_chain");
+    CBlockchainDB chain_db;
+    BOOST_REQUIRE(chain_db.Open(scope_chain.path(), true));
+    ClusterChainFixture fix;
+    fix.Build(2, chain_db);
+
+    CRPCServer srv(0);
+    srv.RegisterBlockchain(&chain_db);
+    srv.RegisterChainState(&g_chainstate);
+
+    // Use the user (non-coinbase) tx from height 0.
+    auto& txs = fix.per_height_txs[0];
+    BOOST_REQUIRE_EQUAL(txs.size(), 2u);
+    uint256 wanted_txid = txs[1]->GetHash();
+    uint256 block_hash  = fix.per_height_hash[0];
+
+    std::string proof_params =
+        std::string("{\"txids\":[\"") + wanted_txid.GetHex() +
+        "\"],\"blockhash\":\"" + block_hash.GetHex() + "\"}";
+    std::string proof_response = srv.RPC_GetTxOutProof(proof_params);
+
+    // Strip the surrounding quotes to get the raw hex.
+    BOOST_REQUIRE_GT(proof_response.size(), 2u);
+    BOOST_CHECK_EQUAL(proof_response.front(), '"');
+    BOOST_CHECK_EQUAL(proof_response.back(),  '"');
+    std::string proof_hex = proof_response.substr(1, proof_response.size() - 2);
+
+    // Verify round-trips.
+    std::string verify_params = "{\"proof\":\"" + proof_hex + "\"}";
+    std::string verify_response = CRPCServer::RPC_VerifyTxOutProof(verify_params);
+
+    // The recovered txid list must contain our wanted txid; the recovered
+    // merkle root must equal the block's stored merkle root.
+    BOOST_CHECK(verify_response.find(wanted_txid.GetHex()) != std::string::npos);
+
+    std::string root_hex;
+    BOOST_REQUIRE(ExtractScalar(verify_response, "merkleroot", root_hex));
+    BOOST_CHECK_EQUAL(root_hex, fix.per_height_block[0].hashMerkleRoot.GetHex());
+
+    std::string returned_block_hash;
+    BOOST_REQUIRE(ExtractScalar(verify_response, "blockhash",
+                                returned_block_hash));
+    BOOST_CHECK_EQUAL(returned_block_hash, block_hash.GetHex());
+
+    g_chainstate.Cleanup();
+}
+
+BOOST_AUTO_TEST_CASE(gettxoutproof_unknown_txid_rejected) {
+    TempDbScope scope_chain("gettxoutproof_neg");
+    CBlockchainDB chain_db;
+    BOOST_REQUIRE(chain_db.Open(scope_chain.path(), true));
+    ClusterChainFixture fix;
+    fix.Build(1, chain_db);
+
+    CRPCServer srv(0);
+    srv.RegisterBlockchain(&chain_db);
+    srv.RegisterChainState(&g_chainstate);
+
+    // A txid that is NOT in the supplied block.
+    uint256 ghost;
+    std::memset(ghost.data, 0xAA, 32);
+
+    std::string params =
+        std::string("{\"txids\":[\"") + ghost.GetHex() +
+        "\"],\"blockhash\":\"" + fix.per_height_hash[0].GetHex() + "\"}";
+    BOOST_CHECK_THROW(srv.RPC_GetTxOutProof(params), std::runtime_error);
+
+    g_chainstate.Cleanup();
+}
+
+BOOST_AUTO_TEST_CASE(verifytxoutproof_corrupted_hex_rejected) {
+    // Truncated header (less than 32 bytes for blockhash).
+    BOOST_CHECK_THROW(
+        CRPCServer::RPC_VerifyTxOutProof("{\"proof\":\"deadbeef\"}"),
+        std::runtime_error);
+    // Non-hex.
+    BOOST_CHECK_THROW(
+        CRPCServer::RPC_VerifyTxOutProof("{\"proof\":\"zzz\"}"),
+        std::runtime_error);
+    // Missing param.
+    BOOST_CHECK_THROW(
+        CRPCServer::RPC_VerifyTxOutProof("{}"),
+        std::runtime_error);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/rpc_small_cluster_tests.cpp
+++ b/src/test/rpc_small_cluster_tests.cpp
@@ -34,10 +34,13 @@
 #include <primitives/block.h>
 #include <primitives/transaction.h>
 
+#include <atomic>
 #include <chrono>
 #include <cstring>
 #include <filesystem>
+#include <iomanip>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <system_error>
 #include <thread>
@@ -164,6 +167,24 @@ struct ClusterChainFixture {
     std::vector<std::vector<CTransactionRef>>        per_height_txs;
     std::vector<CBlock>                              per_height_block;
 
+    // PR #38 red-team C6: save/restore g_chainParams. The fixture mutates
+    // a process-wide global; per project convention (see
+    // src/test/timestamp_tests.cpp, src/test/chain_selector_tests.cpp:698)
+    // tests that touch g_chainParams should save the prior pointer and
+    // restore on teardown. Otherwise a later test that depends on a
+    // different g_chainParams gets state pollution from this fixture.
+    Dilithion::ChainParams* m_prev_chain_params = nullptr;
+
+    ~ClusterChainFixture() {
+        // Restore prior g_chainParams. The static cluster_test_params
+        // we set lives binary-long, so restoring just decouples our
+        // fixture from later tests' expected pointer.
+        Dilithion::g_chainParams = m_prev_chain_params;
+        // Belt-and-suspenders: make sure our SetTipForTest doesn't leak
+        // either.
+        g_chainstate.Cleanup();
+    }
+
     void Build(int n_blocks, CBlockchainDB& chain_db) {
         per_height_hash.clear();
         per_height_txs.clear();
@@ -173,6 +194,10 @@ struct ClusterChainFixture {
         per_height_block.reserve(n_blocks);
 
         g_chainstate.Cleanup();
+
+        // PR #38 red-team C6: capture prior g_chainParams BEFORE we
+        // potentially overwrite it.
+        m_prev_chain_params = Dilithion::g_chainParams;
 
         // Ensure chain params are initialized before any subsidy/difficulty
         // computation. CalculateBlockSubsidy reads halvingInterval from
@@ -528,6 +553,119 @@ BOOST_AUTO_TEST_CASE(verifytxoutproof_corrupted_hex_rejected) {
     BOOST_CHECK_THROW(
         CRPCServer::RPC_VerifyTxOutProof("{}"),
         std::runtime_error);
+}
+
+// ---- PR #38 red-team C8: missing test cases the first round didn't cover.
+
+// C8(a): concurrent waiters parked on the cluster CV are ALL woken by a
+// single NotifyBlockTipChanged(). The notify_all() semantics in the code
+// are correct but the prior suite only had one waiter at a time -- a
+// regression that swapped notify_all for notify_one would silently slip
+// past the existing tests.
+BOOST_AUTO_TEST_CASE(waitforblockheight_notify_wakes_multiple_waiters) {
+    TempDbScope scope_chain("multi_waiter_chain");
+    CBlockchainDB chain_db;
+    BOOST_REQUIRE(chain_db.Open(scope_chain.path(), true));
+    ClusterChainFixture fix;
+    fix.Build(2, chain_db);  // tip at height 1
+
+    // Spawn 3 waiters on the same height target.
+    std::atomic<int> woke_count{0};
+    auto waiter = [&]() {
+        std::string result = CRPCServer::RPC_WaitForBlockHeight(
+            "{\"height\":2,\"timeout_ms\":5000}");
+        std::string h_str;
+        if (ExtractScalar(result, "height", h_str) && h_str == "2") {
+            ++woke_count;
+        }
+    };
+    std::thread w1(waiter);
+    std::thread w2(waiter);
+    std::thread w3(waiter);
+
+    // Wait briefly for all 3 to park on the CV.
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    // Advance the chain (mirrors what waitforblockheight_wakes_on_notify
+    // does for one waiter, but here we have three).
+    uint256 block_hash = SyntheticBlockHash(0xF2);
+    auto cb  = MakeCoinbaseTx(CBlockValidator::CalculateBlockSubsidy(0), 0xCA);
+    CBlock block = MakeBlock({cb});
+    block.nTime = 1700000999;
+    block.hashPrevBlock = fix.per_height_hash.back();
+    chain_db.WriteBlock(block_hash, block);
+    {
+        CBlockIndex idx_persist;
+        idx_persist.nHeight = 2;
+        idx_persist.phashBlock = block_hash;
+        idx_persist.nTime = block.nTime;
+        idx_persist.nVersion = block.nVersion;
+        idx_persist.header.hashMerkleRoot = block.hashMerkleRoot;
+        idx_persist.header.hashPrevBlock = block.hashPrevBlock;
+        idx_persist.nBits = block.nBits;
+        idx_persist.nNonce = block.nNonce;
+        idx_persist.nStatus = CBlockIndex::BLOCK_VALID_HEADER |
+                              CBlockIndex::BLOCK_HAVE_DATA;
+        chain_db.WriteBlockIndex(block_hash, idx_persist);
+    }
+    auto pidx = std::make_unique<CBlockIndex>();
+    pidx->nHeight = 2;
+    pidx->phashBlock = block_hash;
+    pidx->pprev = g_chainstate.GetTip();
+    pidx->nTime = block.nTime;
+    pidx->nStatus = CBlockIndex::BLOCK_VALID_HEADER |
+                    CBlockIndex::BLOCK_HAVE_DATA;
+    CBlockIndex* raw = pidx.get();
+    g_chainstate.AddBlockIndex(block_hash, std::move(pidx));
+    if (auto* prev = g_chainstate.GetTip()) prev->pnext = raw;
+    g_chainstate.SetTipForTest(raw);
+
+    // Single notify_all() should wake all three waiters. notify_one()
+    // would only wake one and the other two would time out.
+    CRPCServer::NotifyBlockTipChanged();
+
+    w1.join();
+    w2.join();
+    w3.join();
+
+    // All 3 must have woken with the correct height. notify_one would
+    // produce woke_count == 1.
+    BOOST_CHECK_EQUAL(woke_count.load(), 3);
+}
+
+// C8(b): verifytxoutproof must reject nTransactions = 0xFFFFFFFF without
+// hanging the worker thread. Pre-fix: MerkleTreeHeight's `1u << height`
+// is UB at height >= 32; on x86_64 the shift count is masked to 5 bits
+// so `1u << 32` = 1 and the loop never terminates (authenticated DoS).
+// Post-fix: handler caps nTransactions at kVerifyTxOutProofMaxTxs and
+// MerkleTreeHeight has a 32-iteration upper bound as defense in depth.
+BOOST_AUTO_TEST_CASE(verifytxoutproof_oversize_ntxs_rejected) {
+    // Build a 41-byte proof prefix: 32-byte block hash + 4-byte
+    // nTransactions = 0xFFFFFFFF + 1-byte CompactSize nHashes = 0.
+    std::vector<uint8_t> bytes;
+    for (int i = 0; i < 32; ++i) bytes.push_back(0x42);  // block hash
+    bytes.push_back(0xFF); bytes.push_back(0xFF);
+    bytes.push_back(0xFF); bytes.push_back(0xFF);  // nTransactions
+    bytes.push_back(0x00);  // nHashes = 0
+    bytes.push_back(0x00);  // nFlagBytes = 0
+
+    std::ostringstream hex;
+    for (uint8_t b : bytes) {
+        hex << std::hex << std::setw(2) << std::setfill('0')
+            << static_cast<int>(b);
+    }
+    std::string params = "{\"proof\":\"" + hex.str() + "\"}";
+
+    // Must throw quickly (no infinite loop, no OOM crash). The exact
+    // error message is implementation detail; we only assert the
+    // call returns within a reasonable time.
+    auto t0 = std::chrono::steady_clock::now();
+    BOOST_CHECK_THROW(CRPCServer::RPC_VerifyTxOutProof(params),
+                      std::runtime_error);
+    auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - t0).count();
+    // Pre-fix this would never return. Post-fix the cap rejects in <100ms.
+    BOOST_CHECK_LT(elapsed, 5000);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/rpc_small_cluster_tests.cpp
+++ b/src/test/rpc_small_cluster_tests.cpp
@@ -195,6 +195,14 @@ struct ClusterChainFixture {
 
         g_chainstate.Cleanup();
 
+        // PR #38 red-team C5 follow-up: clear the cluster shutdown flag.
+        // Other test suites in the same binary may have called
+        // CRPCServer::Stop() (which sets the flag) before us. Without
+        // this reset, wait-* RPC predicates would short-circuit on
+        // shutdown=true and the cluster tests would fail with the chain
+        // returning immediately at the wrong height.
+        CRPCServer::ResetClusterStateForTests();
+
         // PR #38 red-team C6: capture prior g_chainParams BEFORE we
         // potentially overwrite it.
         m_prev_chain_params = Dilithion::g_chainParams;


### PR DESCRIPTION
## Summary

Ports 5 small read-only / blocking RPCs from Bitcoin Core v28.0 (T1.B from `docs/ROADMAP-MAINNET-PRODUCTION-PARITY.md`):

- `waitfornewblock`
- `waitforblock`
- `waitforblockheight`
- `gettxoutproof`
- `verifytxoutproof`

**`getblockstats` is intentionally NOT in this cluster.** It requires per-tx fee fields (`avgfee`, `medianfee`, `feerate_percentiles`, ...) computed from undo-data prevout lookups, which Dilithion doesn't currently expose at the RPC layer. Shipping with those fields omitted would break BC-compatible client tooling — violating the project's "do not defer" + "world-class port from Bitcoin Core" principles. It lands in a separate workstream alongside `coinstatsindex` + undo-data exposure (see follow-up contract).

## Threading model (wait-* family)

`std::condition_variable` notified from the chainstate connect callback. Default timeout 30s, max 300s. DoS guard against worker thread exhaustion in the ~8-thread RPC pool.

## Audit chain

- **Coding agent run:** background autonomous coding agent against the contract `.claude/contracts/contract_small_rpcs_cluster.md`.
- **CI on first push:** 4 failing checks (clang Debug, clang Release, gcc Debug, gcc Release — all "Build and Test"). Investigation surfaced **integer divide-by-zero in `CalculateBlockSubsidy` from un-initialized `g_chainParams`**. Root cause: `ClusterChainFixture::Build` called `CalculateBlockSubsidy(0)` without ensuring `g_chainParams` was set up; CI's fresh binary state hit the divide-by-zero, while the local agent run passed only because of test-order-dependent prior state.
- **Follow-up commit (`9dae162`):** dropped `getblockstats` per the principle re-evaluation; fixed `ClusterChainFixture::Build` to initialize `g_chainParams` to `Mainnet()` defaults if null or zeroed.

## Test plan

- [x] Build clean (zero new warnings on touched files)
- [x] **11 cluster test cases pass** (was 13; the 2 getblockstats cases removed)
- [x] Full regression: 69 test cases / **20235 assertions** all pass across `tx_index_tests`, `tx_index_integration_tests`, `mempool_persist_tests`, `rpc_small_cluster_tests`
- [x] Both binaries (`dilithion-node`, `dilv-node`) build clean
- [x] CI (re-run after this push) — expected to clear the previous 4 failures since the divide-by-zero was the root cause

## Followups (not blocking this PR)

- **Bundled contract** for `getblockstats` + undo-data exposure + `coinstatsindex` (T1.G + the deferred portion of T1.B)
- **`CalculateBlockSubsidy` defensive guard:** consider whether the production function should defend against `halvingInterval==0` rather than relying on callers to set up chain params. Filed as a follow-up issue, not load-bearing for this PR — the test fixture is the only caller that hits the un-init case in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)