### PR TITLE
fix(bootstrap): chain-aware pgrep check (don't abort on unrelated chain)

### DIFF
--- a/package-bootstrap.sh
+++ b/package-bootstrap.sh
@@ -27,16 +27,19 @@ case "$NETWORK" in
         DATA_DIR="${HOME}/.dilithion"
         RPC_PORT=8332
         NETWORK_LABEL="dil"
+        BINARY_NAME="dilithion-node"
         ;;
     testnet|test)
         DATA_DIR="${HOME}/.dilithion-testnet"
         RPC_PORT=18332
         NETWORK_LABEL="testnet"
+        BINARY_NAME="dilithion-node"
         ;;
     dilv)
         DATA_DIR="${HOME}/.dilv"
         RPC_PORT=9332
         NETWORK_LABEL="dilv"
+        BINARY_NAME="dilv-node"
         ;;
     *)
         echo "Usage: $0 [dil|mainnet|testnet|dilv]"
@@ -95,15 +98,20 @@ echo ""
 # CRITICAL: Node MUST be stopped for a clean snapshot
 # LevelDB corruption WILL occur if you archive while the node is running.
 # Use RPC stop or kill -15 (SIGTERM). NEVER use kill -9 or pkill.
-if pgrep -f dilithion-node > /dev/null 2>&1 || pgrep -f dilv-node > /dev/null 2>&1; then
-    echo "ERROR: Node is still running! LevelDB data will be corrupt."
+# Chain-aware check: only abort if the chain we're bootstrapping is still running.
+# Other chains run independently with separate data dirs — their state doesn't
+# affect this bootstrap. Use pgrep -x (exact binary name match) instead of -f
+# (full command line match) so we don't false-match on script content that
+# contains the binary name as a string.
+if pgrep -x "$BINARY_NAME" > /dev/null 2>&1; then
+    echo "ERROR: ${BINARY_NAME} is still running! LevelDB data will be corrupt."
     echo ""
     echo "Stop gracefully with RPC:"
     echo "  curl -s --user rpc:rpc -H 'X-Dilithion-RPC: 1' -H 'content-type:application/json' \\"
     echo "    --data-binary '{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"stop\",\"params\":{\"confirm\":true}}' \\"
     echo "    http://127.0.0.1:${RPC_PORT}/"
     echo ""
-    echo "Or: kill -15 \$(pgrep -f dilithion-node)  # then WAIT for exit"
+    echo "Or: kill -15 \$(pgrep -x ${BINARY_NAME})  # then WAIT for exit"
     echo ""
     echo "NEVER use kill -9 or pkill — LevelDB WAL won't flush."
     exit 1


### PR DESCRIPTION
## Summary

`package-bootstrap.sh` aborted with "Node is still running" when creating a DilV bootstrap on LDN because LDN runs both `dilithion-node` (DIL mainnet) and `dilv-node` (DilV mainnet). The script's pgrep check matched BOTH chains, even though a DilV bootstrap only touches `~/.dilv/` (separate from `~/.dilithion/`).

This forces operators to stop the unrelated chain too, doubling the outage window for no functional reason.

## Fix

- Set `BINARY_NAME` per chain in the case statement (`dilithion-node` for dil/mainnet/testnet; `dilv-node` for dilv)
- Replace ``pgrep -f`` with ``pgrep -x "\$BINARY_NAME"`` — exact binary name match; immune to script-content false-positives (which caused separate debugging confusion during the 2026-05-09 SGP rolling deploy)
- Error + hint messages now name the specific blocking binary

## Verified

Behavior verified during v4.4.0 release (today):
- **Pre-fix:** SIGTERM the DilV node → script still aborted because `pgrep -f dilithion-node` matched the running DIL node
- **Post-fix:** Same procedure (stop DilV only, leave DIL alone) → bootstrap created cleanly

## Impact

- All future bootstraps for one chain can run while other chains stay up on the same host
- Operator confusion from ``pgrep -f`` false-matching script content (the SGP cutover bug) eliminated by switching to ``pgrep -x``

## Test plan

- [x] Ran the patched script on LDN against a live two-chain host (DIL up, DilV stopped) — produced a clean bootstrap-dilv-*.tar.gz
- [ ] CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)