### PR TITLE
Bitcoin Core port — Phase 0: interface contracts + scaffolding

### DIFF
--- a/src/consensus/ichain_selector.h
+++ b/src/consensus/ichain_selector.h
@@ -1,0 +1,98 @@
+// Copyright (c) 2026 The Dilithion Core developers
+// Distributed under the MIT software license
+//
+// Phase 5 interface contract. The chain selector is the heart of the port —
+// it holds the block index tree, applies max-cumulative-work selection,
+// and reorgs when a better leaf appears.
+//
+// Bitcoin Core's ChainstateManager / Chainstate are the upstream model.
+// CONSENSUS BOUNDARY: the underlying validation (CheckBlock,
+// ContextualCheckBlock, ConnectBlock) is NOT changed by the port —
+// only the storage + selection plumbing is.
+
+#ifndef DILITHION_CONSENSUS_ICHAIN_SELECTOR_H
+#define DILITHION_CONSENSUS_ICHAIN_SELECTOR_H
+
+#include <cstdint>
+#include <vector>
+#include <memory>
+#include <uint256.h>
+
+class CBlock;
+class CBlockHeader;
+class CBlockIndex;
+
+namespace dilithion::consensus {
+
+// View of a chain tip (active or competing).
+struct ChainTipInfo {
+    uint256 hash;
+    int height;
+    int branchlen;                   // 0 for active tip; >0 for fork
+    enum class Status {
+        Active,                      // The current best tip
+        ValidFork,                   // Validated alternative chain
+        ValidHeaders,                // Headers known, blocks not all here
+        InvalidBlock,                // A block on this chain is invalid
+        Unknown,                     // Headers point here but no validation yet
+    } status;
+    uint256 chain_work;
+};
+
+class IChainSelector {
+public:
+    virtual ~IChainSelector() = default;
+
+    // ============================================================
+    // Block-receipt entry point — called by IBlockSink impl.
+    // ============================================================
+    // Process a newly-received block. Returns true on success (block
+    // accepted, possibly triggering reorg). False on validation failure.
+    virtual bool ProcessNewBlock(std::shared_ptr<const CBlock> block,
+                                 bool force_processing,
+                                 bool* triggered_reorg = nullptr) = 0;
+
+    // Process a header — used by HeadersSync. Stores in block index tree
+    // (every header gets a CBlockIndex entry, including competing siblings).
+    // Returns true on success.
+    virtual bool ProcessNewHeader(const CBlockHeader& header) = 0;
+
+    // ============================================================
+    // Chain tip queries — replaces fork_manager + chain_tips_tracker.
+    // ============================================================
+    virtual CBlockIndex* GetActiveTip() const = 0;
+    virtual int GetActiveHeight() const = 0;
+    virtual uint256 GetActiveTipHash() const = 0;
+
+    // All known chain tips (for getchaintips RPC). Walks the block index
+    // tree's leaves; never reads a separate "competing tips" cache.
+    virtual std::vector<ChainTipInfo> GetChainTips() const = 0;
+
+    // Find the leaf with maximum cumulative work. This is the chain
+    // selector's core responsibility. Called automatically on every
+    // header receipt; exposed for diagnostics + testing.
+    virtual CBlockIndex* FindMostWorkChain() const = 0;
+
+    // Walk the block index tree to find a block by hash. Returns nullptr
+    // if not known. (This replaces ForkManager::IsBlockForActiveFork —
+    // every block lookup goes through the index tree.)
+    virtual CBlockIndex* LookupBlockIndex(const uint256& hash) const = 0;
+
+    // ============================================================
+    // Manual operator overrides — RPC-callable.
+    // ============================================================
+    // Mark a block as invalid; triggers re-selection of best chain.
+    virtual bool InvalidateBlock(const uint256& hash) = 0;
+
+    // Reverse InvalidateBlock; triggers re-selection.
+    virtual bool ReconsiderBlock(const uint256& hash) = 0;
+
+    // ============================================================
+    // Sync state queries (for getblockchaininfo).
+    // ============================================================
+    virtual bool IsInitialBlockDownload() const = 0;
+};
+
+}  // namespace dilithion::consensus
+
+#endif  // DILITHION_CONSENSUS_ICHAIN_SELECTOR_H

