### PR TITLE
fix(consensus): BUG-003 — reconcile block-size limit + fix coinbase reserve undercount

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -489,7 +489,7 @@ dilv-genesis-vdf: $(CORE_OBJECTS) $(OBJ_DIR)/tools/dilv_genesis_vdf.o $(DILITHIU
 # Test Binaries
 # ============================================================================
 
-tests: phase1_test miner_tests wallet_tests rpc_tests rpc_auth_tests timestamp_tests crypter_tests wallet_encryption_integration_tests wallet_persistence_tests integration_tests net_tests connman_tests tx_validation_tests tx_relay_tests mining_integration_tests dfmp_mik_tests mik_registration_persistence_tests dna_propagation_tests test_passphrase_validator script_tests addrman_v2_tests peer_scorer_tests peer_scorer_banman_integration_tests header_proof_checker_tests chain_selector_tests getchaintips_equivalence_tests chain_case_2_5_equivalence_tests chain_work_smoke_tests reorg_wal_crash_injection_tests competing_sibling_below_checkpoint_tests headers_manager_to_chain_selector_wiring_tests fast_path_2_boundary_tests v4_1_checkpoint_enforcement_tests v4_1_chain_selector_suppression_tests auto_rebuild_marker_mode_symmetry_tests add_block_index_flag_merge_tests port_chain_selector_invariants_tests legacy_vs_port_differential_tests chainstate_integrity_tests
+tests: phase1_test miner_tests wallet_tests rpc_tests rpc_auth_tests timestamp_tests crypter_tests wallet_encryption_integration_tests wallet_persistence_tests integration_tests net_tests connman_tests tx_validation_tests tx_relay_tests mining_integration_tests bug_003_block_size_tests dfmp_mik_tests mik_registration_persistence_tests dna_propagation_tests test_passphrase_validator script_tests addrman_v2_tests peer_scorer_tests peer_scorer_banman_integration_tests header_proof_checker_tests chain_selector_tests getchaintips_equivalence_tests chain_case_2_5_equivalence_tests chain_work_smoke_tests reorg_wal_crash_injection_tests competing_sibling_below_checkpoint_tests headers_manager_to_chain_selector_wiring_tests fast_path_2_boundary_tests v4_1_checkpoint_enforcement_tests v4_1_chain_selector_suppression_tests auto_rebuild_marker_mode_symmetry_tests add_block_index_flag_merge_tests port_chain_selector_invariants_tests legacy_vs_port_differential_tests chainstate_integrity_tests
 	@echo "$(COLOR_GREEN)✓ All tests built successfully$(COLOR_RESET)"
 
 phase1_test: $(CORE_OBJECTS) $(OBJ_DIR)/test/phase1_simple_test.o $(DILITHIUM_OBJECTS) $(CHIAVDF_OBJECTS)
@@ -565,6 +565,11 @@ tx_relay_tests: $(CORE_OBJECTS) $(OBJ_DIR)/test/tx_relay_tests.o $(DILITHIUM_OBJ
 	@$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LIBS)
 
 mining_integration_tests: $(CORE_OBJECTS) $(OBJ_DIR)/test/mining_integration_tests.o $(DILITHIUM_OBJECTS) $(CHIAVDF_OBJECTS)
+	@echo "$(COLOR_BLUE)[LINK]$(COLOR_RESET) $@"
+	@$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LIBS)
+
+# BUG-003 F-06: block-size limit reconciliation tests
+bug_003_block_size_tests: $(CORE_OBJECTS) $(OBJ_DIR)/test/bug_003_block_size_tests.o $(DILITHIUM_OBJECTS) $(CHIAVDF_OBJECTS)
 	@echo "$(COLOR_BLUE)[LINK]$(COLOR_RESET) $@"
 	@$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LIBS)
 

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -73,8 +73,42 @@ static const size_t MAX_BASE58_LENGTH = 1024;
 /** Maximum RPC request size in bytes (1 MB limit) */
 static const size_t MAX_REQUEST_SIZE = 1024 * 1024;
 
-/** Maximum block size in bytes (1 MB, same as early Bitcoin) */
-static const size_t MAX_BLOCK_SIZE = 1000000;
+/**
+ * Maximum block size in bytes (4 MB).
+ *
+ * Sized for post-quantum signatures (ML-DSA), which are far larger than ECDSA.
+ * This is the SINGLE SOURCE OF TRUTH for the block `vtx` serialized-blob byte
+ * size: every block-size-limit site (storage write, P2P receive, mining
+ * templates, the dead CheckBlock validator) must reference this constant —
+ * no local hard-coded literals.
+ */
+static const size_t MAX_BLOCK_SIZE = 4 * 1024 * 1024;
+
+/**
+ * Safety margin (16 KB) subtracted from MAX_BLOCK_SIZE when building mining
+ * templates. Size estimates during transaction selection have small jitter;
+ * budgeting against MAX_BLOCK_SIZE - BLOCK_SIZE_SAFETY_MARGIN guarantees the
+ * finished template can never produce a block the storage/consensus layer
+ * rejects as oversize.
+ */
+static const size_t BLOCK_SIZE_SAFETY_MARGIN = 16 * 1024;
+
+/**
+ * Upper-bound byte overhead of a coinbase transaction EXCLUDING its scriptSig.
+ *
+ * BUG-003 Bug B: mining-template builders that finalize the coinbase scriptSig
+ * before knowing the final vout can seed their size budget with
+ *   coinbaseScriptSig.size() + COINBASE_NON_SCRIPTSIG_OVERHEAD
+ * instead of a flat (and badly-undersized) 200-byte estimate.
+ *
+ * Covers, generously: 4-byte version + 4-byte locktime + vin count varint +
+ * 32-byte prevout hash + 4-byte prevout index + 4-byte nSequence +
+ * scriptSig-length varint + vout count varint + up to 3 outputs, each an
+ * 8-byte nValue + a script-length varint + a ~25-byte P2PKH script. 256 bytes
+ * comfortably exceeds that (~150 bytes actual) and also absorbs the block
+ * tx-count varint prefix.
+ */
+static const size_t COINBASE_NON_SCRIPTSIG_OVERHEAD = 256;
 
 //==============================================================================
 // Port Range Validation

