### PR TITLE
feat(policy): estimatesmartfee core + persistence [PR-EF-1]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -271,6 +271,12 @@ SCRIPT_SOURCES := src/script/interpreter.cpp \
                   src/script/htlc.cpp \
                   src/script/atomic_swap.cpp
 
+# Policy module: fee estimator + fee_estimates.dat persistence (BC port,
+# PR-EF-1). Pure module addition; mempool/chainstate hooks land in PR-EF-2,
+# RPC handlers land in PR-EF-3.
+POLICY_SOURCES := src/policy/fees.cpp \
+                  src/policy/fee_persist.cpp
+
 WALLET_SOURCES := src/wallet/wallet.cpp \
                   src/wallet/crypter.cpp \
                   src/wallet/passphrase_validator.cpp \
@@ -312,6 +318,7 @@ CORE_SOURCES := $(CONSENSUS_SOURCES) \
                 $(API_SOURCES) \
                 $(X402_SOURCES) \
                 $(SCRIPT_SOURCES) \
+                $(POLICY_SOURCES) \
                 $(UTIL_SOURCES) \
                 $(WALLET_SOURCES)
 
@@ -623,6 +630,8 @@ BOOST_TEST_OBJECTS := $(OBJ_DIR)/test/test_dilithion.o \
 	$(OBJ_DIR)/test/tx_index_tests.o \
 	$(OBJ_DIR)/test/tx_index_integration_tests.o \
 	$(OBJ_DIR)/test/mempool_persist_tests.o \
+	$(OBJ_DIR)/test/fee_estimator_tests.o \
+	$(OBJ_DIR)/test/fee_persist_tests.o \
 	$(CRYPTO_PROPERTY_OBJECTS)
 
 # Link test objects + full library (CORE_OBJECTS) to avoid hand-picked object drift
@@ -729,6 +738,7 @@ $(OBJ_DIR)/vdf \
 $(OBJ_DIR)/chiavdf \
 $(OBJ_DIR)/digital_dna \
 $(OBJ_DIR)/script \
+$(OBJ_DIR)/policy \
 $(OBJ_DIR)/tools \
 $(OBJ_DIR)/x402 \
 $(OBJ_DIR)/test \
@@ -736,7 +746,7 @@ $(OBJ_DIR)/test/fuzz:
 	@mkdir -p $@
 
 # Compile C++ source files
-$(OBJ_DIR)/%.o: src/%.cpp | $(OBJ_DIR)/attestation $(OBJ_DIR)/consensus $(OBJ_DIR)/core $(OBJ_DIR)/crypto $(OBJ_DIR)/db $(OBJ_DIR)/dfmp $(OBJ_DIR)/index $(OBJ_DIR)/miner $(OBJ_DIR)/net $(OBJ_DIR)/node $(OBJ_DIR)/primitives $(OBJ_DIR)/rpc $(OBJ_DIR)/wallet $(OBJ_DIR)/util $(OBJ_DIR)/api $(OBJ_DIR)/vdf $(OBJ_DIR)/digital_dna $(OBJ_DIR)/script $(OBJ_DIR)/tools $(OBJ_DIR)/x402 $(OBJ_DIR)/test
+$(OBJ_DIR)/%.o: src/%.cpp | $(OBJ_DIR)/attestation $(OBJ_DIR)/consensus $(OBJ_DIR)/core $(OBJ_DIR)/crypto $(OBJ_DIR)/db $(OBJ_DIR)/dfmp $(OBJ_DIR)/index $(OBJ_DIR)/miner $(OBJ_DIR)/net $(OBJ_DIR)/node $(OBJ_DIR)/primitives $(OBJ_DIR)/rpc $(OBJ_DIR)/wallet $(OBJ_DIR)/util $(OBJ_DIR)/api $(OBJ_DIR)/vdf $(OBJ_DIR)/digital_dna $(OBJ_DIR)/script $(OBJ_DIR)/policy $(OBJ_DIR)/tools $(OBJ_DIR)/x402 $(OBJ_DIR)/test
 	@echo "$(COLOR_BLUE)[CXX]$(COLOR_RESET)  $<"
 	@$(CXX) $(CXXFLAGS) $(INCLUDES) -c $< -o $@
 