--- a/src/consensus/port/.gitkeep
+++ b/src/consensus/port/.gitkeep
@@ -1,0 +1,1 @@
+Phase 5+ ported files land here. See .claude/contracts/port_phase_0_code_mapping.md

--- a/src/net/iaddress_manager.h
+++ b/src/net/iaddress_manager.h
@@ -1,0 +1,95 @@
+// Copyright (c) 2026 The Dilithion Core developers
+// Distributed under the MIT software license
+//
+// Phase 1 interface contract for the Bitcoin Core peer/IBD/chain-selection port.
+// Architecture document: .claude/contracts/bitcoin_core_port_architecture.md
+// Code mapping: .claude/contracts/port_phase_0_code_mapping.md
+//
+// IAddressManager is the abstraction over Bitcoin Core's AddrMan (address
+// manager). Phase 1 produces the concrete implementation in src/net/addrman.h
+// (replacing the existing stub). PeerManager (Phase 6) and ConnMan (Phase 4)
+// consume this interface, never the concrete class — keeps phases independently
+// mergeable.
+
+#ifndef DILITHION_NET_IADDRESS_MANAGER_H
+#define DILITHION_NET_IADDRESS_MANAGER_H
+
+#include <cstdint>
+#include <vector>
+#include <optional>
+
+// Forward declaration — concrete CAddress lives in net/protocol.h.
+namespace NetProtocol { class CAddress; }
+
+namespace dilithion::net {
+
+// Outcome of a peer's most recent connection attempt — feeds the AddrMan
+// quality model (terrible-peer eviction, retry backoff).
+enum class ConnectionOutcome {
+    Success,                 // Successful handshake AND useful data exchange
+    HandshakeFailed,         // TCP connected but handshake didn't complete
+    Timeout,                 // No response within reasonable time
+    PeerMisbehaved,          // Banned for protocol violation
+    LocalDisconnect,         // We disconnected (eviction, shutdown, etc.)
+};
+
+// Connection class for outbound peers — Bitcoin Core's net/connection_types.h
+// equivalent. Phase 4 consumes this when selecting outbound targets.
+enum class OutboundClass {
+    FullRelay,        // Default outbound, exchanges blocks + tx + addrs
+    BlockRelay,       // Blocks only (no tx, no addr — anti-eclipse)
+    Manual,           // --connect / --addnode persistent
+    Feeler,           // Brief connect to refresh AddrMan freshness
+};
+
+class IAddressManager {
+public:
+    virtual ~IAddressManager() = default;
+
+    // Add a peer address learned from any source (DNS seed, peer ADDR message,
+    // command-line --addnode). Source affects bucketing/quality.
+    virtual bool Add(const NetProtocol::CAddress& addr,
+                     const NetProtocol::CAddress& source) = 0;
+
+    // Mark a peer as having a connection attempted/completed/failed.
+    // Updates AddrMan's quality model.
+    virtual void RecordAttempt(const NetProtocol::CAddress& addr,
+                               ConnectionOutcome outcome) = 0;
+
+    // Select an address to attempt outbound connection to, biased by:
+    // - Quality (success rate, freshness)
+    // - Group diversity (no two outbound peers in same /16 + /32 group)
+    // - Connection class requirements (FullRelay vs BlockRelay vs Feeler)
+    // Returns nullopt if no suitable address available.
+    virtual std::optional<NetProtocol::CAddress> Select(OutboundClass cls) = 0;
+
+    // Select N addresses for ADDR-message gossip to a peer (Bitcoin Core's
+    // GetAddr) — picks random subset of "good" addresses, biased by group.
+    virtual std::vector<NetProtocol::CAddress> GetAddresses(
+        size_t max_count,
+        size_t max_pct,        // Limit to N% of total (anti-fingerprint)
+        std::optional<int> network_filter) = 0;
+
+    // Persist current state to peers.dat. Called periodically + at shutdown.
+    virtual bool Save() = 0;
+
+    // Load state from peers.dat. Called at startup. Returns false if file
+    // missing / corrupt; caller should initialize empty in that case.
+    virtual bool Load() = 0;
+
+    // Diagnostics — number of addresses tracked.
+    virtual size_t Size() const = 0;
+
+    // ============================================================
+    // Dilithion-specific extension (advisory, NOT consensus)
+    // ============================================================
+    // When a peer announces a MIK identity hash, AddrMan can record it for
+    // diagnostics + advisory tie-breaking on outbound selection. Purely
+    // optional; Bitcoin Core's AddrMan ignores this entirely.
+    virtual void SetPeerMIKHint(const NetProtocol::CAddress& addr,
+                                const std::vector<uint8_t>& mik_identity) = 0;
+};
+
+}  // namespace dilithion::net
+
+#endif  // DILITHION_NET_IADDRESS_MANAGER_H

