### PR TITLE
feat(storage): undo-data read accessor [PR-BA-1]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -623,6 +623,7 @@ BOOST_TEST_OBJECTS := $(OBJ_DIR)/test/test_dilithion.o \
 	$(OBJ_DIR)/test/tx_index_tests.o \
 	$(OBJ_DIR)/test/tx_index_integration_tests.o \
 	$(OBJ_DIR)/test/mempool_persist_tests.o \
+	$(OBJ_DIR)/test/undo_data_tests.o \
 	$(CRYPTO_PROPERTY_OBJECTS)
 
 # Link test objects + full library (CORE_OBJECTS) to avoid hand-picked object drift

--- a/src/node/undo_data.h
+++ b/src/node/undo_data.h
@@ -1,0 +1,90 @@
+// Copyright (c) 2026 The Dilithion Core developers
+// Distributed under the MIT software license
+
+#ifndef DILITHION_NODE_UNDO_DATA_H
+#define DILITHION_NODE_UNDO_DATA_H
+
+#include <primitives/transaction.h>
+#include <uint256.h>
+
+#include <cstdint>
+#include <vector>
+
+/**
+ * Block undo data -- Dilithion-native types.
+ *
+ * --- Bitcoin Core port note ----------------------------------------------
+ *
+ * Bitcoin Core organises undo data per-tx as `CBlockUndo { vtxundo: vector<
+ * CTxUndo> }` where `CTxUndo` holds `vprevout: vector<Coin>`. The grouping
+ * preserves which `Coin` was spent by which transaction in the block.
+ *
+ * Dilithion's existing on-disk format (written by `CUTXOSet::ApplyBlock` and
+ * read by `CUTXOSet::UndoBlock`) does NOT preserve per-tx grouping. The
+ * writer iterates txs in order and serialises every spent input into one
+ * flat list:
+ *
+ *     count : uint32_t        (number of spent inputs across the whole block)
+ *     for each spent input:
+ *         hash         : 32 bytes        (prevout txid)
+ *         n            : uint32_t        (prevout index)
+ *         nValue       : uint64_t        (spent value, in ions)
+ *         script_len   : uint32_t        (scriptPubKey length)
+ *         scriptPubKey : script_len bytes
+ *         nHeight      : uint32_t        (height when the spent UTXO was created)
+ *         fCoinBase    : uint8_t         (1 if the spent UTXO was a coinbase output)
+ *     sha3_checksum : 32 bytes           (SHA3-256 of all preceding bytes)
+ *
+ * This means a `CBlockUndo` returned from disk is a flat list, not a list of
+ * lists. The order matches the writer's iteration order (txs in vtx order,
+ * inputs in vin order, coinbase skipped). For the consumers this read
+ * accessor was added for (per-block fee aggregation, UTXO-set statistics
+ * indexing), the flat layout is sufficient -- aggregate metrics do not care
+ * which tx a spent input belonged to.
+ *
+ * If a future port (e.g. a full BC-style fee-distribution-by-tx breakdown)
+ * needs per-tx grouping, the writer in `ApplyBlock` will need an additional
+ * boundary marker; this is out of scope for the read accessor.
+ *
+ * --- Concurrency ---------------------------------------------------------
+ *
+ * `CBlockUndo` is a plain value type. Reads from disk are serialised by the
+ * `CUTXOSet` mutex; the returned object is owned by the caller.
+ * -------------------------------------------------------------------------
+ */
+
+/**
+ * One spent input restored from a block's undo data.
+ *
+ * Mirrors the inner record written in `CUTXOSet::ApplyBlock`. Equivalent in
+ * spirit to BC's `Coin` (the previous-output payload that the input spent),
+ * with the addition of the outpoint identifier so a reader can reconstruct
+ * which UTXO was consumed without consulting the block's tx body.
+ */
+struct CSpentInput {
+    COutPoint outpoint;                  // prevout that was spent
+    CTxOut    out;                       // spent UTXO payload (value + scriptPubKey)
+    uint32_t  nHeight;                   // height where the spent UTXO was created
+    bool      fCoinBase;                 // true if the spent UTXO was a coinbase output
+
+    CSpentInput() : nHeight(0), fCoinBase(false) {}
+    CSpentInput(const COutPoint& op, const CTxOut& o, uint32_t h, bool cb)
+        : outpoint(op), out(o), nHeight(h), fCoinBase(cb) {}
+};
+
+/**
+ * All spent inputs for one block, flat list.
+ *
+ * See the file-level docblock for the layout rationale and the deviation
+ * from Bitcoin Core's per-tx-grouped CBlockUndo.
+ */
+struct CBlockUndo {
+    std::vector<CSpentInput> vSpent;     // all spent inputs in writer order
+
+    bool empty() const { return vSpent.empty(); }
+    size_t size() const { return vSpent.size(); }
+
+    void Clear() { vSpent.clear(); }
+};
+
+#endif // DILITHION_NODE_UNDO_DATA_H

--- a/src/node/utxo_set.cpp
+++ b/src/node/utxo_set.cpp
@@ -1163,3 +1163,162 @@ bool CUTXOSet::HasUndoData(const uint256& blockHash) const {
     leveldb::Status status = db->Get(leveldb::ReadOptions(), undoKey, &undoValue);
     return status.ok();
 }
