### PR TITLE
fix(ci): init depends/libzmq submodule in macOS build workflows

### DIFF
--- a/.github/workflows/build-dilv-macos.yml
+++ b/.github/workflows/build-dilv-macos.yml
@@ -18,6 +18,9 @@ jobs:
       run: |
         git submodule update --init depends/chiavdf
         git submodule update --init depends/dilithium
+        # libzmq is a submodule (depends/libzmq) — required by the Makefile's
+        # `libzmq` target which all node binaries depend on.
+        git submodule update --init depends/libzmq
         # RandomX not needed for dilv-node but init to avoid any Makefile errors
         git submodule update --init depends/randomx || true
 

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -18,6 +18,9 @@ jobs:
       run: |
         git submodule update --init depends/randomx
         git submodule update --init depends/chiavdf
+        # libzmq is a submodule (depends/libzmq) — required by the Makefile's
+        # `libzmq` target which all node binaries depend on.
+        git submodule update --init depends/libzmq
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/macos-mik-diagnostic.yml
+++ b/.github/workflows/macos-mik-diagnostic.yml
@@ -41,6 +41,7 @@ jobs:
       run: |
         git submodule update --init depends/chiavdf
         git submodule update --init depends/dilithium
+        git submodule update --init depends/libzmq
         git submodule update --init depends/randomx || true
 
     - name: Runner environment


### PR DESCRIPTION
## Problem

`depends/libzmq` is a git submodule (added in `72ad68a` "vendor libzmq"),
but **none of the macOS CI workflows initialize it**. The Makefile's
`libzmq` target runs `cmake` inside `depends/libzmq`, and every node
binary depends on that target — so on a fresh CI checkout the build dies:

```
CMake Error: source directory ".../depends/libzmq" does not appear to contain CMakeLists.txt
make: *** [libzmq] Error 1
```

This means **macOS release builds are currently broken** — both
`build-dilv-macos.yml` and `build-macos.yml` would fail any release
build since libzmq landed. It was surfaced by the `macos-mik-diagnostic`
workflow's `macos-14` job failing at the build step.

## Fix

Add `git submodule update --init depends/libzmq` to the "Checkout
submodules" step of all three macOS workflows:

- `build-macos.yml` (DIL release)
- `build-dilv-macos.yml` (DilV release)
- `macos-mik-diagnostic.yml` (diagnostic)

CI-only change — no source, build-logic, or consensus impact.

## Note

The Linux workflows already pull submodules differently and are
unaffected; this PR is scoped to the macOS gap that was actually
observed failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
