### PR TITLE
fix(explorer): nodes.php cache + single-flight, document cache perms gotcha

### DIFF
--- a/explorer/api/metrics_helpers.php
+++ b/explorer/api/metrics_helpers.php
@@ -32,6 +32,14 @@ const SEED_NODES = [
 // Cache dir lives at explorer/cache (sibling of api/). PHP-FPM (www-data)
 // must be able to write here. Bootstrap on first call so a fresh deploy
 // doesn't need a manual mkdir.
+//
+// IMPORTANT operator note: if the cache dir already exists owned by root
+// (e.g. created by a manual `mkdir` or a one-off root-run script), this
+// function does NOT chown it. www-data will fail _acquireSingleFlight()
+// silently (fopen 'c' returns false), every miss falls into the contended
+// path, and the explorer appears to flap. Fix: `chown -R www-data:www-data
+// /root/dilithion/explorer/cache/`. Lesson from the 2026-05-03 explorer
+// flap incident.
 function _explorerCacheDir(): string {
     $dir = __DIR__ . "/../cache";
     if (!is_dir($dir)) @mkdir($dir, 0775, true);

--- a/explorer/api/nodes.php
+++ b/explorer/api/nodes.php
@@ -8,26 +8,41 @@
  */
 
 require_once __DIR__ . "/rpc.php";
+require_once __DIR__ . "/metrics_helpers.php";
 
 $config = getChainConfig();
 $chain = $config['chain'];
 $rpcPort = $config['rpc_port'];
 
-// 3-second cache
-$cacheFile = __DIR__ . "/../cache/nodes-{$chain}.json";
-if (file_exists($cacheFile)) {
-    $cacheAge = time() - filemtime($cacheFile);
-    if ($cacheAge < 3) {
-        $cached = file_get_contents($cacheFile);
-        if ($cached !== false) {
-            $data = json_decode($cached, true);
-            if ($data !== null) {
-                $data['cached'] = true;
-                $data['cacheAge'] = $cacheAge;
-                sendJSON($data);
-            }
-        }
-    }
+// 15-second cache + single-flight. Without single-flight, every cache expiry
+// races N FPM workers into the same fan-out (12 RPCs across 4 seeds), bursting
+// the seed rate-limiter (10 tokens / 1 RPS per IP) and making remote seeds
+// flicker offline in the UI. Pattern is the same as PR #49 stats.php.
+$cacheFile = _explorerCacheDir() . "/nodes-{$chain}.json";
+
+function _serveCache(string $file, int $maxAge, bool $allowStale = false): bool {
+    if (!file_exists($file)) return false;
+    $age = time() - filemtime($file);
+    if (!$allowStale && $age >= $maxAge) return false;
+    $cached = file_get_contents($file);
+    if ($cached === false) return false;
+    $data = json_decode($cached, true);
+    if ($data === null) return false;
+    $data['cached'] = true;
+    $data['cacheAge'] = $age;
+    sendJSON($data);
+    return true;
+}
+
+if (_serveCache($cacheFile, 15)) { /* unreachable; sendJSON exits */ }
+
+$lock = _acquireSingleFlight($cacheFile);
+if (!$lock) {
+    // Another worker is recomputing — serve whatever cache we have, even if
+    // older than the 15s window. Better stale than stampede.
+    if (_serveCache($cacheFile, PHP_INT_MAX, true)) { /* exits */ }
+    // No cache at all and contended → return empty rather than stampede.
+    sendJSON(['nodes' => [], 'chain' => $chain, 'consensusHeight' => 0, 'contended' => true]);
 }
 
 $seedNodes = [
@@ -133,4 +148,5 @@ $response = [
 ];
 
 @file_put_contents($cacheFile, json_encode($response));
+_releaseSingleFlight($lock);
 sendJSON($response);


### PR DESCRIPTION
## Summary

Two fixes for `/api/nodes.php` and one operator-doc note for `_explorerCacheDir()`. Triggered by the 2026-05-03 explorer-flap incident where remote seeds appeared to drop in and out of the UI.

### nodes.php

- Cache TTL bumped 3s → 15s. The 12-RPC fan-out (3 methods × 4 seeds) at 3s TTL exceeded the seed rate-limiter (10 burst / 1 RPS per IP), so remote seeds returned `Rate limit exceeded` JSON without a `result` field — treated as offline by the explorer. 15s drops query rate to ~0.07 RPS per remote seed.
- Added single-flight via `_acquireSingleFlight()` (same pattern as PR #49). Without it, concurrent FPM workers stampede the same RPC fan-out on every cache expiry. Contended workers now serve stale cache; only one worker recomputes.

### metrics_helpers.php (doc-only)

Added an operator note to `_explorerCacheDir()`: if the cache dir already exists owned by root, www-data silently fails on `fopen('c')` for the `.lock` file → every request falls into the contended path → explorer flap. `mkdir` doesn't fix this; needs an explicit `chown -R www-data:www-data`.

## Test plan

- [x] Deployed to NYC manually, 6 consecutive polls show all 4 nodes online with 100% cache hits
- [ ] CI on this PR completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)