--- a/src/net/iconnection_manager.h
+++ b/src/net/iconnection_manager.h
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 The Dilithion Core developers
+// Distributed under the MIT software license
+//
+// Phase 2 interface contract. Connection management surface that PeerManager
+// (Phase 6) needs from CConnman. Decouples high-level peer logic from
+// socket-level details.
+
+#ifndef DILITHION_NET_ICONNECTION_MANAGER_H
+#define DILITHION_NET_ICONNECTION_MANAGER_H
+
+#include <cstdint>
+#include <string>
+#include <vector>
+#include <net/iaddress_manager.h>  // OutboundClass enum
+
+namespace dilithion::net {
+
+using NodeId = int;
+
+// Snapshot of a connection for PeerManager queries. Bigger than NodeId
+// because PeerManager needs to know connection class, manual flag, etc.
+struct ConnectionInfo {
+    NodeId node_id;
+    bool is_outbound;
+    bool is_manual;                    // --connect / --addnode
+    OutboundClass outbound_class;     // FullRelay, BlockRelay, Manual, Feeler
+    std::string remote_addr_string;   // For logging only
+};
+
+class IConnectionManager {
+public:
+    virtual ~IConnectionManager() = default;
+
+    // Disconnect a peer. Reason string is for logging only.
+    virtual void DisconnectNode(NodeId peer, const std::string& reason) = 0;
+
+    // Initiate outbound connection to address. Returns NodeId on success,
+    // -1 on failure. PeerManager calls this when it wants to fill an
+    // outbound slot via AddrMan-selected target.
+    virtual NodeId ConnectNode(const std::string& addr,
+                               OutboundClass cls) = 0;
+
+    // Snapshot of all current connections. Used by PeerManager for
+    // periodic reconciliation (target counts, eviction, etc.).
+    virtual std::vector<ConnectionInfo> GetConnections() const = 0;
+
+    // Configured target count for an outbound class. Phase 4 / Phase 6
+    // queries this to know how many slots to fill.
+    virtual int GetOutboundTarget(OutboundClass cls) const = 0;
+
+    // Check if address is banned. PeerManager queries before connect.
+    virtual bool IsBanned(const std::string& addr) const = 0;
+
+    // Currently connected count by class — for reconciliation.
+    virtual int GetConnectionCount(OutboundClass cls) const = 0;
+    virtual int GetTotalInbound() const = 0;
+    virtual int GetTotalOutbound() const = 0;
+};
+
+}  // namespace dilithion::net
+
+#endif  // DILITHION_NET_ICONNECTION_MANAGER_H

