### PR TITLE
rpc: savemempool RPC handler [PR-MP-3]

### DIFF
--- a/docs/MEMPOOL-PERSISTENCE.md
+++ b/docs/MEMPOOL-PERSISTENCE.md
@@ -177,6 +177,32 @@ Shutdown (failure -- best-effort, does not block shutdown):
 [mempool] DumpMempool failed: <reason> -- prior mempool.dat retained
 ```
 
+### `savemempool` JSON-RPC
+
+Bitcoin Core port (`src/rpc/mempool.cpp::savemempool` v28.0). Triggers an
+immediate `mempool.dat` write while the node is running, without waiting
+for shutdown. Useful for: pre-restart drain + verification, migrating a
+mempool snapshot to another datadir, sanity-checking the persistence
+subsystem is healthy.
+
+```bash
+curl -s --user rpc:rpc -H 'X-Dilithion-RPC: 1' -H 'content-type:application/json' \
+  --data-binary '{"jsonrpc":"2.0","id":1,"method":"savemempool","params":{}}' \
+  http://127.0.0.1:8332/
+```
+
+Response (matches Bitcoin Core v28.0's `savemempool` response schema):
+
+```json
+{ "filename": "/root/.dilithion/mempool.dat" }
+```
+
+Errors as JSON-RPC error responses if the mempool is not registered, the
+data directory is unset, or `DumpMempool` fails (disk full, permissions).
+
+The handler is safe to call repeatedly; each call atomically rewrites
+`mempool.dat`. Concurrent saves serialize on the mempool lock.
+
 ### Recovery
 
 If the operator wants to start with an empty mempool (e.g. they suspect

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -29,6 +29,7 @@
 #include <consensus/pow.h>
 #include <consensus/validation.h>  // For DeserializeBlockTransactions
 #include <index/tx_index.h>  // PR-5: txindex fast-path for getrawtransaction/gettransaction
+#include <node/mempool_persist.h>  // PR-MP-3: savemempool RPC handler
 #include <cmath>  // For pow()
 #include <util/base58.h>           // For EncodeBase58Check
 #include <dfmp/dfmp.h>  // DFMP v2.0
@@ -262,6 +263,7 @@ CRPCServer::CRPCServer(uint16_t port)
     m_handlers["getrawtransaction"] = [this](const std::string& p) { return RPC_GetRawTransaction(p); };
     m_handlers["decoderawtransaction"] = [this](const std::string& p) { return RPC_DecodeRawTransaction(p); };
     m_handlers["getindexinfo"] = [](const std::string& p) { return RPC_GetIndexInfo(p); };
+    m_handlers["savemempool"] = [this](const std::string& p) { return RPC_SaveMempool(p); };
     m_handlers["addnode"] = [this](const std::string& p) { return RPC_AddNode(p); };
     m_handlers["disconnectnode"] = [this](const std::string& p) { return RPC_DisconnectNode(p); };  // v4.0.22 manual peer disconnect
 
@@ -5327,6 +5329,7 @@ std::string CRPCServer::RPC_Help(const std::string& params) {
     oss << "\"getblockhash - Get block hash by height\",";
     oss << "\"gettxout - Get UTXO information\",";
     oss << "\"getindexinfo - Get sync state of all enabled indexes (txindex, ...)\",";
+    oss << "\"savemempool - Save mempool.dat to disk on demand (returns {filename: <path>})\",";
     oss << "\"checkchain - Verify your chain matches official checkpoints (detect forks)\",";
     oss << "\"checkblockdb - Check for missing blocks in database (diagnostic)\",";
     oss << "\"repairblocks - Repair blocks stored under wrong hashes (Bug #243 fix)\",";
@@ -5476,6 +5479,54 @@ std::string CRPCServer::RPC_GetIndexInfo(const std::string& params) {
     }
 
     oss << "}";
+    return oss.str();
+}
+
+// Bitcoin Core port: src/rpc/mempool.cpp::savemempool (v28.0).
+//
+// Triggers an immediate mempool.dat write while the node is running.
+// Useful for ops scenarios such as: pre-restart drain + verification,
+// migrating a mempool snapshot to another datadir, sanity-check that
+// the persistence subsystem is healthy without waiting for shutdown.
+//
+// Returns: {"filename": "<absolute-path>"} on success. Field name
+// matches Bitcoin Core v28.0 (and has done since v23.0) so client
+// tooling targeting BC's savemempool schema works against Dilithion
+// without modification.
+//
+// Throws: std::runtime_error on failure (mempool not registered, datadir
+// not set, or DumpMempool failure -- e.g. disk full, permissions).
+//
+// No params. Object-style empty params object expected by JSON-RPC
+// dispatcher; we ignore the params content. The path string is JSON-
+// escaped for `\` and `"`; control characters (U+0000-U+001F) are
+// assumed not present because the path is operator-controlled (it's
+// the configured datadir, not attacker input).
+std::string CRPCServer::RPC_SaveMempool(const std::string& params) {
+    (void)params;
+
+    if (!m_mempool) {
+        throw std::runtime_error("Mempool not registered with RPC server");
+    }
+    if (m_dataDir.empty()) {
+        throw std::runtime_error("Data directory not registered with RPC server");
+    }
+
+    const auto result = mempool_persist::DumpMempool(
+        *m_mempool, std::filesystem::path(m_dataDir));
+    if (!result.success) {
+        throw std::runtime_error("savemempool failed: " + result.error_message);
+    }
+
+    std::ostringstream oss;
+    oss << "{\"filename\":\"";
+    // Escape backslashes in Windows paths so the JSON stays valid.
+    for (char c : result.final_path) {
+        if (c == '\\') oss << "\\\\";
+        else if (c == '"') oss << "\\\"";
+        else oss << c;
+    }
+    oss << "\"}";
     return oss.str();
 }
 

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -635,6 +635,14 @@ public:
     // process-wide `g_tx_index` global. Public + static lets tests exercise the formatter
     // directly without standing up a full HTTP server (schema-lock-in coverage).
     static std::string RPC_GetIndexInfo(const std::string& params);
