### PR TITLE
ci(macos): stop overriding CXXFLAGS so Makefile's += accumulates

### DIFF
--- a/.github/workflows/build-dilv-macos.yml
+++ b/.github/workflows/build-dilv-macos.yml
@@ -43,7 +43,7 @@ jobs:
         export CFLAGS="-I$OPENSSL_PREFIX/include -I$MINIUPNPC_PREFIX/include -I$GMP_PREFIX/include"
         export CXXFLAGS="-std=c++17 -I$OPENSSL_PREFIX/include -I$MINIUPNPC_PREFIX/include -I$GMP_PREFIX/include"
         make clean
-        make dilv-node check-wallet-balance -j$(sysctl -n hw.ncpu) CXXFLAGS="$CXXFLAGS" CPPFLAGS="$CPPFLAGS" LDFLAGS="$LDFLAGS"
+        make dilv-node check-wallet-balance -j$(sysctl -n hw.ncpu)
         ls -lh dilv-node check-wallet-balance
 
     - name: Extract version from tag

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -46,7 +46,7 @@ jobs:
         export CFLAGS="-I$OPENSSL_PREFIX/include -I$MINIUPNPC_PREFIX/include -I$GMP_PREFIX/include"
         export CXXFLAGS="-std=c++17 -I$OPENSSL_PREFIX/include -I$MINIUPNPC_PREFIX/include -I$GMP_PREFIX/include"
         make clean
-        make -j$(sysctl -n hw.ncpu) CXXFLAGS="$CXXFLAGS" CPPFLAGS="$CPPFLAGS" LDFLAGS="$LDFLAGS"
+        make -j$(sysctl -n hw.ncpu)
         ls -lh dilithion-node check-wallet-balance genesis_gen
 
     - name: Extract version from tag


### PR DESCRIPTION
## Summary

The macOS CI workflows pass `CXXFLAGS="..."` on the `make` command line, which takes override precedence over the Makefile's `+=` lines. This silently drops:

- `CXXFLAGS += -DDILITHION_VERSION='"$(GIT_VERSION)"'` — version macro, so subversion reports `dev` via `getnetworkinfo`
- The Makefile's `?=` defaults: `-Wall -Wextra -O2 -pipe -fstack-protector-strong -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security`
- `CXXFLAGS += -MMD -MP` — header dependency tracking

The exported env vars are already respected by the Makefile's `?=` lines, so removing the redundant cmdline override lets everything accumulate correctly.

This bug shipped real macOS binaries to users via v4.2.0 (binary labeled `dev`, no `-O2`, no stack protector). Caught after Discord reports of macOS issues. Already shipped fix as v4.2.1 via cherry-pick of this commit; this PR lands the fix on `main` for posterity.

## Why only macOS

- Windows workflow does not have a cmdline override — Windows binaries always built correctly
- Linux release binary is built on the NYC seed host, not in CI — also unaffected

## Test plan

- [x] v4.2.1 release shipped using this fix; macOS binary confirmed to embed `v4.2.1` and the security/optimization flags
- [ ] CI run on this PR completes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)