--- a/src/net/iheader_proof_checker.h
+++ b/src/net/iheader_proof_checker.h
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 The Dilithion Core developers
+// Distributed under the MIT software license
+//
+// Phase 3 interface contract for the Bitcoin Core peer/IBD/chain-selection port.
+// Architecture document: .claude/contracts/bitcoin_core_port_architecture.md
+//
+// IHeaderProofChecker abstracts the chain-specific proof check (RandomX PoW
+// for DIL, VDF for DilV) behind a single interface. HeadersSync (Phase 3)
+// and chain selection (Phase 5) consume this — they never call into the
+// concrete VDF or RandomX code directly. This makes the port truly
+// chain-agnostic.
+
+#ifndef DILITHION_NET_IHEADER_PROOF_CHECKER_H
+#define DILITHION_NET_IHEADER_PROOF_CHECKER_H
+
+#include <cstdint>
+#include <uint256.h>
+
+class CBlockHeader;
+
+namespace dilithion::net {
+
+class IHeaderProofChecker {
+public:
+    virtual ~IHeaderProofChecker() = default;
+
+    // Validate the cryptographic proof in the header (PoW hash check, or
+    // VDF iteration count + output check). Read-only — does not modify
+    // any state. Must be deterministic.
+    //
+    // Returns true if the header's proof is valid given its declared
+    // difficulty/iteration target. Returns false otherwise; caller may
+    // mark the source peer as misbehaving.
+    virtual bool CheckHeaderProof(const CBlockHeader& header) const = 0;
+
+    // Compute the cumulative-work contribution this header makes to the
+    // chain. For PoW: 2^256 / (target + 1) per Bitcoin convention. For
+    // VDF: a monotone function of iteration count. The unit is opaque —
+    // chain-selection only compares uint256 values pairwise via
+    // ChainWorkGreaterThan, never sums across chain types.
+    //
+    // Must be pure and deterministic.
+    virtual uint256 ChainWorkContribution(const CBlockHeader& header) const = 0;
+
+    // Compare two cumulative chain works. Encapsulated here because for VDF
+    // chains we may eventually want to add tiebreakers (lowest hash, etc.).
+    // For now: simple uint256 > uint256.
+    virtual bool ChainWorkGreaterThan(const uint256& a, const uint256& b) const = 0;
+};
+
+}  // namespace dilithion::net
+
+#endif  // DILITHION_NET_IHEADER_PROOF_CHECKER_H

--- a/src/net/ipeer_scorer.h
+++ b/src/net/ipeer_scorer.h
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 The Dilithion Core developers
+// Distributed under the MIT software license
+//
+// Phase 6 interface contract. Tracks misbehavior score per peer; bans when
+// threshold exceeded. Bitcoin Core's Misbehaving() pattern.
+//
+// Categories include both protocol-level misbehavior (invalid signatures,
+// malformed messages) and Dilithion-specific (invalid MIK signature,
+// invalid DFMP cooldown proof, malformed DNA Phase 1.5 envelope).
+
+#ifndef DILITHION_NET_IPEER_SCORER_H
+#define DILITHION_NET_IPEER_SCORER_H
+
+#include <cstdint>
+#include <string>
+
+namespace dilithion::net {
+
+using NodeId = int;
+
+// Categories of misbehavior, each with a default weight. Per-instance
+// weights configurable (Phase 6 introduces a config knob).
+enum class MisbehaviorType {
+    // Bitcoin Core equivalents
+    InvalidSignature,             // weight 100
+    InvalidBlock,                 // weight 100
+    InvalidHeader,                // weight 50
+    InvalidPoW,                   // weight 100  (DIL only — VDF uses InvalidVDFProof)
+    OversizedMessage,             // weight 20
+    UnknownMessage,               // weight 1
+    NonContinuousHeaders,         // weight 20
+    DuplicateVersion,             // weight 1
+
+    // Dilithion-specific
+    InvalidMIKSignature,          // weight 100
+    InvalidDFMPCooldown,          // weight 50
+    InvalidVDFProof,              // weight 100
+    InvalidDNAEnvelope,           // weight 25
+    MalformedSMP1Trailer,         // weight 5
+    PrematureDNASample,           // weight 10
+    GetDataRateExceeded,          // weight 10
+};
+
+class IPeerScorer {
+public:
+    virtual ~IPeerScorer() = default;
+
+    // Add to peer's misbehavior score. Returns true if the peer should
+    // be disconnected and banned (score crossed threshold).
+    virtual bool Misbehaving(NodeId peer,
+                             MisbehaviorType type,
+                             const std::string& reason = "") = 0;
+
+    // Misbehaving with explicit weight (for one-off cases).
+    virtual bool Misbehaving(NodeId peer,
+                             int weight,
+                             const std::string& reason = "") = 0;
+
+    // Get current score for diagnostic RPC.
+    virtual int GetScore(NodeId peer) const = 0;
+
+    // Reset score (for testing or operator override).
+    virtual void ResetScore(NodeId peer) = 0;
+
+    // Configure ban threshold (default 100). Score >= threshold => disconnect+ban.
+    virtual void SetBanThreshold(int threshold) = 0;
+    virtual int GetBanThreshold() const = 0;
+};
+
+}  // namespace dilithion::net
+
+#endif  // DILITHION_NET_IPEER_SCORER_H