--- a/src/consensus/pow.cpp
+++ b/src/consensus/pow.cpp
@@ -165,7 +165,7 @@ bool CheckProofOfWorkDFMP(
     // check for VDF blocks (their "PoW" is the VDF proof, not RandomX).
     if (block.IsVDFBlock()) {
         if (Dilithion::g_chainParams && height >= Dilithion::g_chainParams->vdfActivationHeight) {
-            return true;  // VDF proof checked separately in CheckBlock()
+            return true;  // VDF proof checked separately by CheckVDFProof() in the block validation pipeline
         }
         // VDF block before activation height is invalid.
         return false;

--- a/src/consensus/validation.cpp
+++ b/src/consensus/validation.cpp
@@ -495,13 +495,14 @@ bool CBlockValidator::CheckBlock(
     // Check cheap conditions first before expensive PoW validation
 
     // P1-5 FIX: Block size limit - check serialized transaction data size
-    // MAX_BLOCK_SIZE = 1MB (like Bitcoin's original limit)
+    // BUG-003: use the single source of truth Consensus::MAX_BLOCK_SIZE (4 MB).
     // Note: block.vtx is a vector<uint8_t> containing serialized transaction data
-    static constexpr size_t MAX_BLOCK_SIZE = 1000000;  // 1 MB
+    // NOTE: this CheckBlock member is currently dead code (zero callers); the
+    // active enforcement is the storage-layer cap and the P2P MAX_BLOCK_VTX_BYTES.
 
     // Check serialized transaction data size
-    if (block.vtx.size() > MAX_BLOCK_SIZE) {
-        error = "Block transaction data exceeds maximum size (" + std::to_string(block.vtx.size()) + " > " + std::to_string(MAX_BLOCK_SIZE) + " bytes)";
+    if (block.vtx.size() > Consensus::MAX_BLOCK_SIZE) {
+        error = "Block transaction data exceeds maximum size (" + std::to_string(block.vtx.size()) + " > " + std::to_string(Consensus::MAX_BLOCK_SIZE) + " bytes)";
         return false;
     }
 

--- a/src/core/chainparams.cpp
+++ b/src/core/chainparams.cpp
@@ -44,7 +44,7 @@ ChainParams ChainParams::Mainnet() {
     params.difficultyForkHeight = 18500;   // Activate v2 difficulty at this height (moved from 20160 to fix sign bit + EDA interaction)
     params.difficultyMaxChange = 2;        // 2x max change per retarget (post-fork, pre-v3)
     params.difficultyV3ForkHeight = 20520; // v3: 4x clamp + 1-hour EDA threshold (15 blocks)
-    params.maxBlockSize = 4 * 1024 * 1024; // 4 MB (for post-quantum signatures)
+    params.maxBlockSize = 4 * 1024 * 1024; // 4 MB (for post-quantum signatures) — BUG-003: must equal Consensus::MAX_BLOCK_SIZE (consensus/params.h)
 
     // Mining parameters
     params.initialReward = 50ULL * 100000000ULL; // 50 DIL (in ions: 1 DIL = 100,000,000 ions)
@@ -267,7 +267,7 @@ ChainParams ChainParams::Testnet() {
     params.difficultyForkHeight = 0;       // Active from genesis on testnet
     params.difficultyMaxChange = 2;        // 2x max change per retarget (pre-v3)
     params.difficultyV3ForkHeight = 0;     // v3 active from genesis on testnet
-    params.maxBlockSize = 4 * 1024 * 1024; // 4 MB (same as mainnet)
+    params.maxBlockSize = 4 * 1024 * 1024; // 4 MB (same as mainnet) — BUG-003: must equal Consensus::MAX_BLOCK_SIZE (consensus/params.h)
 
     // Mining parameters (same as mainnet)
     params.initialReward = 50ULL * 100000000ULL; // 50 DIL (same as mainnet)
@@ -440,7 +440,7 @@ ChainParams ChainParams::DilV() {
     params.difficultyForkHeight = 999999999;   // Disabled
     params.difficultyMaxChange = 0;            // Unused
     params.difficultyV3ForkHeight = 999999999; // Disabled
-    params.maxBlockSize = 4 * 1024 * 1024;     // 4 MB (same as DIL — room for Dilithium signatures)
+    params.maxBlockSize = 4 * 1024 * 1024;     // 4 MB (same as DIL — room for Dilithium signatures) — BUG-003: must equal Consensus::MAX_BLOCK_SIZE (consensus/params.h)
 
     // Mining parameters
     params.initialReward = 100ULL * 100000000ULL; // 100 DilV per block (in volts: 1 DilV = 100,000,000 volts)

--- a/src/miner/controller.cpp
+++ b/src/miner/controller.cpp
@@ -819,16 +819,26 @@ std::vector<CTransactionRef> CMiningController::SelectTransactionsForBlock(
     CUTXOSet& utxoSet,
     uint32_t nHeight,
     size_t maxBlockSize,
+    size_t coinbaseReserve,
     uint64_t& totalFees
 ) {
     std::vector<CTransactionRef> selectedTxs;
     totalFees = 0;
 
-    // Reserve space for coinbase (conservative estimate: 200 bytes)
-    size_t currentBlockSize = 200;
+    // BUG-003 Bug B: seed the size budget from the coinbase's REAL serialized
+    // size (passed in by the caller), not a flat 200-byte estimate. The real
+    // coinbase carries up to ~5.3 KB of MIK scriptSig + up to 3 outputs.
+    // Add a generous varint allowance for the block tx-count prefix.
+    static constexpr size_t TX_COUNT_VARINT_ALLOWANCE = 9;  // max varint width
+    size_t currentBlockSize = coinbaseReserve + TX_COUNT_VARINT_ALLOWANCE;
 
-    // Maximum block size (1 MB)
-    const size_t MAX_BLOCK_SIZE = maxBlockSize > 0 ? maxBlockSize : 1000000;
+    // Maximum block size — single source of truth Consensus::MAX_BLOCK_SIZE (4 MB).
+    const size_t cap = maxBlockSize > 0 ? maxBlockSize : Consensus::MAX_BLOCK_SIZE;
+    // BUG-003 F-05: budget against the cap minus a safety margin so size-estimate
+    // jitter never produces a block the storage/consensus layer rejects.
+    const size_t MAX_BLOCK_SIZE = cap > Consensus::BLOCK_SIZE_SAFETY_MARGIN
+                                      ? cap - Consensus::BLOCK_SIZE_SAFETY_MARGIN
+                                      : cap;
 
     // MINE-007 FIX: Resource limits to prevent DoS
     // Limit number of candidates to prevent unbounded iteration
@@ -983,6 +993,25 @@ std::optional<CBlockTemplate> CMiningController::CreateBlockTemplate(
         return std::nullopt;
     }
 
+    // BUG-003 Bug B: build the coinbase BEFORE transaction selection so the
+    // selection loop can budget against the coinbase's real serialized size.
+    // The coinbase serialized size is fee-independent — fees change only the
+    // fixed-width 8-byte nValue; output count and script sizes do not depend on
+    // fees (contract R2). We therefore build a probe coinbase with totalFees=0
+    // here purely to measure its size, then rebuild with the real fees below.
+    BENCHMARK_START("mining_create_coinbase");
+    CTransactionRef coinbaseTx;
+    try {
+        coinbaseTx = CreateCoinbaseTransaction(nHeight, /*totalFees=*/0, minerAddress, mikData);
+    } catch (const std::runtime_error& e) {
+        error = std::string("Coinbase creation failed: ") + e.what();
+        (void)BENCHMARK_END("mining_create_coinbase");
+        (void)BENCHMARK_END("mining_create_template");
+        return std::nullopt;
+    }
+    const size_t coinbaseReserve = coinbaseTx->GetSerializedSize();
+    (void)BENCHMARK_END("mining_create_coinbase");
+
     // Step 1: Select transactions from mempool
     BENCHMARK_START("mining_select_txs");
     uint64_t totalFees = 0;
@@ -990,15 +1019,15 @@ std::optional<CBlockTemplate> CMiningController::CreateBlockTemplate(
         mempool,
         utxoSet,
         nHeight,  // Pass height for coinbase maturity validation
-        1000000,  // 1 MB max block size
+        Consensus::MAX_BLOCK_SIZE,  // BUG-003: single source of truth (4 MB)
+        coinbaseReserve,            // BUG-003 Bug B: real coinbase size
         totalFees
     );
     (void)BENCHMARK_END("mining_select_txs");
 
-    // Step 2: Create coinbase transaction
-    // MINE-001 FIX: Catch overflow exceptions from coinbase creation
+    // Step 2: Rebuild the coinbase with the real total fees now that selection
+    // is done. Size is unchanged vs. the probe coinbase above (fee-independent).
     BENCHMARK_START("mining_create_coinbase");
-    CTransactionRef coinbaseTx;
     try {
         coinbaseTx = CreateCoinbaseTransaction(nHeight, totalFees, minerAddress, mikData);
     } catch (const std::runtime_error& e) {
@@ -1215,7 +1244,10 @@ std::optional<CBlockTemplate> CMiningController::CreateBlockTemplate(
     const size_t BLOCK_HEADER_SIZE = 80;
     size_t totalBlockSize = BLOCK_HEADER_SIZE + block.vtx.size();
 
-    // Enforce consensus maximum block size (1 MB)
+    // Enforce consensus maximum block size (Consensus::MAX_BLOCK_SIZE, 4 MB).
+    // Conservative: counts the 80-byte header on top of the vtx blob, whereas
+    // the storage layer caps the vtx blob alone — so this never lets through a
+    // block the storage layer would reject.
     if (totalBlockSize > Consensus::MAX_BLOCK_SIZE) {
         error = "Block size exceeds consensus maximum: " +
                 std::to_string(totalBlockSize) + " > " +

--- a/src/miner/controller.h
+++ b/src/miner/controller.h
@@ -304,6 +304,9 @@ private:
     friend void test_merkle_root_calculation();
     friend void test_block_validation_no_duplicates();
     friend void test_subsidy_consistency();
+    // BUG-003 F-06: Bug-B regression test drives SelectTransactionsForBlock /
+    // CreateCoinbaseTransaction directly. Test-access only; no behaviour change.
+    friend void test_template_overshoot_regression_bug_b();
 
     /**
      * SelectTransactionsForBlock - Choose transactions from mempool
@@ -314,7 +317,12 @@ private:
      * @param mempool Transaction mempool
      * @param utxoSet UTXO set for input validation
      * @param nHeight Current block height (for coinbase maturity validation)
-     * @param maxBlockSize Maximum block size in bytes (default: 1MB)
+     * @param maxBlockSize Maximum block size in bytes (0 = use Consensus::MAX_BLOCK_SIZE fallback).
+     *        Must be 0 or a sane value >= the coinbase reserve; a tiny positive value
+     *        yields a budget smaller than the coinbase seed and selects zero transactions.
+     * @param coinbaseReserve Real serialized size of the coinbase transaction
+     *        (BUG-003: replaces the old flat 200-byte estimate). The size budget
+     *        is seeded from this so a saturated template cannot overshoot the cap.
      * @param totalFees Output: total fees from selected transactions
      * @return Vector of selected transactions
      */
@@ -323,6 +331,7 @@ private:
         CUTXOSet& utxoSet,
         uint32_t nHeight,
         size_t maxBlockSize,
+        size_t coinbaseReserve,
         uint64_t& totalFees
     );
 

--- a/src/net/net.cpp
+++ b/src/net/net.cpp
@@ -50,8 +50,8 @@
 // NET-003 FIX: Define consensus limits to prevent integer overflow in vector resize
 // These prevent DoS attacks via malicious size values causing heap corruption
 // Note: vtx is a byte vector (serialized tx data), so this limits BYTES not tx count.
-// Must be >= consensus MAX_BLOCK_SIZE (1 MB) to accept all valid blocks.
-static const uint64_t MAX_BLOCK_VTX_BYTES = 4 * 1024 * 1024;  // 4 MB (matches storage layer)
+// Must equal consensus Consensus::MAX_BLOCK_SIZE (4 MB) to accept all valid blocks.
+static const uint64_t MAX_BLOCK_VTX_BYTES = 4 * 1024 * 1024;  // 4 MB (matches Consensus::MAX_BLOCK_SIZE / storage layer)
 static const uint64_t MAX_TX_INPUTS = 10000;            // Max inputs per transaction
 static const uint64_t MAX_TX_OUTPUTS = 10000;           // Max outputs per transaction
 static const uint64_t MAX_SCRIPT_SIZE = 20000;          // Max script size (raised for Dilithium sigs)

--- a/src/node/block_validation_queue.cpp
+++ b/src/node/block_validation_queue.cpp
@@ -141,9 +141,11 @@ bool CBlockValidationQueue::QueueBlock(int peer_id, const CBlock& block, int exp
 
     // Coinbase validation removed from QueueBlock - it passed fees=0 which rejected
     // valid blocks that collected transaction fees, and banned the sending peer.
-    // Coinbase is validated authoritatively in:
-    // 1. ProcessNewBlock Phase 2.5 (with correct fee calculation)
-    // 2. ConnectTip → CheckBlock (final validation)
+    // Coinbase is validated authoritatively in ProcessNewBlock Phase 2.5 (with
+    // correct fee calculation) and again as part of ConnectTip's checks.
+    // NOTE: CBlockValidator::CheckBlock is NOT in this path — it is dead code
+    // (zero callers). Block-size enforcement is done by the storage-layer 4 MB
+    // cap (blockchain_storage.cpp) and the P2P MAX_BLOCK_VTX_BYTES cap (net.cpp).
 
     // Check if we already have this block
     CBlockIndex* existing = m_chainstate.GetBlockIndex(blockHash);

--- a/src/node/blockchain_storage.cpp
+++ b/src/node/blockchain_storage.cpp
@@ -8,6 +8,7 @@
 #include <leveldb/options.h>
 #include <leveldb/iterator.h>  // Phase 4.2: For reindex iteration
 #include <crypto/sha3.h>  // DB-001 FIX: For SHA-256 checksums
+#include <consensus/params.h>  // BUG-003: single source of truth for MAX_BLOCK_SIZE
 #include <db/db_errors.h>  // Phase 4.2: Enhanced error handling
 #include <util/logging.h>  // Phase 4.2: Use structured logging
 #include <cstring>
@@ -270,8 +271,8 @@ bool CBlockchainDB::WriteBlock(const uint256& hash, const CBlock& block) {
         return false;
     }
     // DB-005 FIX: Enforce maximum block size (4 MB consensus limit)
-    const size_t MAX_BLOCK_SIZE = 4 * 1024 * 1024;
-    if (block.vtx.size() > MAX_BLOCK_SIZE) {
+    // BUG-003: reference the single source of truth Consensus::MAX_BLOCK_SIZE.
+    if (block.vtx.size() > Consensus::MAX_BLOCK_SIZE) {
         ErrorMessage error = CErrorFormatter::ValidationError("block", 
             "Block exceeds maximum size (4 MB)");
         std::cerr << CErrorFormatter::FormatForUser(error) << std::endl;
@@ -391,8 +392,9 @@ bool CBlockchainDB::ReadBlock(const uint256& hash, CBlock& block) {
     offset += sizeof(data_length);
 
     // DB-012 FIX: Validate data_length is reasonable (max 4 MB block size)
-    const uint32_t MAX_BLOCK_SIZE = 4 * 1024 * 1024;
-    if (data_length > MAX_BLOCK_SIZE) {
+    // BUG-003 M-1: use the unified Consensus::MAX_BLOCK_SIZE constant rather than
+    // a local literal so the read-path cap tracks the single source of truth.
+    if (data_length > Consensus::MAX_BLOCK_SIZE) {
         ErrorMessage error = CErrorFormatter::DatabaseError("read block", 
             "Data length exceeds maximum (4 MB)");
         std::cerr << CErrorFormatter::FormatForUser(error) << std::endl;

--- a/src/node/dilithion-node.cpp
+++ b/src/node/dilithion-node.cpp
@@ -1387,9 +1387,19 @@ std::optional<CBlockTemplate> BuildMiningTemplate(CBlockchainDB& blockchain, CWa
 
         // Limit candidates and set resource limits
         const size_t MAX_CANDIDATES = 50000;
-        const size_t MAX_BLOCK_SIZE = Dilithion::g_chainParams
-            ? Dilithion::g_chainParams->maxBlockSize : 4 * 1024 * 1024;  // Use chain params (4 MB)
-        size_t currentBlockSize = 200;  // Reserve for coinbase
+        // chainParams->maxBlockSize is kept in lockstep with Consensus::MAX_BLOCK_SIZE (4 MB).
+        const size_t chainMaxBlockSize = Dilithion::g_chainParams
+            ? Dilithion::g_chainParams->maxBlockSize : Consensus::MAX_BLOCK_SIZE;
+        // BUG-003 F-05: budget against the cap minus a safety margin so size-estimate
+        // jitter never produces a block the storage/consensus layer rejects.
+        const size_t MAX_BLOCK_SIZE = chainMaxBlockSize > Consensus::BLOCK_SIZE_SAFETY_MARGIN
+            ? chainMaxBlockSize - Consensus::BLOCK_SIZE_SAFETY_MARGIN
+            : chainMaxBlockSize;
+        // BUG-003 Bug B: seed the budget from the coinbase's real size, not a flat
+        // 200. The coinbase scriptSig is already finalized above; its outputs are
+        // added after this loop but COINBASE_NON_SCRIPTSIG_OVERHEAD upper-bounds
+        // version + vin framing + up to 3 outputs + locktime + tx-count varint.
+        size_t currentBlockSize = scriptSig.size() + Consensus::COINBASE_NON_SCRIPTSIG_OVERHEAD;
 
         if (candidateTxs.size() > MAX_CANDIDATES) {
             candidateTxs.resize(MAX_CANDIDATES);
@@ -1596,6 +1606,18 @@ std::optional<CBlockTemplate> BuildMiningTemplate(CBlockchainDB& blockchain, CWa
     for (const auto& tx : selectedTxs) {
         std::vector<uint8_t> txData = tx->Serialize();
         block.vtx.insert(block.vtx.end(), txData.begin(), txData.end());
+    }
+
+    // BUG-003 L-1: Final post-assembly block-size guard. The in-loop budget plus
+    // the F-05 safety margin should keep the assembled blob within the cap, but
+    // mirror controller.cpp:1251's independent final check so this daemon-side
+    // path is not the only one without a backstop. Abort the template if it
+    // overshoots — the miner keeps its previous valid template.
+    if (block.vtx.size() > Consensus::MAX_BLOCK_SIZE) {
+        std::cerr << "[Mining] Template rejected - assembled block size "
+                  << block.vtx.size() << " exceeds consensus maximum "
+                  << Consensus::MAX_BLOCK_SIZE << " bytes" << std::endl;
+        return std::nullopt;
     }
 
     // BUG #109 FIX: Calculate merkle root from ALL transaction hashes

--- a/src/node/dilv-node.cpp
+++ b/src/node/dilv-node.cpp
@@ -1363,9 +1363,19 @@ std::optional<CBlockTemplate> BuildMiningTemplate(CBlockchainDB& blockchain, CWa
 
         // Limit candidates and set resource limits
         const size_t MAX_CANDIDATES = 50000;
-        const size_t MAX_BLOCK_SIZE = Dilithion::g_chainParams
-            ? Dilithion::g_chainParams->maxBlockSize : 4 * 1024 * 1024;  // Use chain params (4 MB)
-        size_t currentBlockSize = 200;  // Reserve for coinbase
+        // chainParams->maxBlockSize is kept in lockstep with Consensus::MAX_BLOCK_SIZE (4 MB).
+        const size_t chainMaxBlockSize = Dilithion::g_chainParams
+            ? Dilithion::g_chainParams->maxBlockSize : Consensus::MAX_BLOCK_SIZE;
+        // BUG-003 F-05: budget against the cap minus a safety margin so size-estimate
+        // jitter never produces a block the storage/consensus layer rejects.
+        const size_t MAX_BLOCK_SIZE = chainMaxBlockSize > Consensus::BLOCK_SIZE_SAFETY_MARGIN
+            ? chainMaxBlockSize - Consensus::BLOCK_SIZE_SAFETY_MARGIN
+            : chainMaxBlockSize;
+        // BUG-003 Bug B: seed the budget from the coinbase's real size, not a flat
+        // 200. The coinbase scriptSig is already finalized above; its outputs are
+        // added after this loop but COINBASE_NON_SCRIPTSIG_OVERHEAD upper-bounds
+        // version + vin framing + up to 3 outputs + locktime + tx-count varint.
+        size_t currentBlockSize = scriptSig.size() + Consensus::COINBASE_NON_SCRIPTSIG_OVERHEAD;
 
         if (candidateTxs.size() > MAX_CANDIDATES) {
             candidateTxs.resize(MAX_CANDIDATES);
@@ -1572,6 +1582,18 @@ std::optional<CBlockTemplate> BuildMiningTemplate(CBlockchainDB& blockchain, CWa
     for (const auto& tx : selectedTxs) {
         std::vector<uint8_t> txData = tx->Serialize();
         block.vtx.insert(block.vtx.end(), txData.begin(), txData.end());
+    }
+
+    // BUG-003 L-1: Final post-assembly block-size guard. The in-loop budget plus
+    // the F-05 safety margin should keep the assembled blob within the cap, but
+    // mirror controller.cpp:1251's independent final check so this daemon-side
+    // path is not the only one without a backstop. Abort the template if it
+    // overshoots — the miner keeps its previous valid template.
+    if (block.vtx.size() > Consensus::MAX_BLOCK_SIZE) {
+        std::cerr << "[Mining] Template rejected - assembled block size "
+                  << block.vtx.size() << " exceeds consensus maximum "
+                  << Consensus::MAX_BLOCK_SIZE << " bytes" << std::endl;
+        return std::nullopt;
     }
 
     // BUG #109 FIX: Calculate merkle root from ALL transaction hashes

--- a/src/node/iblock_sink.h
+++ b/src/node/iblock_sink.h
@@ -37,9 +37,11 @@ public:
     virtual ~IBlockSink() = default;
 
     // Submit a block received from a peer. Returns the validation outcome.
-    // The implementation is expected to call into the chain selector
-    // (which goes through CheckBlock -> ContextualCheckBlock -> ConnectBlock
-    // -> ActivateBestChain).
+    // The implementation is expected to call into the chain selector, which
+    // runs ProcessNewBlock then ConnectTip/ActivateBestChain. Block-size limits
+    // are enforced by the P2P receive layer (MAX_BLOCK_VTX_BYTES, net.cpp) and
+    // the storage-layer 4 MB cap (blockchain_storage.cpp) — NOT by
+    // CBlockValidator::CheckBlock, which is dead code with zero callers.
     //
     // CONSENSUS BOUNDARY: the implementation MUST call ProcessNewBlock
     // exactly once with the same arguments today's code uses. No new

--- a/src/test/bug_003_block_size_tests.cpp
+++ b/src/test/bug_003_block_size_tests.cpp
@@ -1,0 +1,656 @@
+// Copyright (c) 2026 The Dilithion Core developers
+// Distributed under the MIT software license
+
+/**
+ * BUG-003 — Block-size limit reconciliation tests (F-06).
+ *
+ * Covers contract assertions:
+ *   A-04 — CBlockValidator::CheckBlock (dead but testable) uses the 4 MB constant.
+ *   A-05 — A block with vtx.size() == MAX_BLOCK_SIZE stores; MAX_BLOCK_SIZE + 1 is rejected.
+ *          Exercises the ACTIVE path: CBlockchainDB::WriteBlock.
+ *   A-02 — A mempool-saturated mining template with a maximum-size MIK coinbase
+ *          produces a block.vtx blob whose .size() <= Consensus::MAX_BLOCK_SIZE.
+ *          This is the Bug-B regression test: it overshoots under the old flat
+ *          200-byte coinbase reserve and fits under the F-02 fix.
+ *
+ * Uses the custom TEST()/ASSERT/ASSERT_EQ framework (modelled on
+ * mining_integration_tests.cpp), not Boost, so it can drive CMiningController,
+ * CBlockchainDB and CBlockValidator directly.
+ */
+
+#include <consensus/params.h>
+#include <consensus/validation.h>
+#include <consensus/tx_validation.h>
+#include <miner/controller.h>
+#include <node/blockchain_storage.h>
+#include <node/mempool.h>
+#include <node/utxo_set.h>
+#include <primitives/block.h>
+#include <primitives/transaction.h>
+#include <wallet/wallet.h>
+#include <dfmp/mik.h>
+#include <amount.h>
+#include <core/chainparams.h>
+#include <crypto/randomx_hash.h>
+
+#include <chrono>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <iostream>
+#include <string>
+#include <vector>
+
+// ANSI color codes
+#define RESET   "\033[0m"
+#define GREEN   "\033[32m"
+#define RED     "\033[31m"
+#define YELLOW  "\033[33m"
+#define BLUE    "\033[34m"
+
+int g_tests_passed = 0;
+int g_tests_failed = 0;
+
+#define TEST(name) \
+    void test_##name(); \
+    void test_##name##_wrapper() { \
+        std::cout << BLUE << "[TEST] " << #name << RESET << std::endl; \
+        try { \
+            test_##name(); \
+            std::cout << GREEN << "  PASSED" << RESET << std::endl; \
+            g_tests_passed++; \
+        } catch (const std::exception& e) { \
+            std::cout << RED << "  FAILED: " << e.what() << RESET << std::endl; \
+            g_tests_failed++; \
+        } catch (...) { \
+            std::cout << RED << "  FAILED: Unknown exception" << RESET << std::endl; \
+            g_tests_failed++; \
+        } \
+    } \
+    void test_##name()
+
+#define ASSERT(condition, message) \
+    if (!(condition)) { \
+        throw std::runtime_error(message); \
+    }
+
+#define ASSERT_EQ(a, b, message) \
+    if ((a) != (b)) { \
+        throw std::runtime_error(std::string(message) + " (expected " + \
+            std::to_string(b) + ", got " + std::to_string(a) + ")"); \
+    }
+
+// --- helpers --------------------------------------------------------------
+
+static std::vector<uint8_t> CreateMinerAddress() {
+    std::vector<uint8_t> addr(25);
+    addr[0] = 0x76; addr[1] = 0xa9; addr[2] = 0x14;
+    for (int i = 0; i < 20; i++) addr[3 + i] = static_cast<uint8_t>(i);
+    addr[23] = 0x88; addr[24] = 0xac;
+    return addr;
+}
+
+// Build a CBlock whose serialized-transaction blob (vtx) is exactly `n` bytes.
+// vtx is a std::vector<uint8_t> blob; .size() is the byte count the storage and
+// CheckBlock size checks compare against Consensus::MAX_BLOCK_SIZE.
+static CBlock MakeBlockWithVtxSize(size_t n) {
+    CBlock block;
+    block.nVersion = 1;
+    block.nBits = 0x1f00ffff;
+    block.nTime = 1700000000;
+    block.nNonce = 1;
+    block.vtx.assign(n, 0xAB);
+    return block;
+}
+
+// =======================================================================
+// A-05 (ACTIVE PATH) — CBlockchainDB::WriteBlock block-size boundary.
+//   vtx.size() == MAX_BLOCK_SIZE      -> accepted
+//   vtx.size() == MAX_BLOCK_SIZE + 1  -> rejected
+// =======================================================================
+TEST(storage_writeblock_size_boundary) {
+    const size_t kMax = Consensus::MAX_BLOCK_SIZE;
+    ASSERT_EQ(kMax, static_cast<size_t>(4 * 1024 * 1024),
+              "Consensus::MAX_BLOCK_SIZE must be 4 MB");
+
+    std::string dbPath = ".test-bug003-storage";
+    std::error_code ec;
+    std::filesystem::remove_all(dbPath, ec);
+
+    CBlockchainDB db;
+    ASSERT(db.Open(dbPath, true), "Failed to open blockchain DB");
+
+    // Exactly at the limit: must be accepted.
+    {
+        CBlock atLimit = MakeBlockWithVtxSize(kMax);
+        ASSERT_EQ(atLimit.vtx.size(), kMax, "vtx size setup wrong (at-limit)");
+        uint256 h; h.SetHex("00000000000000000000000000000000000000000000000000000000000000a1");
+        bool ok = db.WriteBlock(h, atLimit);
+        ASSERT(ok, "Block with vtx.size()==MAX_BLOCK_SIZE was REJECTED by WriteBlock");
+        std::cout << "    WriteBlock accepted vtx.size()==" << kMax << " (4 MB)" << std::endl;
+    }
+
+    // One byte over the limit: must be rejected.
+    {
+        CBlock overLimit = MakeBlockWithVtxSize(kMax + 1);
+        ASSERT_EQ(overLimit.vtx.size(), kMax + 1, "vtx size setup wrong (over-limit)");
+        uint256 h; h.SetHex("00000000000000000000000000000000000000000000000000000000000000a2");
+        bool ok = db.WriteBlock(h, overLimit);
+        ASSERT(!ok, "Block with vtx.size()==MAX_BLOCK_SIZE+1 was ACCEPTED by WriteBlock");
+        std::cout << "    WriteBlock rejected vtx.size()==" << (kMax + 1) << std::endl;
+    }
+
+    db.Close();
+    std::filesystem::remove_all(dbPath, ec);
+}
+
+// =======================================================================
+// A-04 — CBlockValidator::CheckBlock size constant is 4 MB (not 1 MB).
+//   CheckBlock is dead code (zero callers) but is testable directly. Its
+//   block-size check runs FIRST, before header / deserialize. We assert:
+//     * a 4 MB + 1 block is rejected with the size error;
+//     * a 4 MB block is NOT rejected for size (it fails later, for other
+//       reasons — proving the size constant moved from 1 MB to 4 MB; under
+//       the old 1 MB constant a 4 MB block would fail the size check).
+// =======================================================================
+TEST(checkblock_size_constant_is_4mb) {
+    const size_t kMax = Consensus::MAX_BLOCK_SIZE;
+    CBlockValidator validator;
+    CUTXOSet utxoSet;
+    std::string utxoPath = ".test-bug003-checkblock-utxo";
+    std::error_code ec;
+    std::filesystem::remove_all(utxoPath, ec);
+    ASSERT(utxoSet.Open(utxoPath, true), "Failed to open UTXO set");
+
+    const std::string sizeErrFragment = "exceeds maximum size";
+
+    // 4 MB + 1: must be rejected, and specifically for SIZE.
+    {
+        CBlock overLimit = MakeBlockWithVtxSize(kMax + 1);
+        std::string error;
+        bool ok = validator.CheckBlock(overLimit, utxoSet, 1, error);
+        ASSERT(!ok, "CheckBlock accepted a 4 MB + 1 block");
+        ASSERT(error.find(sizeErrFragment) != std::string::npos,
+               "CheckBlock rejected 4 MB + 1 but NOT for size; error: " + error);
+        std::cout << "    CheckBlock rejected 4 MB + 1 for size: " << error << std::endl;
+    }
+
+    // Exactly 4 MB: must NOT be rejected for size. (It fails later for other
+    // reasons — a blob of 0xAB bytes is not a valid header/tx set.) The key
+    // assertion: the failure reason is NOT the size check. Under the old
+    // 1 MB constant this same block WOULD fail the size check.
+    {
+        CBlock atLimit = MakeBlockWithVtxSize(kMax);
+        std::string error;
+        bool ok = validator.CheckBlock(atLimit, utxoSet, 1, error);
+        ASSERT(!ok, "Garbage 4 MB block unexpectedly passed full CheckBlock");
+        ASSERT(error.find(sizeErrFragment) == std::string::npos,
+               "CheckBlock rejected an exactly-4 MB block FOR SIZE — constant is "
+               "still < 4 MB; error: " + error);
+        std::cout << "    CheckBlock did NOT reject 4 MB for size (failed later: "
+                  << error << ")" << std::endl;
+    }
+
+    utxoSet.Close();
+    std::filesystem::remove_all(utxoPath, ec);
+}
+
+// =======================================================================
+// A-02 — Bug-B regression: mempool-saturated mining template with a
+// maximum-size MIK coinbase yields a vtx blob <= Consensus::MAX_BLOCK_SIZE.
+//
+// Bug B: the template builders seeded their byte budget with a flat 200-byte
+// coinbase reserve, but a real MIK-registration coinbase carries ~5.3 KB of
+// scriptSig + outputs. A saturated template therefore overshot the cap by
+// ~(coinbaseReserve - 200) bytes and was rejected by storage/P2P.
+//
+// This test:
+//   1. Builds a real maximum-size MIK-registration coinbase and measures its
+//      true serialized size (coinbaseReserve).
+//   2. Saturates a real mempool with valid Dilithium-signed transactions until
+//      it holds well over 4 MB of transaction data.
+//   3. Drives the FIXED selection path SelectTransactionsForBlock with the real
+//      coinbaseReserve and maxBlockSize = Consensus::MAX_BLOCK_SIZE, then
+//      assembles the vtx blob exactly as CreateBlockTemplate does, and asserts
+//      vtx.size() <= Consensus::MAX_BLOCK_SIZE.
+//   4. Re-runs the SAME selection with the OLD flat-200 seed simulated, and
+//      asserts that blob WOULD have exceeded the cap — proving the regression
+//      test actually catches Bug B.
+// =======================================================================
+
+// Assemble a vtx blob the same way CMiningController::CreateBlockTemplate does:
+// a CompactSize tx-count prefix followed by each transaction's Serialize().
+static std::vector<uint8_t> AssembleVtx(const CTransactionRef& coinbase,
+                                        const std::vector<CTransactionRef>& selected) {
+    std::vector<uint8_t> vtx;
+    uint64_t txCount = 1 + selected.size();
+    if (txCount < 253) {
+        vtx.push_back(static_cast<uint8_t>(txCount));
+    } else if (txCount <= 0xFFFF) {
+        vtx.push_back(253);
+        vtx.push_back(static_cast<uint8_t>(txCount));
+        vtx.push_back(static_cast<uint8_t>(txCount >> 8));
+    } else {
+        vtx.push_back(254);
+        vtx.push_back(static_cast<uint8_t>(txCount));
+        vtx.push_back(static_cast<uint8_t>(txCount >> 8));
+        vtx.push_back(static_cast<uint8_t>(txCount >> 16));
+        vtx.push_back(static_cast<uint8_t>(txCount >> 24));
+    }
+    {
+        std::vector<uint8_t> d = coinbase->Serialize();
+        vtx.insert(vtx.end(), d.begin(), d.end());
+    }
+    for (const auto& tx : selected) {
+        std::vector<uint8_t> d = tx->Serialize();
+        vtx.insert(vtx.end(), d.begin(), d.end());
+    }
+    return vtx;
+}
+
+TEST(template_overshoot_regression_bug_b) {
+    const size_t kMax = Consensus::MAX_BLOCK_SIZE;
+
+    // ---- 1. Build a real maximum-size MIK-registration coinbase ----------
+    CMiningController miner(1);
+    std::vector<uint8_t> minerAddr = CreateMinerAddress();
+
+    CMIKCoinbaseData mikData;
+    mikData.hasMIK = true;
+    mikData.isRegistration = true;                       // largest scriptSig form
+    mikData.pubkey.assign(DFMP::MIK_PUBKEY_SIZE, 0x11);  // 1952 bytes
+    mikData.signature.assign(3309, 0x22);                // Dilithium3 signature
+    mikData.registrationNonce = 0x0123456789ABCDEFULL;
+
+    CTransactionRef coinbase =
+        miner.CreateCoinbaseTransaction(1, /*totalFees=*/0, minerAddr, mikData);
+    ASSERT(coinbase != nullptr, "Failed to build MIK coinbase");
+    ASSERT(coinbase->IsCoinBase(), "MIK coinbase is not a coinbase");
+
+    const size_t coinbaseReserve = coinbase->GetSerializedSize();
+    std::cout << "    Real max-size MIK coinbase serialized size: "
+              << coinbaseReserve << " bytes" << std::endl;
+    ASSERT(coinbaseReserve > 5000,
+           "Max-size MIK coinbase smaller than expected (~5.3 KB)");
+    ASSERT(coinbaseReserve > 200,
+           "Coinbase fits in the old 200-byte estimate — fixture invalid");
+
+    // ---- 2. Saturate a mempool with valid signed transactions ------------
+    CUTXOSet utxoSet;
+    std::string utxoPath = ".test-bug003-tmpl-utxo";
+    std::error_code ec;
+    std::filesystem::remove_all(utxoPath, ec);
+    ASSERT(utxoSet.Open(utxoPath, true), "Failed to open UTXO set");
+
+    CWallet senderWallet;
+    ASSERT(senderWallet.GenerateNewKey(), "Failed to generate wallet key");
+    CDilithiumAddress senderAddr = senderWallet.GetNewAddress();
+
+    CWallet recipientWallet;
+    ASSERT(recipientWallet.GenerateNewKey(), "Failed to generate recipient key");
+    CDilithiumAddress recipientAddr = recipientWallet.GetNewAddress();
+
+    std::vector<uint8_t> senderHash = senderWallet.GetPubKeyHash();
+    std::vector<uint8_t> senderScript = WalletCrypto::CreateScriptPubKey(senderHash);
+
+    CTxMemPool mempool;
+    const unsigned int currentHeight = 200;     // funding UTXOs mature at h<=100
+    const CAmount fundAmount = 100000000;       // 1 DIL per UTXO
+    const CAmount sendAmount = 50000000;        // 0.5 DIL
+    const CAmount fee = 100000;                 // 0.001 DIL (>= min relay fee)
+
+    // Each 1-input wallet tx carries a Dilithium scriptSig (~5.3 KB). Fund
+    // enough independent UTXOs to push the mempool well past 4 MB so the
+    // selection loop is genuinely saturated.
+    size_t mempoolBytes = 0;
+    size_t txCreated = 0;
+    const size_t targetMempoolBytes = kMax + (kMax / 4);  // ~5 MB of tx data
+    const size_t maxFundingUtxos = 4000;                  // safety bound
+
+    for (size_t i = 0; i < maxFundingUtxos && mempoolBytes < targetMempoolBytes; i++) {
+        uint256 fundTxid;
+        // Distinct funding txid per UTXO.
+        fundTxid.data[0] = static_cast<uint8_t>(i & 0xFF);
+        fundTxid.data[1] = static_cast<uint8_t>((i >> 8) & 0xFF);
+        fundTxid.data[2] = 0xF0;
+
+        senderWallet.AddTxOut(fundTxid, 0, fundAmount, senderAddr, 100);
+        CTxOut fundOut(fundAmount, senderScript);
+        utxoSet.AddUTXO(COutPoint(fundTxid, 0), fundOut, 100, false);
+    }
+    utxoSet.Flush();
+
+    for (size_t i = 0; i < maxFundingUtxos && mempoolBytes < targetMempoolBytes; i++) {
+        uint256 fundTxid;
+        fundTxid.data[0] = static_cast<uint8_t>(i & 0xFF);
+        fundTxid.data[1] = static_cast<uint8_t>((i >> 8) & 0xFF);
+        fundTxid.data[2] = 0xF0;
+        CDilithiumAddress fromAddr = senderAddr;
+
+        CTransactionRef tx;
+        std::string error;
+        if (!senderWallet.CreateTransaction(recipientAddr, sendAmount, fee,
+                                            utxoSet, currentHeight, tx, error,
+                                            fromAddr)) {
+            // Out of spendable UTXOs / coin-selection limit reached.
+            if (txCreated == 0) {
+                throw std::runtime_error(
+                    "CreateTransaction failed on first tx: " + error);
+            }
+            break;
+        }
+        size_t txSize = tx->GetSerializedSize();
+        std::string mpErr;
+        if (!mempool.AddTx(tx, fee, 1700000000, currentHeight, &mpErr,
+                           /*bypass_fee_check=*/true)) {
+            break;
+        }
+        mempoolBytes += txSize;
+        txCreated++;
+    }
+
+    std::cout << "    Mempool saturated: " << txCreated << " txs, "
+              << mempoolBytes << " bytes of tx data" << std::endl;
+    ASSERT(mempoolBytes > kMax,
+           "Mempool not saturated past 4 MB — cannot exercise overshoot ("
+           + std::to_string(mempoolBytes) + " bytes)");
+
+    // ---- 3. Production-path check (A-02): margin active ------------------
+    // The real CreateBlockTemplate path budgets against (cap - SAFETY_MARGIN).
+    // SelectTransactionsForBlock is private; the test is a declared friend.
+    uint64_t totalFeesProd = 0;
+    std::vector<CTransactionRef> selectedProd = miner.SelectTransactionsForBlock(
+        mempool, utxoSet, currentHeight,
+        /*maxBlockSize=*/kMax,                  // production cap; loop applies F-05 margin
+        /*coinbaseReserve=*/coinbaseReserve,    // F-02: real coinbase size
+        totalFeesProd);
+
+    CTransactionRef coinbaseFinal =
+        miner.CreateCoinbaseTransaction(1, totalFeesProd, minerAddr, mikData);
+    // Contract R2: coinbase serialized size is fee-independent.
+    ASSERT_EQ(coinbaseFinal->GetSerializedSize(), coinbaseReserve,
+              "Coinbase serialized size changed with fees (contract R2 violated)");
+
+    std::vector<uint8_t> vtxProd = AssembleVtx(coinbaseFinal, selectedProd);
+    std::cout << "    PRODUCTION path (F-05 margin active): "
+              << selectedProd.size() << " txs, vtx.size()=" << vtxProd.size()
+              << " (cap " << kMax << ")" << std::endl;
+    ASSERT(vtxProd.size() <= kMax,
+           "BUG-003 A-02 FAILED: production-path template vtx.size()="
+           + std::to_string(vtxProd.size()) + " exceeds MAX_BLOCK_SIZE="
+           + std::to_string(kMax));
+
+    // ---- 4. Bug-B isolation: regression catches the F-02 fix -------------
+    // BUG-003 M-2: the regression must PROVABLY fail on the pre-F-02 code and
+    // must not be sensitive to mempool-fixture granularity. Asserting on raw
+    // byte totals (vtxOld.size() > kMax) is fixture-fragile: the seed
+    // difference (coinbaseReserve - 200 ~= 5.2 KB) is less than one sample tx,
+    // so whether the old seed overshoots the 4 MB cap depends on where the
+    // last candidate tx happens to land. Instead we assert on the real
+    // invariant — the old (undercounting) seed selects strictly MORE
+    // transactions than the fixed seed — and we make that strict inequality
+    // DETERMINISTIC by choosing the budget from measured tx sizes.
+    //
+    // The greedy loop seeds currentBlockSize = coinbaseReserve + 9 (the
+    // TX_COUNT_VARINT_ALLOWANCE) and selects a tx while
+    // currentBlockSize + txSize <= budget. The sample mempool is uniform
+    // (every tx is a 1-input wallet tx of identical serialized size T), so the
+    // selected count is floor((budget - seed) / T). Pick:
+    //
+    //   budget = coinbaseReserve + 9 + (K + 1) * T - 1
+    //
+    // Then:
+    //   * FIXED seed (coinbaseReserve): selects exactly K     txs.
+    //   * OLD   seed (200):             selects exactly K + 1 txs,
+    // because the 200-byte seed frees (coinbaseReserve - 200) bytes, which is
+    // > 0 and < T (asserted below) — exactly enough for one more tx and never
+    // two. So selectedOld.size() == selectedFixed.size() + 1, provably, on the
+    // current (fixed) code; the pre-F-02 code (which always seeded with 200)
+    // would itself behave as the OLD path and overshoot the real cap.
+    //
+    // SelectTransactionsForBlock subtracts BLOCK_SIZE_SAFETY_MARGIN from the
+    // maxBlockSize argument, so we pass (budget + SAFETY_MARGIN) to make the
+    // loop's effective budget exactly `budget`.
+    const size_t TX_COUNT_VARINT_ALLOWANCE = 9;  // mirrors controller.cpp:832
+
+    // Uniform sample-tx size T, taken from a real selected tx and verified
+    // uniform across the production selection so the budget arithmetic holds.
+    ASSERT(!selectedProd.empty(),
+           "Regression setup error: production path selected zero txs");
+    const size_t T = selectedProd.front()->GetSerializedSize();
+    for (const auto& tx : selectedProd) {
+        ASSERT_EQ(tx->GetSerializedSize(), T,
+                  "Sample mempool is not uniform — budget arithmetic invalid");
+    }
+    // The +1 (and not +2) selection step depends on 0 < coinbaseReserve-200 < T.
+    ASSERT(coinbaseReserve > 200 + TX_COUNT_VARINT_ALLOWANCE,
+           "Coinbase reserve too small for the regression to be meaningful");
+    ASSERT(coinbaseReserve - 200 < T,
+           "Coinbase undercount >= one tx — regression would over-select by >1");
+
+    const size_t kSelectK = 8;  // small, fast, far from fixture saturation edge
+    const size_t budget =
+        coinbaseReserve + TX_COUNT_VARINT_ALLOWANCE + (kSelectK + 1) * T - 1;
+    const size_t maxBlockSizeArg = budget + Consensus::BLOCK_SIZE_SAFETY_MARGIN;
+
+    uint64_t totalFeesFixed = 0;
+    std::vector<CTransactionRef> selectedFixed = miner.SelectTransactionsForBlock(
+        mempool, utxoSet, currentHeight,
+        /*maxBlockSize=*/maxBlockSizeArg,       // effective budget == `budget`
+        /*coinbaseReserve=*/coinbaseReserve,    // F-02 fix: real coinbase size
+        totalFeesFixed);
+    std::vector<uint8_t> vtxFixed = AssembleVtx(coinbaseFinal, selectedFixed);
+
+    uint64_t totalFeesOld = 0;
+    std::vector<CTransactionRef> selectedOld = miner.SelectTransactionsForBlock(
+        mempool, utxoSet, currentHeight,
+        /*maxBlockSize=*/maxBlockSizeArg,       // effective budget == `budget`
+        /*coinbaseReserve=*/200,                // simulate pre-F-02 flat estimate
+        totalFeesOld);
+    std::vector<uint8_t> vtxOld = AssembleVtx(coinbaseFinal, selectedOld);
+
+    std::cout << "    Bug-B isolation (deterministic, sample tx size T=" << T
+              << ", K=" << kSelectK << "):" << std::endl;
+    std::cout << "      FIXED seed (" << coinbaseReserve << "): "
+              << selectedFixed.size() << " txs, vtx.size()=" << vtxFixed.size()
+              << std::endl;
+    std::cout << "      OLD   seed (200): " << selectedOld.size()
+              << " txs, vtx.size()=" << vtxOld.size() << std::endl;
+
+    // Production-path invariant (A-02): the fixed seed stays within the cap.
+    ASSERT(vtxFixed.size() <= kMax,
+           "F-02 fix FAILED: fixed-seed template vtx.size()="
+           + std::to_string(vtxFixed.size()) + " > cap " + std::to_string(kMax));
+
+    // The real Bug-B invariant: the undercounting (old) seed selects strictly
+    // MORE transactions than the fixed seed. Deterministic given the budget
+    // arithmetic above — provably fails on pre-F-02 (always-200) behaviour.
+    ASSERT(selectedOld.size() > selectedFixed.size(),
+           "BUG-003 regression FAILED: old 200-byte seed did NOT over-select "
+           "(old=" + std::to_string(selectedOld.size()) + ", fixed="
+           + std::to_string(selectedFixed.size()) + ") — F-02 not load-bearing");
+    ASSERT_EQ(selectedOld.size(), selectedFixed.size() + 1,
+              "BUG-003 regression: expected old seed to select exactly one "
+              "extra tx (deterministic budget) — fixture/arithmetic drift");
+    std::cout << "      => OLD seed over-selects by "
+              << (selectedOld.size() - selectedFixed.size())
+              << " tx; F-02's real coinbase reserve prevents the overshoot."
+              << std::endl;
+
+    mempool.Clear();
+    utxoSet.Close();
+    std::filesystem::remove_all(utxoPath, ec);
+}
+
+// =======================================================================
+// A-09 — Worst-case 4 MB block verification-time measurement.
+//
+// The dominant cost of validating a block is post-quantum (ML-DSA / Dilithium3)
+// signature verification, run once per transaction input via
+// CTransactionValidator::CheckTransaction. We:
+//   1. Build a batch of real Dilithium-signed 1-input transactions, each with
+//      its funding UTXO present.
+//   2. Time CheckTransaction over the batch -> per-transaction verification
+//      cost (this is exactly the per-tx work a full block connect performs).
+//   3. Extrapolate to a full 4 MB block: tx_count = 4 MB / mean serialized
+//      tx size; worst-case block verify time = tx_count * per-tx cost.
+//   4. Express the result as a fraction of the DIL and DilV target block times.
+//
+// This is a measurement, not a pass/fail gate — but it FAILS LOUDLY if the
+// worst-case verify time exceeds the DilV 45 s target block time, which would
+// be a genuine consensus-safety concern worth escalating.
+// =======================================================================
+TEST(worst_case_4mb_block_verify_time) {
+    const size_t kMax = Consensus::MAX_BLOCK_SIZE;
+
+    CUTXOSet utxoSet;
+    std::string utxoPath = ".test-bug003-verify-utxo";
+    std::error_code ec;
+    std::filesystem::remove_all(utxoPath, ec);
+    ASSERT(utxoSet.Open(utxoPath, true), "Failed to open UTXO set");
+
+    CWallet senderWallet;
+    ASSERT(senderWallet.GenerateNewKey(), "Failed to generate wallet key");
+    CDilithiumAddress senderAddr = senderWallet.GetNewAddress();
+    CWallet recipientWallet;
+    ASSERT(recipientWallet.GenerateNewKey(), "Failed to generate recipient key");
+    CDilithiumAddress recipientAddr = recipientWallet.GetNewAddress();
+
+    std::vector<uint8_t> senderHash = senderWallet.GetPubKeyHash();
+    std::vector<uint8_t> senderScript = WalletCrypto::CreateScriptPubKey(senderHash);
+
+    const unsigned int currentHeight = 200;
+    const CAmount fundAmount = 100000000;
+    const CAmount sendAmount = 50000000;
+    const CAmount fee = 100000;
+
+    // A representative sample of signed transactions. 250 is enough for a
+    // stable per-tx mean and keeps the test fast.
+    const size_t kSampleTxs = 250;
+
+    for (size_t i = 0; i < kSampleTxs; i++) {
+        uint256 fundTxid;
+        fundTxid.data[0] = static_cast<uint8_t>(i & 0xFF);
+        fundTxid.data[1] = static_cast<uint8_t>((i >> 8) & 0xFF);
+        fundTxid.data[2] = 0xE0;
+        senderWallet.AddTxOut(fundTxid, 0, fundAmount, senderAddr, 100);
+        CTxOut fundOut(fundAmount, senderScript);
+        utxoSet.AddUTXO(COutPoint(fundTxid, 0), fundOut, 100, false);
+    }
+    utxoSet.Flush();
+
+    std::vector<CTransactionRef> sample;
+    size_t totalTxBytes = 0;
+    for (size_t i = 0; i < kSampleTxs; i++) {
+        uint256 fundTxid;
+        fundTxid.data[0] = static_cast<uint8_t>(i & 0xFF);
+        fundTxid.data[1] = static_cast<uint8_t>((i >> 8) & 0xFF);
+        fundTxid.data[2] = 0xE0;
+        CTransactionRef tx;
+        std::string error;
+        if (!senderWallet.CreateTransaction(recipientAddr, sendAmount, fee,
+                                            utxoSet, currentHeight, tx, error,
+                                            senderAddr)) {
+            break;
+        }
+        totalTxBytes += tx->GetSerializedSize();
+        sample.push_back(tx);
+    }
+    ASSERT(sample.size() >= 100,
+           "Too few sample transactions built for a stable measurement ("
+           + std::to_string(sample.size()) + ")");
+
+    const double meanTxBytes =
+        static_cast<double>(totalTxBytes) / static_cast<double>(sample.size());
+
+    // Time full validation (incl. ML-DSA signature verification) of the sample.
+    CTransactionValidator validator;
+    auto t0 = std::chrono::steady_clock::now();
+    size_t verified = 0;
+    for (const auto& tx : sample) {
+        CAmount txFee = 0;
+        std::string error;
+        if (validator.CheckTransaction(*tx, utxoSet, currentHeight, txFee, error)) {
+            verified++;
+        }
+    }
+    auto t1 = std::chrono::steady_clock::now();
+    const double elapsedMs =
+        std::chrono::duration<double, std::milli>(t1 - t0).count();
+
+    ASSERT(verified == sample.size(),
+           "Some sample transactions failed validation — measurement invalid ("
+           + std::to_string(verified) + "/" + std::to_string(sample.size()) + ")");
+
+    const double perTxMs = elapsedMs / static_cast<double>(sample.size());
+
+    // Extrapolate to a worst-case full 4 MB block.
+    const double txPerBlock = static_cast<double>(kMax) / meanTxBytes;
+    const double blockVerifyMs = perTxMs * txPerBlock;
+    const double blockVerifySec = blockVerifyMs / 1000.0;
+
+    // Target block times (src/core/chainparams.cpp `params.blockTime`):
+    //   DIL  mainnet : 240 s (4 min)  — ChainParams::Mainnet().
+    //   DilV         :  45 s          — ChainParams::DilV().
+    const double dilTargetSec  = 240.0;
+    const double dilvTargetSec = 45.0;
+
+    std::cout << "    --- T4: worst-case 4 MB block verification time ---" << std::endl;
+    std::cout << "    sample txs measured     : " << sample.size() << std::endl;
+    std::cout << "    mean serialized tx size : " << meanTxBytes << " bytes" << std::endl;
+    std::cout << "    per-tx CheckTransaction : " << perTxMs << " ms" << std::endl;
+    std::cout << "    txs in a full 4 MB block: " << txPerBlock << std::endl;
+    std::cout << "    worst-case block verify : " << blockVerifyMs << " ms ("
+              << blockVerifySec << " s)" << std::endl;
+    std::cout << "    fraction of DIL  240 s  : "
+              << (blockVerifySec / dilTargetSec * 100.0) << " %" << std::endl;
+    std::cout << "    fraction of DilV  45 s  : "
+              << (blockVerifySec / dilvTargetSec * 100.0) << " %" << std::endl;
+
+    // Safety gate: a full block must verify in well under the block interval.
+    ASSERT(blockVerifySec < dilvTargetSec,
+           "CONCERN: worst-case 4 MB block verify time ("
+           + std::to_string(blockVerifySec)
+           + " s) exceeds the DilV 60 s target block time — escalate.");
+    if (blockVerifySec > dilvTargetSec * 0.10) {
+        std::cout << "    NOTE: block verify exceeds 10% of the DilV block time"
+                  << " — flag for review." << std::endl;
+    }
+
+    utxoSet.Close();
+    std::filesystem::remove_all(utxoPath, ec);
+}
+
+// =======================================================================
+int main() {
+    std::cout << YELLOW << "========================================" << RESET << std::endl;
+    std::cout << YELLOW << "BUG-003 Block-Size Limit Tests (F-06)"   << RESET << std::endl;
+    std::cout << YELLOW << "========================================" << RESET << std::endl;
+    std::cout << std::endl;
+
+    // CBlockValidator::CheckBlock -> CheckBlockHeader -> CheckProofOfWork uses
+    // RandomX; chainparams must be initialised before mining/wallet calls.
+    static Dilithion::ChainParams s_params = Dilithion::ChainParams::Mainnet();
+    Dilithion::g_chainParams = &s_params;
+    const char* rxKey = "Dilithion-RandomX-v1";
+    randomx_init_for_hashing(rxKey, strlen(rxKey), 1);  // light mode for tests
+
+    test_storage_writeblock_size_boundary_wrapper();
+    test_checkblock_size_constant_is_4mb_wrapper();
+    test_template_overshoot_regression_bug_b_wrapper();
+    test_worst_case_4mb_block_verify_time_wrapper();
+
+    std::cout << std::endl;
+    std::cout << YELLOW << "========================================" << RESET << std::endl;
+    std::cout << GREEN  << "Passed: " << g_tests_passed << RESET << std::endl;
+    std::cout << RED    << "Failed: " << g_tests_failed << RESET << std::endl;
+    std::cout << YELLOW << "Total:  " << (g_tests_passed + g_tests_failed) << RESET << std::endl;
+    std::cout << std::endl;
+
+    if (g_tests_failed == 0) {
+        std::cout << GREEN << "ALL TESTS PASSED" << RESET << std::endl;
+        return 0;
+    }
+    std::cout << RED << "SOME TESTS FAILED" << RESET << std::endl;
+    return 1;
+}

--- a/src/test/fuzz/fuzz_block.cpp
+++ b/src/test/fuzz/fuzz_block.cpp
@@ -4,6 +4,7 @@
 #include "fuzz.h"
 #include "util.h"
 #include "../../primitives/block.h"
+#include <consensus/params.h>
 #include <vector>
 #include <cstring>
 
@@ -129,7 +130,7 @@ FUZZ_TARGET(block_deserialize)
 
         // Check transactions
         size_t tx_count = block.vtx.size();
-        if (tx_count > MAX_BLOCK_SIZE / 100) {
+        if (tx_count > Consensus::MAX_BLOCK_SIZE / 100) {
             // Too many transactions
             return;
         }
@@ -154,7 +155,7 @@ FUZZ_TARGET(block_deserialize)
         ss_out << block;
 
         // Check size is reasonable
-        if (ss_out.size() > MAX_BLOCK_SIZE) {
+        if (ss_out.size() > Consensus::MAX_BLOCK_SIZE) {
             return;
         }
 
@@ -238,7 +239,7 @@ FUZZ_TARGET(block_validation)
 
         // 1. Check block size
         size_t block_size = ::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION);
-        if (block_size > MAX_BLOCK_SIZE) {
+        if (block_size > Consensus::MAX_BLOCK_SIZE) {
             // Block too large
             return;
         }


### PR DESCRIPTION
## BUG-003 — Block-size limit reconciliation + coinbase reserve fix

**Reporter:** Роман (Telegram) — block 68864 rejected with `Block exceeds maximum size (4 MB)` / `[VDF] ERROR: Failed to save block`, both DIL and DilV affected.
**Bug tracker:** `BUG-003` (local `.claude/bug_tracker.md`).
**Branch:** `fix/bug-003-block-size-limit` (this PR).

### What this fix does
Reconciles five disagreeing block-size limits onto one `Consensus::MAX_BLOCK_SIZE = 4 MB` constant and fixes the coinbase-reserve undercount that produced the rejection.

- **Bug A — limit inconsistency**: `validation.cpp`'s `CheckBlock` and `Consensus::MAX_BLOCK_SIZE` were 1 MB while chainparams, both mining template paths, and the storage layer used 4 MB. A red-team call-graph confirmed `CheckBlock` is **dead code** (zero production callers), so this is **not a hard fork** — the effective network limit was already 4 MB at the storage and P2P layers. The dead constant is corrected (not deleted) so it can never re-introduce a fork landmine if wired in later.
- **Bug B — coinbase reserve undercount** (the production symptom): the three mining-template builders seeded their byte budget with a flat 200-byte coinbase reserve, while the real coinbase carries up to ~5.3 KB of MIK scriptSig + outputs. A mempool-saturated template overshot the cap and was rejected at `blockchain_storage`. `controller.cpp` now finalises the coinbase fully (fees-0 probe) before tx selection and seeds from its real `GetSerializedSize()`; the two node files seed from `scriptSig.size() + Consensus::COINBASE_NON_SCRIPTSIG_OVERHEAD` (256 — worst case 155 + 9 < 256). All three apply a **16 KB `BLOCK_SIZE_SAFETY_MARGIN`**, and both node-file paths gained a post-assembly size guard mirroring `controller.cpp`'s.

### Stale comments corrected
`block_validation_queue.cpp:146`, `iblock_sink.h:41`, `pow.cpp:168`, `net.cpp:53` — all implied a non-existent `ConnectTip → CheckBlock` chain. Now describe the real enforcement (storage 4 MB + P2P `MAX_BLOCK_VTX_BYTES`).

### Tests (`src/test/bug_003_block_size_tests.cpp`)
- Boundary: 4 MB block accepted, 4 MB + 1 rejected (active storage path).
- `CheckBlock` constant now at 4 MB.
- **Bug-B regression — deterministic**: old 200-byte seed selects strictly more txs than the fixed seed (asserts on tx count, fixture-independent).
- **Worst-case 4 MB block verification time**: **~107 ms** — 0.044% of DIL block time, 0.24% of DilV.

### Review trail (mandatory two-layer for consensus-touching)
- **F-01 gate** — fresh-context `red-team-validator` call-graph confirmation that `CheckBlock` has zero production callers → not a hard fork.
- **Pre-impl Cursor review** — proceed-with-revisions, folded into the contract.
- **Close-readiness `red-team-validator`** (fresh context, consensus lens) — CLOSE-WITH-FIXES → M-1, M-2, L-1, L-3, N-1 all applied.
- **Close-readiness Cursor** — **CLOSE-CLEAN** (all 7 questions PASS bar one non-blocking CONCERN, see Follow-up below).
- `/evaluate` — PASS across all 7 categories (verdict pinned at HEAD).

### Build
Clean MSYS2 build of `dilithion-node` + `dilv-node`: PASS. Pre-existing `-Wunused-parameter` warnings only.

### Follow-up (deferred, value-correct today)
`net/net.cpp:MAX_BLOCK_VTX_BYTES` and `core/chainparams.cpp:maxBlockSize` remain parallel 4 MB literals. Same value today; drift risk if `Consensus::MAX_BLOCK_SIZE` is ever raised. Flagged by Cursor as non-blocking — to be reconciled in a follow-up PR.

### Deploy note
Header changed (`consensus/params.h`) — seed deploys must `make clean` before rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