+
+// ============================================================================
+// PR-BA-1: ReadUndoBlock -- structured read accessor for block-analytics.
+// ============================================================================
+// Reads the on-disk undo entry written by ApplyBlock and returns a populated
+// CBlockUndo. Mirrors the parser inside UndoBlock (utxo_set.cpp ~line 700)
+// but does NOT mutate the database or cache. SHA3-256 footer is verified
+// before parsing. See node/undo_data.h for the layout docblock and the BC
+// deviation rationale.
+
+bool CUTXOSet::ReadUndoBlock(const uint256& blockHash, CBlockUndo& undo_out) const {
+    undo_out.Clear();
+
+    if (!IsOpen()) {
+        std::cerr << "[ERROR] CUTXOSet::ReadUndoBlock: Database not open" << std::endl;
+        return false;
+    }
+
+    std::lock_guard<std::recursive_mutex> lock(cs_utxo);
+
+    // Step 1: Fetch raw value from LevelDB.
+    std::string undoKey = "undo_";
+    undoKey.append(reinterpret_cast<const char*>(blockHash.data), 32);
+
+    std::string undoValue;
+    leveldb::Status status = db->Get(leveldb::ReadOptions(), undoKey, &undoValue);
+    if (!status.ok()) {
+        // Missing-block is a normal "not found" outcome (e.g. genesis on a
+        // freshly opened db, or a block that was never applied). Caller
+        // distinguishes this from corruption via the boolean return.
+        return false;
+    }
+
+    // Step 2: Verify size. Minimum is spentCount(4) + sha3-256 footer(32).
+    if (undoValue.size() < 4 + 32) {
+        std::cerr << "[ERROR] CUTXOSet::ReadUndoBlock: Undo entry too small ("
+                  << undoValue.size() << " bytes) for block "
+                  << blockHash.GetHex() << std::endl;
+        return false;
+    }
+
+    const uint8_t* raw_data = reinterpret_cast<const uint8_t*>(undoValue.data());
+    size_t data_size = undoValue.size() - 32;  // excludes trailing checksum
+
+    // Step 3: Verify SHA3-256 footer.
+    const uint8_t* stored_checksum = raw_data + data_size;
+    uint8_t computed_checksum[32];
+    SHA3_256(raw_data, data_size, computed_checksum);
+    if (std::memcmp(stored_checksum, computed_checksum, 32) != 0) {
+        std::cerr << "[ERROR] CUTXOSet::ReadUndoBlock: Checksum mismatch for block "
+                  << blockHash.GetHex() << std::endl;
+        return false;
+    }
+
+    // Step 4: Parse the body (same layout as ApplyBlock writer).
+    const uint8_t* ptr = raw_data;
+    const uint8_t* end = raw_data + data_size;
+
+    uint32_t spentCount = 0;
+    std::memcpy(&spentCount, ptr, 4);
+    ptr += 4;
+
+    // Sanity bound: each record is at least 32 (hash) + 4 (n) + 8 (value)
+    // + 4 (script_len) + 0 (empty script) + 4 (height) + 1 (coinbase) = 53
+    // bytes. Reject obviously-corrupt counts up front rather than malloc-
+    // bombing on a bogus length.
+    const size_t kMinRecordBytes = 32 + 4 + 8 + 4 + 4 + 1;
+    if (static_cast<uint64_t>(spentCount) * kMinRecordBytes >
+        static_cast<uint64_t>(end - ptr)) {
+        std::cerr << "[ERROR] CUTXOSet::ReadUndoBlock: Spent count "
+                  << spentCount << " exceeds payload bounds for block "
+                  << blockHash.GetHex() << std::endl;
+        return false;
+    }
+
+    undo_out.vSpent.reserve(spentCount);
+
+    for (uint32_t i = 0; i < spentCount; ++i) {
+        // outpoint: hash(32) + n(4)
+        if (end - ptr < 32 + 4) {
+            std::cerr << "[ERROR] CUTXOSet::ReadUndoBlock: Truncated at outpoint "
+                      << i << std::endl;
+            undo_out.Clear();
+            return false;
+        }
+        uint256 prev_hash;
+        std::memcpy(prev_hash.data, ptr, 32);
+        ptr += 32;
+        uint32_t prev_n = 0;
+        std::memcpy(&prev_n, ptr, 4);
+        ptr += 4;
+
+        // nValue (8)
+        if (end - ptr < 8) {
+            std::cerr << "[ERROR] CUTXOSet::ReadUndoBlock: Truncated at nValue "
+                      << i << std::endl;
+            undo_out.Clear();
+            return false;
+        }
+        uint64_t nValue = 0;
+        std::memcpy(&nValue, ptr, 8);
+        ptr += 8;
+
+        // script length (4)
+        if (end - ptr < 4) {
+            std::cerr << "[ERROR] CUTXOSet::ReadUndoBlock: Truncated at script_len "
+                      << i << std::endl;
+            undo_out.Clear();
+            return false;
+        }
+        uint32_t script_len = 0;
+        std::memcpy(&script_len, ptr, 4);
+        ptr += 4;
+
+        // script body (script_len bytes)
+        if (static_cast<uint64_t>(script_len) >
+            static_cast<uint64_t>(end - ptr)) {
+            std::cerr << "[ERROR] CUTXOSet::ReadUndoBlock: Truncated at scriptPubKey "
+                      << i << " (len=" << script_len << ")" << std::endl;
+            undo_out.Clear();
+            return false;
+        }
+        std::vector<uint8_t> scriptPubKey(ptr, ptr + script_len);
+        ptr += script_len;
+
+        // height (4) + coinbase (1)
+        if (end - ptr < 4 + 1) {
+            std::cerr << "[ERROR] CUTXOSet::ReadUndoBlock: Truncated at height/coinbase "
+                      << i << std::endl;
+            undo_out.Clear();
+            return false;
+        }
+        uint32_t prev_height = 0;
+        std::memcpy(&prev_height, ptr, 4);
+        ptr += 4;
+        bool fCoinBase = (*ptr != 0);
+        ptr++;
+
+        undo_out.vSpent.emplace_back(
+            COutPoint(prev_hash, prev_n),
+            CTxOut(nValue, scriptPubKey),
+            prev_height,
+            fCoinBase);
+    }
+
+    // Step 5: Trailing-bytes check. The body must consume exactly the
+    // pre-checksum region; surplus bytes between the last record and the
+    // checksum indicate corruption that the per-record bounds checks did
+    // not flag.
+    if (ptr != end) {
+        std::cerr << "[ERROR] CUTXOSet::ReadUndoBlock: Trailing bytes after "
+                  << "spentCount=" << spentCount << " for block "
+                  << blockHash.GetHex() << std::endl;
+        undo_out.Clear();
+        return false;
+    }
+
+    return true;
+}