--- a/src/net/ipeer_selector.h
+++ b/src/net/ipeer_selector.h
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 The Dilithion Core developers
+// Distributed under the MIT software license
+//
+// Phase 4 interface contract. Selects the sync peer + block-relay targets
+// from a candidate set of connected peers. Replaces the broken
+// IBDCoordinator::SelectHeadersSyncPeer logic where a single bad sync peer
+// could pin the node forever.
+
+#ifndef DILITHION_NET_IPEER_SELECTOR_H
+#define DILITHION_NET_IPEER_SELECTOR_H
+
+#include <cstdint>
+#include <chrono>
+#include <optional>
+#include <vector>
+
+namespace dilithion::net {
+
+using NodeId = int;
+
+// A candidate peer for selection. Bigger struct than just NodeId because
+// the selector needs to make informed choices (height, last-progress time,
+// connection class, score).
+struct PeerCandidate {
+    NodeId node_id;
+    int64_t best_known_height;
+    int64_t starting_height;
+    bool is_outbound;
+    bool is_manual;                                // --addnode persistent
+    int misbehavior_score;
+    std::chrono::steady_clock::time_point last_block_received;
+    std::chrono::steady_clock::time_point last_header_received;
+    std::chrono::steady_clock::time_point connected_at;
+    int blocks_in_flight;
+};
+
+// Reason a peer was de-selected, used to decide whether to penalize them
+// in the AddrMan quality model. (v4.0.22 Patch F gated penalty by reason —
+// upstream PeerManager does this properly via a typed enum.)
+enum class DeselectReason {
+    Disconnected,            // Peer dropped; not a fault
+    StalledNoBlocks,         // Selected but never delivered blocks
+    StalledNoHeaders,        // Selected but never delivered headers
+    OutOfSyncHeight,         // Peer's claimed height is below our tip
+    PoolExhausted,           // No better candidate; reset pool
+    BadFork,                 // Peer is on a chain that fails validation
+    Replaced,                // Just rotated; not a fault
+};
+
+class IPeerSelector {
+public:
+    virtual ~IPeerSelector() = default;
+
+    // Pick the best peer for HEADERS sync from candidates. Bias:
+    //   1. Highest-known-height (must exceed our tip)
+    //   2. Outbound > Inbound
+    //   3. Manual > Discovered
+    //   4. Lowest misbehavior_score
+    //   5. Most-recent successful block delivery
+    // Excludes peers in m_bad_set unless pool exhausted (then clears bad set).
+    // Returns nullopt if no candidate is acceptable.
+    virtual std::optional<NodeId> SelectHeadersSyncPeer(
+        const std::vector<PeerCandidate>& candidates) = 0;
+
+    // Pick a peer for BLOCK fetch (separate from headers). Same bias but
+    // also avoids peers at MAX_BLOCKS_IN_TRANSIT_PER_PEER.
+    virtual std::optional<NodeId> SelectBlockFetchPeer(
+        const std::vector<PeerCandidate>& candidates) = 0;
+
+    // Notify selector that a peer was de-selected and why. Selector may
+    // add to bad_set, update score, or ignore depending on reason.
+    virtual void NotifyDeselected(NodeId peer, DeselectReason reason) = 0;
+
+    // Test if peer is currently in the bad set. Public for diagnostic RPC.
+    virtual bool IsBadPeer(NodeId peer) const = 0;
+
+    // Force-clear the bad set (operator override / pool-exhausted recovery).
+    virtual void ClearBadSet() = 0;
+
+    // Diagnostics — expose selector state for getpeerinfo.
+    virtual size_t BadSetSize() const = 0;
+};
+
+}  // namespace dilithion::net
+
+#endif  // DILITHION_NET_IPEER_SELECTOR_H

--- a/src/net/port/.gitkeep
+++ b/src/net/port/.gitkeep
@@ -1,0 +1,1 @@
+Phase 1+ ported files land here. See .claude/contracts/port_phase_0_code_mapping.md

