### PR TITLE
diag(mik): instrument registration state machine + macOS arch diagnostic

### DIFF
--- a/.github/workflows/macos-mik-diagnostic.yml
+++ b/.github/workflows/macos-mik-diagnostic.yml
@@ -1,0 +1,117 @@
+name: macOS MIK Registration Diagnostic
+
+# Manual-only diagnostic workflow. Purpose: investigate macOS-specific reports
+# of MIK registration "not working properly" on DilV.
+#
+# It builds dilv-node on BOTH macOS architectures and reports, for each:
+#   - the runner architecture (uname / sysctl)
+#   - the ACTUAL architecture of the produced binary (file / lipo)
+#   - the dynamic libraries it links against (otool -L) -> tests the
+#     "missing/mis-bundled Homebrew dylib" hypothesis
+#   - whether the binary launches and fully initializes (--help + a short
+#     --relay-only run, which captures the new "Build architecture:" log line
+#     and the registration-manager [mik-reg] instrumentation if reached)
+#
+# It deliberately does NOT attempt a live MIK registration against the
+# production DilV seed nodes: that would consume per-/24 attestation
+# rate-limit quota on production infrastructure. A follow-up iteration can
+# add a testnet registration run once the arch hypotheses are settled.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  diagnostic:
+    name: dilv-node on ${{ matrix.label }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-13   # Intel x86_64
+            label: Intel (macos-13)
+          - runner: macos-14   # Apple Silicon arm64
+            label: Apple Silicon (macos-14)
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Checkout submodules
+      run: |
+        git submodule update --init depends/chiavdf
+        git submodule update --init depends/dilithium
+        git submodule update --init depends/randomx || true
+
+    - name: Runner environment
+      run: |
+        echo "=== Runner architecture ==="
+        uname -mrs
+        arch || true
+        sysctl -n machdep.cpu.brand_string || true
+        sw_vers || true
+
+    - name: Install dependencies
+      run: |
+        brew install leveldb cmake openssl miniupnpc gmp
+
+    - name: Build RandomX (for shared Makefile compatibility)
+      run: |
+        cd depends/randomx
+        mkdir -p build
+        cd build
+        cmake .. -DCMAKE_BUILD_TYPE=Release
+        make -j$(sysctl -n hw.ncpu)
+
+    - name: Build dilv-node
+      run: |
+        OPENSSL_PREFIX=$(brew --prefix openssl@3 2>/dev/null || brew --prefix openssl 2>/dev/null || echo "/opt/homebrew/opt/openssl@3")
+        MINIUPNPC_PREFIX=$(brew --prefix miniupnpc)
+        GMP_PREFIX=$(brew --prefix gmp)
+        export CPPFLAGS="-I$OPENSSL_PREFIX/include -I$MINIUPNPC_PREFIX/include -I$GMP_PREFIX/include"
+        export LDFLAGS="-L$OPENSSL_PREFIX/lib -Ldepends/randomx/build -L$(brew --prefix leveldb)/lib -L$MINIUPNPC_PREFIX/lib -L$GMP_PREFIX/lib"
+        export CFLAGS="-I$OPENSSL_PREFIX/include -I$MINIUPNPC_PREFIX/include -I$GMP_PREFIX/include"
+        export CXXFLAGS="-std=c++17 -I$OPENSSL_PREFIX/include -I$MINIUPNPC_PREFIX/include -I$GMP_PREFIX/include"
+        make clean
+        make dilv-node -j$(sysctl -n hw.ncpu)
+        ls -lh dilv-node
+
+    - name: Binary architecture and linkage
+      run: |
+        echo "=== file ==="
+        file dilv-node
+        echo "=== lipo -info ==="
+        lipo -info dilv-node || true
+        echo "=== otool -L (linked dynamic libraries) ==="
+        otool -L dilv-node || true
+
+    - name: Launch test (--help)
+      run: |
+        echo "Exercising binary execution on this architecture..."
+        ./dilv-node --help
+        echo "Exit code: $? (0 = binary executes on this arch)"
+
+    - name: Short relay-only run (captures startup + arch log line)
+      continue-on-error: true
+      run: |
+        # --relay-only skips the wallet wizard entirely; benign (no mining,
+        # no registration). 60s is enough to capture full init + the new
+        # "Build architecture:" log line.
+        mkdir -p diagdir
+        timeout 60 ./dilv-node --datadir=./diagdir --relay-only --verbose \
+          > relay-run-stdout.log 2>&1 || true
+        echo "=== relay-run-stdout.log (tail) ==="
+        tail -n 120 relay-run-stdout.log || true
+        echo "=== datadir log files ==="
+        ls -la diagdir || true
+        find diagdir -name '*.log' -exec sh -c 'echo "--- {} ---"; tail -n 120 "{}"' \; || true
+
+    - name: Upload diagnostic logs
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: mik-diagnostic-${{ matrix.runner }}
+        path: |
+          relay-run-stdout.log
+          diagdir/*.log
+        if-no-files-found: warn

--- a/src/node/dilithion-node.cpp
+++ b/src/node/dilithion-node.cpp
@@ -23,6 +23,11 @@
 #include <malloc.h>  // malloc_trim()
 #endif
 
+// macOS: detect Rosetta 2 translation (x86_64 binary on Apple Silicon)
+#ifdef __APPLE__
+#include <sys/sysctl.h>
+#endif
+
 // v4.1-rc2 ISSUE-2 fix: isatty() check for non-interactive stdin detection
 #ifdef _WIN32
 #include <io.h>      // _isatty / _fileno
@@ -2159,6 +2164,31 @@ int main(int argc, char* argv[]) {
     }
     InstallTimestampedStreams();
     LogPrintf(ALL, INFO, "Dilithion Node starting");
+    {
+        // Platform/architecture diagnostic. macOS ships an x86_64-only release
+        // binary; on Apple Silicon it runs under Rosetta 2. Logging the build
+        // arch + translation status makes platform-specific bug reports (e.g.
+        // MIK registration failures) diagnosable without a round-trip.
+#if defined(__aarch64__) || defined(__arm64__)
+        const char* kBuildArch = "arm64";
+#elif defined(__x86_64__)
+        const char* kBuildArch = "x86_64";
+#else
+        const char* kBuildArch = "unknown";
+#endif
+        std::string archMsg = std::string("Build architecture: ") + kBuildArch;
+#ifdef __APPLE__
+        int translated = 0;
+        size_t tsz = sizeof(translated);
+        if (sysctlbyname("sysctl.proc_translated", &translated, &tsz, nullptr, 0) == 0
+            && translated == 1) {
+            archMsg += " (running under Rosetta 2 translation on Apple Silicon)";
+        } else {
+            archMsg += " (running natively)";
+        }
+#endif
+        LogPrintf(ALL, INFO, "%s", archMsg.c_str());
+    }
     LogPrintf(ALL, INFO, "Data directory: %s", config.datadir.c_str());
     LogPrintf(ALL, INFO, "P2P port: %d", config.p2pport);
     LogPrintf(ALL, INFO, "RPC port: %d", config.rpcport);

--- a/src/node/dilv-node.cpp
+++ b/src/node/dilv-node.cpp
@@ -19,6 +19,11 @@
 #include <malloc.h>  // malloc_trim()
 #endif
 
+// macOS: detect Rosetta 2 translation (x86_64 binary on Apple Silicon)
+#ifdef __APPLE__
+#include <sys/sysctl.h>
+#endif
+
 // v4.1-rc2 ISSUE-2 fix: isatty() check for non-interactive stdin detection
 #ifdef _WIN32
 #include <io.h>      // _isatty / _fileno
@@ -2099,6 +2104,31 @@ int main(int argc, char* argv[]) {
     }
     InstallTimestampedStreams();
     LogPrintf(ALL, INFO, "DilV Node starting");
+    {
+        // Platform/architecture diagnostic. macOS ships an x86_64-only release
+        // binary; on Apple Silicon it runs under Rosetta 2. Logging the build
+        // arch + translation status makes platform-specific bug reports (e.g.
+        // MIK registration failures) diagnosable without a round-trip.
+#if defined(__aarch64__) || defined(__arm64__)
+        const char* kBuildArch = "arm64";
+#elif defined(__x86_64__)
+        const char* kBuildArch = "x86_64";
+#else
+        const char* kBuildArch = "unknown";
+#endif
+        std::string archMsg = std::string("Build architecture: ") + kBuildArch;
+#ifdef __APPLE__
+        int translated = 0;
+        size_t tsz = sizeof(translated);
+        if (sysctlbyname("sysctl.proc_translated", &translated, &tsz, nullptr, 0) == 0
+            && translated == 1) {
+            archMsg += " (running under Rosetta 2 translation on Apple Silicon)";
+        } else {
+            archMsg += " (running natively)";
+        }
+#endif
+        LogPrintf(ALL, INFO, "%s", archMsg.c_str());
+    }
     LogPrintf(ALL, INFO, "Data directory: %s", config.datadir.c_str());
     LogPrintf(ALL, INFO, "P2P port: %d", config.p2pport);
     LogPrintf(ALL, INFO, "RPC port: %d", config.rpcport);

--- a/src/node/registration_manager.cpp
+++ b/src/node/registration_manager.cpp
@@ -3,6 +3,8 @@
 
 #include <node/registration_manager.h>
 
+#include <util/logging.h>
+
 #include <algorithm>
 #include <chrono>
 #include <ctime>
@@ -446,6 +448,8 @@ void CRegistrationManager::HandleDnaPending_() {
         bool allZero = std::all_of(hash.begin(), hash.end(),
                                    [](uint8_t b) { return b == 0; });
         if (!allZero) {
+            LogPrintf(MINING, INFO, "[mik-reg] DNA hash collected after %u poll(s)",
+                      session_.dnaPolls);
             session_.dnaHash = hash;
             session_.hasDnaHash = true;
             Transition_(Event::DNA_READY);
@@ -453,7 +457,10 @@ void CRegistrationManager::HandleDnaPending_() {
             return;
         }
     }
-    // Not ready yet — wake again in dnaPollInterval_.
+    // Not ready yet — wake again in dnaPollInterval_. DEBUG level (--verbose)
+    // to avoid steady-state noise; visible in diagnostic runs.
+    LogPrintf(MINING, DEBUG, "[mik-reg] DNA not ready yet (poll %u) — retrying",
+              session_.dnaPolls);
     nextRetryAt_ = std::chrono::system_clock::now() + dnaPollInterval_;
 }
 
@@ -482,6 +489,9 @@ void CRegistrationManager::HandleAttestPending_() {
     uint64_t sessionId = session_.sessionId;
 
     stateMutex_.unlock();
+    LogPrintf(MINING, INFO, "[mik-reg] requesting attestations from seed nodes "
+              "(attempt %d/%d)",
+              session_.attestationRetries + 1, maxAttestationRetries_);
     Attestation::CAttestationSet fresh;
     std::string err;
     bool ok = env_->CollectAttestations(pubkey, dnaHash, fresh, err);
@@ -492,6 +502,7 @@ void CRegistrationManager::HandleAttestPending_() {
     if (session_.sessionId != sessionId || shutdownRequested_.load()) return;
 
     if (ok) {
+        LogPrintf(MINING, INFO, "[mik-reg] attestations collected successfully");
         session_.attestations =
             std::make_unique<Attestation::CAttestationSet>(std::move(fresh));
         session_.hasValidAttestations = true;
@@ -530,6 +541,8 @@ void CRegistrationManager::HandlePowPending_() {
     uint64_t sessionId = session_.sessionId;
     int bits = env_->RegistrationPowBits();
 
+    LogPrintf(MINING, INFO, "[mik-reg] starting registration PoW (%d bits) — "
+              "this can take 15-30 minutes", bits);
     powRunning_.store(true);
     stateMutex_.unlock();
     uint64_t nonce = 0;
@@ -542,6 +555,8 @@ void CRegistrationManager::HandlePowPending_() {
     }
 
     if (ok) {
+        LogPrintf(MINING, INFO, "[mik-reg] registration PoW solved (nonce=%llu)",
+                  static_cast<unsigned long long>(nonce));
         session_.regNonce = nonce;
         session_.hasRegNonce = true;
         // Persist only once we have a fully coherent (pubkey, dna, nonce).
@@ -707,6 +722,13 @@ void CRegistrationManager::Transition_(Event ev, const std::string& detail) {
 
 void CRegistrationManager::EnterState_(State s) {
     if (state_ == s) return;
+    // [mik-reg] Boundary instrumentation: every registration state transition
+    // is logged so a stuck/looping miner (any platform) leaves a diagnosable
+    // trail. INFO level — always visible without --verbose.
+    LogPrintf(MINING, INFO, "[mik-reg] state: %s -> %s (tip=%u session=%llu)",
+              StateToString(state_), StateToString(s),
+              latestTipHeight_.load(),
+              static_cast<unsigned long long>(session_.sessionId));
     state_ = s;
     // Clear retry timer when transitioning to a non-backoff state.
     if (s != State::LONG_BACKOFF_USER_ACTIONABLE &&
@@ -870,6 +892,8 @@ void CRegistrationManager::OnTransientError_(const std::string& err,
                                              std::chrono::seconds backoff) {
     lastError_ = err;
     nextRetryAt_ = std::chrono::system_clock::now() + backoff;
+    LogPrintf(MINING, WARN, "[mik-reg] transient error: %s (retry in %llds)",
+              err.c_str(), static_cast<long long>(backoff.count()));
 }
 
 void CRegistrationManager::OnUserActionRequired_(const std::string& err,
@@ -878,11 +902,14 @@ void CRegistrationManager::OnUserActionRequired_(const std::string& err,
     lastError_ = err;
     userActionHint_ = hint;
     nextRetryAt_ = std::chrono::system_clock::now() + backoff;
+    LogPrintf(MINING, WARN, "[mik-reg] user action required: %s | hint: %s",
+              err.c_str(), hint.c_str());
     EnterState_(State::LONG_BACKOFF_USER_ACTIONABLE);
 }
 
 void CRegistrationManager::OnFatalError_(const std::string& err) {
     lastError_ = err;
+    LogPrintf(MINING, ERROR, "[mik-reg] FATAL: %s", err.c_str());
     EnterState_(State::FAILED_FATAL);
 }
 


### PR DESCRIPTION
## Why

macOS users report DilV **MIK registration "isn't working properly"** — but
the registration state machine in `registration_manager.cpp` has **zero
logging**, so every report is undiagnosable without a round-trip to the
reporter (who is often offline).

An initial audit disproved the three first-pass hypotheses (SIGPIPE crash —
already handled process-wide; `substr` + flag-parser bugs — already fixed in
`eb80975`). The leading untested hypotheses are now **environment-level**:
the macOS release is built/packaged `-x64` while CI runs on `macos-latest`
(Apple Silicon), so the binary's real architecture and dylib linkage are
unverified.

## What this PR does (instrumentation only — no logic changes)

- **`registration_manager.cpp`** — `[mik-reg]`-tagged logs at every state
  machine boundary: state transitions, DNA collection, attestation
  request/result, PoW start/solve, and all error paths. State/error logs at
  INFO/WARN/ERROR; per-poll DNA progress at DEBUG (`--verbose`).
- **`dilv-node.cpp` / `dilithion-node.cpp`** — log build architecture at
  startup and, on macOS, whether the process runs natively or under
  **Rosetta 2**.
- **`.github/workflows/macos-mik-diagnostic.yml`** — manual-trigger
  (`workflow_dispatch`) workflow that builds `dilv-node` on **both**
  `macos-13` (Intel) and `macos-14` (Apple Silicon) and reports
  `file` / `lipo` / `otool -L` linkage, a launch test, and a 60s
  `--relay-only` run with logs uploaded as artifacts.

## What it deliberately does NOT do

It does **not** exercise a live MIK registration against the production DilV
seed nodes — that would consume per-/24 attestation rate-limit quota on
production infrastructure (an outward-facing action). The instrumentation is
compiled into the binary regardless, so the next real macOS report carries a
full `[mik-reg]` trace.

## Verification

All three changed translation units compile cleanly (object files built,
warnings only). The workflow must land on `main` before it can be dispatched
(`workflow_dispatch` is only exposed from the default branch).

## Hypothesis coverage

A run confirms-or-discounts the arch (#1), dylib-bundling (#2), and
Intel-binary (#5) hypotheses outright. Even a clean run is a win: it narrows
the fault to the registration logic itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