--- a/src/node/utxo_set.h
+++ b/src/node/utxo_set.h
@@ -198,10 +198,32 @@ public:
      * Foundational accessor for block-analytics consumers (per-block fee
      * aggregation, coinstatsindex). PR-BA-1 in the block-analytics bundle.
      *
+     * Behaviour notes for downstream consumers (PR-BA-2 / PR-BA-3):
+     *
+     *   - **Reorged-out blocks return false.** UndoBlock deletes the entry
+     *     after applying the rollback. A successful write followed by a
+     *     reorg produces "missing-block" on this reader. Consumers querying
+     *     historical blocks should ensure the block is on the active chain
+     *     before invoking; otherwise a false-negative window exists during
+     *     reorg processing.
+     *   - **Memory bounds.** Allocates O(spentCount) records; with the
+     *     writer's current block-size cap (`maxBlockSize` in chainparams)
+     *     this is bounded by ~maxBlockSize / kMinRecordBytes records and
+     *     ~maxBlockSize bytes of script payload. Consumers should not call
+     *     this in unbounded loops over arbitrary blockhashes; rate-limit at
+     *     the caller (e.g. RPC handler) if invoked from operator input.
+     *   - **No schema version byte.** The on-disk format is the writer's
+     *     existing layout (see node/undo_data.h). Any future writer-side
+     *     schema change must be coordinated with all readers in the same
+     *     commit (currently `UndoBlock` and `ReadUndoBlock`); a content-
+     *     compatible-shape change without a version byte will be silently
+     *     misparsed by stale readers.
+     *
      * @param blockHash The block hash whose undo data to read
      * @param undo_out  Filled with the parsed block undo on success
-     * @return true on success; false if the entry is missing, truncated, or
-     *         the SHA3-256 footer fails to verify.
+     * @return true on success; false if the entry is missing (never
+     *         written or reorged out), truncated, or the SHA3-256 footer
+     *         fails to verify.
      */
     bool ReadUndoBlock(const uint256& blockHash, CBlockUndo& undo_out) const;
 

--- a/src/node/utxo_set.h
+++ b/src/node/utxo_set.h
@@ -6,6 +6,7 @@
 
 #include <primitives/transaction.h>
 #include <primitives/block.h>
+#include <node/undo_data.h>
 #include <leveldb/db.h>
 #include <string>
 #include <memory>
@@ -181,6 +182,28 @@ public:
      * @return true if an undo_<blockhash> entry exists in LevelDB
      */
     bool HasUndoData(const uint256& blockHash) const;