--- a/src/net/port/addrman_v2.h
+++ b/src/net/port/addrman_v2.h
@@ -1,0 +1,194 @@
+// Copyright (c) 2026 The Dilithion Core developers
+// Distributed under the MIT software license
+//
+// Phase 1 starting point — port of Bitcoin Core's AddrMan (v28.0).
+// This is a SKELETON. Declarations only. Implementation lands in Phase 1
+// when it begins. Code compiles when included alongside addrman_v2.cpp
+// (also a Phase-1 deliverable).
+//
+// Bitcoin Core source for this port:
+//   https://github.com/bitcoin/bitcoin/blob/v28.0/src/addrman.h
+//   https://github.com/bitcoin/bitcoin/blob/v28.0/src/addrman.cpp
+//   https://github.com/bitcoin/bitcoin/blob/v28.0/src/addrman_impl.h
+//
+// Architecture: implements net/iaddress_manager.h.
+// MIT-licensed source per Bitcoin Core; this port preserves attribution.
+
+#ifndef DILITHION_NET_PORT_ADDRMAN_V2_H
+#define DILITHION_NET_PORT_ADDRMAN_V2_H
+
+#include <net/iaddress_manager.h>
+#include <chrono>
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace dilithion::net::port {
+
+// ============================================================================
+// Configuration constants — from Bitcoin Core's addrman_impl.h
+// ============================================================================
+
+// Total number of buckets in the "new" (untried) table.
+constexpr int ADDRMAN_NEW_BUCKET_COUNT = 1024;
+
+// Total number of buckets in the "tried" (verified-reachable) table.
+constexpr int ADDRMAN_TRIED_BUCKET_COUNT = 256;
+
+// Buckets to look in to determine if an address is in "new".
+constexpr int ADDRMAN_NEW_BUCKETS_PER_SOURCE_GROUP = 64;
+
+// Buckets a particular address can land in, in the "new" table.
+constexpr int ADDRMAN_NEW_BUCKETS_PER_ADDRESS = 8;
+
+// In each bucket: addresses go into one of N positions, deterministically
+// chosen by hash so the same address always lands in the same slot.
+constexpr int ADDRMAN_BUCKET_SIZE = 64;
+
+// Number of buckets a tried-table entry can land in.
+constexpr int ADDRMAN_TRIED_BUCKETS_PER_ADDRESS = 8;
+
+// Min number of failed connection attempts in a row before considered
+// "terrible" and eligible for eviction.
+constexpr int ADDRMAN_RETRIES = 3;
+
+// How many recently-failed attempts make an address "terrible".
+constexpr int ADDRMAN_MAX_FAILURES = 10;
+
+// Minimum quality (success rate) required to remain in tried table.
+constexpr double ADDRMAN_MIN_QUALITY = 0.05;
+
+// Selection bias towards tried table, expressed as percentage.
+// Higher = more bias towards proven-good peers.
+constexpr int ADDRMAN_SELECT_TRIED_PCT_DEFAULT = 50;
+
+// ============================================================================
+// AddrInfo — a single tracked address with its quality state.
+// ============================================================================
+//
+// Mirrors bitcoin/src/addrman_impl.h::AddrInfo. Adds a Dilithion-specific
+// optional MIK identity hint (advisory; not consensus).
+
+struct AddrInfo {
+    NetProtocol::CAddress addr;        // The actual address+port
+    NetProtocol::CAddress source;      // Address we learned this peer from
+    int64_t last_try_secs = 0;         // Last connection attempt (epoch secs)
+    int64_t last_success_secs = 0;     // Last successful connection
+    int64_t last_count_attempt_secs = 0;  // Last attempt counted in n_attempts
+    int n_attempts = 0;                // Recent failed attempts in a row
+    bool in_tried = false;             // Currently in tried table
+    int random_pos = -1;               // Index in vRandom
+
+    // Dilithion extension — advisory MIK hint, see iaddress_manager.h.
+    std::vector<uint8_t> mik_identity;
+
+    // Returns true if this peer should be evicted (too many recent failures
+    // or never-successful + old enough).
+    bool IsTerrible(int64_t now_secs) const;
+
+    // Quality score for tie-breaking selection — Bitcoin uses exponential
+    // backoff over recent success rate.
+    double GetChance(int64_t now_secs) const;
+};
+
+// ============================================================================
+// CAddrMan_v2 — concrete implementation of IAddressManager.
+// ============================================================================
+//
+// Phase 1 deliverable. Replaces src/net/addrman.{h,cpp} once Phase 1 lands.
+// The "_v2" suffix is the cutover marker; rename to CAddrMan in Phase 7.
+
+class CAddrMan_v2 final : public IAddressManager {
+public:
+    CAddrMan_v2();
+    ~CAddrMan_v2() override;
+
+    // ---- IAddressManager interface ----
+    bool Add(const NetProtocol::CAddress& addr,
+             const NetProtocol::CAddress& source) override;
+
+    void RecordAttempt(const NetProtocol::CAddress& addr,
+                       ConnectionOutcome outcome) override;
+
+    std::optional<NetProtocol::CAddress> Select(OutboundClass cls) override;
+
+    std::vector<NetProtocol::CAddress> GetAddresses(
+        size_t max_count,
+        size_t max_pct,
+        std::optional<int> network_filter) override;
+
+    bool Save() override;
+    bool Load() override;
+    size_t Size() const override;
+
+    void SetPeerMIKHint(const NetProtocol::CAddress& addr,
+                        const std::vector<uint8_t>& mik_identity) override;
+
+    // Set persistence path (called at construction by node startup).
+    // Default is "<datadir>/peers.dat".
+    void SetDataPath(const std::string& path);
+
+    // For tests: deterministic key for bucket selection. In production this
+    // is randomized at first run and persisted in peers.dat.
+    void SetBucketSecret(const uint256& key);
+
+private:
+    // Mutex protects all member state below.
+    mutable std::mutex m_mutex;
+
+    // Path to peers.dat for persistence.
+    std::string m_data_path;
+
+    // Per-instance secret for bucket selection (anti-eclipse — different
+    // nodes bucket addresses differently).
+    uint256 m_bucket_secret;
+
+    // Address → AddrInfo (the source of truth).
+    std::map<int, AddrInfo> m_addr_info;
+    int m_next_id = 1;
+
+    // Address-string → id map for quick lookup.
+    std::map<std::string, int> m_id_by_addr;
+
+    // The "new" table — N buckets, each with M slots.
+    std::vector<std::vector<int>> m_new_buckets;
+
+    // The "tried" table — proven-good peers.
+    std::vector<std::vector<int>> m_tried_buckets;
+
+    // For random selection — shuffle this and pop.
+    std::vector<int> m_random;
+
+    // ---- Internal helpers (Bitcoin Core: AddrManImpl::*) ----
+
+    // Hash an address into one of the N "new" buckets.
+    int GetNewBucket(const NetProtocol::CAddress& addr,
+                     const NetProtocol::CAddress& source) const;
+
+    // Hash an address into one of the N "tried" buckets.
+    int GetTriedBucket(const NetProtocol::CAddress& addr) const;
+
+    // Within a bucket, hash to a slot.
+    int GetBucketPosition(int bucket, bool tried,
+                          const NetProtocol::CAddress& addr) const;
+
+    // Promote an address from "new" to "tried" after successful connection.
+    void MakeTried(int id);
+
+    // Evict a terrible address from a bucket.
+    void EvictFromBucket(int bucket, int slot, bool tried);
+
+    // Pick a candidate from the tried table (biased random).
+    std::optional<int> SelectFromTried() const;
+
+    // Pick a candidate from the new table.
+    std::optional<int> SelectFromNew() const;
+};
+
+}  // namespace dilithion::net::port
+
+#endif  // DILITHION_NET_PORT_ADDRMAN_V2_H

