### PR TITLE
ci: bump sanitizer timeouts 60 -> 120 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
   sanitizer-asan:
     name: AddressSanitizer (Memory Safety)
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
+    timeout-minutes: 120
 
     steps:
     - name: Checkout code
@@ -178,7 +178,7 @@ jobs:
   sanitizer-ubsan:
     name: UndefinedBehaviorSanitizer
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
+    timeout-minutes: 120
 
     steps:
     - name: Checkout code
@@ -252,7 +252,7 @@ jobs:
   sanitizer-tsan:
     name: ThreadSanitizer (Data Races)
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
+    timeout-minutes: 120
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
## Summary

ASAN, UBSAN, and TSAN jobs in `.github/workflows/ci.yml` were each capped at 60 minutes. The workflow runs the entire Dilithion test suite under sanitizer instrumentation, which has grown past 60 minutes for the full codebase.

## Why now

PR #52 (Phase 0 of the Bitcoin Core port merge to main) hit the timeout twice in a row:
- First run: ASAN + TSAN both cancelled at 60 min, workflow concluded `cancelled`.
- Re-run: Same — TSAN cancelled at the 60-min mark.

With 11 phase PRs to land for the Bitcoin Core port (+ supplementary PRs), each PR spending 2-3 hours bouncing between cancellations and re-runs is not sustainable.

## Change

Bump `timeout-minutes` from 60 to 120 for the three sanitizer jobs:
- `sanitizer-asan` (line 107)
- `sanitizer-ubsan` (line 181)
- `sanitizer-tsan` (line 255)

3 insertions, 3 deletions. No test or code changes.

## Long-term plan

This is the same-day fix to unblock the port phase PRs. The right long-term answer is to move ASAN/TSAN to a nightly main-only workflow (standard pattern for large C++ projects — Bitcoin Core does this). That requires more workflow restructure and will land post-v4.3-deploy.

## Test plan

- [x] Diff is exactly 3 lines (60 -> 120, 3 occurrences)
- [ ] CI completes within new 120-min budget on this PR
- [ ] PR #52 (Phase 0) re-runs successfully after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)