+
+    /**
+     * Read undo data for a block as a structured CBlockUndo.
+     *
+     * Read-only accessor on the existing on-disk format (key "undo_<blockhash>"
+     * written by ApplyBlock; consumed and deleted by UndoBlock). Does NOT
+     * mutate disk or the UTXO cache.
+     *
+     * Layout, validation, and the deviation from Bitcoin Core's per-tx
+     * grouping are documented in node/undo_data.h. The SHA3-256 footer is
+     * verified before parsing; corruption surfaces as a `false` return with
+     * `undo_out` left in an unspecified state, never a crash.
+     *
+     * Foundational accessor for block-analytics consumers (per-block fee
+     * aggregation, coinstatsindex). PR-BA-1 in the block-analytics bundle.
+     *
+     * @param blockHash The block hash whose undo data to read
+     * @param undo_out  Filled with the parsed block undo on success
+     * @return true on success; false if the entry is missing, truncated, or
+     *         the SHA3-256 footer fails to verify.
+     */
+    bool ReadUndoBlock(const uint256& blockHash, CBlockUndo& undo_out) const;
 
     /**
      * Flush all pending changes to disk

--- a/src/test/undo_data_tests.cpp
+++ b/src/test/undo_data_tests.cpp
@@ -1,0 +1,550 @@
+// Copyright (c) 2026 The Dilithion Core developers
+// Distributed under the MIT software license
+
+/**
+ * Undo-data read accessor tests -- PR-BA-1.
+ *
+ * Exercises CUTXOSet::ReadUndoBlock on:
+ *   - round-trip from ApplyBlock (the on-disk writer) through ReadUndoBlock
+ *     (the new reader), confirming every spent input survives byte-identical
+ *   - missing-block lookup (returns false, leaves output cleared)
+ *   - empty-undo block (a coinbase-only block produces an undo record with
+ *     spentCount=0 and a SHA3 footer; reader returns true with empty vSpent)
+ *   - large-block round-trip with many spent inputs
+ *   - corruption detection (flipped checksum byte, truncated record,
+ *     bogus spentCount) -- defensive surface for the analytics consumers
+ *     that will call this from tight RPC loops.
+ *
+ * Tests build their own UTXO set on a temp directory; no shared chainstate.
+ */
+
+#include <boost/test/unit_test.hpp>
+
+#include <node/utxo_set.h>
+#include <node/undo_data.h>
+
+#include <consensus/validation.h>
+#include <crypto/sha3.h>
+#include <primitives/block.h>
+#include <primitives/transaction.h>
+#include <uint256.h>
+
+#include <leveldb/db.h>
+#include <leveldb/options.h>
+
+#include <chrono>
+#include <cstring>
+#include <ctime>
+#include <filesystem>
+#include <random>
+#include <string>
+#include <system_error>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(undo_data_tests)
+
+namespace {
+
+// ---------------------------------------------------------------------------
+// Temp-dir helpers (mirrors the convention used in tx_index_tests +
+// mempool_persist_tests).
+// ---------------------------------------------------------------------------
+
+std::filesystem::path MakeTempDir(const std::string& tag) {
+    auto base = std::filesystem::temp_directory_path();
+    auto path = base / ("undo_data_test_" + tag + "_" +
+        std::to_string(static_cast<long long>(
+            std::chrono::steady_clock::now().time_since_epoch().count())));
+    std::filesystem::create_directories(path);
+    return path;
+}
+
+void CleanupTempDir(const std::filesystem::path& path) {
+    std::error_code ec;
+    std::filesystem::remove_all(path, ec);
+}
+
+class TempUtxoScope {
+public:
+    explicit TempUtxoScope(const std::string& tag)
+        : m_path(MakeTempDir(tag)) {
+        BOOST_REQUIRE(m_utxo.Open(m_path.string(), true));
+    }
+    ~TempUtxoScope() {
+        m_utxo.Close();
+        CleanupTempDir(m_path);
+    }
+    CUTXOSet& utxo() { return m_utxo; }
+    const std::filesystem::path& path() const { return m_path; }
+    TempUtxoScope(const TempUtxoScope&) = delete;
+    TempUtxoScope& operator=(const TempUtxoScope&) = delete;
+private:
+    std::filesystem::path m_path;
+    CUTXOSet              m_utxo;
+};
+
+// ---------------------------------------------------------------------------
+// Block / tx fabrication helpers.
+// ---------------------------------------------------------------------------
+
+uint256 MakeHash(uint8_t seed) {
+    uint256 h;
+    std::memset(h.data, seed, 32);
+    return h;
+}
+
+void WriteCompactSize(std::vector<uint8_t>& data, uint64_t size) {
+    if (size < 253) {
+        data.push_back(static_cast<uint8_t>(size));
+    } else if (size <= 0xFFFF) {
+        data.push_back(253);
+        data.push_back(static_cast<uint8_t>(size & 0xFF));
+        data.push_back(static_cast<uint8_t>((size >> 8) & 0xFF));
+    } else if (size <= 0xFFFFFFFF) {
+        data.push_back(254);
+        for (int i = 0; i < 4; ++i) {
+            data.push_back(static_cast<uint8_t>((size >> (i * 8)) & 0xFF));
+        }
+    } else {
+        data.push_back(255);
+        for (int i = 0; i < 8; ++i) {
+            data.push_back(static_cast<uint8_t>((size >> (i * 8)) & 0xFF));
+        }
+    }
+}
+
+CTransactionRef MakeCoinbase(uint32_t height_marker,
+                             uint64_t reward,
+                             uint8_t  spk_seed) {
+    CTransaction tx;
+    tx.nVersion = 1;
+    tx.nLockTime = 0;
+    std::vector<uint8_t> sig;
+    sig.push_back(0x04);
+    sig.push_back(static_cast<uint8_t>(height_marker & 0xFF));
+    sig.push_back(static_cast<uint8_t>((height_marker >> 8) & 0xFF));
+    sig.push_back(static_cast<uint8_t>((height_marker >> 16) & 0xFF));
+    sig.push_back(static_cast<uint8_t>((height_marker >> 24) & 0xFF));
+    tx.vin.push_back(CTxIn(COutPoint(), sig));
+    std::vector<uint8_t> spk(25, spk_seed);
+    spk[0] = 0x76; spk[1] = 0xa9; spk[2] = 0x14;
+    spk[23] = 0x88; spk[24] = 0xac;
+    tx.vout.push_back(CTxOut(reward, spk));
+    return MakeTransactionRef(tx);
+}
+
+CTransactionRef MakeSpender(const std::vector<COutPoint>& inputs,
+                            const std::vector<uint64_t>& output_values,
+                            uint8_t spk_seed) {
+    CTransaction tx;
+    tx.nVersion = 1;
+    tx.nLockTime = 0;
+    for (const auto& op : inputs) {
+        std::vector<uint8_t> sig(64, 0xAA);
+        tx.vin.push_back(CTxIn(op, sig, CTxIn::SEQUENCE_FINAL));
+    }
+    for (uint64_t v : output_values) {
+        std::vector<uint8_t> spk(25, spk_seed);
+        spk[0] = 0x76; spk[1] = 0xa9; spk[2] = 0x14;
+        spk[23] = 0x88; spk[24] = 0xac;
+        tx.vout.push_back(CTxOut(v, spk));
+    }
+    return MakeTransactionRef(tx);
+}
+
+CBlock MakeBlock(const std::vector<CTransactionRef>& txs, uint32_t time_off) {
+    CBlock block;
+    block.nVersion = 1;
+    block.nTime = 1700000000u + time_off;
+    block.nBits = 0x1d00ffff;
+    block.nNonce = 0;
+
+    std::vector<uint8_t> vtx_data;
+    WriteCompactSize(vtx_data, txs.size());
+    for (const auto& tx : txs) {
+        auto data = tx->Serialize();
+        vtx_data.insert(vtx_data.end(), data.begin(), data.end());
+    }
+    block.vtx = std::move(vtx_data);
+
+    CBlockValidator validator;
+    block.hashMerkleRoot = validator.BuildMerkleRoot(txs);
+    return block;
+}
+
+// Seed the UTXO set with a coinbase output so a follow-up block has
+// something to spend. Returns the outpoint of the seeded UTXO and the
+// payload (value + script) for round-trip comparison.
+struct Seeded {
+    COutPoint outpoint;
+    CTxOut    out;
+    uint32_t  height;
+    bool      fCoinBase;
+};
+
+Seeded SeedUtxo(CUTXOSet& utxo,
+                uint8_t   seed,
+                uint64_t  value,
+                uint32_t  height,
+                bool      coinbase) {
+    Seeded s;
+    s.outpoint = COutPoint(MakeHash(seed), 0);
+    std::vector<uint8_t> spk(25, seed);
+    spk[0] = 0x76; spk[1] = 0xa9; spk[2] = 0x14;
+    spk[23] = 0x88; spk[24] = 0xac;
+    s.out = CTxOut(value, spk);
+    s.height = height;
+    s.fCoinBase = coinbase;
+    BOOST_REQUIRE(utxo.AddUTXO(s.outpoint, s.out, height, coinbase));
+    BOOST_REQUIRE(utxo.Flush());
+    return s;
+}
+
+} // namespace
+
+// ===========================================================================
+// Test 1: round-trip on a typical block (1 coinbase + 1 spender of 2 inputs).
+// ===========================================================================
+
+BOOST_AUTO_TEST_CASE(read_undo_round_trip) {
+    TempUtxoScope scope("round_trip");
+
+    // Seed two existing UTXOs that the new block will spend.
+    auto seed_a = SeedUtxo(scope.utxo(), 0xA1, 50'000'000ULL, 10, false);
+    auto seed_b = SeedUtxo(scope.utxo(), 0xB2, 75'000'000ULL, 11, true);
+
+    // Build a block: coinbase + spender consuming both seeded UTXOs.
+    auto coinbase = MakeCoinbase(/*height=*/100, /*reward=*/12'500'000ULL, 0xC0);
+    auto spender  = MakeSpender({seed_a.outpoint, seed_b.outpoint},
+                                {30'000'000ULL, 90'000'000ULL},
+                                0xD0);
+    auto block    = MakeBlock({coinbase, spender}, /*time_off=*/0);
+    auto block_hash = MakeHash(0x42);
+
+    BOOST_REQUIRE(scope.utxo().ApplyBlock(block, /*height=*/100, block_hash));
+    BOOST_REQUIRE(scope.utxo().HasUndoData(block_hash));
+
+    CBlockUndo undo;
+    BOOST_REQUIRE(scope.utxo().ReadUndoBlock(block_hash, undo));
+
+    // Two spent inputs, in the order the writer iterates (vin order of
+    // the spender; coinbase is skipped).
+    BOOST_REQUIRE_EQUAL(undo.size(), 2u);
+
+    BOOST_CHECK(undo.vSpent[0].outpoint == seed_a.outpoint);
+    BOOST_CHECK_EQUAL(undo.vSpent[0].out.nValue, seed_a.out.nValue);
+    BOOST_CHECK(undo.vSpent[0].out.scriptPubKey == seed_a.out.scriptPubKey);
+    BOOST_CHECK_EQUAL(undo.vSpent[0].nHeight, seed_a.height);
+    BOOST_CHECK_EQUAL(undo.vSpent[0].fCoinBase, seed_a.fCoinBase);
+
+    BOOST_CHECK(undo.vSpent[1].outpoint == seed_b.outpoint);
+    BOOST_CHECK_EQUAL(undo.vSpent[1].out.nValue, seed_b.out.nValue);
+    BOOST_CHECK(undo.vSpent[1].out.scriptPubKey == seed_b.out.scriptPubKey);
+    BOOST_CHECK_EQUAL(undo.vSpent[1].nHeight, seed_b.height);
+    BOOST_CHECK_EQUAL(undo.vSpent[1].fCoinBase, seed_b.fCoinBase);
+}
+
+// ===========================================================================
+// Test 2: missing-block lookup returns false and clears the output.
+// ===========================================================================
+
+BOOST_AUTO_TEST_CASE(read_undo_missing_block) {
+    TempUtxoScope scope("missing");
+
+    // Pre-populate the output with junk so we can prove ReadUndoBlock
+    // clears it on failure.
+    CBlockUndo undo;
+    undo.vSpent.emplace_back(
+        COutPoint(MakeHash(0xEE), 7),
+        CTxOut(999ULL, std::vector<uint8_t>{0x01, 0x02}),
+        42u, false);
+    BOOST_REQUIRE_EQUAL(undo.size(), 1u);
+
+    auto absent = MakeHash(0xFF);
+    BOOST_CHECK(!scope.utxo().HasUndoData(absent));
+
+    bool ok = scope.utxo().ReadUndoBlock(absent, undo);
+    BOOST_CHECK(!ok);
+    BOOST_CHECK(undo.empty());  // cleared on failure
+}
+
+// ===========================================================================
+// Test 3: empty-undo block (coinbase-only -> spentCount=0).
+// ===========================================================================
+
+BOOST_AUTO_TEST_CASE(read_undo_empty_block) {
+    TempUtxoScope scope("empty");
+
+    auto coinbase = MakeCoinbase(/*height=*/0, /*reward=*/50'000'000ULL, 0xC1);
+    auto block    = MakeBlock({coinbase}, /*time_off=*/0);
+    auto block_hash = MakeHash(0x01);
+
+    BOOST_REQUIRE(scope.utxo().ApplyBlock(block, /*height=*/0, block_hash));
+    BOOST_REQUIRE(scope.utxo().HasUndoData(block_hash));
+
+    CBlockUndo undo;
+    BOOST_REQUIRE(scope.utxo().ReadUndoBlock(block_hash, undo));
+    BOOST_CHECK(undo.empty());
+    BOOST_CHECK_EQUAL(undo.size(), 0u);
+}
+
+// ===========================================================================
+// Test 4: large-block round-trip (1 coinbase + 1 spender consuming 256
+// seeded UTXOs).
+// ===========================================================================
+
+BOOST_AUTO_TEST_CASE(read_undo_large_block) {
+    TempUtxoScope scope("large");
+
+    constexpr size_t kInputs = 256;
+
+    // Seed kInputs UTXOs with varying value, height, coinbase flag, and
+    // script length so the round-trip exercises every record field.
+    std::vector<Seeded> seeded;
+    seeded.reserve(kInputs);
+    std::mt19937 rng(0xC0FFEE);
+    for (size_t i = 0; i < kInputs; ++i) {
+        Seeded s;
+        s.outpoint = COutPoint(MakeHash(static_cast<uint8_t>(i & 0xFF)),
+                               static_cast<uint32_t>(i));
+        // Vary script size 1..200 to exercise multi-byte boundary cases.
+        const size_t script_size = 1 + (i % 200);
+        std::vector<uint8_t> spk(script_size,
+                                 static_cast<uint8_t>(rng() & 0xFF));
+        s.out = CTxOut(1'000ULL + i, spk);
+        s.height = static_cast<uint32_t>(i + 1);
+        s.fCoinBase = (i % 7 == 0);
+        BOOST_REQUIRE(scope.utxo().AddUTXO(s.outpoint, s.out, s.height, s.fCoinBase));
+        seeded.push_back(s);
+    }
+    BOOST_REQUIRE(scope.utxo().Flush());
+
+    // Build the spender that consumes every seeded UTXO.
+    std::vector<COutPoint> inputs;
+    inputs.reserve(kInputs);
+    for (const auto& s : seeded) inputs.push_back(s.outpoint);
+
+    auto coinbase = MakeCoinbase(/*height=*/500, /*reward=*/12'500'000ULL, 0xC2);
+    auto spender  = MakeSpender(inputs, {1'000'000ULL}, 0xD2);
+    auto block    = MakeBlock({coinbase, spender}, /*time_off=*/1);
+    auto block_hash = MakeHash(0xAB);
+
+    BOOST_REQUIRE(scope.utxo().ApplyBlock(block, /*height=*/500, block_hash));
+
+    CBlockUndo undo;
+    BOOST_REQUIRE(scope.utxo().ReadUndoBlock(block_hash, undo));
+    BOOST_REQUIRE_EQUAL(undo.size(), kInputs);
+
+    // Verify every record byte-for-byte against the seeded values.
+    for (size_t i = 0; i < kInputs; ++i) {
+        BOOST_CHECK(undo.vSpent[i].outpoint == seeded[i].outpoint);
+        BOOST_CHECK_EQUAL(undo.vSpent[i].out.nValue, seeded[i].out.nValue);
+        BOOST_CHECK(undo.vSpent[i].out.scriptPubKey == seeded[i].out.scriptPubKey);
+        BOOST_CHECK_EQUAL(undo.vSpent[i].nHeight, seeded[i].height);
+        BOOST_CHECK_EQUAL(undo.vSpent[i].fCoinBase, seeded[i].fCoinBase);
+    }
+}
+
+// ===========================================================================
+// Test 5: closed db -> ReadUndoBlock returns false (no crash).
+// ===========================================================================
+
+BOOST_AUTO_TEST_CASE(read_undo_closed_db) {
+    CUTXOSet utxo;
+    BOOST_CHECK(!utxo.IsOpen());
+
+    CBlockUndo undo;
+    bool ok = utxo.ReadUndoBlock(MakeHash(0x77), undo);
+    BOOST_CHECK(!ok);
+    BOOST_CHECK(undo.empty());
+}
+
+// ===========================================================================
+// Test 6: corrupted footer -> ReadUndoBlock returns false. We round-trip
+// through ApplyBlock to write a real entry, then reach into the LevelDB
+// directly to flip the last byte (the SHA3 footer).
+// ===========================================================================
+
+BOOST_AUTO_TEST_CASE(read_undo_corrupted_checksum) {
+    auto path = MakeTempDir("corruption");
+
+    auto block_hash = MakeHash(0x55);
+    auto seed       = MakeHash(0xA9);
+
+    {
+        CUTXOSet utxo;
+        BOOST_REQUIRE(utxo.Open(path.string(), true));
+
+        // Seed + spend so we have a non-trivial undo entry.
+        Seeded s;
+        s.outpoint = COutPoint(seed, 0);
+        std::vector<uint8_t> spk(25, 0xA9);
+        spk[0] = 0x76; spk[1] = 0xa9; spk[2] = 0x14;
+        spk[23] = 0x88; spk[24] = 0xac;
+        s.out = CTxOut(50'000'000ULL, spk);
+        BOOST_REQUIRE(utxo.AddUTXO(s.outpoint, s.out, 5, false));
+        BOOST_REQUIRE(utxo.Flush());
+
+        auto coinbase = MakeCoinbase(/*height=*/200, /*reward=*/12'500'000ULL, 0xC3);
+        auto spender  = MakeSpender({s.outpoint}, {40'000'000ULL}, 0xD3);
+        auto block    = MakeBlock({coinbase, spender}, /*time_off=*/2);
+
+        BOOST_REQUIRE(utxo.ApplyBlock(block, /*height=*/200, block_hash));
+
+        // Sanity: clean read works.
+        CBlockUndo undo;
+        BOOST_REQUIRE(utxo.ReadUndoBlock(block_hash, undo));
+        BOOST_REQUIRE_EQUAL(undo.size(), 1u);
+
+        utxo.Close();
+    }
+
+    // Reach into the underlying LevelDB and flip the last byte of the
+    // undo entry (the SHA3 checksum). Then reopen via CUTXOSet and confirm
+    // ReadUndoBlock rejects the entry.
+    {
+        leveldb::DB* raw_db = nullptr;
+        leveldb::Options opts;
+        opts.create_if_missing = false;
+        BOOST_REQUIRE(leveldb::DB::Open(opts, path.string(), &raw_db).ok());
+        std::unique_ptr<leveldb::DB> db_owner(raw_db);
+
+        std::string key = "undo_";
+        key.append(reinterpret_cast<const char*>(block_hash.data), 32);
+
+        std::string val;
+        BOOST_REQUIRE(db_owner->Get(leveldb::ReadOptions(), key, &val).ok());
+        BOOST_REQUIRE(val.size() >= 36u);
+        // Flip the last byte.
+        val[val.size() - 1] ^= 0xFF;
+        BOOST_REQUIRE(db_owner->Put(leveldb::WriteOptions(), key, val).ok());
+        db_owner.reset();
+    }
+
+    {
+        CUTXOSet utxo;
+        BOOST_REQUIRE(utxo.Open(path.string(), false));
+
+        CBlockUndo undo;
+        bool ok = utxo.ReadUndoBlock(block_hash, undo);
+        BOOST_CHECK(!ok);
+        BOOST_CHECK(undo.empty());
+
+        utxo.Close();
+    }
+
+    CleanupTempDir(path);
+}
+
+// ===========================================================================
+// Test 7: truncated entry -> ReadUndoBlock returns false. Same setup as the
+// checksum test, but we lop off the last 16 bytes (which puts the read
+// below the 36-byte minimum required).
+// ===========================================================================
+
+BOOST_AUTO_TEST_CASE(read_undo_truncated) {
+    auto path = MakeTempDir("truncated");
+
+    auto block_hash = MakeHash(0x66);
+
+    {
+        CUTXOSet utxo;
+        BOOST_REQUIRE(utxo.Open(path.string(), true));
+
+        auto coinbase = MakeCoinbase(/*height=*/0, /*reward=*/50'000'000ULL, 0xC4);
+        auto block    = MakeBlock({coinbase}, /*time_off=*/3);
+
+        BOOST_REQUIRE(utxo.ApplyBlock(block, /*height=*/0, block_hash));
+        utxo.Close();
+    }
+
+    {
+        leveldb::DB* raw_db = nullptr;
+        leveldb::Options opts;
+        opts.create_if_missing = false;
+        BOOST_REQUIRE(leveldb::DB::Open(opts, path.string(), &raw_db).ok());
+        std::unique_ptr<leveldb::DB> db_owner(raw_db);
+
+        std::string key = "undo_";
+        key.append(reinterpret_cast<const char*>(block_hash.data), 32);
+
+        std::string val;
+        BOOST_REQUIRE(db_owner->Get(leveldb::ReadOptions(), key, &val).ok());
+        // Truncate so the value is below the minimum (4 + 32 = 36 bytes).
+        // An empty-undo entry is exactly 36 bytes; lopping any non-zero
+        // amount off pushes us under.
+        val.resize(val.size() / 2);
+        BOOST_REQUIRE(db_owner->Put(leveldb::WriteOptions(), key, val).ok());
+        db_owner.reset();
+    }
+
+    {
+        CUTXOSet utxo;
+        BOOST_REQUIRE(utxo.Open(path.string(), false));
+
+        CBlockUndo undo;
+        bool ok = utxo.ReadUndoBlock(block_hash, undo);
+        BOOST_CHECK(!ok);
+        BOOST_CHECK(undo.empty());
+
+        utxo.Close();
+    }
+
+    CleanupTempDir(path);
+}
+
+// ===========================================================================
+// Test 8: bogus spentCount that overflows the payload bound. We craft a raw
+// LevelDB entry with a huge declared count and a fresh SHA3 footer so the
+// checksum passes; the per-record bound check must reject it before any
+// allocation.
+// ===========================================================================
+
+BOOST_AUTO_TEST_CASE(read_undo_bogus_spent_count) {
+    auto path = MakeTempDir("bogus_count");
+    auto block_hash = MakeHash(0x99);
+
+    {
+        CUTXOSet utxo;
+        BOOST_REQUIRE(utxo.Open(path.string(), true));
+        utxo.Close();
+    }
+
+    {
+        leveldb::DB* raw_db = nullptr;
+        leveldb::Options opts;
+        opts.create_if_missing = false;
+        BOOST_REQUIRE(leveldb::DB::Open(opts, path.string(), &raw_db).ok());
+        std::unique_ptr<leveldb::DB> db_owner(raw_db);
+
+        // Body: spentCount = 0xFFFFFFFF, then no records.
+        std::vector<uint8_t> body(4, 0xFF);
+
+        // Append a valid SHA3-256 footer over body.
+        uint8_t checksum[32];
+        SHA3_256(body.data(), body.size(), checksum);
+        body.insert(body.end(), checksum, checksum + 32);
+
+        std::string key = "undo_";
+        key.append(reinterpret_cast<const char*>(block_hash.data), 32);
+        std::string val(reinterpret_cast<const char*>(body.data()), body.size());
+        BOOST_REQUIRE(db_owner->Put(leveldb::WriteOptions(), key, val).ok());
+        db_owner.reset();
+    }
+
+    {
+        CUTXOSet utxo;
+        BOOST_REQUIRE(utxo.Open(path.string(), false));
+
+        CBlockUndo undo;
+        bool ok = utxo.ReadUndoBlock(block_hash, undo);
+        BOOST_CHECK(!ok);
+        BOOST_CHECK(undo.empty());
+
+        utxo.Close();
+    }
+
+    CleanupTempDir(path);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/undo_data_tests.cpp
+++ b/src/test/undo_data_tests.cpp
@@ -547,4 +547,121 @@ BOOST_AUTO_TEST_CASE(read_undo_bogus_spent_count) {
     CleanupTempDir(path);
 }
 
+// ===========================================================================
+// Test 9: per-record bounds checks — body declares spentCount=2 but only
+// has enough bytes for ~1.5 records. This drives the per-record loop into a
+// mid-record truncation, exercising the inline `end - ptr < 32 + 4`,
+// `< 8`, `< 4`, `script_len > end - ptr`, and `< 4 + 1` bounds checks that
+// the upfront `spentCount * kMinRecordBytes` floor doesn't reach.
+//
+// Closes the test-coverage gap red-team Finding 1: prior tests only
+// exercised the upfront 36-byte floor or the upfront kMinRecordBytes guard;
+// none crossed into the per-record parser with a truncation. A regression
+// that swapped, removed, or off-by-oned any of the per-record checks would
+// have slipped past the existing suite.
+// ===========================================================================
+BOOST_AUTO_TEST_CASE(read_undo_per_record_truncation) {
+    auto path = MakeTempDir("per_record_truncation");
+    auto block_hash = MakeHash(0xAB);
+
+    {
+        CUTXOSet utxo;
+        BOOST_REQUIRE(utxo.Open(path.string(), true));
+        utxo.Close();
+    }
+
+    {
+        leveldb::DB* raw_db = nullptr;
+        leveldb::Options opts;
+        opts.create_if_missing = false;
+        BOOST_REQUIRE(leveldb::DB::Open(opts, path.string(), &raw_db).ok());
+        std::unique_ptr<leveldb::DB> db_owner(raw_db);
+
+        // Body: spentCount=2, then ONE valid record (53 bytes minimum),
+        // then truncated bytes for the second record (only 20 bytes — not
+        // even the 32-byte outpoint hash). Upfront kMinRecordBytes guard
+        // (53 * 2 = 106 bytes, body has 4 + 53 + 20 = 77 bytes) would
+        // catch this -- so we intentionally pad it to satisfy the upfront
+        // check while still mid-record-truncating in the loop.
+        std::vector<uint8_t> body;
+
+        // u32 spentCount = 2
+        const uint32_t count = 2;
+        for (int i = 0; i < 4; ++i) {
+            body.push_back(static_cast<uint8_t>((count >> (i * 8)) & 0xFF));
+        }
+
+        // Record 1: complete 53-byte minimum (no script).
+        // outpoint hash (32 bytes)
+        for (int i = 0; i < 32; ++i) body.push_back(static_cast<uint8_t>(i));
+        // outpoint n (u32) = 0
+        for (int i = 0; i < 4; ++i) body.push_back(0);
+        // nValue (i64) = 1000
+        const int64_t nValue = 1000;
+        for (int i = 0; i < 8; ++i) {
+            body.push_back(static_cast<uint8_t>((nValue >> (i * 8)) & 0xFF));
+        }
+        // scriptLen (u32) = 0
+        for (int i = 0; i < 4; ++i) body.push_back(0);
+        // prevHeight (u32) = 1
+        body.push_back(0x01);
+        body.push_back(0x00);
+        body.push_back(0x00);
+        body.push_back(0x00);
+        // fCoinBase (u8) = 0
+        body.push_back(0x00);
+        // Record 1 size: 32 + 4 + 8 + 4 + 4 + 1 = 53 bytes.
+
+        // Record 2: pad with 53 bytes of garbage to satisfy the upfront
+        // kMinRecordBytes floor, but with internal layout that drives the
+        // per-record loop into truncation. Layout for record 2:
+        //   - outpoint hash (32 bytes) — fine
+        //   - outpoint n (4 bytes) — fine
+        //   - nValue (8 bytes) — fine
+        //   - scriptLen (4 bytes) — declare 9999 (too large for remaining body)
+        //   - script body — remaining bytes (insufficient for declared 9999)
+        // After scriptLen claims 9999, the per-record `script_len > end - ptr`
+        // bound check trips. With 53 bytes of record-2 body + 32-byte footer,
+        // the upfront floor passes (4 + 53 + 53 = 110 > kMinRecordBytes*2).
+        for (int i = 0; i < 32; ++i) body.push_back(0xCC);  // hash
+        for (int i = 0; i < 4; ++i) body.push_back(0x00);   // n=0
+        for (int i = 0; i < 8; ++i) body.push_back(0x00);   // nValue=0
+        // scriptLen = 9999 (causes per-record bound trip)
+        body.push_back(0x0F);
+        body.push_back(0x27);
+        body.push_back(0x00);
+        body.push_back(0x00);
+        // 5 trailing bytes -- not enough for the declared 9999-byte script.
+        for (int i = 0; i < 5; ++i) body.push_back(0x00);
+
+        // Append a valid SHA3-256 footer so the up-front checksum passes.
+        uint8_t checksum[32];
+        SHA3_256(body.data(), body.size(), checksum);
+        body.insert(body.end(), checksum, checksum + 32);
+
+        std::string key = "undo_";
+        key.append(reinterpret_cast<const char*>(block_hash.data), 32);
+        std::string val(reinterpret_cast<const char*>(body.data()), body.size());
+        BOOST_REQUIRE(db_owner->Put(leveldb::WriteOptions(), key, val).ok());
+        db_owner.reset();
+    }
+
+    {
+        CUTXOSet utxo;
+        BOOST_REQUIRE(utxo.Open(path.string(), false));
+
+        CBlockUndo undo;
+        bool ok = utxo.ReadUndoBlock(block_hash, undo);
+        // Per-record bound check (`script_len > end - ptr`) must reject.
+        BOOST_CHECK(!ok);
+        // On any failure post-Clear(), undo must be empty -- the partial
+        // record-1 parse must NOT leak through.
+        BOOST_CHECK(undo.empty());
+
+        utxo.Close();
+    }
+
+    CleanupTempDir(path);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary

First sub-PR of the block-analytics bundle. Adds a read-only accessor on top of Dilithion's existing on-disk undo-data format so subsequent PRs (PR-BA-2 coinstatsindex, PR-BA-3 getblockstats) can build on it without touching the storage layer again.

- New: `CUTXOSet::ReadUndoBlock(blockhash, CBlockUndo&)` -- read-only, no mutation, SHA3-256 footer verified before parsing.
- New: `src/node/undo_data.h` with `CSpentInput` and `CBlockUndo` types and a docblock that documents the divergence from Bitcoin Core's per-tx-grouped `CBlockUndo`.
- New: `src/test/undo_data_tests.cpp` with 8 cases / 1601 assertions.
- No RPC wiring, no `coinstatsindex` -- those land in PR-BA-2 and PR-BA-3.

## Format divergence (documented inline)

Dilithion writes one flat list of spent inputs per block (count + records + SHA3-256 footer). Bitcoin Core groups them per-tx (`vector<CTxUndo>` containing `vector<Coin>`). The new docblock in `node/undo_data.h` explains why the flat layout suffices for the analytics consumers PR-BA-2/3 will add (per-block fee aggregation and UTXO-set stats indexing don't need per-tx grouping). If a future port needs per-tx grouping, the writer in `ApplyBlock` will have to add a boundary marker -- out of scope here.

## Test coverage

- round-trip: 1 coinbase + 1 spender of 2 inputs, byte-for-byte equality
- missing-block lookup returns `false` and clears the output
- empty-undo block (coinbase-only, `spentCount=0`)
- large-block round-trip (256 spent inputs, varying script lengths, heights, and coinbase flags) -- exercises every record field
- closed-db read returns `false` without crashing
- corrupted SHA3 footer rejected
- truncated entry below minimum size rejected
- bogus `spentCount` (4 billion records, valid checksum) rejected before any allocation

## Test plan

- [x] `make test_dilithion` clean
- [x] `undo_data_tests`: 8/8 pass, 1601/1601 assertions
- [x] Regression: `utxo_tests`, `tx_index_tests`, `tx_index_integration_tests`, `mempool_persist_tests` -- 81/81 cases, 20578/20578 assertions
- [x] `dilithion-node` and `dilv-node` build clean
- [x] No new warnings on touched files

## Methodology

Per the contract (`.claude/contracts/contract_block_analytics_undo_data.md`), PR-BA-1 risk is MEDIUM; methodology is **contract dual-val + diff red-team**. The contract is the dual-val artifact; diff red-team will run after this push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)