--- a/src/node/iblock_sink.h
+++ b/src/node/iblock_sink.h
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 The Dilithion Core developers
+// Distributed under the MIT software license
+//
+// Phase 4 interface contract. Receives a fully-downloaded block from
+// PeerManager and hands it to the chain selector (Phase 5). Decouples
+// peer-layer block reception from consensus-layer block validation.
+
+#ifndef DILITHION_NODE_IBLOCK_SINK_H
+#define DILITHION_NODE_IBLOCK_SINK_H
+
+#include <memory>
+#include <cstdint>
+
+class CBlock;
+
+namespace dilithion::net {
+using NodeId = int;
+}
+
+namespace dilithion::node {
+
+// Outcome of submitting a block to the chain. PeerManager uses this to
+// update peer score (invalid block => Misbehaving) and tracking state
+// (block delivered => clear in-flight).
+enum class BlockSubmissionResult {
+    Accepted,                // Block validated and connected to chain
+    AlreadyHave,             // Block was already known; no-op
+    InvalidBlock,            // Block failed validation; misbehavior
+    InvalidHeader,           // Header check failed; misbehavior
+    Orphan,                  // Block valid but parent unknown; queued
+    Stored,                  // Block valid but didn't trigger reorg
+    InternalError,           // Validation crashed/IO error; not peer's fault
+};
+
+class IBlockSink {
+public:
+    virtual ~IBlockSink() = default;
+
+    // Submit a block received from a peer. Returns the validation outcome.
+    // The implementation is expected to call into the chain selector
+    // (which goes through CheckBlock -> ContextualCheckBlock -> ConnectBlock
+    // -> ActivateBestChain).
+    //
+    // CONSENSUS BOUNDARY: the implementation MUST call ProcessNewBlock
+    // exactly once with the same arguments today's code uses. No new
+    // validation logic. No new bypasses.
+    virtual BlockSubmissionResult SubmitBlock(
+        std::shared_ptr<const CBlock> block,
+        dilithion::net::NodeId source_peer) = 0;
+};
+
+}  // namespace dilithion::node
+
+#endif  // DILITHION_NODE_IBLOCK_SINK_H