--- a/src/policy/fee_persist.cpp
+++ b/src/policy/fee_persist.cpp
@@ -491,6 +491,30 @@ LoadResult LoadFeeEstimates(CBlockPolicyEstimator& estimator,
         snap.historical_first = stream.ReadUint32();
         snap.historical_best  = stream.ReadUint32();
 
+        // PR-EF-1-FIX Finding F7: validate historical ordering. A footer-
+        // valid file (the file is on operator-controlled disk; an attacker
+        // with FS write access could compute a fresh SHA3 footer over
+        // forged bytes) could declare historical_first > historical_best.
+        // Without this check, the unsigned subtraction
+        // `historical_best - historical_first` wraps to a huge number,
+        // which the accumulation gate at fees.cpp ~370 then "passes",
+        // bypassing the insufficient-data window. Treat inconsistent
+        // ordering as cold-start.
+        // Both-zero is the legitimate "never observed a block" state.
+        if (snap.historical_first != 0 &&
+            snap.historical_first > snap.historical_best) {
+            result.success = true;
+            result.cold_start = true;
+            result.cold_start_reason = "historical_first (" +
+                std::to_string(snap.historical_first) +
+                ") > historical_best (" +
+                std::to_string(snap.historical_best) + ")";
+            std::cerr << "[fee_estimator] LoadFeeEstimates: "
+                      << result.cold_start_reason
+                      << " -- starting fresh" << std::endl;
+            return result;
+        }
+
         const uint32_t bucket_count = stream.ReadUint32();
         if (bucket_count == 0 || bucket_count > MAX_BUCKET_COUNT) {
             result.success = true;

--- a/src/policy/fee_persist.cpp
+++ b/src/policy/fee_persist.cpp
@@ -1,0 +1,593 @@
+// Copyright (c) 2026 The Dilithion Core developers
+// Distributed under the MIT software license
+
+#include <policy/fee_persist.h>
+
+#include <policy/fees.h>
+#include <net/serialize.h>
+#include <crypto/sha3.h>
+#include <uint256.h>
+
+#include <cerrno>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <random>
+#include <system_error>
+#include <vector>
+
+#ifdef _WIN32
+#include <io.h>
+#include <fcntl.h>
+#define POSIX_FSYNC(fd) _commit(fd)
+#else
+#include <fcntl.h>
+#include <unistd.h>
+#define POSIX_FSYNC(fd) fsync(fd)
+#endif
+
+namespace policy {
+namespace fee_persist {
+
+namespace test_hooks {
+std::atomic<bool> g_force_dump_failure{false};
+std::atomic<bool> g_force_late_dump_failure{false};
+}
+
+namespace {
+
+using policy::fee_estimator::CBlockPolicyEstimator;
+using policy::fee_estimator::TxConfirmStats;
+
+// ---------------------------------------------------------------------------
+// Numeric encoding
+// ---------------------------------------------------------------------------
+
+// Bucket boundary encoding: store as int64 = round(ld * 1e6). At our bucket
+// range (1000 .. 1e7) this gives us 6 decimal digits of precision -- vastly
+// more than the 1.05x bucket spacing requires (about 2% of the smallest
+// bucket). The INF_FEERATE sentinel (MAX_MONEY) is stored as INT64_MAX to
+// avoid overflow; DecodeBucket recognizes it and returns INF_FEERATE.
+// Long-double comparison in restore() uses 1e-3 RELATIVE tolerance to absorb
+// the loss-y round-trip (precision ~1e-6 of value at BUCKET_SCALE=1e6).
+constexpr long double BUCKET_SCALE = 1e6L;
+
+int64_t EncodeBucket(long double ld) {
+    // INF sentinel: any value at or above the in-memory INF_FEERATE
+    // encodes to INT64_MAX. (Not technically Inf -- it's MAX_MONEY -- but
+    // we treat the top-of-ladder bucket as "out of range high" semantically.)
+    if (ld >= policy::fee_estimator::INF_FEERATE) return INT64_MAX;
+    // Avoid std::llround on Windows (LLP64) -- round explicitly.
+    const long double scaled = ld * BUCKET_SCALE;
+    if (scaled >= static_cast<long double>(INT64_MAX) - 1) return INT64_MAX;
+    if (scaled <= static_cast<long double>(INT64_MIN) + 1) return INT64_MIN;
+    const long double rounded = (scaled >= 0.0L)
+        ? std::floor(scaled + 0.5L)
+        : std::ceil(scaled - 0.5L);
+    return static_cast<int64_t>(rounded);
+}
+
+long double DecodeBucket(int64_t v) {
+    if (v == INT64_MAX) return policy::fee_estimator::INF_FEERATE;
+    return static_cast<long double>(v) / BUCKET_SCALE;
+}
+
+// Counter encoding: Q32.32 fixed-point. The decayed counters accumulate
+// values up to a few thousand (in real workloads); 32 fractional bits give
+// us ~2.3e-10 precision, far more than the long-double-decay-step error.
+// 32 integer bits give us up to ~2 billion observations, more than enough.
+constexpr long double Q32_SCALE = 4294967296.0L;  // 2^32
+
+int64_t EncodeCounter(long double ld) {
+    if (ld <= 0.0L) return 0;
+    const long double scaled = ld * Q32_SCALE;
+    if (scaled >= static_cast<long double>(INT64_MAX)) return INT64_MAX;
+    return static_cast<int64_t>(static_cast<double>(scaled));
+}
+
+long double DecodeCounter(int64_t v) {
+    if (v <= 0) return 0.0L;
+    return static_cast<long double>(v) / Q32_SCALE;
+}
+
+// ---------------------------------------------------------------------------
+// SHA3-256 footer + XOR-scramble (verbatim from mempool_persist)
+// ---------------------------------------------------------------------------
+
+std::vector<uint8_t> ComputeFooter(const std::vector<uint8_t>& payload) {
+    uint8_t full[32];
+    SHA3_256(payload.data(), payload.size(), full);
+    return std::vector<uint8_t>(full, full + FOOTER_SIZE);
+}
+
+bool VerifyFooter(const std::vector<uint8_t>& whole_file) {
+    if (whole_file.size() < FOOTER_SIZE) return false;
+    const size_t payload_size = whole_file.size() - FOOTER_SIZE;
+    uint8_t computed[32];
+    SHA3_256(whole_file.data(), payload_size, computed);
+    return std::memcmp(computed, whole_file.data() + payload_size,
+                       FOOTER_SIZE) == 0;
+}
+
+std::vector<uint8_t> GenerateXorKey() {
+    std::vector<uint8_t> key(XOR_KEY_SIZE);
+    std::random_device rd;
+    std::uniform_int_distribution<int> dist(0, 255);
+    for (size_t i = 0; i < XOR_KEY_SIZE; ++i) {
+        key[i] = static_cast<uint8_t>(dist(rd));
+    }
+    return key;
+}
+
+void XorScramble(uint8_t* data, size_t length,
+                 const std::vector<uint8_t>& key, size_t offset = 0) {
+    for (size_t i = 0; i < length; ++i) {
+        data[i] ^= key[(i + offset) % XOR_KEY_SIZE];
+    }
+}
+
+std::string FsyncParentDir(const std::filesystem::path& file_path) {
+#ifdef _WIN32
+    (void)file_path;
+    return std::string();
+#else
+    const std::filesystem::path parent = file_path.parent_path();
+    if (parent.empty()) return std::string();
+    int dir_fd = ::open(parent.c_str(), O_RDONLY);
+    if (dir_fd < 0) {
+        return "open parent dir for fsync failed: " +
+               std::string(std::strerror(errno));
+    }
+    if (::fsync(dir_fd) != 0) {
+        const std::string err = std::strerror(errno);
+        ::close(dir_fd);
+        return "fsync parent dir failed: " + err;
+    }
+    ::close(dir_fd);
+    return std::string();
+#endif
+}
+
+std::string AtomicWrite(const std::filesystem::path& target,
+                        const std::vector<uint8_t>& bytes) {
+    if (test_hooks::g_force_dump_failure.load(std::memory_order_relaxed)) {
+        return "forced dump failure (test, early)";
+    }
+
+    const std::filesystem::path tmp = target.parent_path() / FILENAME_TMP;
+    auto cleanup_tmp = [&]() {
+        std::error_code ec_unused;
+        std::filesystem::remove(tmp, ec_unused);
+    };
+
+    FILE* f = std::fopen(tmp.string().c_str(), "wb");
+    if (f == nullptr) {
+        return "fopen(" + tmp.string() + ") failed: " + std::strerror(errno);
+    }
+    const size_t written = std::fwrite(bytes.data(), 1, bytes.size(), f);
+    if (written != bytes.size()) {
+        const std::string err = std::strerror(errno);
+        std::fclose(f);
+        cleanup_tmp();
+        return "fwrite short: " + err;
+    }
+    if (std::fflush(f) != 0) {
+        const std::string err = std::strerror(errno);
+        std::fclose(f);
+        cleanup_tmp();
+        return "fflush failed: " + err;
+    }
+
+    if (test_hooks::g_force_late_dump_failure.load(
+            std::memory_order_relaxed)) {
+        std::fclose(f);
+        cleanup_tmp();
+        return "forced dump failure (test, late)";
+    }
+
+#ifdef _WIN32
+    const int fd = _fileno(f);
+#else
+    const int fd = fileno(f);
+#endif
+    if (fd < 0 || POSIX_FSYNC(fd) != 0) {
+        const std::string err = std::strerror(errno);
+        std::fclose(f);
+        cleanup_tmp();
+        return "fsync failed: " + err;
+    }
+    std::fclose(f);
+
+    std::error_code ec;
+    std::filesystem::rename(tmp, target, ec);
+    if (ec) {
+        const std::string err = ec.message();
+        cleanup_tmp();
+        return "rename(" + tmp.string() + " -> " + target.string() +
+               ") failed: " + err;
+    }
+
+    const std::string dir_err = FsyncParentDir(target);
+    if (!dir_err.empty()) return dir_err;
+    return std::string();
+}
+
+// ---------------------------------------------------------------------------
+// Stats serialization
+// ---------------------------------------------------------------------------
+
+void WriteStats(CDataStream& s, const TxConfirmStats& stats) {
+    const size_t bucket_count = stats.tx_ct_avg.size();
+    const uint32_t periods = static_cast<uint32_t>(stats.conf_avg.size());
+    const uint32_t depth   = static_cast<uint32_t>(stats.unconf_txs.size());
+    s.WriteUint32(periods);
+    s.WriteUint32(static_cast<uint32_t>(bucket_count));
+    s.WriteUint32(depth);
+
+    for (uint32_t p = 0; p < periods; ++p) {
+        for (size_t b = 0; b < bucket_count; ++b) {
+            s.WriteInt64(EncodeCounter(stats.conf_avg[p][b]));
+        }
+    }
+    for (uint32_t p = 0; p < periods; ++p) {
+        for (size_t b = 0; b < bucket_count; ++b) {
+            s.WriteInt64(EncodeCounter(stats.fail_avg[p][b]));
+        }
+    }
+    for (size_t b = 0; b < bucket_count; ++b) {
+        s.WriteInt64(EncodeCounter(stats.tx_ct_avg[b]));
+    }
+    for (uint32_t a = 0; a < depth; ++a) {
+        for (size_t b = 0; b < bucket_count; ++b) {
+            s.WriteInt32(static_cast<int32_t>(stats.unconf_txs[a][b]));
+        }
+    }
+    for (size_t b = 0; b < bucket_count; ++b) {
+        s.WriteInt32(static_cast<int32_t>(stats.old_unconf_txs[b]));
+    }
+}
+
+bool ReadStats(CDataStream& s, TxConfirmStats& out, std::string& err) {
+    const uint32_t periods = s.ReadUint32();
+    const uint32_t bucket_count_raw = s.ReadUint32();
+    const uint32_t depth   = s.ReadUint32();
+
+    if (periods == 0 || periods > MAX_PERIODS) {
+        err = "stats periods=" + std::to_string(periods) + " out of range";
+        return false;
+    }
+    if (bucket_count_raw == 0 || bucket_count_raw > MAX_BUCKET_COUNT) {
+        err = "stats bucket_count=" + std::to_string(bucket_count_raw) +
+              " out of range";
+        return false;
+    }
+    if (depth > MAX_UNCONF_DEPTH) {
+        err = "stats unconf_depth=" + std::to_string(depth) +
+              " out of range";
+        return false;
+    }
+    const size_t bucket_count = static_cast<size_t>(bucket_count_raw);
+
+    out.conf_avg.assign(periods,
+                        std::vector<long double>(bucket_count, 0.0L));
+    out.fail_avg.assign(periods,
+                        std::vector<long double>(bucket_count, 0.0L));
+    out.tx_ct_avg.assign(bucket_count, 0.0L);
+    out.unconf_txs.assign(depth, std::vector<int>(bucket_count, 0));
+    out.old_unconf_txs.assign(bucket_count, 0);
+
+    for (uint32_t p = 0; p < periods; ++p) {
+        for (size_t b = 0; b < bucket_count; ++b) {
+            out.conf_avg[p][b] = DecodeCounter(s.ReadInt64());
+        }
+    }
+    for (uint32_t p = 0; p < periods; ++p) {
+        for (size_t b = 0; b < bucket_count; ++b) {
+            out.fail_avg[p][b] = DecodeCounter(s.ReadInt64());
+        }
+    }
+    for (size_t b = 0; b < bucket_count; ++b) {
+        out.tx_ct_avg[b] = DecodeCounter(s.ReadInt64());
+    }
+    for (uint32_t a = 0; a < depth; ++a) {
+        for (size_t b = 0; b < bucket_count; ++b) {
+            out.unconf_txs[a][b] = static_cast<int>(s.ReadInt32());
+        }
+    }
+    for (size_t b = 0; b < bucket_count; ++b) {
+        out.old_unconf_txs[b] = static_cast<int>(s.ReadInt32());
+    }
+    return true;
+}
+
+}  // anonymous namespace
+
+DumpResult DumpFeeEstimates(const CBlockPolicyEstimator& estimator,
+                            const std::filesystem::path& datadir) {
+    DumpResult result;
+
+    auto snap = estimator.snapshot();
+
+    if (snap.tracked_txs.size() > MAX_TRACKED_TX) {
+        result.error_message = "tracked tx count " +
+            std::to_string(snap.tracked_txs.size()) +
+            " exceeds dump cap " + std::to_string(MAX_TRACKED_TX);
+        return result;
+    }
+    if (snap.buckets.size() > MAX_BUCKET_COUNT) {
+        result.error_message = "bucket count " +
+            std::to_string(snap.buckets.size()) +
+            " exceeds dump cap " + std::to_string(MAX_BUCKET_COUNT);
+        return result;
+    }
+
+    CDataStream stream;
+    stream.reserve(8192);
+
+    stream.WriteUint8(SCHEMA_VERSION);
+    const std::vector<uint8_t> xor_key = GenerateXorKey();
+    stream.write(xor_key.data(), xor_key.size());
+
+    const size_t body_start = stream.size();
+
+    // Header
+    stream.WriteUint32(snap.best_seen_height);
+    stream.WriteUint32(snap.historical_first);
+    stream.WriteUint32(snap.historical_best);
+
+    // Buckets
+    stream.WriteUint32(static_cast<uint32_t>(snap.buckets.size()));
+    for (long double b : snap.buckets) {
+        stream.WriteInt64(EncodeBucket(b));
+    }
+
+    // Three stat collections
+    WriteStats(stream, snap.short_stats);
+    WriteStats(stream, snap.med_stats);
+    WriteStats(stream, snap.long_stats);
+
+    // Tracked txs
+    stream.WriteUint64(static_cast<uint64_t>(snap.tracked_txs.size()));
+    for (const auto& [h, t] : snap.tracked_txs) {
+        stream.WriteUint256(h);
+        stream.WriteUint32(t.height);
+        stream.WriteUint32(t.bucket_index);
+        stream.WriteUint8(t.horizon_mask);
+    }
+
+    std::vector<uint8_t> bytes = stream.GetData();
+    const std::vector<uint8_t> footer = ComputeFooter(bytes);
+
+    // Scramble body (everything after version + key).
+    if (bytes.size() > body_start) {
+        XorScramble(bytes.data() + body_start, bytes.size() - body_start,
+                    xor_key);
+    }
+    // Append scrambled footer.
+    const size_t footer_offset_in_body = bytes.size() - body_start;
+    bytes.insert(bytes.end(), footer.begin(), footer.end());
+    XorScramble(bytes.data() + body_start + footer_offset_in_body, FOOTER_SIZE,
+                xor_key, footer_offset_in_body);
+
+    if (bytes.size() > MAX_FILE_SIZE) {
+        result.error_message = "computed file size " +
+            std::to_string(bytes.size()) + " exceeds MAX_FILE_SIZE " +
+            std::to_string(MAX_FILE_SIZE);
+        return result;
+    }
+
+    const std::filesystem::path target = datadir / FILENAME;
+    const std::string write_error = AtomicWrite(target, bytes);
+    if (!write_error.empty()) {
+        result.error_message = write_error;
+        return result;
+    }
+
+    result.success = true;
+    result.bytes_written = bytes.size();
+    result.tracked_tx_count = snap.tracked_txs.size();
+    result.final_path = target.string();
+    std::cout << "[fee_estimator] DumpFeeEstimates: wrote "
+              << bytes.size() << " bytes ("
+              << snap.tracked_txs.size() << " tracked txs) to "
+              << target.string() << std::endl;
+    return result;
+}
+
+LoadResult LoadFeeEstimates(CBlockPolicyEstimator& estimator,
+                            const std::filesystem::path& datadir) {
+    LoadResult result;
+
+    const std::filesystem::path target = datadir / FILENAME;
+    std::error_code ec;
+
+    if (!std::filesystem::exists(target, ec)) {
+        result.success = true;
+        result.cold_start = true;
+        result.cold_start_reason = "file not found";
+        std::cout << "[fee_estimator] LoadFeeEstimates: " << target.string()
+                  << " not found, starting fresh" << std::endl;
+        return result;
+    }
+
+    const std::uintmax_t reported_size = std::filesystem::file_size(target, ec);
+    if (ec) {
+        result.error_message = "file_size(" + target.string() +
+            ") failed: " + ec.message();
+        return result;
+    }
+    if (reported_size > MAX_FILE_SIZE) {
+        result.success = true;
+        result.cold_start = true;
+        result.cold_start_reason = "file size " +
+            std::to_string(reported_size) + " exceeds MAX_FILE_SIZE " +
+            std::to_string(MAX_FILE_SIZE);
+        std::cerr << "[fee_estimator] LoadFeeEstimates: "
+                  << result.cold_start_reason << " -- starting fresh"
+                  << std::endl;
+        return result;
+    }
+    if (reported_size < MIN_FILE_SIZE) {
+        result.success = true;
+        result.cold_start = true;
+        result.cold_start_reason = "file too small (" +
+            std::to_string(reported_size) + " bytes, minimum " +
+            std::to_string(MIN_FILE_SIZE) + ")";
+        std::cerr << "[fee_estimator] LoadFeeEstimates: "
+                  << result.cold_start_reason << " -- starting fresh"
+                  << std::endl;
+        return result;
+    }
+
+    std::ifstream in(target.string(), std::ios::binary);
+    if (!in.is_open()) {
+        result.error_message = "failed to open " + target.string();
+        return result;
+    }
+    std::vector<uint8_t> whole_file(static_cast<size_t>(reported_size));
+    if (!in.read(reinterpret_cast<char*>(whole_file.data()), reported_size)) {
+        result.error_message = "read failed on " + target.string();
+        return result;
+    }
+    in.close();
+
+    const uint8_t version = whole_file[0];
+    if (version != SCHEMA_VERSION) {
+        result.success = true;
+        result.cold_start = true;
+        result.cold_start_reason = "unknown schema version " +
+            std::to_string(version);
+        std::cerr << "[fee_estimator] LoadFeeEstimates: "
+                  << result.cold_start_reason << " -- starting fresh"
+                  << std::endl;
+        return result;
+    }
+
+    std::vector<uint8_t> xor_key(whole_file.begin() + 1,
+                                  whole_file.begin() + 1 + XOR_KEY_SIZE);
+    const size_t body_start = 1 + XOR_KEY_SIZE;
+    XorScramble(whole_file.data() + body_start,
+                whole_file.size() - body_start, xor_key);
+
+    if (!VerifyFooter(whole_file)) {
+        result.success = true;
+        result.cold_start = true;
+        result.cold_start_reason = "integrity footer mismatch";
+        std::cerr << "[fee_estimator] LoadFeeEstimates: "
+                  << result.cold_start_reason << " -- starting fresh"
+                  << std::endl;
+        return result;
+    }
+
+    std::vector<uint8_t> payload(whole_file.begin() + body_start,
+                                  whole_file.end() - FOOTER_SIZE);
+    CDataStream stream(payload);
+
+    try {
+        CBlockPolicyEstimator::Snapshot snap;
+        snap.best_seen_height = stream.ReadUint32();
+        snap.historical_first = stream.ReadUint32();
+        snap.historical_best  = stream.ReadUint32();
+
+        const uint32_t bucket_count = stream.ReadUint32();
+        if (bucket_count == 0 || bucket_count > MAX_BUCKET_COUNT) {
+            result.success = true;
+            result.cold_start = true;
+            result.cold_start_reason = "bucket_count " +
+                std::to_string(bucket_count) + " out of range";
+            std::cerr << "[fee_estimator] LoadFeeEstimates: "
+                      << result.cold_start_reason
+                      << " -- starting fresh" << std::endl;
+            return result;
+        }
+        snap.buckets.reserve(bucket_count);
+        for (uint32_t i = 0; i < bucket_count; ++i) {
+            snap.buckets.push_back(DecodeBucket(stream.ReadInt64()));
+        }
+
+        std::string err;
+        if (!ReadStats(stream, snap.short_stats, err)) {
+            result.success = true;
+            result.cold_start = true;
+            result.cold_start_reason = "short stats: " + err;
+            std::cerr << "[fee_estimator] LoadFeeEstimates: "
+                      << result.cold_start_reason
+                      << " -- starting fresh" << std::endl;
+            return result;
+        }
+        if (!ReadStats(stream, snap.med_stats, err)) {
+            result.success = true;
+            result.cold_start = true;
+            result.cold_start_reason = "med stats: " + err;
+            std::cerr << "[fee_estimator] LoadFeeEstimates: "
+                      << result.cold_start_reason
+                      << " -- starting fresh" << std::endl;
+            return result;
+        }
+        if (!ReadStats(stream, snap.long_stats, err)) {
+            result.success = true;
+            result.cold_start = true;
+            result.cold_start_reason = "long stats: " + err;
+            std::cerr << "[fee_estimator] LoadFeeEstimates: "
+                      << result.cold_start_reason
+                      << " -- starting fresh" << std::endl;
+            return result;
+        }
+
+        const uint64_t tracked_count = stream.ReadUint64();
+        if (tracked_count > MAX_TRACKED_TX) {
+            result.success = true;
+            result.cold_start = true;
+            result.cold_start_reason = "tracked_tx_count " +
+                std::to_string(tracked_count) + " exceeds bound " +
+                std::to_string(MAX_TRACKED_TX);
+            std::cerr << "[fee_estimator] LoadFeeEstimates: "
+                      << result.cold_start_reason
+                      << " -- starting fresh" << std::endl;
+            return result;
+        }
+        snap.tracked_txs.reserve(tracked_count);
+        for (uint64_t i = 0; i < tracked_count; ++i) {
+            uint256 h = stream.ReadUint256();
+            CBlockPolicyEstimator::Snapshot::Tracked t;
+            t.height       = stream.ReadUint32();
+            t.bucket_index = stream.ReadUint32();
+            t.horizon_mask = stream.ReadUint8();
+            snap.tracked_txs.emplace_back(h, t);
+        }
+
+        // Hand off to the estimator. restore() does its own bucket-ladder
+        // and stats-shape sanity check; mismatch -> cold-start.
+        if (!estimator.restore(std::move(snap))) {
+            result.success = true;
+            result.cold_start = true;
+            result.cold_start_reason =
+                "bucket ladder or stats shape mismatch (likely upgrade)";
+            std::cerr << "[fee_estimator] LoadFeeEstimates: "
+                      << result.cold_start_reason
+                      << " -- starting fresh" << std::endl;
+            return result;
+        }
+
+        result.tracked_tx_count = static_cast<size_t>(tracked_count);
+    } catch (const std::exception& e) {
+        result.success = true;
+        result.cold_start = true;
+        result.cold_start_reason = std::string("stream error: ") + e.what();
+        std::cerr << "[fee_estimator] LoadFeeEstimates: "
+                  << result.cold_start_reason << " -- starting fresh"
+                  << std::endl;
+        return result;
+    }
+
+    result.success = true;
+    std::cout << "[fee_estimator] LoadFeeEstimates: restored "
+              << result.tracked_tx_count
+              << " tracked txs from " << target.string() << std::endl;
+    return result;
+}
+
+}  // namespace fee_persist
+}  // namespace policy

--- a/src/policy/fee_persist.h
+++ b/src/policy/fee_persist.h
@@ -1,0 +1,147 @@
+// Copyright (c) 2026 The Dilithion Core developers
+// Distributed under the MIT software license
+
+#ifndef DILITHION_POLICY_FEE_PERSIST_H
+#define DILITHION_POLICY_FEE_PERSIST_H
+
+// Fee-estimator persistence -- mirror of node/mempool_persist.{h,cpp}.
+// Saves CBlockPolicyEstimator state to <datadir>/fee_estimates.dat on
+// shutdown; restores on startup.
+//
+// Schema (fee_estimates.dat layout) -- byte-for-byte parallel to
+// mempool.dat for project-wide schema consistency:
+//
+//   +0     u8       version_byte = FEE_ESTIMATES_FILE_VERSION
+//   +1     u8[32]   xor_key                                    [in the clear]
+//   +33    ...      scrambled body
+//   +N     u8[8]    sha3_256_truncated                         [scrambled]
+//
+// Body (logical fields, XOR-scrambled on disk):
+//   u32   best_seen_height
+//   u32   historical_first
+//   u32   historical_best
+//   u32   bucket_count
+//   for each bucket:
+//       i64   bucket_upper_bound_milli_ions  (long double * 1e6, rounded;
+//                                             tolerates platform LD precision)
+//   for each horizon (3 collections, in order: short, med, long):
+//       u32   confirm_periods
+//       u32   bucket_count
+//       u32   unconf_depth
+//       for each [period][bucket]: i64 conf_avg (Q32.32 fixed-point)
+//       for each [period][bucket]: i64 fail_avg (Q32.32 fixed-point)
+//       for each bucket:           i64 tx_ct_avg (Q32.32 fixed-point)
+//       for each [age][bucket]:    i32 unconf_count
+//       for each bucket:           i32 old_unconf
+//   u64   tracked_tx_count
+//   for each tracked tx:
+//       u8[32] txhash
+//       u32    height
+//       u32    bucket_index
+//       u8     horizon_mask
+//
+// XOR-scramble + SHA3-256 truncated footer rationale: identical to
+// mempool.dat. AV-signature mitigation + integrity-detection at sub-ms
+// load cost. See node/mempool_persist.h for full rationale.
+//
+// Atomicity: write to <datadir>/fee_estimates.dat.new, fsync, rename,
+// fsync parent directory. On torn write, prior file remains intact.
+//
+// Cold-start semantics: any of (file missing, version mismatch, footer
+// mismatch, malformed body, bucket-ladder mismatch) yields LoadResult{
+// success=true, cold_start=true} -- the estimator stays as a fresh
+// instance and accumulates from the next block. NEVER throws.
+
+#include <atomic>
+#include <cstddef>
+#include <filesystem>
+#include <string>
+
+namespace policy {
+namespace fee_estimator {
+class CBlockPolicyEstimator;
+}  // namespace fee_estimator
+}  // namespace policy
+
+namespace policy {
+namespace fee_persist {
+
+// Test-hook seams for failure injection. Mirrors mempool_persist's
+// pattern verbatim. Production reads are relaxed-atomic loads (sub-ns).
+//
+// g_force_dump_failure       -- fires BEFORE fopen (no .new file created)
+// g_force_late_dump_failure  -- fires AFTER .new is fully written; exercises
+//                                the cleanup path (.new removal, prior
+//                                file intact)
+namespace test_hooks {
+extern std::atomic<bool> g_force_dump_failure;
+extern std::atomic<bool> g_force_late_dump_failure;
+}
+
+constexpr uint8_t  SCHEMA_VERSION = 0x01;
+constexpr size_t   FOOTER_SIZE    = 8;            // truncated SHA3-256
+constexpr size_t   XOR_KEY_SIZE   = 32;           // matches mempool_persist
+constexpr size_t   MIN_FILE_SIZE  = 1 + XOR_KEY_SIZE + 16 + FOOTER_SIZE;
+                                                  // version + key + minimum body + footer
+constexpr size_t   MAX_FILE_SIZE  = 64ULL * 1024 * 1024;
+                                                  // 64 MB hard cap. Even a fully populated
+                                                  // estimator with 100k tracked txs and the
+                                                  // full 200-bucket ladder x 42 periods x 3
+                                                  // horizons fits in well under 16 MB; 64
+                                                  // MB is 4x safety margin.
+constexpr uint64_t MAX_TRACKED_TX = 200'000;      // 2x DEFAULT_MAX_MEMPOOL_COUNT
+constexpr uint32_t MAX_BUCKET_COUNT = 1024;       // sanity bound; real ladder is ~200
+constexpr uint32_t MAX_PERIODS      = 1024;       // sanity bound; max real periods = 42
+constexpr uint32_t MAX_UNCONF_DEPTH = 4096;       // sanity bound; max real depth = 42*24
+
+const std::string FILENAME     = "fee_estimates.dat";
+const std::string FILENAME_TMP = "fee_estimates.dat.new";
+
+struct DumpResult {
+    bool        success = false;
+    std::string error_message;        // populated when !success
+    size_t      bytes_written = 0;
+    size_t      tracked_tx_count = 0;
+    std::string final_path;           // <datadir>/fee_estimates.dat on success, empty otherwise
+};
+
+struct LoadResult {
+    bool        success = false;       // true even on cold-start
+    std::string error_message;         // populated only on hard error
+    size_t      tracked_tx_count = 0;
+    bool        cold_start = false;    // true if file missing / corrupted / mismatched
+    std::string cold_start_reason;     // populated when cold_start == true
+};
+
+/**
+ * Atomic save: write to <datadir>/fee_estimates.dat.new, fsync, rename to
+ * fee_estimates.dat. Caller must hold no estimator lock; this function
+ * takes the estimator's internal mutex via snapshot().
+ *
+ * On disk-full or transient failure, returns success=false with an error
+ * message; the prior fee_estimates.dat (if any) is left intact.
+ */
+DumpResult DumpFeeEstimates(const policy::fee_estimator::CBlockPolicyEstimator& estimator,
+                            const std::filesystem::path& datadir);
+
+/**
+ * Read from <datadir>/fee_estimates.dat, validate, restore via
+ * estimator.restore().
+ *
+ * On any non-catastrophic problem (file missing, version mismatch, integrity
+ * footer mismatch, malformed body, bucket-ladder mismatch), this function
+ * returns LoadResult{success=true, cold_start=true} and leaves the estimator
+ * in whatever state it was on entry (typically fresh).
+ *
+ * Hard errors (datadir unreadable) return success=false.
+ *
+ * @param estimator       The destination estimator (will be mutated via restore()).
+ * @param datadir         The Dilithion data directory.
+ */
+LoadResult LoadFeeEstimates(policy::fee_estimator::CBlockPolicyEstimator& estimator,
+                            const std::filesystem::path& datadir);
+
+}  // namespace fee_persist
+}  // namespace policy
+
+#endif  // DILITHION_POLICY_FEE_PERSIST_H

--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -1,0 +1,532 @@
+// Copyright (c) 2026 The Dilithion Core developers
+// Distributed under the MIT software license
+
+#include <policy/fees.h>
+
+#include <algorithm>
+#include <cmath>
+#include <stdexcept>
+
+namespace policy {
+namespace fee_estimator {
+
+namespace {
+
+// Compute a sentinel value used internally by the bucket map: the bucket
+// boundaries are upper-bounds, so we look up via lower_bound on the map.
+// Using `long double` keys is safe here because the bucket ladder has
+// O(200) entries, and ladder construction is deterministic from the
+// pinned constants.
+long double NormalizeFeerate(CAmount fee, size_t vsize) {
+    if (vsize == 0) return 0.0L;
+    // Ions per 1000 bytes. Match BC's CFeeRate convention: integer-divide
+    // semantics aren't needed here since we're only used as a bucket lookup
+    // key, not in consensus.
+    return static_cast<long double>(fee) * 1000.0L /
+           static_cast<long double>(vsize);
+}
+
+// Initialize a TxConfirmStats with zero-filled vectors. confirm_periods is
+// the per-horizon bucket count (12, 24, 42).
+void InitTxConfirmStats(TxConfirmStats& stats,
+                        size_t bucket_count,
+                        unsigned int confirm_periods,
+                        unsigned int scale,
+                        long double decay) {
+    stats.scale = scale;
+    stats.decay = decay;
+    stats.conf_avg.assign(confirm_periods,
+                          std::vector<long double>(bucket_count, 0.0L));
+    stats.fail_avg.assign(confirm_periods,
+                          std::vector<long double>(bucket_count, 0.0L));
+    stats.tx_ct_avg.assign(bucket_count, 0.0L);
+    // Unconfirmed-ring depth: we track up to confirm_periods*scale blocks of
+    // age. At confirm_periods=12, scale=1, this is 12 buckets of age.
+    stats.unconf_txs.assign(confirm_periods * scale,
+                            std::vector<int>(bucket_count, 0));
+    stats.old_unconf_txs.assign(bucket_count, 0);
+}
+
+}  // anonymous namespace
+
+CBlockPolicyEstimator::CBlockPolicyEstimator() {
+    initBuckets();
+    initStats();
+}
+
+CBlockPolicyEstimator::~CBlockPolicyEstimator() = default;
+
+void CBlockPolicyEstimator::initBuckets() {
+    m_buckets.clear();
+    m_bucket_map.clear();
+    long double bucket = MIN_BUCKET_FEERATE;
+    while (bucket <= MAX_BUCKET_FEERATE) {
+        m_buckets.push_back(bucket);
+        m_bucket_map[bucket] = static_cast<unsigned int>(m_buckets.size() - 1);
+        bucket *= FEE_SPACING;
+    }
+    // Top-of-ladder sentinel for "anything above MAX_BUCKET_FEERATE".
+    m_buckets.push_back(INF_FEERATE);
+    m_bucket_map[INF_FEERATE] =
+        static_cast<unsigned int>(m_buckets.size() - 1);
+}
+
+void CBlockPolicyEstimator::initStats() {
+    const size_t bucket_count = m_buckets.size();
+    InitTxConfirmStats(m_short, bucket_count, SHORT_BLOCK_PERIODS,
+                       SHORT_SCALE, SHORT_DECAY);
+    InitTxConfirmStats(m_med,   bucket_count, MED_BLOCK_PERIODS,
+                       MED_SCALE,   MED_DECAY);
+    InitTxConfirmStats(m_long,  bucket_count, LONG_BLOCK_PERIODS,
+                       LONG_SCALE,  LONG_DECAY);
+}
+
+unsigned int CBlockPolicyEstimator::findBucket(long double feerate) const {
+    // lower_bound returns the first bucket whose upper-bound >= feerate.
+    auto it = m_bucket_map.lower_bound(feerate);
+    if (it == m_bucket_map.end()) {
+        // feerate exceeds all bucket boundaries -- bucket into INF.
+        return static_cast<unsigned int>(m_buckets.size() - 1);
+    }
+    return it->second;
+}
+
+void CBlockPolicyEstimator::recordTxAdmit(TxConfirmStats& stats,
+                                          unsigned int bucket_index) {
+    if (bucket_index >= stats.tx_ct_avg.size()) return;
+    stats.tx_ct_avg[bucket_index] += 1.0L;
+    // The newest age slot is row 0 of the ring. processBlock rotates the
+    // ring forward so a tx admitted at block H sits in row 0 until H+1,
+    // then row 1, and so on.
+    if (!stats.unconf_txs.empty() &&
+        bucket_index < stats.unconf_txs[0].size()) {
+        stats.unconf_txs[0][bucket_index] += 1;
+    }
+}
+
+void CBlockPolicyEstimator::recordBlockTx(TxConfirmStats& stats,
+                                          unsigned int blocks_to_confirm,
+                                          unsigned int bucket_index) {
+    if (bucket_index >= stats.tx_ct_avg.size()) return;
+    if (blocks_to_confirm == 0) blocks_to_confirm = 1;
+
+    // For every confirmation target d >= blocks_to_confirm, this tx counts
+    // as a SUCCESS for that target (it confirmed within d blocks).
+    const unsigned int max_track = static_cast<unsigned int>(stats.conf_avg.size());
+    const unsigned int from = std::min(blocks_to_confirm, max_track);
+    for (unsigned int d = from; d <= max_track; ++d) {
+        const unsigned int row = d - 1;
+        if (row < stats.conf_avg.size() &&
+            bucket_index < stats.conf_avg[row].size()) {
+            stats.conf_avg[row][bucket_index] += 1.0L;
+        }
+    }
+    // Also remove from the unconfirmed ring -- the tx confirmed.
+    // We don't know which ring slot it's in without extra bookkeeping, so
+    // we walk and decrement the first non-zero slot at this bucket. This
+    // matches BC's behavior in `removeTx` with `inBlock=true`.
+    for (auto& row : stats.unconf_txs) {
+        if (bucket_index < row.size() && row[bucket_index] > 0) {
+            row[bucket_index] -= 1;
+            return;
+        }
+    }
+    // Could be in the aged-out bin.
+    if (bucket_index < stats.old_unconf_txs.size() &&
+        stats.old_unconf_txs[bucket_index] > 0) {
+        stats.old_unconf_txs[bucket_index] -= 1;
+    }
+}
+
+void CBlockPolicyEstimator::decayStats(TxConfirmStats& stats) {
+    for (auto& row : stats.conf_avg) {
+        for (auto& v : row) v *= stats.decay;
+    }
+    for (auto& row : stats.fail_avg) {
+        for (auto& v : row) v *= stats.decay;
+    }
+    for (auto& v : stats.tx_ct_avg) v *= stats.decay;
+}
+
+void CBlockPolicyEstimator::agingUnconfirmed(TxConfirmStats& stats) {
+    if (stats.unconf_txs.empty()) return;
+    // Rotate ring forward: row N-1 ages out into old_unconf_txs (counted
+    // as failures), rows 1..N-2 shift down, row 0 starts fresh.
+    const size_t depth = stats.unconf_txs.size();
+    if (depth == 0) return;
+    const size_t bucket_count = stats.unconf_txs[0].size();
+
+    // The aged-out row becomes part of fail_avg (timed out without
+    // confirming) and is added to old_unconf_txs.
+    for (unsigned int b = 0; b < bucket_count; ++b) {
+        const int aged_out = stats.unconf_txs[depth - 1][b];
+        if (aged_out > 0) {
+            stats.old_unconf_txs[b] += aged_out;
+            // For every confirmation target d, txs that didn't confirm in
+            // d blocks count as failures at that target. The aged-out
+            // slot represents txs >= depth blocks old, so they failed at
+            // every target up to stats.conf_avg.size().
+            for (size_t d = 0; d < stats.fail_avg.size(); ++d) {
+                if (b < stats.fail_avg[d].size()) {
+                    stats.fail_avg[d][b] += static_cast<long double>(aged_out);
+                }
+            }
+        }
+    }
+    // Shift rows: row[i] = row[i-1] for i >= 1; row[0] becomes zeroed.
+    for (size_t i = depth - 1; i > 0; --i) {
+        stats.unconf_txs[i] = stats.unconf_txs[i - 1];
+    }
+    std::fill(stats.unconf_txs[0].begin(), stats.unconf_txs[0].end(), 0);
+}
+
+void CBlockPolicyEstimator::processTx(const uint256& txhash,
+                                      unsigned int height,
+                                      CAmount fee,
+                                      size_t vsize,
+                                      bool valid_fee_estimate) {
+    if (!valid_fee_estimate) return;
+    if (vsize == 0) return;
+    if (fee < 0) return;  // CAmount overflow / sentinel guard
+
+    const long double feerate = NormalizeFeerate(fee, vsize);
+    if (feerate <= 0.0L) return;
+
+    std::lock_guard<std::mutex> lk(m_mutex);
+
+    // Don't accept retro observations for blocks we already aged past --
+    // matches BC's anti-replay behavior on restore-from-disk.
+    if (m_best_seen_height > 0 && height < m_best_seen_height) return;
+
+    if (m_tracked.count(txhash)) return;  // already tracked -- ignore
+
+    const unsigned int bucket_index = findBucket(feerate);
+
+    TrackedTx t;
+    t.height       = height;
+    t.bucket_index = bucket_index;
+    t.horizon_mask = 0x07;  // start tracked across all three horizons
+
+    m_tracked[txhash] = t;
+
+    recordTxAdmit(m_short, bucket_index);
+    recordTxAdmit(m_med,   bucket_index);
+    recordTxAdmit(m_long,  bucket_index);
+}
+
+bool CBlockPolicyEstimator::processBlockTx(unsigned int block_height,
+                                           const uint256& txhash) {
+    std::lock_guard<std::mutex> lk(m_mutex);
+    auto it = m_tracked.find(txhash);
+    if (it == m_tracked.end()) return false;
+
+    const unsigned int admit_height = it->second.height;
+    const unsigned int bucket_index = it->second.bucket_index;
+    const unsigned int blocks_to_confirm =
+        block_height >= admit_height ? (block_height - admit_height) : 0;
+
+    if (it->second.horizon_mask & 0x01) {
+        recordBlockTx(m_short, blocks_to_confirm, bucket_index);
+    }
+    if (it->second.horizon_mask & 0x02) {
+        recordBlockTx(m_med, blocks_to_confirm, bucket_index);
+    }
+    if (it->second.horizon_mask & 0x04) {
+        recordBlockTx(m_long, blocks_to_confirm, bucket_index);
+    }
+
+    m_tracked.erase(it);
+    return true;
+}
+
+void CBlockPolicyEstimator::processBlock(
+        unsigned int block_height,
+        const std::vector<uint256>& confirmed_txhashes) {
+    {
+        std::lock_guard<std::mutex> lk(m_mutex);
+        if (m_historical_first == 0) m_historical_first = block_height;
+        if (block_height > m_best_seen_height) m_best_seen_height = block_height;
+        m_historical_best = block_height;
+    }
+
+    // Confirm each tx (each acquires the lock briefly).
+    for (const auto& h : confirmed_txhashes) {
+        processBlockTx(block_height, h);
+    }
+
+    // Decay + age unconfirmed ring once per block.
+    std::lock_guard<std::mutex> lk(m_mutex);
+    decayStats(m_short);
+    decayStats(m_med);
+    decayStats(m_long);
+    agingUnconfirmed(m_short);
+    agingUnconfirmed(m_med);
+    agingUnconfirmed(m_long);
+}
+
+void CBlockPolicyEstimator::removeTx(const uint256& txhash, bool in_block) {
+    std::lock_guard<std::mutex> lk(m_mutex);
+    auto it = m_tracked.find(txhash);
+    if (it == m_tracked.end()) return;
+
+    const unsigned int bucket_index = it->second.bucket_index;
+    if (!in_block) {
+        // Decrement unconfirmed-ring counts for all horizons -- BC's
+        // removeTx(inBlock=false) treats the tx as "evicted, not confirmed":
+        // it goes neither in conf_avg nor fail_avg.
+        auto strip = [&](TxConfirmStats& stats) {
+            for (auto& row : stats.unconf_txs) {
+                if (bucket_index < row.size() && row[bucket_index] > 0) {
+                    row[bucket_index] -= 1;
+                    return;
+                }
+            }
+            if (bucket_index < stats.old_unconf_txs.size() &&
+                stats.old_unconf_txs[bucket_index] > 0) {
+                stats.old_unconf_txs[bucket_index] -= 1;
+            }
+        };
+        if (it->second.horizon_mask & 0x01) strip(m_short);
+        if (it->second.horizon_mask & 0x02) strip(m_med);
+        if (it->second.horizon_mask & 0x04) strip(m_long);
+    }
+    m_tracked.erase(it);
+}
+
+long double CBlockPolicyEstimator::estimateMedianFee(
+        const TxConfirmStats& stats,
+        unsigned int target_blocks,
+        double success_threshold) const {
+    if (target_blocks == 0) return -1.0L;
+    if (stats.conf_avg.empty()) return -1.0L;
+    if (target_blocks > stats.conf_avg.size())
+        target_blocks = static_cast<unsigned int>(stats.conf_avg.size());
+
+    const unsigned int row = target_blocks - 1;
+
+    // Walk buckets from highest feerate down. Find the lowest feerate
+    // bucket whose confirm-success rate within target_blocks meets the
+    // threshold. BC's algorithm has more sophistication (confidence
+    // intervals, multi-bucket smoothing); for PR-EF-1 we ship a faithful
+    // BUT simpler "first bucket meeting threshold" estimator. PR-EF-2 can
+    // upgrade to BC's full algorithm once mempool wiring lands.
+    if (row >= stats.conf_avg.size()) return -1.0L;
+    const auto& confs  = stats.conf_avg[row];
+    const auto& tx_cts = stats.tx_ct_avg;
+
+    // Aggregate from highest bucket down. We're looking for the lowest-
+    // feerate bucket where the cumulative confirm rate >= threshold.
+    long double total_cts   = 0.0L;
+    long double total_confs = 0.0L;
+    long double last_good_feerate = -1.0L;
+
+    for (size_t b = m_buckets.size(); b-- > 0;) {
+        if (b >= confs.size() || b >= tx_cts.size()) continue;
+        total_cts   += tx_cts[b];
+        total_confs += confs[b];
+        // Need at least a small base of observations before declaring an
+        // estimate -- otherwise a bucket with 0.5 confirms / 0.5 admits
+        // would always beat the threshold trivially.
+        constexpr long double MIN_BUCKET_OBSERVATIONS = 0.5L;
+        if (total_cts < MIN_BUCKET_OBSERVATIONS) continue;
+        const long double rate = total_confs / total_cts;
+        if (rate >= static_cast<long double>(success_threshold)) {
+            // This bucket (and all lower ones we already aggregated) meet
+            // the threshold. The "lowest feerate that still satisfies" is
+            // the bucket we're currently at; remember it.
+            last_good_feerate = m_buckets[b];
+        } else {
+            // Aggregating lower-feerate buckets only DECREASES the success
+            // rate. We can stop here.
+            break;
+        }
+    }
+
+    return last_good_feerate;
+}
+
+EstimationResult CBlockPolicyEstimator::estimateRawFee(
+        unsigned int target_blocks,
+        double success_threshold,
+        EstimateHorizon horizon) const {
+    EstimationResult out;
+    out.target_blocks = target_blocks;
+
+    std::lock_guard<std::mutex> lk(m_mutex);
+
+    if (m_historical_best == 0 ||
+        (m_historical_best - m_historical_first) < ACCUMULATION_BLOCKS_MIN) {
+        out.error = "insufficient data: estimator still in accumulation window "
+                    "(need >= " + std::to_string(ACCUMULATION_BLOCKS_MIN) +
+                    " blocks observed)";
+        return out;
+    }
+
+    const TxConfirmStats* stats = nullptr;
+    switch (horizon) {
+        case EstimateHorizon::SHORT_HALFLIFE: stats = &m_short; break;
+        case EstimateHorizon::MED_HALFLIFE:   stats = &m_med;   break;
+        case EstimateHorizon::LONG_HALFLIFE:  stats = &m_long;  break;
+    }
+    if (stats == nullptr) {
+        out.error = "invalid horizon";
+        return out;
+    }
+
+    out.feerate = estimateMedianFee(*stats, target_blocks, success_threshold);
+    if (out.feerate < 0.0L) {
+        out.error = "no bucket met success_threshold for target";
+    }
+    return out;
+}
+
+EstimationResult CBlockPolicyEstimator::estimateSmartFee(
+        unsigned int target_blocks,
+        EstimateMode mode) const {
+    const double threshold = (mode == EstimateMode::CONSERVATIVE)
+                                ? SUCCESS_PCT_CONSERVATIVE
+                                : SUCCESS_PCT_ECONOMICAL;
+
+    // Try short first, then medium, then long, picking the highest
+    // estimate (CONSERVATIVE) or first-good (ECONOMICAL). This mirrors
+    // BC's progressive horizon fallback.
+    auto r_short = estimateRawFee(target_blocks, threshold,
+                                  EstimateHorizon::SHORT_HALFLIFE);
+    auto r_med   = estimateRawFee(target_blocks, threshold,
+                                  EstimateHorizon::MED_HALFLIFE);
+    auto r_long  = estimateRawFee(target_blocks, threshold,
+                                  EstimateHorizon::LONG_HALFLIFE);
+
+    EstimationResult best;
+    best.target_blocks = target_blocks;
+    best.feerate = -1.0L;
+
+    auto consider = [&](const EstimationResult& r) {
+        if (r.feerate <= 0.0L) return;
+        if (mode == EstimateMode::CONSERVATIVE) {
+            if (r.feerate > best.feerate) best.feerate = r.feerate;
+        } else {
+            if (best.feerate < 0.0L || r.feerate < best.feerate) {
+                best.feerate = r.feerate;
+            }
+        }
+    };
+    consider(r_short);
+    consider(r_med);
+    consider(r_long);
+
+    if (best.feerate < 0.0L) {
+        // Coalesce the three error messages so the RPC layer can surface
+        // the most informative one.
+        if (!r_short.error.empty()) best.error = r_short.error;
+        else if (!r_med.error.empty()) best.error = r_med.error;
+        else if (!r_long.error.empty()) best.error = r_long.error;
+        else best.error = "no estimate available";
+    }
+    return best;
+}
+
+unsigned int CBlockPolicyEstimator::getBestSeenHeight() const {
+    std::lock_guard<std::mutex> lk(m_mutex);
+    return m_best_seen_height;
+}
+
+unsigned int CBlockPolicyEstimator::getBlocksObserved() const {
+    std::lock_guard<std::mutex> lk(m_mutex);
+    if (m_historical_best == 0) return 0;
+    return m_historical_best - m_historical_first + 1;
+}
+
+std::vector<long double> CBlockPolicyEstimator::getBuckets() const {
+    std::lock_guard<std::mutex> lk(m_mutex);
+    return m_buckets;
+}
+
+size_t CBlockPolicyEstimator::getTrackedTxCount() const {
+    std::lock_guard<std::mutex> lk(m_mutex);
+    return m_tracked.size();
+}
+
+CBlockPolicyEstimator::Snapshot CBlockPolicyEstimator::snapshot() const {
+    std::lock_guard<std::mutex> lk(m_mutex);
+    Snapshot s;
+    s.best_seen_height = m_best_seen_height;
+    s.historical_first = m_historical_first;
+    s.historical_best  = m_historical_best;
+    s.buckets          = m_buckets;
+    s.short_stats      = m_short;
+    s.med_stats        = m_med;
+    s.long_stats       = m_long;
+    s.tracked_txs.reserve(m_tracked.size());
+    for (const auto& [k, v] : m_tracked) {
+        Snapshot::Tracked t{v.height, v.bucket_index, v.horizon_mask};
+        s.tracked_txs.emplace_back(k, t);
+    }
+    return s;
+}
+
+bool CBlockPolicyEstimator::restore(Snapshot s) {
+    std::lock_guard<std::mutex> lk(m_mutex);
+
+    // Sanity-check the bucket ladder matches our compiled-in constants.
+    // If it doesn't, a future code change has changed the bucket schema
+    // and we must cold-start.
+    if (s.buckets.size() != m_buckets.size()) return false;
+    for (size_t i = 0; i < m_buckets.size(); ++i) {
+        // The bucket ladder is constructed deterministically from compiled-in
+        // constants. We allow a 1e-3 RELATIVE tolerance to absorb the loss-y
+        // round-trip from on-disk Q-encoded bucket boundaries (BUCKET_SCALE
+        // gives ~6 decimal digits of precision per bucket value); this is
+        // far below the inter-bucket spacing of 5%, so a corrupted or
+        // schema-mismatched ladder is still detected.
+        const long double a = m_buckets[i];
+        const long double b = s.buckets[i];
+        const long double diff_ld = (a > b) ? (a - b) : (b - a);
+        const long double abs_a   = (a < 0.0L) ? -a : a;
+        const long double tol     = abs_a * 1e-3L + 1e-6L;
+        if (diff_ld > tol) return false;
+    }
+
+    // Sanity-check stats shape.
+    auto stats_shape_ok = [](const TxConfirmStats& s,
+                             unsigned int periods, size_t bucket_count) {
+        if (s.conf_avg.size() != periods)  return false;
+        if (s.fail_avg.size() != periods)  return false;
+        if (s.tx_ct_avg.size() != bucket_count) return false;
+        for (const auto& row : s.conf_avg)
+            if (row.size() != bucket_count) return false;
+        for (const auto& row : s.fail_avg)
+            if (row.size() != bucket_count) return false;
+        return true;
+    };
+    if (!stats_shape_ok(s.short_stats, SHORT_BLOCK_PERIODS, m_buckets.size()))
+        return false;
+    if (!stats_shape_ok(s.med_stats,   MED_BLOCK_PERIODS,   m_buckets.size()))
+        return false;
+    if (!stats_shape_ok(s.long_stats,  LONG_BLOCK_PERIODS,  m_buckets.size()))
+        return false;
+
+    m_best_seen_height = s.best_seen_height;
+    m_historical_first = s.historical_first;
+    m_historical_best  = s.historical_best;
+    m_short            = std::move(s.short_stats);
+    m_med              = std::move(s.med_stats);
+    m_long             = std::move(s.long_stats);
+
+    // Restore decay/scale -- the constants in the file might disagree with
+    // our compiled-in values (across upgrades); we trust the in-memory
+    // constants and overwrite the snapshot's.
+    m_short.decay = SHORT_DECAY; m_short.scale = SHORT_SCALE;
+    m_med.decay   = MED_DECAY;   m_med.scale   = MED_SCALE;
+    m_long.decay  = LONG_DECAY;  m_long.scale  = LONG_SCALE;
+
+    m_tracked.clear();
+    for (const auto& [k, t] : s.tracked_txs) {
+        TrackedTx tt{t.height, t.bucket_index, t.horizon_mask};
+        m_tracked[k] = tt;
+    }
+    return true;
+}
+
+}  // namespace fee_estimator
+}  // namespace policy

--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -217,6 +217,14 @@ void CBlockPolicyEstimator::processTx(const uint256& txhash,
 bool CBlockPolicyEstimator::processBlockTx(unsigned int block_height,
                                            const uint256& txhash) {
     std::lock_guard<std::mutex> lk(m_mutex);
+    return processBlockTxLocked(block_height, txhash);
+}
+
+// PR-EF-1-FIX Finding F2: extracted from processBlockTx so processBlock
+// can call it WITHOUT releasing/reacquiring the lock between phases.
+// Caller MUST hold m_mutex.
+bool CBlockPolicyEstimator::processBlockTxLocked(unsigned int block_height,
+                                                 const uint256& txhash) {
     auto it = m_tracked.find(txhash);
     if (it == m_tracked.end()) return false;
 
@@ -242,20 +250,24 @@ bool CBlockPolicyEstimator::processBlockTx(unsigned int block_height,
 void CBlockPolicyEstimator::processBlock(
         unsigned int block_height,
         const std::vector<uint256>& confirmed_txhashes) {
-    {
-        std::lock_guard<std::mutex> lk(m_mutex);
-        if (m_historical_first == 0) m_historical_first = block_height;
-        if (block_height > m_best_seen_height) m_best_seen_height = block_height;
-        m_historical_best = block_height;
-    }
-
-    // Confirm each tx (each acquires the lock briefly).
-    for (const auto& h : confirmed_txhashes) {
-        processBlockTx(block_height, h);
-    }
-
-    // Decay + age unconfirmed ring once per block.
+    // PR-EF-1-FIX Finding F2: hold the lock for the ENTIRE call. Pre-fix
+    // the lock was released between (a) the height update, (b) the
+    // per-tx confirm loop, and (c) the decay+age phase. A concurrent
+    // snapshot()/DumpFeeEstimates between phases would persist
+    // internally inconsistent state (height advanced but unconf_txs
+    // ring not yet aged). The header docstring claimed "single mutex"
+    // and "coarse locking is adequate" -- both were lies pre-fix.
+    // Now true: one acquire, one release, full atomicity.
     std::lock_guard<std::mutex> lk(m_mutex);
+
+    if (m_historical_first == 0) m_historical_first = block_height;
+    if (block_height > m_best_seen_height) m_best_seen_height = block_height;
+    m_historical_best = block_height;
+
+    for (const auto& h : confirmed_txhashes) {
+        processBlockTxLocked(block_height, h);
+    }
+
     decayStats(m_short);
     decayStats(m_med);
     decayStats(m_long);
@@ -354,11 +366,20 @@ EstimationResult CBlockPolicyEstimator::estimateRawFee(
 
     std::lock_guard<std::mutex> lk(m_mutex);
 
+    // PR-EF-1-FIX Finding F1: off-by-one. Number of observed blocks is
+    // (best - first + 1), not (best - first). With heights 1..25 observed
+    // (count = 25), pre-fix `25 - 1 = 24 < 25` → still accumulating. The
+    // gate would only release after 26 blocks, contradicting the contract
+    // C3 claim "Estimator returns null until enough data accumulated
+    // (~25 blocks)" and the docstring "Below this many blocks of
+    // accumulation, the estimator must report 'insufficient data'."
+    // Use getBlocksObserved() which already includes the +1 correctly.
     if (m_historical_best == 0 ||
-        (m_historical_best - m_historical_first) < ACCUMULATION_BLOCKS_MIN) {
+        getBlocksObservedLocked() < ACCUMULATION_BLOCKS_MIN) {
         out.error = "insufficient data: estimator still in accumulation window "
-                    "(need >= " + std::to_string(ACCUMULATION_BLOCKS_MIN) +
-                    " blocks observed)";
+                    "(observed " + std::to_string(getBlocksObservedLocked()) +
+                    " blocks, need >= " +
+                    std::to_string(ACCUMULATION_BLOCKS_MIN) + ")";
         return out;
     }
 
@@ -433,6 +454,11 @@ unsigned int CBlockPolicyEstimator::getBestSeenHeight() const {
 
 unsigned int CBlockPolicyEstimator::getBlocksObserved() const {
     std::lock_guard<std::mutex> lk(m_mutex);
+    return getBlocksObservedLocked();
+}
+
+// Caller must hold m_mutex.
+unsigned int CBlockPolicyEstimator::getBlocksObservedLocked() const {
     if (m_historical_best == 0) return 0;
     return m_historical_best - m_historical_first + 1;
 }

--- a/src/policy/fees.h
+++ b/src/policy/fees.h
@@ -39,11 +39,18 @@
 //   constants verbatim is the correct call.
 //
 // Concurrency:
-//   All public methods acquire a single std::mutex. The estimator's working
-//   set is small (~1 MB even at maximum bucket count) so coarse locking is
-//   adequate; we follow Bitcoin Core's pattern of a single estimator-wide
-//   lock rather than per-collection locks. Default seq_cst ordering on the
-//   atomics.
+//   All public methods acquire m_mutex on entry and hold it for the entire
+//   call body. processBlock in particular holds the lock continuously
+//   across the height-update + per-tx-confirm + decay+age phases (see
+//   processBlockTxLocked); a concurrent snapshot()/DumpFeeEstimates
+//   between phases would otherwise persist internally inconsistent state.
+//   The estimator's working set is small (~1 MB even at maximum bucket
+//   count) so coarse locking is adequate; we follow Bitcoin Core's
+//   pattern of a single estimator-wide lock rather than per-collection
+//   locks. Default seq_cst ordering on the atomics.
+//   (PR-EF-1-FIX Finding F2 corrected the previous claim that "coarse
+//   locking suffices" without surfacing the lock-release-reacquire
+//   between phases.)
 
 #include <amount.h>
 #include <uint256.h>
@@ -116,13 +123,13 @@ constexpr double SUCCESS_PCT_CONSERVATIVE = 0.85;
 // "insufficient data" (BC behavior; matches the C3 acceptance criterion).
 constexpr unsigned int ACCUMULATION_BLOCKS_MIN = 25;
 
-// Maximum number of confirmations we track. Anything older than this is
-// treated as "didn't confirm" for the failure stats. BC: 1008 = ~1 week
-// of mainnet blocks; we keep the same sentinel.
-constexpr unsigned int MAX_CONFIRM_TRACK = 1008;
-
 // File-format version for fee_estimates.dat. Bump on any wire-format
 // change; LoadFeeEstimates returns cold-start on mismatch.
+//
+// (PR-EF-1-FIX Finding F8: dead constant MAX_CONFIRM_TRACK removed.
+// Per-horizon confirmation tracking is bounded by the SHORT/MED/LONG
+// _BLOCK_PERIODS constants and the per-horizon scale; no need for a
+// global cap that nothing referenced.)
 constexpr uint8_t FEE_ESTIMATES_FILE_VERSION = 0x01;
 
 // Estimate mode -- matches Bitcoin Core's FeeEstimateMode enum (only
@@ -285,6 +292,18 @@ public:
     bool restore(Snapshot s);
 
 private:
+    // Caller must hold m_mutex. Body of processBlockTx, extracted so
+    // processBlock can call it without releasing/reacquiring the lock.
+    // PR-EF-1-FIX Finding F2.
+    bool processBlockTxLocked(unsigned int block_height, const uint256& txhash);
+
+    // Caller must hold m_mutex. Body of getBlocksObserved, extracted so
+    // estimateRawFee's accumulation gate can use it without nested
+    // locking. Returns 0 when no blocks have been observed; otherwise
+    // (m_historical_best - m_historical_first + 1) -- the +1 closes
+    // PR-EF-1-FIX Finding F1's off-by-one.
+    unsigned int getBlocksObservedLocked() const;
+
     mutable std::mutex m_mutex;
 
     // Bucket ladder: bucket[i] is the upper bound (ions/kB) of feerate

--- a/src/policy/fees.h
+++ b/src/policy/fees.h
@@ -1,0 +1,348 @@
+// Copyright (c) 2026 The Dilithion Core developers
+// Distributed under the MIT software license
+
+#ifndef DILITHION_POLICY_FEES_H
+#define DILITHION_POLICY_FEES_H
+
+// Adaptive fee estimator -- port of Bitcoin Core v28.0
+// `src/policy/fees.{h,cpp}` (CBlockPolicyEstimator). PR-EF-1: estimator core
+// + persistence module ONLY. Mempool/chainstate hooks land in PR-EF-2; RPC
+// handlers land in PR-EF-3.
+//
+// Algorithm overview (verbatim port from Bitcoin Core):
+//   - On every successful mempool admit, the estimator records the entry
+//     height + feerate of the tx (processTx).
+//   - On every block connect, for each tx that confirmed in this block, we
+//     record the number of blocks elapsed since admit (processBlockTx) into
+//     a per-bucket-per-confirmation-target histogram.
+//   - Three independent stat collections track different time horizons:
+//       short  -- 12 buckets of confirmation-period weight, decay 0.962
+//       medium -- 24 buckets, decay 0.9952
+//       long   -- 42 buckets, decay 0.99931
+//   - Each collection has its own decay parameter so a sudden spike in fees
+//     dominates the short-horizon estimate first; slow-moving averages
+//     dominate the long-horizon estimate.
+//   - estimateRawFee(target, threshold, horizon) returns the lowest feerate
+//     bucket whose historical confirmation rate within `target` blocks
+//     exceeds `threshold` (0.85 by default; 0.95 for CONSERVATIVE mode).
+//   - estimateSmartFee combines all three horizons + falls back to longer
+//     horizons when the requested horizon lacks data.
+//
+// CAmount adaptation:
+//   Bitcoin Core uses CFeeRate(sat/kvB). Dilithion uses CAmount (ions, where
+//   1 DIL = 1e8 ions). We model feerate as CAmount-per-1000-bytes (a `long
+//   double` internally for buckets, since we multiply / divide constantly).
+//   The bucket constants (MIN/MAX_BUCKET_FEERATE, FEE_SPACING) are pinned to
+//   Bitcoin Core's values; this is intentional. Dilithion's smallest-unit
+//   semantics match Bitcoin's at the ion/satoshi level (both 1e-8 of base
+//   coin), so the fee-discovery dynamic range is the same and porting the
+//   constants verbatim is the correct call.
+//
+// Concurrency:
+//   All public methods acquire a single std::mutex. The estimator's working
+//   set is small (~1 MB even at maximum bucket count) so coarse locking is
+//   adequate; we follow Bitcoin Core's pattern of a single estimator-wide
+//   lock rather than per-collection locks. Default seq_cst ordering on the
+//   atomics.
+
+#include <amount.h>
+#include <uint256.h>
+
+#include <atomic>
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <vector>
+
+class CTransaction;
+
+namespace policy {
+namespace fee_estimator {
+
+// ---------------------------------------------------------------------------
+// Bucket constants -- pinned to Bitcoin Core v28.0 src/policy/fees.cpp.
+// Do not adjust without bumping FEE_ESTIMATES_FILE_VERSION below.
+// ---------------------------------------------------------------------------
+
+// Minimum bucket feerate (ions per 1000 bytes). BC: MIN_BUCKET_FEERATE = 1000.
+constexpr long double MIN_BUCKET_FEERATE = 1000.0L;
+
+// Maximum bucket feerate (ions per 1000 bytes). BC: MAX_BUCKET_FEERATE = 1e7.
+constexpr long double MAX_BUCKET_FEERATE = 1e7L;
+
+// Bucket spacing factor: each bucket is FEE_SPACING * previous bucket.
+// BC: FEE_SPACING = 1.05 (5% increments).
+constexpr long double FEE_SPACING = 1.05L;
+
+// "Infinite" feerate sentinel for the top-of-ladder bucket. BC: INF_FEERATE.
+// Set to MAX_MONEY (21M DIL in ions) so any conceivable real feerate falls
+// below it.
+constexpr long double INF_FEERATE = static_cast<long double>(MAX_MONEY);
+
+// Confirmation-target horizons (blocks). BC: src/policy/fees.h.
+//   short  -- 1..2 hour estimates (typical wallet send)
+//   medium -- 2..24 hour estimates (default RPC target)
+//   long   -- multi-day estimates (cold-storage sweeps)
+constexpr unsigned int SHORT_BLOCK_PERIODS = 12;
+constexpr unsigned int MED_BLOCK_PERIODS   = 24;
+constexpr unsigned int LONG_BLOCK_PERIODS  = 42;
+
+// Decay parameter per horizon. Each block, every bucket's confirmation
+// counter is multiplied by the decay; older confirmations weigh less.
+//   - short:  0.962    -- recent ~25-block window dominates
+//   - medium: 0.9952   -- recent ~200-block window dominates
+//   - long:   0.99931  -- recent ~1500-block window dominates
+constexpr long double SHORT_DECAY = 0.962L;
+constexpr long double MED_DECAY   = 0.9952L;
+constexpr long double LONG_DECAY  = 0.99931L;
+
+// "Half-life" for the rolling block windows. BC: SHORT_SCALE = 1, MED_SCALE = 2,
+// LONG_SCALE = 24. Decimates how many entries are kept per bucket.
+constexpr unsigned int SHORT_SCALE = 1;
+constexpr unsigned int MED_SCALE   = 2;
+constexpr unsigned int LONG_SCALE  = 24;
+
+// Confidence success threshold per estimate mode (matches BC v28.0).
+//   ECONOMICAL: 0.60  (faster confirms but more variance)
+//   CONSERVATIVE: 0.85 default RPC threshold; aim for 85% confirm success
+constexpr double SUCCESS_PCT_ECONOMICAL   = 0.60;
+constexpr double SUCCESS_PCT_CONSERVATIVE = 0.85;
+
+// Number of blocks observed before any estimate is returned. Below this
+// many blocks of accumulation, the estimator must report
+// "insufficient data" (BC behavior; matches the C3 acceptance criterion).
+constexpr unsigned int ACCUMULATION_BLOCKS_MIN = 25;
+
+// Maximum number of confirmations we track. Anything older than this is
+// treated as "didn't confirm" for the failure stats. BC: 1008 = ~1 week
+// of mainnet blocks; we keep the same sentinel.
+constexpr unsigned int MAX_CONFIRM_TRACK = 1008;
+
+// File-format version for fee_estimates.dat. Bump on any wire-format
+// change; LoadFeeEstimates returns cold-start on mismatch.
+constexpr uint8_t FEE_ESTIMATES_FILE_VERSION = 0x01;
+
+// Estimate mode -- matches Bitcoin Core's FeeEstimateMode enum (only
+// CONSERVATIVE / ECONOMICAL are implemented; UNSET maps to default).
+enum class EstimateMode : uint8_t {
+    UNSET        = 0,
+    ECONOMICAL   = 1,
+    CONSERVATIVE = 2,
+};
+
+// Estimate horizon -- which of the three internal stat collections to consult.
+enum class EstimateHorizon : uint8_t {
+    SHORT_HALFLIFE = 0,  // 12-block window
+    MED_HALFLIFE   = 1,  // 24-block window
+    LONG_HALFLIFE  = 2,  // 42-block window
+};
+
+// Per-bucket per-confirmation-target counters used internally.
+//
+// Bitcoin Core's TxConfirmStats keeps three parallel arrays:
+//   - confAvg[target][bucket]  -- decayed count of txs in this bucket that
+//                                  confirmed within `target` blocks
+//   - failAvg[target][bucket]  -- decayed count that did NOT confirm in
+//                                  `target` blocks (aged out)
+//   - txCtAvg[bucket]          -- decayed count of txs entering this bucket
+//
+// All three decay every block. We mirror the same shape; bucket index is
+// the upper-bound bucket ladder index (see ConstructBuckets).
+struct TxConfirmStats {
+    // confAvg[d][b] = fraction of bucket-b txs that confirmed within d+1 blocks
+    std::vector<std::vector<long double>> conf_avg;
+    // failAvg[d][b] = fraction that did NOT confirm in d+1 blocks
+    std::vector<std::vector<long double>> fail_avg;
+    // txCtAvg[b] = decayed count of txs that entered bucket b
+    std::vector<long double> tx_ct_avg;
+    // unconfTxs[blocks_in_pool][bucket] -- ring buffer of unconfirmed txs
+    // indexed by their age-in-pool. When a tx's age exceeds the buffer's
+    // depth, it counts as a failure.
+    std::vector<std::vector<int>> unconf_txs;
+    // oldUnconfTxs[bucket] -- aged-out unconfirmed counts
+    std::vector<int> old_unconf_txs;
+    // Decay parameter for this stats collection.
+    long double decay = 0.0L;
+    // Scale (window) for this stats collection.
+    unsigned int scale = 1;
+};
+
+// Public-facing estimate result. `feerate` is in ions per 1000 bytes; if
+// `feerate` is negative, the estimator did not have enough data. Errors
+// is non-empty when the caller should surface a textual diagnostic.
+struct EstimationResult {
+    // Bucket-aligned feerate -- ions per 1000 bytes. -1 = no estimate.
+    long double feerate = -1.0L;
+    // The number of blocks the estimate is valid for.
+    unsigned int target_blocks = 0;
+    // Per-target diagnostic; populated by estimateRawFee.
+    std::string error;
+};
+
+// ---------------------------------------------------------------------------
+// CBlockPolicyEstimator
+// ---------------------------------------------------------------------------
+
+class CBlockPolicyEstimator {
+public:
+    CBlockPolicyEstimator();
+    ~CBlockPolicyEstimator();
+
+    CBlockPolicyEstimator(const CBlockPolicyEstimator&)            = delete;
+    CBlockPolicyEstimator& operator=(const CBlockPolicyEstimator&) = delete;
+
+    // -- Observation surface -----------------------------------------------
+    //
+    // processTx -- record an admitted-to-mempool tx. Called by PR-EF-2 from
+    // CTxMemPool::AddTx. validFeeEstimate==false means "this tx came in via
+    // a special path (block, bypass) and should NOT influence the estimator"
+    // -- mirrors BC's `validFeeEstimate` flag.
+    void processTx(const uint256& txhash,
+                   unsigned int height,
+                   CAmount fee,
+                   size_t vsize,
+                   bool valid_fee_estimate);
+
+    // processBlockTx -- record a tx confirming in a block. age_in_pool is the
+    // # of blocks since processTx was called for this txhash.
+    // Returns true if the tx was tracked by the estimator (else it's a tx
+    // we didn't see admitted, e.g. came in via a private relay).
+    bool processBlockTx(unsigned int block_height, const uint256& txhash);
+
+    // processBlock -- aging tick. Called once per block-connect from
+    // PR-EF-2. Walks each stats collection and decays counters; ages out
+    // unconfirmed-tx ring buffer slots.
+    void processBlock(unsigned int block_height,
+                      const std::vector<uint256>& confirmed_txhashes);
+
+    // removeTx -- called when a tx is removed from the mempool BEFORE it
+    // confirmed (eviction, replacement, expiration). Drops the tx from
+    // the unconfirmed ring buffers without updating fail counters --
+    // mirroring BC behavior.
+    void removeTx(const uint256& txhash, bool in_block);
+
+    // -- Estimate surface --------------------------------------------------
+    //
+    // estimateRawFee -- raw histogram lookup. Returns the lowest feerate
+    // bucket whose historical confirm rate within `target` exceeds
+    // `success_threshold` (e.g. 0.85). If no bucket satisfies, feerate=-1.
+    EstimationResult estimateRawFee(unsigned int target_blocks,
+                                    double success_threshold,
+                                    EstimateHorizon horizon) const;
+
+    // estimateSmartFee -- combines the three horizons. PR-EF-3's
+    // `estimatesmartfee` RPC calls this. mode selects success threshold.
+    EstimationResult estimateSmartFee(unsigned int target_blocks,
+                                      EstimateMode mode) const;
+
+    // -- Diagnostic -----------------------------------------------------
+    //
+    // Get the highest block height ever observed.
+    unsigned int getBestSeenHeight() const;
+
+    // Get the count of blocks observed since startup. Below
+    // ACCUMULATION_BLOCKS_MIN, no estimate is returned.
+    unsigned int getBlocksObserved() const;
+
+    // Bucket ladder accessor (for tests + persistence).
+    std::vector<long double> getBuckets() const;
+
+    // Tracked-tx count. Used by tests and the savefeeestimates RPC.
+    size_t getTrackedTxCount() const;
+
+    // -- Persistence helpers --------------------------------------------
+    //
+    // Below: serialization-friendly snapshots of internal state. The
+    // fee_persist module uses these (rather than friend-access) to dump
+    // and restore the estimator. All snapshots are taken under the
+    // estimator's internal mutex; the returned values are by-value copies.
+
+    struct Snapshot {
+        unsigned int                              best_seen_height = 0;
+        unsigned int                              historical_first = 0;
+        unsigned int                              historical_best  = 0;
+        std::vector<long double>                  buckets;
+        TxConfirmStats                            short_stats;
+        TxConfirmStats                            med_stats;
+        TxConfirmStats                            long_stats;
+        // Tracked txs: txhash -> (height_admitted, bucket_index, horizon_mask).
+        // horizon_mask: bit0=short, bit1=medium, bit2=long.
+        struct Tracked {
+            unsigned int height;
+            unsigned int bucket_index;
+            uint8_t      horizon_mask;
+        };
+        std::vector<std::pair<uint256, Tracked>>  tracked_txs;
+    };
+
+    Snapshot snapshot() const;
+
+    // Restore from a snapshot. Returns false on internal-shape mismatch
+    // (caller should treat as cold-start).
+    bool restore(Snapshot s);
+
+private:
+    mutable std::mutex m_mutex;
+
+    // Bucket ladder: bucket[i] is the upper bound (ions/kB) of feerate
+    // bucket i. bucket[0] = MIN_BUCKET_FEERATE; bucket[N-1] = INF_FEERATE.
+    std::vector<long double> m_buckets;
+
+    // bucketMap: feerate -> bucket-index. Exact-match-or-lower-bound
+    // lookup; saves doing a binary search on every observation.
+    std::map<long double, unsigned int> m_bucket_map;
+
+    // Three stat collections (one per horizon).
+    TxConfirmStats m_short;
+    TxConfirmStats m_med;
+    TxConfirmStats m_long;
+
+    // Currently tracked unconfirmed txs. Maps txhash to (height_admitted,
+    // bucket_index, horizon_mask). The horizon mask says which of the
+    // three stat collections this tx is currently being tracked by.
+    struct TrackedTx {
+        unsigned int height;
+        unsigned int bucket_index;
+        uint8_t      horizon_mask;  // bit0=short, bit1=medium, bit2=long
+    };
+    std::map<uint256, TrackedTx> m_tracked;
+
+    // The highest block height we've observed (anti-replay during
+    // restore-from-disk: don't replay ages that have already passed).
+    unsigned int m_best_seen_height = 0;
+    unsigned int m_historical_first = 0;  // first block we observed
+    unsigned int m_historical_best  = 0;  // last block we observed
+
+    // Construct the bucket ladder from MIN_BUCKET_FEERATE to MAX_BUCKET_FEERATE
+    // by FEE_SPACING; append INF_FEERATE.
+    void initBuckets();
+
+    // Lazy-init the three stats collections based on current bucket ladder.
+    void initStats();
+
+    // Helpers used by both observe and decay paths.
+    unsigned int findBucket(long double feerate) const;
+    void recordBlockTx(TxConfirmStats& stats,
+                       unsigned int blocks_to_confirm,
+                       unsigned int bucket_index);
+    void recordTxAdmit(TxConfirmStats& stats, unsigned int bucket_index);
+    void decayStats(TxConfirmStats& stats);
+    void agingUnconfirmed(TxConfirmStats& stats);
+
+    // Estimate within a single horizon. Returns -1 if the bucket histogram
+    // has insufficient data.
+    long double estimateMedianFee(const TxConfirmStats& stats,
+                                  unsigned int target_blocks,
+                                  double success_threshold) const;
+};
+
+// Smart pointer for shared use; mirrors BC's `std::unique_ptr<CBlockPolicyEstimator>`.
+using EstimatorPtr = std::shared_ptr<CBlockPolicyEstimator>;
+
+}  // namespace fee_estimator
+}  // namespace policy
+
+#endif  // DILITHION_POLICY_FEES_H

--- a/src/test/fee_estimator_tests.cpp
+++ b/src/test/fee_estimator_tests.cpp
@@ -1,0 +1,381 @@
+// Copyright (c) 2026 The Dilithion Core developers
+// Distributed under the MIT software license
+
+#include <boost/test/unit_test.hpp>
+
+#include <policy/fees.h>
+#include <uint256.h>
+
+#include <cstring>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(fee_estimator_tests)
+
+namespace {
+
+// Make a unique deterministic txhash from a seed.
+uint256 MakeTxHash(uint32_t seed) {
+    uint256 h;
+    std::memset(h.data, 0, 32);
+    h.data[0] = static_cast<uint8_t>(seed & 0xFF);
+    h.data[1] = static_cast<uint8_t>((seed >> 8) & 0xFF);
+    h.data[2] = static_cast<uint8_t>((seed >> 16) & 0xFF);
+    h.data[3] = static_cast<uint8_t>((seed >> 24) & 0xFF);
+    // Spread some entropy to avoid map-collision pathologies.
+    h.data[31] = static_cast<uint8_t>(seed * 0x9E + 0x37);
+    return h;
+}
+
+}  // anonymous namespace
+
+// ---- Bucket ladder shape -----------------------------------------------
+
+BOOST_AUTO_TEST_CASE(bucket_ladder_shape) {
+    using namespace policy::fee_estimator;
+    CBlockPolicyEstimator est;
+    auto buckets = est.getBuckets();
+
+    // First bucket is MIN_BUCKET_FEERATE; last is INF_FEERATE sentinel.
+    BOOST_REQUIRE_GT(buckets.size(), 2u);
+    BOOST_CHECK(static_cast<double>(buckets.front()) ==
+                static_cast<double>(MIN_BUCKET_FEERATE));
+    BOOST_CHECK(static_cast<double>(buckets.back()) ==
+                static_cast<double>(INF_FEERATE));
+
+    // Each bucket strictly greater than previous.
+    for (size_t i = 1; i < buckets.size(); ++i) {
+        BOOST_CHECK(static_cast<double>(buckets[i]) >
+                    static_cast<double>(buckets[i - 1]));
+    }
+
+    // Estimator starts in accumulation window.
+    BOOST_CHECK_EQUAL(est.getBlocksObserved(), 0u);
+    BOOST_CHECK_EQUAL(est.getBestSeenHeight(), 0u);
+    BOOST_CHECK_EQUAL(est.getTrackedTxCount(), 0u);
+}
+
+// ---- Insufficient-data path ---------------------------------------------
+
+BOOST_AUTO_TEST_CASE(insufficient_data_returns_error) {
+    using namespace policy::fee_estimator;
+    CBlockPolicyEstimator est;
+
+    // No blocks observed -> raw and smart return error.
+    auto raw = est.estimateRawFee(6, 0.85,
+                                  EstimateHorizon::MED_HALFLIFE);
+    BOOST_CHECK(raw.feerate < 0.0L);
+    BOOST_CHECK(!raw.error.empty());
+    BOOST_CHECK(raw.error.find("insufficient data") != std::string::npos);
+
+    auto smart = est.estimateSmartFee(6, EstimateMode::CONSERVATIVE);
+    BOOST_CHECK(smart.feerate < 0.0L);
+    BOOST_CHECK(!smart.error.empty());
+
+    // Even after a few blocks (< ACCUMULATION_BLOCKS_MIN) we still error.
+    for (unsigned int h = 1; h <= 10; ++h) {
+        est.processBlock(h, /*confirmed=*/{});
+    }
+    auto still = est.estimateSmartFee(6, EstimateMode::CONSERVATIVE);
+    BOOST_CHECK(still.feerate < 0.0L);
+}
+
+// ---- Accumulation crosses the threshold ---------------------------------
+
+BOOST_AUTO_TEST_CASE(crosses_accumulation_threshold) {
+    using namespace policy::fee_estimator;
+    CBlockPolicyEstimator est;
+    for (unsigned int h = 1; h <= ACCUMULATION_BLOCKS_MIN + 5; ++h) {
+        est.processBlock(h, /*confirmed=*/{});
+    }
+    BOOST_CHECK_GE(est.getBlocksObserved(), ACCUMULATION_BLOCKS_MIN);
+    BOOST_CHECK_EQUAL(est.getBestSeenHeight(), ACCUMULATION_BLOCKS_MIN + 5);
+    // Even with no tx data we may not yet have a bucket meeting threshold;
+    // that's an "insufficient bucket data" error, not the accumulation error.
+    auto r = est.estimateSmartFee(6, EstimateMode::CONSERVATIVE);
+    BOOST_CHECK(r.feerate < 0.0L);
+    // Error MUST NOT mention "accumulation" anymore.
+    BOOST_CHECK(r.error.find("accumulation") == std::string::npos);
+}
+
+// ---- Synthetic mempool driver: high-fee txs confirm fast ---------------
+
+BOOST_AUTO_TEST_CASE(high_fee_confirms_fast) {
+    using namespace policy::fee_estimator;
+    CBlockPolicyEstimator est;
+
+    // Drive 30 blocks. In each block:
+    //   - admit 5 high-fee txs (50000 ions/250 vsize = 200_000 ions/kB)
+    //   - admit 5 low-fee txs (5000 ions/250 vsize  =  20_000 ions/kB)
+    //   - confirm all 5 high-fee txs in this same block (1-block confirm)
+    //   - confirm low-fee txs only in next block (2-block confirm)
+    constexpr CAmount kHighFee = 50000;
+    constexpr CAmount kLowFee  = 5000;
+    constexpr size_t  kVsize   = 250;
+    std::vector<uint256> last_low;
+
+    for (unsigned int h = 1; h <= 30; ++h) {
+        std::vector<uint256> high_hashes, low_hashes;
+        for (uint32_t i = 0; i < 5; ++i) {
+            uint256 hh = MakeTxHash(h * 1000 + i);
+            est.processTx(hh, h, kHighFee, kVsize, true);
+            high_hashes.push_back(hh);
+            uint256 lh = MakeTxHash(h * 1000 + 100 + i);
+            est.processTx(lh, h, kLowFee, kVsize, true);
+            low_hashes.push_back(lh);
+        }
+        // Confirm last block's low-fee txs + this block's high-fee txs.
+        std::vector<uint256> confirmed = last_low;
+        confirmed.insert(confirmed.end(), high_hashes.begin(), high_hashes.end());
+        est.processBlock(h, confirmed);
+        last_low = low_hashes;
+    }
+
+    // After 30 blocks of consistent behavior we should have:
+    //   - some bucket showing a strong confirm-rate at target=1 around 200k
+    //   - a lower bucket showing strong confirm-rate at target=2 around 20k
+    // Because our estimator returns the LOWEST feerate that meets threshold,
+    // target=1 estimate should pick up the lowest bucket whose cumulative
+    // (from-top-down) success rate exceeds the threshold.
+    auto r1 = est.estimateRawFee(1, 0.80,
+                                 EstimateHorizon::SHORT_HALFLIFE);
+    BOOST_TEST_MESSAGE("target=1 r1.feerate=" << static_cast<double>(r1.feerate)
+                       << " err='" << r1.error << "'");
+    BOOST_CHECK(r1.feerate > 0.0L);
+
+    auto r2 = est.estimateRawFee(2, 0.80,
+                                 EstimateHorizon::MED_HALFLIFE);
+    BOOST_TEST_MESSAGE("target=2 r2.feerate=" << static_cast<double>(r2.feerate)
+                       << " err='" << r2.error << "'");
+    BOOST_CHECK(r2.feerate > 0.0L);
+
+    // Smart estimate must succeed too (CONSERVATIVE picks max across horizons).
+    auto smart = est.estimateSmartFee(2, EstimateMode::CONSERVATIVE);
+    BOOST_TEST_MESSAGE("smart target=2 feerate=" << static_cast<double>(smart.feerate)
+                       << " err='" << smart.error << "'");
+    BOOST_CHECK(smart.feerate > 0.0L);
+}
+
+// ---- valid_fee_estimate=false is ignored -------------------------------
+
+BOOST_AUTO_TEST_CASE(invalid_fee_estimate_flag_ignored) {
+    using namespace policy::fee_estimator;
+    CBlockPolicyEstimator est;
+    uint256 h = MakeTxHash(42);
+    est.processTx(h, /*height=*/1, /*fee=*/100000,
+                  /*vsize=*/250, /*valid_fee_estimate=*/false);
+    BOOST_CHECK_EQUAL(est.getTrackedTxCount(), 0u);
+    // processBlockTx for an untracked hash must return false cleanly.
+    BOOST_CHECK(!est.processBlockTx(2, h));
+}
+
+// ---- Zero-vsize tx is dropped -----------------------------------------
+
+BOOST_AUTO_TEST_CASE(zero_vsize_dropped) {
+    using namespace policy::fee_estimator;
+    CBlockPolicyEstimator est;
+    est.processTx(MakeTxHash(1), 1, 100000, 0, true);
+    BOOST_CHECK_EQUAL(est.getTrackedTxCount(), 0u);
+}
+
+// ---- Negative fee dropped ----------------------------------------------
+
+BOOST_AUTO_TEST_CASE(negative_fee_dropped) {
+    using namespace policy::fee_estimator;
+    CBlockPolicyEstimator est;
+    est.processTx(MakeTxHash(1), 1, -1, 250, true);
+    BOOST_CHECK_EQUAL(est.getTrackedTxCount(), 0u);
+}
+
+// ---- Saturating fee at INF bucket --------------------------------------
+
+BOOST_AUTO_TEST_CASE(massive_fee_saturates_to_inf_bucket) {
+    using namespace policy::fee_estimator;
+    CBlockPolicyEstimator est;
+    // Fee = MAX_MONEY, vsize = 250 -> feerate = MAX_MONEY * 1000 / 250
+    // = 8.4e15 ions/kB, far above MAX_BUCKET_FEERATE=1e7. Should bucket
+    // into the INF sentinel rather than wrap or crash.
+    est.processTx(MakeTxHash(1), 1, MAX_MONEY, 250, true);
+    BOOST_CHECK_EQUAL(est.getTrackedTxCount(), 1u);
+    BOOST_CHECK(est.processBlockTx(1, MakeTxHash(1)));
+}
+
+// ---- Anti-replay: later-tx with earlier-than-best height is dropped ----
+
+BOOST_AUTO_TEST_CASE(anti_replay_drops_older_height) {
+    using namespace policy::fee_estimator;
+    CBlockPolicyEstimator est;
+    for (unsigned int h = 1; h <= 30; ++h) {
+        est.processBlock(h, /*confirmed=*/{});
+    }
+    BOOST_REQUIRE_EQUAL(est.getBestSeenHeight(), 30u);
+    // Now feed a tx with height=10 -- before our best-seen.
+    est.processTx(MakeTxHash(99), /*height=*/10, 100000, 250, true);
+    BOOST_CHECK_EQUAL(est.getTrackedTxCount(), 0u);
+}
+
+// ---- Reorg behavior: subsequent confirmations self-correct -------------
+
+BOOST_AUTO_TEST_CASE(reorg_self_corrects) {
+    using namespace policy::fee_estimator;
+    CBlockPolicyEstimator est;
+
+    // Phase 1: feed 30 blocks with consistent fees.
+    for (unsigned int h = 1; h <= 30; ++h) {
+        std::vector<uint256> confirmed;
+        for (uint32_t i = 0; i < 5; ++i) {
+            uint256 t = MakeTxHash(h * 100 + i);
+            est.processTx(t, h, 50000, 250, true);
+            confirmed.push_back(t);
+        }
+        est.processBlock(h, confirmed);
+    }
+    const auto baseline_height = est.getBestSeenHeight();
+    BOOST_CHECK_EQUAL(baseline_height, 30u);
+    auto raw_pre = est.estimateRawFee(2, 0.80,
+                                      EstimateHorizon::MED_HALFLIFE);
+    BOOST_CHECK(raw_pre.feerate > 0.0L);
+
+    // Phase 2: simulate a reorg by replaying processBlock for blocks 28-30
+    // with different (replayed) confirms. The estimator's state should not
+    // crash, NaN, or wrap; subsequent observations on a higher height
+    // should still produce sensible estimates.
+    for (unsigned int h = 28; h <= 30; ++h) {
+        est.processBlock(h, /*confirmed=*/{});  // reorg-out
+    }
+    // Now extend on a fresh fork at heights 31-50 with consistent fees.
+    for (unsigned int h = 31; h <= 50; ++h) {
+        std::vector<uint256> confirmed;
+        for (uint32_t i = 0; i < 5; ++i) {
+            uint256 t = MakeTxHash(h * 100 + i + 99999);
+            est.processTx(t, h, 80000, 250, true);
+            confirmed.push_back(t);
+        }
+        est.processBlock(h, confirmed);
+    }
+    auto raw_post = est.estimateRawFee(2, 0.80,
+                                       EstimateHorizon::MED_HALFLIFE);
+    BOOST_CHECK(raw_post.feerate > 0.0L);
+    // Sanity bound: must not wrap to negative, must be within bucket range.
+    BOOST_CHECK(raw_post.feerate >= MIN_BUCKET_FEERATE);
+    BOOST_CHECK(raw_post.feerate <= INF_FEERATE);
+}
+
+// ---- removeTx (eviction) drops without affecting fail counters ---------
+
+BOOST_AUTO_TEST_CASE(remove_tx_eviction) {
+    using namespace policy::fee_estimator;
+    CBlockPolicyEstimator est;
+    uint256 h = MakeTxHash(7);
+    est.processTx(h, 1, 100000, 250, true);
+    BOOST_CHECK_EQUAL(est.getTrackedTxCount(), 1u);
+    est.removeTx(h, /*in_block=*/false);
+    BOOST_CHECK_EQUAL(est.getTrackedTxCount(), 0u);
+    // No-op for an already-removed tx.
+    est.removeTx(h, /*in_block=*/false);
+    BOOST_CHECK_EQUAL(est.getTrackedTxCount(), 0u);
+}
+
+// ---- Snapshot / restore round-trip preserves state ---------------------
+
+BOOST_AUTO_TEST_CASE(snapshot_restore_roundtrip) {
+    using namespace policy::fee_estimator;
+    CBlockPolicyEstimator a;
+
+    // Drive 30 blocks of activity into 'a'.
+    for (unsigned int h = 1; h <= 30; ++h) {
+        std::vector<uint256> confirmed;
+        for (uint32_t i = 0; i < 3; ++i) {
+            uint256 t = MakeTxHash(h * 1000 + i);
+            a.processTx(t, h, 80000 + i * 1000, 250, true);
+            confirmed.push_back(t);
+        }
+        a.processBlock(h, confirmed);
+    }
+    // Leave a few unconfirmed in 'a'.
+    a.processTx(MakeTxHash(7777), 30, 30000, 250, true);
+    a.processTx(MakeTxHash(7778), 30, 60000, 250, true);
+
+    auto snap = a.snapshot();
+    BOOST_CHECK_EQUAL(snap.tracked_txs.size(), 2u);
+    BOOST_CHECK_EQUAL(snap.best_seen_height, 30u);
+
+    CBlockPolicyEstimator b;
+    BOOST_REQUIRE(b.restore(snap));
+
+    BOOST_CHECK_EQUAL(a.getBestSeenHeight(), b.getBestSeenHeight());
+    BOOST_CHECK_EQUAL(a.getTrackedTxCount(), b.getTrackedTxCount());
+    BOOST_CHECK_EQUAL(a.getBlocksObserved(), b.getBlocksObserved());
+
+    // Estimates should match modulo encoding noise.
+    auto ra = a.estimateRawFee(2, 0.80,
+                               EstimateHorizon::MED_HALFLIFE);
+    auto rb = b.estimateRawFee(2, 0.80,
+                               EstimateHorizon::MED_HALFLIFE);
+    BOOST_TEST_MESSAGE("a feerate=" << static_cast<double>(ra.feerate)
+                       << " b feerate=" << static_cast<double>(rb.feerate));
+    if (ra.feerate > 0.0L) {
+        BOOST_REQUIRE(rb.feerate > 0.0L);
+        // After Q32.32 round-trip, exact equality.
+        BOOST_CHECK_EQUAL(static_cast<double>(ra.feerate),
+                          static_cast<double>(rb.feerate));
+    }
+}
+
+// ---- Restore with bucket-shape mismatch returns false ------------------
+
+BOOST_AUTO_TEST_CASE(restore_rejects_bad_bucket_shape) {
+    using namespace policy::fee_estimator;
+    CBlockPolicyEstimator a;
+    auto snap = a.snapshot();
+    // Truncate buckets vector -- restore must reject.
+    snap.buckets.pop_back();
+    BOOST_CHECK(!a.restore(std::move(snap)));
+}
+
+BOOST_AUTO_TEST_CASE(restore_rejects_mangled_bucket_value) {
+    using namespace policy::fee_estimator;
+    CBlockPolicyEstimator a;
+    auto snap = a.snapshot();
+    BOOST_REQUIRE(!snap.buckets.empty());
+    // Flip a bucket boundary far outside tolerance.
+    snap.buckets[0] = snap.buckets[0] * 2.0L;
+    BOOST_CHECK(!a.restore(std::move(snap)));
+}
+
+// ---- Restore with bad stats shape returns false -----------------------
+
+BOOST_AUTO_TEST_CASE(restore_rejects_bad_stats_shape) {
+    using namespace policy::fee_estimator;
+    CBlockPolicyEstimator a;
+    auto snap = a.snapshot();
+    snap.short_stats.tx_ct_avg.pop_back();
+    BOOST_CHECK(!a.restore(std::move(snap)));
+}
+
+// ---- estimateSmartFee CONSERVATIVE >= ECONOMICAL when both succeed ----
+
+BOOST_AUTO_TEST_CASE(conservative_at_least_economical) {
+    using namespace policy::fee_estimator;
+    CBlockPolicyEstimator est;
+    for (unsigned int h = 1; h <= 50; ++h) {
+        std::vector<uint256> confirmed;
+        for (uint32_t i = 0; i < 5; ++i) {
+            uint256 t = MakeTxHash(h * 100 + i);
+            est.processTx(t, h, 50000, 250, true);
+            confirmed.push_back(t);
+        }
+        est.processBlock(h, confirmed);
+    }
+    auto cons = est.estimateSmartFee(2, EstimateMode::CONSERVATIVE);
+    auto econ = est.estimateSmartFee(2, EstimateMode::ECONOMICAL);
+    if (cons.feerate > 0.0L && econ.feerate > 0.0L) {
+        // CONSERVATIVE picks the highest feerate across horizons, ECONOMICAL
+        // picks the lowest. So cons >= econ always.
+        BOOST_CHECK_GE(static_cast<double>(cons.feerate),
+                       static_cast<double>(econ.feerate));
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/fee_persist_tests.cpp
+++ b/src/test/fee_persist_tests.cpp
@@ -151,6 +151,17 @@ BOOST_AUTO_TEST_CASE(roundtrip_basic) {
                                       EstimateHorizon::MED_HALFLIFE);
     auto rl = est_load.estimateRawFee(2, 0.80,
                                       EstimateHorizon::MED_HALFLIFE);
+    // PR-EF-1-FIX Finding F3: pin that the estimate is non-null on the
+    // dump side (else the equality check below is satisfied trivially
+    // by both sides being -1). A regression that loses all conf_avg
+    // data on persistence would otherwise pass under the previous
+    // toothless equality assertion.
+    BOOST_REQUIRE_MESSAGE(rd.feerate > 0,
+        "dump-side estimate must be non-null for the equality check below "
+        "to be load-bearing; got feerate=" << static_cast<double>(rd.feerate));
+    BOOST_REQUIRE_MESSAGE(rl.feerate > 0,
+        "load-side estimate must be non-null after restore; got feerate="
+        << static_cast<double>(rl.feerate));
     BOOST_CHECK_EQUAL(static_cast<double>(rd.feerate),
                       static_cast<double>(rl.feerate));
 }

--- a/src/test/fee_persist_tests.cpp
+++ b/src/test/fee_persist_tests.cpp
@@ -1,0 +1,501 @@
+// Copyright (c) 2026 The Dilithion Core developers
+// Distributed under the MIT software license
+
+#include <boost/test/unit_test.hpp>
+
+#include <policy/fee_persist.h>
+#include <policy/fees.h>
+#include <crypto/sha3.h>
+#include <uint256.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <random>
+#include <string>
+#include <system_error>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(fee_persist_tests)
+
+namespace {
+
+uint256 MakeTxHash(uint32_t seed) {
+    uint256 h;
+    std::memset(h.data, 0, 32);
+    h.data[0] = static_cast<uint8_t>(seed & 0xFF);
+    h.data[1] = static_cast<uint8_t>((seed >> 8) & 0xFF);
+    h.data[2] = static_cast<uint8_t>((seed >> 16) & 0xFF);
+    h.data[3] = static_cast<uint8_t>((seed >> 24) & 0xFF);
+    h.data[31] = static_cast<uint8_t>(seed * 0x9E + 0x37);
+    return h;
+}
+
+std::filesystem::path MakeTempDir(const std::string& tag) {
+    auto base = std::filesystem::temp_directory_path();
+    auto path = base / ("fee_persist_test_" + tag + "_" +
+        std::to_string(static_cast<long long>(
+            std::chrono::steady_clock::now().time_since_epoch().count())));
+    std::filesystem::create_directories(path);
+    return path;
+}
+
+void CleanupTempDir(const std::filesystem::path& path) {
+    std::error_code ec;
+    std::filesystem::remove_all(path, ec);
+}
+
+class TempDir {
+public:
+    explicit TempDir(const std::string& tag) : m_path(MakeTempDir(tag)) {}
+    ~TempDir() { CleanupTempDir(m_path); }
+    const std::filesystem::path& path() const { return m_path; }
+    TempDir(const TempDir&) = delete;
+    TempDir& operator=(const TempDir&) = delete;
+private:
+    std::filesystem::path m_path;
+};
+
+// Drive the estimator through a deterministic synthetic mempool.
+void DriveEstimator(policy::fee_estimator::CBlockPolicyEstimator& est,
+                    unsigned int blocks, uint32_t seed_offset = 0) {
+    using namespace policy::fee_estimator;
+    for (unsigned int h = 1; h <= blocks; ++h) {
+        std::vector<uint256> confirmed;
+        for (uint32_t i = 0; i < 4; ++i) {
+            uint256 t = MakeTxHash(h * 1000 + i + seed_offset);
+            est.processTx(t, h, 50000 + i * 5000, 250, true);
+            confirmed.push_back(t);
+        }
+        // Leave one tx unconfirmed every block for tracked-set non-emptiness.
+        if (h % 5 == 0) {
+            uint256 t = MakeTxHash(h * 1000 + 999 + seed_offset);
+            est.processTx(t, h, 8000, 250, true);
+        }
+        est.processBlock(h, confirmed);
+    }
+}
+
+// Build a forged fee_estimates.dat for malformed-input tests. Caller
+// supplies the in-the-clear payload (everything between version+key and
+// footer); we add the version, key, scramble, and footer.
+void WriteForgedFile(const std::filesystem::path& datadir,
+                     const std::vector<uint8_t>& clear_body) {
+    std::vector<uint8_t> bytes;
+    bytes.reserve(1 + policy::fee_persist::XOR_KEY_SIZE +
+                  clear_body.size() + policy::fee_persist::FOOTER_SIZE);
+    bytes.push_back(policy::fee_persist::SCHEMA_VERSION);
+
+    std::vector<uint8_t> key(policy::fee_persist::XOR_KEY_SIZE);
+    for (size_t i = 0; i < key.size(); ++i)
+        key[i] = static_cast<uint8_t>(i ^ 0x5A);
+    bytes.insert(bytes.end(), key.begin(), key.end());
+
+    std::vector<uint8_t> for_hash = bytes;
+    for_hash.insert(for_hash.end(), clear_body.begin(), clear_body.end());
+    uint8_t hash_full[32];
+    SHA3_256(for_hash.data(), for_hash.size(), hash_full);
+
+    const size_t body_start = bytes.size();
+    bytes.insert(bytes.end(), clear_body.begin(), clear_body.end());
+    for (size_t i = 0; i < clear_body.size(); ++i) {
+        bytes[body_start + i] ^= key[i % key.size()];
+    }
+    const size_t footer_offset = bytes.size() - body_start;
+    for (size_t i = 0; i < policy::fee_persist::FOOTER_SIZE; ++i) {
+        bytes.push_back(hash_full[i] ^ key[(footer_offset + i) % key.size()]);
+    }
+
+    const auto fp = datadir / policy::fee_persist::FILENAME;
+    std::ofstream f(fp.string(), std::ios::binary | std::ios::trunc);
+    f.write(reinterpret_cast<const char*>(bytes.data()), bytes.size());
+}
+
+}  // anonymous namespace
+
+// ---- C1: round-trip basic + identity --------------------------------
+
+BOOST_AUTO_TEST_CASE(roundtrip_basic) {
+    TempDir scope("roundtrip_basic");
+
+    policy::fee_estimator::CBlockPolicyEstimator est_dump;
+    DriveEstimator(est_dump, 30);
+    BOOST_REQUIRE_GE(est_dump.getBestSeenHeight(), 30u);
+    const size_t pre_dump_tracked = est_dump.getTrackedTxCount();
+    BOOST_REQUIRE_GT(pre_dump_tracked, 0u);
+
+    auto dump = policy::fee_persist::DumpFeeEstimates(est_dump, scope.path());
+    BOOST_REQUIRE_MESSAGE(dump.success, "dump error: " << dump.error_message);
+    BOOST_CHECK_EQUAL(dump.tracked_tx_count, pre_dump_tracked);
+    BOOST_CHECK(!dump.final_path.empty());
+
+    policy::fee_estimator::CBlockPolicyEstimator est_load;
+    auto load = policy::fee_persist::LoadFeeEstimates(est_load, scope.path());
+    BOOST_REQUIRE_MESSAGE(load.success,
+                          "load error: " << load.error_message);
+    BOOST_CHECK(!load.cold_start);
+    BOOST_CHECK_EQUAL(load.tracked_tx_count, pre_dump_tracked);
+
+    // Identity assertions.
+    BOOST_CHECK_EQUAL(est_dump.getBestSeenHeight(),
+                      est_load.getBestSeenHeight());
+    BOOST_CHECK_EQUAL(est_dump.getTrackedTxCount(),
+                      est_load.getTrackedTxCount());
+    BOOST_CHECK_EQUAL(est_dump.getBlocksObserved(),
+                      est_load.getBlocksObserved());
+
+    using namespace policy::fee_estimator;
+    auto rd = est_dump.estimateRawFee(2, 0.80,
+                                      EstimateHorizon::MED_HALFLIFE);
+    auto rl = est_load.estimateRawFee(2, 0.80,
+                                      EstimateHorizon::MED_HALFLIFE);
+    BOOST_CHECK_EQUAL(static_cast<double>(rd.feerate),
+                      static_cast<double>(rl.feerate));
+}
+
+// ---- C2: round-trip empty (no observations) --------------------------
+
+BOOST_AUTO_TEST_CASE(roundtrip_empty) {
+    TempDir scope("roundtrip_empty");
+
+    policy::fee_estimator::CBlockPolicyEstimator est_dump;
+    BOOST_REQUIRE_EQUAL(est_dump.getTrackedTxCount(), 0u);
+
+    auto dump = policy::fee_persist::DumpFeeEstimates(est_dump, scope.path());
+    BOOST_REQUIRE(dump.success);
+    BOOST_CHECK_EQUAL(dump.tracked_tx_count, 0u);
+
+    policy::fee_estimator::CBlockPolicyEstimator est_load;
+    auto load = policy::fee_persist::LoadFeeEstimates(est_load, scope.path());
+    BOOST_REQUIRE(load.success);
+    BOOST_CHECK(!load.cold_start);
+    BOOST_CHECK_EQUAL(load.tracked_tx_count, 0u);
+    BOOST_CHECK_EQUAL(est_load.getBestSeenHeight(), 0u);
+}
+
+// ---- C3: round-trip large ------------------------------------------
+
+BOOST_AUTO_TEST_CASE(roundtrip_large) {
+    TempDir scope("roundtrip_large");
+
+    policy::fee_estimator::CBlockPolicyEstimator est_dump;
+    DriveEstimator(est_dump, 100);
+    const size_t pre_dump_tracked = est_dump.getTrackedTxCount();
+
+    auto dump = policy::fee_persist::DumpFeeEstimates(est_dump, scope.path());
+    BOOST_REQUIRE_MESSAGE(dump.success, "dump error: " << dump.error_message);
+
+    policy::fee_estimator::CBlockPolicyEstimator est_load;
+    auto load = policy::fee_persist::LoadFeeEstimates(est_load, scope.path());
+    BOOST_REQUIRE(load.success);
+    BOOST_CHECK(!load.cold_start);
+    BOOST_CHECK_EQUAL(load.tracked_tx_count, pre_dump_tracked);
+}
+
+// ---- C4: missing file -> cold start --------------------------------
+
+BOOST_AUTO_TEST_CASE(missing_file_cold_start) {
+    TempDir scope("missing_file");
+    BOOST_REQUIRE(!std::filesystem::exists(
+        scope.path() / policy::fee_persist::FILENAME));
+
+    policy::fee_estimator::CBlockPolicyEstimator est;
+    auto load = policy::fee_persist::LoadFeeEstimates(est, scope.path());
+    BOOST_REQUIRE(load.success);
+    BOOST_CHECK(load.cold_start);
+    BOOST_CHECK_EQUAL(load.tracked_tx_count, 0u);
+    BOOST_CHECK_EQUAL(est.getBestSeenHeight(), 0u);
+}
+
+// ---- C5: truncated file -> cold start ------------------------------
+
+BOOST_AUTO_TEST_CASE(corrupt_truncated_cold_start) {
+    TempDir scope("corrupt_truncated");
+
+    policy::fee_estimator::CBlockPolicyEstimator est_dump;
+    DriveEstimator(est_dump, 10);
+    BOOST_REQUIRE(policy::fee_persist::DumpFeeEstimates(est_dump,
+                                                        scope.path()).success);
+
+    const auto fp = scope.path() / policy::fee_persist::FILENAME;
+    std::error_code ec;
+    std::filesystem::resize_file(fp,
+        policy::fee_persist::MIN_FILE_SIZE - 1, ec);
+    BOOST_REQUIRE(!ec);
+
+    policy::fee_estimator::CBlockPolicyEstimator est_load;
+    auto load = policy::fee_persist::LoadFeeEstimates(est_load, scope.path());
+    BOOST_REQUIRE(load.success);
+    BOOST_CHECK(load.cold_start);
+    BOOST_CHECK_EQUAL(est_load.getBestSeenHeight(), 0u);
+}
+
+// ---- C6: bad version byte -> cold start ----------------------------
+
+BOOST_AUTO_TEST_CASE(corrupt_bad_version_cold_start) {
+    TempDir scope("corrupt_bad_version");
+
+    policy::fee_estimator::CBlockPolicyEstimator est_dump;
+    DriveEstimator(est_dump, 5);
+    BOOST_REQUIRE(policy::fee_persist::DumpFeeEstimates(est_dump,
+                                                        scope.path()).success);
+
+    const auto fp = scope.path() / policy::fee_persist::FILENAME;
+    {
+        std::fstream f(fp.string(), std::ios::binary | std::ios::in |
+                                     std::ios::out);
+        BOOST_REQUIRE(f.is_open());
+        f.seekp(0);
+        const uint8_t bad = 0xFF;
+        f.write(reinterpret_cast<const char*>(&bad), 1);
+    }
+
+    policy::fee_estimator::CBlockPolicyEstimator est_load;
+    auto load = policy::fee_persist::LoadFeeEstimates(est_load, scope.path());
+    BOOST_REQUIRE(load.success);
+    BOOST_CHECK(load.cold_start);
+    BOOST_CHECK(load.cold_start_reason.find("schema version") !=
+                std::string::npos);
+    BOOST_CHECK_EQUAL(est_load.getBestSeenHeight(), 0u);
+}
+
+// ---- C7: corrupted footer -> cold start ----------------------------
+
+BOOST_AUTO_TEST_CASE(corrupt_footer_cold_start) {
+    TempDir scope("corrupt_footer");
+
+    policy::fee_estimator::CBlockPolicyEstimator est_dump;
+    DriveEstimator(est_dump, 5);
+    BOOST_REQUIRE(policy::fee_persist::DumpFeeEstimates(est_dump,
+                                                        scope.path()).success);
+
+    const auto fp = scope.path() / policy::fee_persist::FILENAME;
+    const auto file_size = std::filesystem::file_size(fp);
+    {
+        std::fstream f(fp.string(), std::ios::binary | std::ios::in |
+                                     std::ios::out);
+        BOOST_REQUIRE(f.is_open());
+        f.seekp(file_size - 1);
+        const uint8_t flipped = 0xCC;
+        f.write(reinterpret_cast<const char*>(&flipped), 1);
+    }
+
+    policy::fee_estimator::CBlockPolicyEstimator est_load;
+    auto load = policy::fee_persist::LoadFeeEstimates(est_load, scope.path());
+    BOOST_REQUIRE(load.success);
+    BOOST_CHECK(load.cold_start);
+    BOOST_CHECK(load.cold_start_reason.find("footer") != std::string::npos);
+    BOOST_CHECK_EQUAL(est_load.getBestSeenHeight(), 0u);
+}
+
+// ---- C8: forced EARLY dump failure -> previous file intact ---------
+
+BOOST_AUTO_TEST_CASE(atomicity_forced_early_failure) {
+    TempDir scope("atomicity_early");
+
+    policy::fee_estimator::CBlockPolicyEstimator est_first;
+    DriveEstimator(est_first, 5);
+    BOOST_REQUIRE(policy::fee_persist::DumpFeeEstimates(est_first,
+                                                        scope.path()).success);
+    const auto fp = scope.path() / policy::fee_persist::FILENAME;
+    BOOST_REQUIRE(std::filesystem::exists(fp));
+    const auto first_size = std::filesystem::file_size(fp);
+
+    policy::fee_estimator::CBlockPolicyEstimator est_second;
+    DriveEstimator(est_second, 50, /*seed_offset=*/100000);
+    policy::fee_persist::test_hooks::g_force_dump_failure.store(true);
+    auto dump = policy::fee_persist::DumpFeeEstimates(est_second,
+                                                      scope.path());
+    policy::fee_persist::test_hooks::g_force_dump_failure.store(false);
+    BOOST_CHECK(!dump.success);
+    BOOST_CHECK(!dump.error_message.empty());
+
+    // Prior file intact.
+    BOOST_REQUIRE(std::filesystem::exists(fp));
+    BOOST_CHECK_EQUAL(std::filesystem::file_size(fp), first_size);
+    BOOST_CHECK(!std::filesystem::exists(
+        scope.path() / policy::fee_persist::FILENAME_TMP));
+
+    // Loading still yields the FIRST estimator's state.
+    policy::fee_estimator::CBlockPolicyEstimator est_load;
+    auto load = policy::fee_persist::LoadFeeEstimates(est_load, scope.path());
+    BOOST_REQUIRE(load.success);
+    BOOST_CHECK(!load.cold_start);
+    BOOST_CHECK_EQUAL(est_load.getBestSeenHeight(),
+                      est_first.getBestSeenHeight());
+}
+
+// ---- C9: forced LATE dump failure -> .new cleaned up, prior intact -
+
+BOOST_AUTO_TEST_CASE(atomicity_forced_late_failure) {
+    TempDir scope("atomicity_late");
+
+    policy::fee_estimator::CBlockPolicyEstimator est_first;
+    DriveEstimator(est_first, 5);
+    BOOST_REQUIRE(policy::fee_persist::DumpFeeEstimates(est_first,
+                                                        scope.path()).success);
+    const auto fp = scope.path() / policy::fee_persist::FILENAME;
+    const auto fp_tmp = scope.path() / policy::fee_persist::FILENAME_TMP;
+    const auto first_size = std::filesystem::file_size(fp);
+
+    policy::fee_estimator::CBlockPolicyEstimator est_second;
+    DriveEstimator(est_second, 75, /*seed_offset=*/200000);
+    policy::fee_persist::test_hooks::g_force_late_dump_failure.store(true);
+    auto dump = policy::fee_persist::DumpFeeEstimates(est_second,
+                                                      scope.path());
+    policy::fee_persist::test_hooks::g_force_late_dump_failure.store(false);
+    BOOST_CHECK(!dump.success);
+    BOOST_CHECK(dump.error_message.find("late") != std::string::npos);
+
+    BOOST_CHECK(!std::filesystem::exists(fp_tmp));
+    BOOST_REQUIRE(std::filesystem::exists(fp));
+    BOOST_CHECK_EQUAL(std::filesystem::file_size(fp), first_size);
+
+    policy::fee_estimator::CBlockPolicyEstimator est_load;
+    auto load = policy::fee_persist::LoadFeeEstimates(est_load, scope.path());
+    BOOST_REQUIRE(load.success);
+    BOOST_CHECK(!load.cold_start);
+    BOOST_CHECK_EQUAL(est_load.getBestSeenHeight(),
+                      est_first.getBestSeenHeight());
+}
+
+// ---- C10: schema lock-in (validates structural shape) --------------
+
+BOOST_AUTO_TEST_CASE(schema_lock_in_structure) {
+    TempDir scope("schema_lock");
+
+    policy::fee_estimator::CBlockPolicyEstimator est;
+    DriveEstimator(est, 3);
+
+    auto dump = policy::fee_persist::DumpFeeEstimates(est, scope.path());
+    BOOST_REQUIRE(dump.success);
+
+    const auto fp = scope.path() / policy::fee_persist::FILENAME;
+    std::ifstream f(fp.string(), std::ios::binary);
+    BOOST_REQUIRE(f.is_open());
+    std::vector<uint8_t> bytes((std::istreambuf_iterator<char>(f)),
+                                std::istreambuf_iterator<char>());
+
+    BOOST_REQUIRE_GT(bytes.size(),
+                     1u + policy::fee_persist::XOR_KEY_SIZE +
+                     policy::fee_persist::FOOTER_SIZE);
+    BOOST_CHECK_EQUAL(bytes[0], policy::fee_persist::SCHEMA_VERSION);
+
+    // Round-trip via LoadFeeEstimates (the real schema verifier).
+    policy::fee_estimator::CBlockPolicyEstimator est_load;
+    auto load = policy::fee_persist::LoadFeeEstimates(est_load, scope.path());
+    BOOST_REQUIRE(load.success);
+    BOOST_CHECK(!load.cold_start);
+    BOOST_CHECK_EQUAL(est_load.getBestSeenHeight(),
+                      est.getBestSeenHeight());
+}
+
+// ---- B1: oversize file -> cold start (DoS protection) -------------
+
+BOOST_AUTO_TEST_CASE(oversize_file_cold_start) {
+    TempDir scope("oversize");
+    const auto fp = scope.path() / policy::fee_persist::FILENAME;
+
+    std::ofstream f(fp.string(), std::ios::binary | std::ios::trunc);
+    f.put(0x01);
+    f.close();
+    std::error_code ec;
+    std::filesystem::resize_file(fp,
+        policy::fee_persist::MAX_FILE_SIZE + 1, ec);
+    BOOST_REQUIRE(!ec);
+
+    policy::fee_estimator::CBlockPolicyEstimator est;
+    auto load = policy::fee_persist::LoadFeeEstimates(est, scope.path());
+    BOOST_REQUIRE(load.success);
+    BOOST_CHECK(load.cold_start);
+    BOOST_CHECK(load.cold_start_reason.find("MAX_FILE_SIZE") !=
+                std::string::npos);
+    BOOST_CHECK_EQUAL(est.getBestSeenHeight(), 0u);
+}
+
+// ---- C11-a: tracked_tx_count > MAX_TRACKED_TX -> cold start --------
+
+BOOST_AUTO_TEST_CASE(overcap_tracked_tx_count_cold_start) {
+    TempDir scope("overcap_tracked");
+
+    // Build a forged body with valid header + minimal stats but
+    // tracked_tx_count = MAX_TRACKED_TX + 1.
+    // Note: this file will fail the bucket-count read instead because we
+    // can't trivially generate a valid stats body. So we test a different
+    // overcap: bucket_count exceeding MAX_BUCKET_COUNT.
+    std::vector<uint8_t> clear_body;
+    auto put_u32 = [&](uint32_t v) {
+        for (int i = 0; i < 4; ++i)
+            clear_body.push_back(static_cast<uint8_t>((v >> (i * 8)) & 0xFF));
+    };
+    put_u32(0);    // best_seen_height
+    put_u32(0);    // historical_first
+    put_u32(0);    // historical_best
+    put_u32(policy::fee_persist::MAX_BUCKET_COUNT + 1);  // bucket_count
+
+    WriteForgedFile(scope.path(), clear_body);
+
+    policy::fee_estimator::CBlockPolicyEstimator est;
+    auto load = policy::fee_persist::LoadFeeEstimates(est, scope.path());
+    BOOST_REQUIRE(load.success);
+    BOOST_CHECK(load.cold_start);
+    BOOST_CHECK(load.cold_start_reason.find("bucket_count") !=
+                std::string::npos);
+}
+
+// ---- C11-b: read-past-end mid-body -> cold start -------------------
+
+BOOST_AUTO_TEST_CASE(read_past_end_cold_start) {
+    TempDir scope("read_past_end");
+
+    std::vector<uint8_t> clear_body;
+    auto put_u32 = [&](uint32_t v) {
+        for (int i = 0; i < 4; ++i)
+            clear_body.push_back(static_cast<uint8_t>((v >> (i * 8)) & 0xFF));
+    };
+    put_u32(0); put_u32(0); put_u32(0);
+    put_u32(2);   // bucket_count = 2 -- will demand 2 i64 bucket entries
+    // ... but we don't write any. Read should throw.
+
+    WriteForgedFile(scope.path(), clear_body);
+
+    policy::fee_estimator::CBlockPolicyEstimator est;
+    auto load = policy::fee_persist::LoadFeeEstimates(est, scope.path());
+    BOOST_REQUIRE(load.success);
+    BOOST_CHECK(load.cold_start);
+    BOOST_CHECK(load.cold_start_reason.find("stream error") !=
+                std::string::npos);
+}
+
+// ---- C12: estimator continues observing post-restore ---------------
+
+BOOST_AUTO_TEST_CASE(restored_estimator_keeps_observing) {
+    TempDir scope("restored_keeps_observing");
+
+    policy::fee_estimator::CBlockPolicyEstimator est_a;
+    DriveEstimator(est_a, 30);
+    BOOST_REQUIRE(policy::fee_persist::DumpFeeEstimates(est_a,
+                                                        scope.path()).success);
+
+    policy::fee_estimator::CBlockPolicyEstimator est_b;
+    BOOST_REQUIRE(policy::fee_persist::LoadFeeEstimates(est_b,
+                                                        scope.path()).success);
+    const auto post_restore_height = est_b.getBestSeenHeight();
+    BOOST_CHECK_EQUAL(post_restore_height, 30u);
+
+    // Continue driving. Anti-replay must let us observe blocks > 30.
+    for (unsigned int h = 31; h <= 35; ++h) {
+        std::vector<uint256> confirmed;
+        for (uint32_t i = 0; i < 3; ++i) {
+            uint256 t = MakeTxHash(h * 5000 + i);
+            est_b.processTx(t, h, 50000, 250, true);
+            confirmed.push_back(t);
+        }
+        est_b.processBlock(h, confirmed);
+    }
+    BOOST_CHECK_EQUAL(est_b.getBestSeenHeight(), 35u);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary

PR-EF-1 of the `estimatesmartfee` port (T1.D in `ROADMAP-MAINNET-PRODUCTION-PARITY`). Pure module addition: `CBlockPolicyEstimator` adapted from Bitcoin Core v28.0 + `fee_estimates.dat` persistence. Mempool/chainstate hooks come in PR-EF-2; RPC handlers come in PR-EF-3.

- New: `src/policy/fees.{h,cpp}` -- `CBlockPolicyEstimator` (BC v28.0 port)
- New: `src/policy/fee_persist.{h,cpp}` -- `fee_estimates.dat` save/load (mirrors `node/mempool_persist.{h,cpp}` schema)
- New: `src/test/fee_estimator_tests.cpp` (16 cases, 237 assertions) + `src/test/fee_persist_tests.cpp` (14 cases, 86 assertions)
- `Makefile` registers new sources + test targets

Bitcoin Core constants pinned verbatim: `MIN/MAX_BUCKET_FEERATE`, `FEE_SPACING=1.05`, three confirmation horizons (12/24/42 blocks) with their exact decay parameters (0.962 / 0.9952 / 0.99931), and the 0.85/0.60 success thresholds for CONSERVATIVE/ECONOMICAL modes.

CAmount adaptation: Bitcoin's `sat/kvB` maps 1:1 to Dilithion's `ions/1000-byte` (both 1e-8 of base coin), so the bucket ladder semantics are preserved unchanged.

Persistence mirrors `mempool_persist`: version byte + 32-byte XOR key (cleartext) + scrambled body + SHA3-256-truncated 8-byte footer. Atomic write via `.new` + fsync + rename + parent fsync. Same antivirus-mitigation + integrity-detection semantics as `mempool.dat`.

## Test plan

- [x] `fee_estimator_tests` -- 16 cases pass
- [x] `fee_persist_tests` -- 14 cases pass
- [x] Combined regression with `tx_index_tests + mempool_persist_tests` -- 83 cases / 20163 assertions pass
- [x] Build clean: `dilithion-node`, `dilv-node`, `test_dilithion` -- no new warnings on touched files
- [ ] Diff red-team review (will be requested separately)

## Out-of-scope (deferred)

- Mempool admission hooks (`processTx` from `CTxMemPool::AddTx`) -- PR-EF-2
- Block-connect hooks (`processBlock` from `ConnectTip`) -- PR-EF-2
- Save/load wiring in `dilithion-node`/`dilv-node` startup/shutdown -- PR-EF-2
- `-feeestimates` CLI flag -- PR-EF-2
- `estimatesmartfee` / `estimaterawfee` / `savefeeestimates` RPC handlers -- PR-EF-3
- Operator runbook `docs/FEE-ESTIMATION.md` -- PR-EF-2 / PR-EF-3

## Notes for reviewers

- Estimator algorithm is intentionally a **simpler "first bucket meeting threshold"** than Bitcoin Core's full multi-bucket smoothing. The histogram shape, decay logic, anti-replay guard, and aging-ring rotation are faithful ports; the **estimator-from-histogram extraction** is the simplified piece. Upgrading to BC's full algorithm is straightforward and can land in a follow-up once mempool wiring is real.
- `fee_estimates.dat` schema bumps require a `FEE_ESTIMATES_FILE_VERSION` increment; mismatch triggers cold-start (warn-log, fresh accumulation window).
- INF bucket sentinel is encoded as `INT64_MAX` to avoid overflow when `MAX_MONEY * 1000 / vsize` is multiplied by the on-disk Q-scale; `DecodeBucket` recognizes the sentinel and restores `INF_FEERATE`.
- Bucket ladder restore tolerance is 1e-3 RELATIVE -- far below the 5% inter-bucket spacing, so a corrupted or schema-mismatched ladder is still detected.