### PR TITLE
fix(consensus): BUG-003 follow-up — unify last two block-size literals onto Consensus::MAX_BLOCK_SIZE

### DIFF
--- a/src/core/chainparams.cpp
+++ b/src/core/chainparams.cpp
@@ -2,6 +2,7 @@
 #include "../attestation/seed_pubkeys_testnet.h"
 #include "../attestation/seed_pubkeys_mainnet.h"
 #include <util/system.h>
+#include <consensus/params.h>  // BUG-003 follow-up: maxBlockSize references Consensus::MAX_BLOCK_SIZE
 
 namespace Dilithion {
 
@@ -44,7 +45,7 @@ ChainParams ChainParams::Mainnet() {
     params.difficultyForkHeight = 18500;   // Activate v2 difficulty at this height (moved from 20160 to fix sign bit + EDA interaction)
     params.difficultyMaxChange = 2;        // 2x max change per retarget (post-fork, pre-v3)
     params.difficultyV3ForkHeight = 20520; // v3: 4x clamp + 1-hour EDA threshold (15 blocks)
-    params.maxBlockSize = 4 * 1024 * 1024; // 4 MB (for post-quantum signatures) — BUG-003: must equal Consensus::MAX_BLOCK_SIZE (consensus/params.h)
+    params.maxBlockSize = static_cast<uint32_t>(Consensus::MAX_BLOCK_SIZE); // 4 MB (for post-quantum signatures); BUG-003 follow-up: single source of truth
 
     // Mining parameters
     params.initialReward = 50ULL * 100000000ULL; // 50 DIL (in ions: 1 DIL = 100,000,000 ions)
@@ -267,7 +268,7 @@ ChainParams ChainParams::Testnet() {
     params.difficultyForkHeight = 0;       // Active from genesis on testnet
     params.difficultyMaxChange = 2;        // 2x max change per retarget (pre-v3)
     params.difficultyV3ForkHeight = 0;     // v3 active from genesis on testnet
-    params.maxBlockSize = 4 * 1024 * 1024; // 4 MB (same as mainnet) — BUG-003: must equal Consensus::MAX_BLOCK_SIZE (consensus/params.h)
+    params.maxBlockSize = static_cast<uint32_t>(Consensus::MAX_BLOCK_SIZE); // 4 MB (same as mainnet); BUG-003 follow-up: single source of truth
 
     // Mining parameters (same as mainnet)
     params.initialReward = 50ULL * 100000000ULL; // 50 DIL (same as mainnet)
@@ -440,7 +441,7 @@ ChainParams ChainParams::DilV() {
     params.difficultyForkHeight = 999999999;   // Disabled
     params.difficultyMaxChange = 0;            // Unused
     params.difficultyV3ForkHeight = 999999999; // Disabled
-    params.maxBlockSize = 4 * 1024 * 1024;     // 4 MB (same as DIL — room for Dilithium signatures) — BUG-003: must equal Consensus::MAX_BLOCK_SIZE (consensus/params.h)
+    params.maxBlockSize = static_cast<uint32_t>(Consensus::MAX_BLOCK_SIZE);     // 4 MB (same as DIL — room for Dilithium signatures); BUG-003 follow-up: single source of truth
 
     // Mining parameters
     params.initialReward = 100ULL * 100000000ULL; // 100 DilV per block (in volts: 1 DilV = 100,000,000 volts)

--- a/src/net/net.cpp
+++ b/src/net/net.cpp
@@ -50,8 +50,9 @@
 // NET-003 FIX: Define consensus limits to prevent integer overflow in vector resize
 // These prevent DoS attacks via malicious size values causing heap corruption
 // Note: vtx is a byte vector (serialized tx data), so this limits BYTES not tx count.
-// Must equal consensus Consensus::MAX_BLOCK_SIZE (4 MB) to accept all valid blocks.
-static const uint64_t MAX_BLOCK_VTX_BYTES = 4 * 1024 * 1024;  // 4 MB (matches Consensus::MAX_BLOCK_SIZE / storage layer)
+// BUG-003 follow-up: references Consensus::MAX_BLOCK_SIZE directly so the P2P
+// receive cap can never drift from the consensus block-size limit.
+static const uint64_t MAX_BLOCK_VTX_BYTES = static_cast<uint64_t>(Consensus::MAX_BLOCK_SIZE);
 static const uint64_t MAX_TX_INPUTS = 10000;            // Max inputs per transaction
 static const uint64_t MAX_TX_OUTPUTS = 10000;           // Max outputs per transaction
 static const uint64_t MAX_SCRIPT_SIZE = 20000;          // Max script size (raised for Dilithium sigs)


### PR DESCRIPTION
## BUG-003 follow-up — unify last two block-size literals onto `Consensus::MAX_BLOCK_SIZE`

Closes the only non-blocking CONCERN from the [#75](https://github.com/dilithion/dilithion/pull/75) close-readiness Cursor review.

### Change
`net/net.cpp:MAX_BLOCK_VTX_BYTES` and the three `core/chainparams.cpp:maxBlockSize` sites were left as parallel `4 * 1024 * 1024` literals after BUG-003 — value-correct today, but a drift landmine if `Consensus::MAX_BLOCK_SIZE` is ever raised. All four now reference `Consensus::MAX_BLOCK_SIZE` directly.

| File | Site(s) | Change |
|---|---|---|
| `src/net/net.cpp` | `MAX_BLOCK_VTX_BYTES` (line 54) — P2P-receive cap | literal → `static_cast<uint64_t>(Consensus::MAX_BLOCK_SIZE)` |
| `src/core/chainparams.cpp` | `Mainnet()`, `Testnet()`, `DilV()` — `params.maxBlockSize` | literal → `static_cast<uint32_t>(Consensus::MAX_BLOCK_SIZE)` + new `#include <consensus/params.h>` |

### Why
`Consensus::MAX_BLOCK_SIZE` is now the strict single source of truth for every block-`vtx` byte-size enforcement site in the codebase. Contract A-03 ("exactly one constant") now holds everywhere, not just the originally listed files.

### Why this is safe / low risk
- **No behaviour change.** Both literals were already 4 MB.
- **No header layout change.** Only `chainparams.cpp` (a `.cpp`) gained an include.
- The P2P-receive cap (net.cpp, `uint64_t`) and chainparams field (`uint32_t`) keep their own widths — the casts are no-ops on 64-bit and defensive on 32-bit.

### Build + tests
- Clean MSYS2 build of `dilithion-node` + `dilv-node`: PASS (pre-existing warnings only).
- `bug_003_block_size_tests`: **4/4 PASS**, worst-case 4 MB block verify still ~108 ms.

### Review
- `/evaluate`: PASS across all 7 categories (verdict pinned at HEAD `2cae759a`).
- No separate red-team — this is a sub-PR-class mechanical change to an already-reviewed moderate contract (BUG-003). The original two-layer review covered the constant-unification logic; this PR extends it to the two remaining sites the original brief explicitly scoped out.

Follow-up to PR #75.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