### PR DESCRIPTION
## Summary

First PR in the Bitcoin Core port merge sequence (Phases 0–10, then A1 fork-staging, then v4.1/v4.2 stabilization, then `--usenewpeerman` activation). This PR brings only the interface contracts and scaffolding — zero behavior change, zero new code paths active.

Cherry-picked from `port/bitcoin-core-peer-ibd` commit `f81be1d` (singular Phase 0 commit).

## What's in this PR

- `src/consensus/ichain_selector.h` — IChainSelector interface
- `src/net/iaddress_manager.h` — IAddressManager interface (for AddrMan port)
- `src/net/iconnection_manager.h` — IConnectionManager interface (for CConnman port)
- `src/net/iheader_proof_checker.h` — IHeaderProofChecker (for headers-sync DoS gating)
- `src/net/ipeer_scorer.h` — IPeerScorer (for peer-scoring port)
- `src/net/ipeer_selector.h` — IPeerSelector
- `src/node/iblock_sink.h` — IBlockSink
- `src/net/port/addrman_v2.h` — forward decl
- `src/consensus/port/.gitkeep`, `src/net/port/.gitkeep` — directory placeholders

10 files, 716 insertions, 0 deletions. No CMakeLists/Makefile changes — these are headers only and nothing yet includes them. Build is unaffected.

## Why this lands first

Phases 1–10 all depend on these interfaces. Without Phase 0 in main, every subsequent phase PR carries a header-soup of forward-decls. Landing Phase 0 standalone gives us a clean foundation for the remaining 10 port phase PRs.

## Review provenance

This commit was originally written and reviewed during the Phase 0–1 port work in late April. Cursor pre-impl review and Layer-2 red-team review applied to the broader port branch — see `docs/retrospectives/track_b_bitcoin_core_port_retrospective.md` once merged.

## Test plan

- [x] Cherry-pick from `port/bitcoin-core-peer-ibd` clean (no conflicts)
- [x] No build changes — headers only, nothing currently includes them
- [ ] CI passes
- [ ] Diff reviewed against `port/bitcoin-core-peer-ibd:f81be1d`

## Sequencing

- Track A (operational): v4.3 deploy ships from `feat/v4_2_0_cooldown` + A1 patch with `––usenewpeerman` activated via wrapper. NOT blocked on this PR.
- Track B (git hygiene): this PR + 10 more phase PRs land on main at review pace. State on main matches `feat/v4_2_0_cooldown` once all PRs merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)