### PR TITLE
fix(release): build macOS releases per-architecture (Intel + Apple Silicon)

### DIFF
--- a/.github/workflows/build-dilv-macos.yml
+++ b/.github/workflows/build-dilv-macos.yml
@@ -8,7 +8,19 @@ on:
 
 jobs:
   build-dilv-macos:
-    runs-on: macos-latest
+    # Per-architecture matrix: build natively on each runner so the produced
+    # binary's architecture is honest. macOS releases used to run only on
+    # `macos-latest` (now Apple Silicon) and ship the arm64 binary under an
+    # `-x64` name — unrunnable on Intel Macs ("Bad CPU type in executable").
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-13   # Intel x86_64
+            arch: x64
+          - runner: macos-14   # Apple Silicon arm64
+            arch: arm64
+    runs-on: ${{ matrix.runner }}
 
     steps:
     - name: Checkout code
@@ -48,6 +60,8 @@ jobs:
         make clean
         make dilv-node check-wallet-balance -j$(sysctl -n hw.ncpu)
         ls -lh dilv-node check-wallet-balance
+        echo "Built architecture:"
+        file dilv-node
 
     - name: Extract version from tag
       id: get_version
@@ -63,6 +77,7 @@ jobs:
     - name: Create release package
       env:
         VERSION: ${{ steps.get_version.outputs.version }}
+        ARCH: ${{ matrix.arch }}
       run: |
         chmod +x package-dilv-macos-release.sh
         ./package-dilv-macos-release.sh
@@ -70,13 +85,13 @@ jobs:
     - name: Upload artifact
       uses: actions/upload-artifact@v7
       with:
-        name: dilv-${{ steps.get_version.outputs.version }}-mainnet-macos-x64
-        path: releases/dilv-${{ steps.get_version.outputs.version }}-mainnet-macos-x64.tar.gz
+        name: dilv-${{ steps.get_version.outputs.version }}-mainnet-macos-${{ matrix.arch }}
+        path: releases/dilv-${{ steps.get_version.outputs.version }}-mainnet-macos-${{ matrix.arch }}.tar.gz
 
     - name: Upload to release (if tag)
       if: startsWith(github.ref, 'refs/tags/')
       uses: softprops/action-gh-release@v1
       with:
-        files: releases/dilv-${{ steps.get_version.outputs.version }}-mainnet-macos-x64.tar.gz
+        files: releases/dilv-${{ steps.get_version.outputs.version }}-mainnet-macos-${{ matrix.arch }}.tar.gz
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -8,7 +8,19 @@ on:
 
 jobs:
   build-macos:
-    runs-on: macos-latest
+    # Per-architecture matrix: build natively on each runner so the produced
+    # binary's architecture is honest. macOS releases used to run only on
+    # `macos-latest` (now Apple Silicon) and ship the arm64 binary under an
+    # `-x64` name — unrunnable on Intel Macs ("Bad CPU type in executable").
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-13   # Intel x86_64
+            arch: x64
+          - runner: macos-14   # Apple Silicon arm64
+            arch: arm64
+    runs-on: ${{ matrix.runner }}
 
     steps:
     - name: Checkout code
@@ -51,6 +63,8 @@ jobs:
         make clean
         make -j$(sysctl -n hw.ncpu)
         ls -lh dilithion-node check-wallet-balance genesis_gen
+        echo "Built architecture:"
+        file dilithion-node
 
     - name: Extract version from tag
       id: get_version
@@ -66,6 +80,7 @@ jobs:
     - name: Create release package
       env:
         VERSION: ${{ steps.get_version.outputs.version }}
+        ARCH: ${{ matrix.arch }}
       run: |
         chmod +x package-macos-release.sh
         ./package-macos-release.sh
@@ -73,13 +88,13 @@ jobs:
     - name: Upload artifact
       uses: actions/upload-artifact@v7
       with:
-        name: dilithion-${{ steps.get_version.outputs.version }}-mainnet-macos-x64
-        path: releases/dilithion-${{ steps.get_version.outputs.version }}-mainnet-macos-x64.tar.gz
+        name: dilithion-${{ steps.get_version.outputs.version }}-mainnet-macos-${{ matrix.arch }}
+        path: releases/dilithion-${{ steps.get_version.outputs.version }}-mainnet-macos-${{ matrix.arch }}.tar.gz
 
     - name: Upload to release (if tag)
       if: startsWith(github.ref, 'refs/tags/')
       uses: softprops/action-gh-release@v1
       with:
-        files: releases/dilithion-${{ steps.get_version.outputs.version }}-mainnet-macos-x64.tar.gz
+        files: releases/dilithion-${{ steps.get_version.outputs.version }}-mainnet-macos-${{ matrix.arch }}.tar.gz
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package-dilv-macos-release.sh
+++ b/package-dilv-macos-release.sh
@@ -8,7 +8,10 @@
 if [ -z "$VERSION" ]; then
     VERSION="v1.0.0"
 fi
-RELEASE_NAME="dilv-${VERSION}-mainnet-macos-x64"
+# ARCH selects the macOS CPU architecture: "x64" (Intel) or "arm64" (Apple
+# Silicon). Defaults to x64 for backward compatibility when run standalone.
+ARCH="${ARCH:-x64}"
+RELEASE_NAME="dilv-${VERSION}-mainnet-macos-${ARCH}"
 RELEASE_DIR="releases/${RELEASE_NAME}"
 
 echo ""

--- a/package-macos-release.sh
+++ b/package-macos-release.sh
@@ -9,7 +9,10 @@
 if [ -z "$VERSION" ]; then
     VERSION="v1.4.0"
 fi
-RELEASE_NAME="dilithion-${VERSION}-mainnet-macos-x64"
+# ARCH selects the macOS CPU architecture: "x64" (Intel) or "arm64" (Apple
+# Silicon). Defaults to x64 for backward compatibility when run standalone.
+ARCH="${ARCH:-x64}"
+RELEASE_NAME="dilithion-${VERSION}-mainnet-macos-${ARCH}"
 RELEASE_DIR="releases/${RELEASE_NAME}"
 
 echo ""


### PR DESCRIPTION
## Problem

The `macos-mik-diagnostic` workflow confirmed it: the macOS release
binary is **`Mach-O 64-bit executable arm64`**.

Both macOS release workflows ran on `runs-on: macos-latest`, which
GitHub now maps to **Apple Silicon**. A plain `make` builds native, so
the output is **arm64** — but it was packaged as `...-macos-x64.tar.gz`.

**An Intel Mac user who downloads "x64" gets an arm64 binary that cannot
run** — `Bad CPU type in executable`. The node never starts, so *nothing*
works for them. This is the leading root cause of the macOS "MIK
registration isn't working" reports: it's not the registration code, the
binary just never executes.

## Fix — per-architecture matrix

Build natively on each architecture and name the artifacts honestly:

| Runner | Arch | Artifact |
|--------|------|----------|
| `macos-13` | x86_64 | `...-macos-x64.tar.gz` |
| `macos-14` | arm64 | `...-macos-arm64.tar.gz` |

No cross-compilation — each runner `brew install`s its own native deps.
This is the approach **Bitcoin Core** uses (separate macOS arm64 /
x86_64 tarballs), and the norm for CLI/infra software with
package-manager native dependencies.

### Changes
- `build-dilv-macos.yml`, `build-macos.yml`: single `macos-latest` job →
  per-arch `strategy.matrix` (`macos-13`/x64 + `macos-14`/arm64),
  `fail-fast: false`. Each build step runs `file` on the binary.
- `package-dilv-macos-release.sh`, `package-macos-release.sh`: the
  release-name `x64` suffix is now an `ARCH` variable (default `x64`
  for standalone runs); the workflow sets it per matrix leg.

CI / release-packaging only — no source, build-logic, or consensus impact.

## Follow-ups (NOT in this PR — need a human/Zach call)

- **Release SOP** (`RELEASE BINARY BUILD SOP`) references a single
  `macos-x64` artifact — needs updating to two macOS artifacts.
- **Website download links** (`website/wallet.html` etc.) point at
  `...-macos-x64.tar.gz` — should offer both, ideally with arch
  detection. Website is Zach's domain.
- **`macos-13` (Intel runner) is on GitHub's deprecation path.** When it
  is retired, the x64 leg will need cross-compilation or to be dropped.
- This changes the release process — **Zach should review** as release
  co-owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