+
+    // Mempool persistence operator-on-demand save (Bitcoin Core port:
+    // savemempool, src/rpc/mempool.cpp v28.0). Triggers an immediate
+    // mempool.dat write without restarting the node. Returns
+    // {"path": "<absolute-path>"} on success or throws on failure.
+    // Instance method (NOT static) because it consults m_mempool +
+    // m_dataDir; tests exercise via constructed CRPCServer instance.
+    std::string RPC_SaveMempool(const std::string& params);
 };
 
 #endif // DILITHION_RPC_SERVER_H

--- a/src/test/mempool_persist_tests.cpp
+++ b/src/test/mempool_persist_tests.cpp
@@ -6,6 +6,7 @@
 #include <node/mempool_persist.h>
 
 #include <node/mempool.h>
+#include <rpc/server.h>
 #include <crypto/sha3.h>
 #include <primitives/transaction.h>
 #include <uint256.h>
@@ -604,6 +605,67 @@ BOOST_AUTO_TEST_CASE(c6_bypass_fee_check_regression) {
     BOOST_CHECK(!load.cold_start);
     BOOST_CHECK_EQUAL(load.txs_admitted, 1u);
     BOOST_CHECK_EQUAL(mp_load.Size(), 1u);
+}
+
+// ---- PR-MP-3: savemempool RPC handler smoke test -----------------------
+
+// Verifies the RPC handler triggers DumpMempool correctly. We don't stand
+// up an HTTP server -- we exercise the handler directly via a minimal
+// CRPCServer instance, mirroring the getindexinfo schema-lock-in pattern.
+BOOST_AUTO_TEST_CASE(savemempool_rpc_handler) {
+    TempDir scope("savemempool_rpc");
+
+    CTxMemPool mp;
+    BOOST_REQUIRE_EQUAL(PopulateMempool(mp, 3), 3u);
+
+    // Stand up a CRPCServer just for the handler call. We don't call Start();
+    // the handler does not depend on the network being up.
+    CRPCServer server(/*port=*/18999);
+    server.RegisterMempool(&mp);
+    server.SetDataDir(scope.path().string());
+
+    // Call the handler directly. It returns JSON {"filename": "<absolute-path>"}
+    // matching Bitcoin Core v28.0's savemempool response schema.
+    const std::string response = server.RPC_SaveMempool("");
+
+    // Response shape lock: must contain "filename" key and the file's
+    // absolute path. We don't pin the exact bytes of the path because
+    // absolute paths are platform-specific (Windows backslashes get
+    // JSON-escaped to "\\\\").
+    BOOST_CHECK(response.find("\"filename\"") != std::string::npos);
+    BOOST_CHECK(response.find(mempool_persist::FILENAME) != std::string::npos);
+
+    // File must actually exist on disk and round-trip correctly.
+    const auto fp = scope.path() / mempool_persist::FILENAME;
+    BOOST_REQUIRE(std::filesystem::exists(fp));
+
+    CTxMemPool mp_load;
+    auto load = mempool_persist::LoadMempool(mp_load, scope.path(), 1);
+    BOOST_REQUIRE(load.success);
+    BOOST_CHECK(!load.cold_start);
+    BOOST_CHECK_EQUAL(load.txs_admitted, 3u);
+}
+
+// Negative path: missing mempool registration must throw with a clear error.
+BOOST_AUTO_TEST_CASE(savemempool_rpc_no_mempool) {
+    TempDir scope("savemempool_no_mempool");
+
+    CRPCServer server(/*port=*/18998);
+    // Deliberately do NOT call RegisterMempool(); m_mempool stays null.
+    server.SetDataDir(scope.path().string());
+
+    BOOST_CHECK_THROW(server.RPC_SaveMempool(""), std::runtime_error);
+}
+
+// Negative path: empty datadir must throw with a clear error.
+BOOST_AUTO_TEST_CASE(savemempool_rpc_no_datadir) {
+    CTxMemPool mp;
+
+    CRPCServer server(/*port=*/18997);
+    server.RegisterMempool(&mp);
+    // Deliberately do NOT call SetDataDir(); m_dataDir stays empty.
+
+    BOOST_CHECK_THROW(server.RPC_SaveMempool(""), std::runtime_error);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary

Third and final sub-PR (PR-MP-3) of the mempool persistence port from Bitcoin Core v28.0. Adds the operator-on-demand `savemempool` JSON-RPC method which triggers an immediate `mempool.dat` write while the node is running, without waiting for shutdown.

This **closes T1.A mempool persistence** (3-PR series complete: PR #36 skeleton → PR #37 wiring → PR-MP-3 savemempool RPC).

Use cases:
- Pre-restart drain + verification.
- Migrating a mempool snapshot to another datadir.
- Sanity-checking the persistence subsystem without operator-visible downtime.

## Schema (matches Bitcoin Core v28.0 exactly)

```bash
curl -s --user rpc:rpc -H 'X-Dilithion-RPC: 1' -H 'content-type:application/json' \
  --data-binary '{"jsonrpc":"2.0","id":1,"method":"savemempool","params":{}}' \
  http://127.0.0.1:8332/
```

Response:

```json
{ "filename": "/root/.dilithion/mempool.dat" }
```

Field name is `filename` (matching Bitcoin Core v28.0 and v23.0+ before that) so client tooling targeting BC's savemempool schema works against Dilithion without modification.

## Audit

Diff red-team verdict: **GO** with 2 CONCERNs; both addressed in this commit per no-defer:

- **CONCERN 1** — schema field renamed from `"path"` to `"filename"` matching Bitcoin Core. Touch sites: handler return, test schema-lock assertion, runbook example, help text.
- **CONCERN 2** — JSON control-char escape assumption documented. Path is operator-controlled (configured datadir, not attacker input); control chars (U+0000–U+001F) don't appear in legitimate paths. Handler escapes the only two characters that legitimately appear in Windows / POSIX paths (`\` and `"`). Comment added inline at the handler.

## Test plan

- [x] Build clean (zero new warnings on touched files)
- [x] 3 new Boost test cases / 9 new assertions:
  - `savemempool_rpc_handler` — positive case: register mempool + datadir, call handler, verify response shape, verify file on disk, verify round-trip via LoadMempool
  - `savemempool_rpc_no_mempool` — negative: throws when mempool not registered
  - `savemempool_rpc_no_datadir` — negative: throws when datadir not set
- [x] Full mempool_persist suite: 20 test cases / 135 assertions all pass
- [x] No regression: tx_index + tx_index_integration suites still pass
- [x] Node binaries (dilithion-node, dilv-node) build clean

## Files

```
 docs/MEMPOOL-PERSISTENCE.md        | 26 ++++++++++++++++
 src/rpc/server.cpp                 | 51 +++++++++++++++++++++++++++++++
 src/rpc/server.h                   |  8 +++++
 src/test/mempool_persist_tests.cpp | 62 ++++++++++++++++++++++++++++++++++++++
 4 files changed, 147 insertions(+)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)