### PR TITLE
chore(packaging): DilV/DIL package symmetry + rename testnet guide for v4.4.1

### DIFF
--- a/START-DILV-MINER-GUI.bat
+++ b/START-DILV-MINER-GUI.bat
@@ -1,0 +1,89 @@
+@echo off
+REM =======================================================
+REM  DILV MINER GUI - ONE-CLICK LAUNCH
+REM =======================================================
+REM  Starts the dilv-node with VDF mining enabled and opens
+REM  the miner dashboard in your default web browser.
+REM =======================================================
+
+cls
+color 0A
+echo.
+echo  ================================================
+echo    DILV MINER GUI
+echo  ================================================
+echo.
+echo  Starting DilV node with VDF mining enabled...
+echo  The miner dashboard will open in your browser.
+echo.
+
+REM Check if dilv-node.exe exists
+if not exist "dilv-node.exe" (
+    echo  ERROR: dilv-node.exe not found!
+    echo  Make sure you extracted the complete release package.
+    echo.
+    pause
+    exit /b 1
+)
+
+REM Check if node is already running by trying RPC (DilV uses X-Dilithion-RPC header)
+curl -s --user rpc:rpc -H "X-Dilithion-RPC: 1" -H "content-type:application/json" --data-binary "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"getblockchaininfo\",\"params\":[]}" http://127.0.0.1:9332/ >nul 2>&1
+if %errorlevel% equ 0 (
+    echo  Node is already running! Opening miner dashboard...
+    start http://127.0.0.1:9332/miner
+    echo.
+    echo  Dashboard opened in your browser.
+    echo  URL: http://127.0.0.1:9332/miner
+    echo.
+    pause
+    exit /b 0
+)
+
+REM Start node in background
+echo  Starting dilv-node...
+start /B dilv-node.exe --mine > nul 2>&1
+
+REM Wait for RPC to become available (up to 60 seconds)
+echo  Waiting for node to initialize...
+set /a count=0
+:waitloop
+timeout /t 2 /nobreak > nul
+curl -s --user rpc:rpc -H "X-Dilithion-RPC: 1" -H "content-type:application/json" --data-binary "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"getblockchaininfo\",\"params\":[]}" http://127.0.0.1:9332/ >nul 2>&1
+if %errorlevel% equ 0 goto :ready
+set /a count+=1
+if %count% geq 30 (
+    echo.
+    echo  WARNING: Node did not respond within 60 seconds.
+    echo  The dashboard may not work until the node finishes starting.
+    echo  Opening browser anyway...
+    goto :ready
+)
+echo  Still waiting... (%count%/30)
+goto :waitloop
+
+:ready
+echo.
+echo  ================================================
+echo    Node is running! Opening miner dashboard...
+echo  ================================================
+echo.
+echo  URL: http://127.0.0.1:9332/miner
+echo.
+echo  Keep this window open while mining.
+echo  Press Ctrl+C to stop the node, or use the
+echo  "Shutdown Node" button in the dashboard.
+echo.
+
+REM Open browser
+start http://127.0.0.1:9332/miner
+
+REM Keep window open (node runs in background)
+echo  Press any key to stop the node and exit...
+pause > nul
+
+REM Stop node gracefully
+echo.
+echo  Shutting down node...
+curl -s --user rpc:rpc -H "X-Dilithion-RPC: 1" -H "content-type:application/json" --data-binary "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"stop\",\"params\":[]}" http://127.0.0.1:9332/ >nul 2>&1
+timeout /t 3 /nobreak > nul
+echo  Done.

--- a/dilv-wallet.bat
+++ b/dilv-wallet.bat
@@ -1,0 +1,501 @@
+@echo off
+REM DilV CLI Wallet Wrapper (Windows) - SECURE VERSION
+REM Simple command-line interface for wallet operations via RPC
+REM Version: 1.0.1-secure
+REM
+REM SECURITY: All user inputs validated before use
+REM - Address format validation (DLT1 + alphanumeric, 44-94 chars)
+REM - Amount validation (positive, no negatives, format check)
+REM - Secure temp file handling with random names
+REM - Proper cleanup on exit
+REM
+
+setlocal enabledelayedexpansion
+
+REM Version
+set VERSION=1.0.1-secure
+
+REM ========================================
+REM SECURITY: Validate environment variables
+REM ========================================
+
+REM Validate TEMP directory
+if not defined TEMP (
+    echo ERROR: TEMP environment variable not set
+    echo Please set TEMP to a valid directory path
+    exit /b 1
+)
+
+REM Check if TEMP directory exists
+if not exist "%TEMP%\" (
+    echo ERROR: TEMP directory does not exist: %TEMP%
+    echo Please create the directory or update TEMP variable
+    exit /b 1
+)
+
+REM Validate RPC host (prevent SSRF attacks)
+if defined DILV_RPC_HOST (
+    echo %DILV_RPC_HOST% | findstr /R /C:"[^a-zA-Z0-9\.\-]" >nul
+    if not errorlevel 1 (
+        echo WARNING: DILV_RPC_HOST contains suspicious characters
+        echo Using default: localhost
+        set DILV_RPC_HOST=localhost
+    )
+)
+
+REM Configuration
+if "%DILV_RPC_HOST%"=="" set DILV_RPC_HOST=localhost
+if "%DILV_RPC_PORT%"=="" set DILV_RPC_PORT=9332
+set RPC_URL=http://!DILV_RPC_HOST!:!DILV_RPC_PORT!
+
+REM Timeout settings (seconds)
+set CURL_TIMEOUT=30
+
+REM Check if curl is available - try multiple locations
+set "CURL_CMD="
+
+REM Try 1: Standard PATH (works if curl is in PATH)
+where curl >nul 2>nul
+if %errorlevel% equ 0 (
+    set "CURL_CMD=curl"
+    goto curl_found
+)
+
+REM Try 2: Windows System32 (Windows 10/11 native curl)
+if exist "C:\Windows\System32\curl.exe" (
+    set "CURL_CMD=C:\Windows\System32\curl.exe"
+    goto curl_found
+)
+
+REM Try 3: Git for Windows (common developer install)
+if exist "C:\Program Files\Git\mingw64\bin\curl.exe" (
+    set "CURL_CMD=C:\Program Files\Git\mingw64\bin\curl.exe"
+    goto curl_found
+)
+
+REM Try 4: Git for Windows (32-bit)
+if exist "C:\Program Files (x86)\Git\mingw64\bin\curl.exe" (
+    set "CURL_CMD=C:\Program Files (x86)\Git\mingw64\bin\curl.exe"
+    goto curl_found
+)
+
+REM Try 5: MSYS2/MinGW (if user has development environment)
+if exist "C:\msys64\usr\bin\curl.exe" (
+    set "CURL_CMD=C:\msys64\usr\bin\curl.exe"
+    goto curl_found
+)
+
+REM curl not found anywhere
+echo ============================================================
+echo ERROR: curl is required but not found
+echo ============================================================
+echo.
+echo DilV wallet requires curl to communicate with the node.
+echo.
+echo SOLUTION for Windows 10 version 1803+ / Windows 11:
+echo   curl should be pre-installed at C:\Windows\System32\curl.exe
+echo   If missing, try Windows Update to upgrade to latest version
+echo.
+echo SOLUTION for Windows 10 pre-1803 (older versions):
+echo   1. Download curl from: https://curl.se/windows/
+echo   2. Extract curl.exe to C:\Windows\System32\
+echo   OR
+echo   3. Install Git for Windows: https://git-scm.com/
+echo      (includes curl at C:\Program Files\Git\mingw64\bin\curl.exe)
+echo.
+echo ALTERNATIVE: Check your Windows version:
+echo   Run: winver
+echo   If older than Windows 10 1803, consider updating Windows
+echo.
+echo For support, join our Discord: https://discord.gg/dilv
+echo ============================================================
+echo.
+echo Press any key to exit...
+pause >nul
+exit /b 1
+
+:curl_found
+echo [OK] Found curl at: %CURL_CMD%
+echo.
+
+REM Get command
+set COMMAND=%1
+
+if "%COMMAND%"=="" (
+    call :show_help
+    echo.
+    echo Press any key to exit...
+    pause >nul
+    exit /b 1
+)
+
+REM Dispatch command
+if /i "%COMMAND%"=="balance" goto cmd_balance
+if /i "%COMMAND%"=="newaddress" goto cmd_newaddress
+if /i "%COMMAND%"=="addresses" goto cmd_addresses
+if /i "%COMMAND%"=="listunspent" goto cmd_listunspent
+if /i "%COMMAND%"=="send" goto cmd_send
+if /i "%COMMAND%"=="version" goto cmd_version
+if /i "%COMMAND%"=="help" goto show_help
+if /i "%COMMAND%"=="--help" goto show_help
+if /i "%COMMAND%"=="-h" goto show_help
+
+echo Error: Unknown command '%COMMAND%'
+echo.
+call :show_help
+echo.
+echo Press any key to exit...
+pause >nul
+exit /b 1
+
+REM ===== VALIDATION FUNCTIONS =====
+
+:validate_address
+set "ADDR=%~1"
+
+REM Check minimum length
+if "%ADDR:~44,1%"=="" (
+    echo Error: Address too short (must be 44-94 characters^)
+    echo Provided address length: %ADDR% characters
+    exit /b 1
+)
+
+REM Check maximum length (approximate)
+if not "%ADDR:~94,1%"=="" (
+    echo Error: Address too long (must be 44-94 characters^)
+    exit /b 1
+)
+
+REM Check prefix
+if not "%ADDR:~0,4%"=="DLT1" (
+    echo Error: Invalid address format
+    echo Address must start with 'DLT1'
+    exit /b 1
+)
+
+REM Check for invalid characters (spaces, special chars)
+echo %ADDR% | findstr /R /C:" " >nul
+if not errorlevel 1 (
+    echo Error: Address contains spaces
+    exit /b 1
+)
+
+echo %ADDR% | findstr /R /C:"[^a-zA-Z0-9]" >nul
+if not errorlevel 1 (
+    REM Check if it's only the DLT1 prefix causing the match
+    set "TEST_ADDR=%ADDR:~4%"
+    echo !TEST_ADDR! | findstr /R /C:"[^a-zA-Z0-9]" >nul
+    if not errorlevel 1 (
+        echo Error: Address contains invalid characters
+        echo Address must be alphanumeric only
+        exit /b 1
+    )
+)
+
+echo [OK] Address validation: PASSED
+exit /b 0
+
+:validate_amount
+set "AMT=%~1"
+
+REM Check for negative (contains minus sign)
+echo %AMT% | findstr "-" >nul
+if not errorlevel 1 (
+    echo Error: Amount cannot be negative
+    exit /b 1
+)
+
+REM Check for spaces
+echo %AMT% | findstr " " >nul
+if not errorlevel 1 (
+    echo Error: Amount contains spaces
+    exit /b 1
+)
+
+REM Check format: only digits and optional single decimal point
+echo %AMT% | findstr /R /C:"^[0-9][0-9]*$" >nul
+if not errorlevel 1 goto amount_format_ok
+
+echo %AMT% | findstr /R /C:"^[0-9][0-9]*\.[0-9][0-9]*$" >nul
+if not errorlevel 1 goto amount_format_ok
+
+echo Error: Amount must be a positive number
+echo Examples: 10, 10.5, 10.12345678
+exit /b 1
+
+:amount_format_ok
+
+REM Check for zero
+if "%AMT%"=="0" (
+    echo Error: Amount must be greater than zero
+    exit /b 1
+)
+
+if "%AMT%"=="0.0" (
+    echo Error: Amount must be greater than zero
+    exit /b 1
+)
+
+if "%AMT%"=="0.00" (
+    echo Error: Amount must be greater than zero
+    exit /b 1
+)
+
+REM Check decimal places (max 8)
+for /f "tokens=2 delims=." %%a in ("%AMT%") do (
+    set "DECIMALS=%%a"
+    if not "!DECIMALS!"=="" (
+        if not "!DECIMALS:~8,1!"=="" (
+            echo Error: Amount has too many decimal places (max 8^)
+            exit /b 1
+        )
+    )
+)
+
+echo [OK] Amount validation: PASSED
+exit /b 0
+
+REM ===== COMMAND IMPLEMENTATIONS =====
+
+:cmd_balance
+echo Fetching wallet balance...
+echo.
+
+REM Generate random temp file
+set "TEMP_FILE=%TEMP%\dilv-%RANDOM%%RANDOM%%TIME:~-5,5%.json"
+
+set "JSON={\"jsonrpc\":\"2.0\",\"method\":\"getbalance\",\"params\":{},\"id\":1}"
+"%CURL_CMD%" --max-time %CURL_TIMEOUT% -s -X POST "%RPC_URL%" -H "Content-Type: application/json" -H "X-Dilithion-RPC: 1" -d "%JSON%" > "!TEMP_FILE!"
+
+REM Check if file was created (connection successful)
+if not exist "!TEMP_FILE!" (
+    echo Error: Could not connect to DilV node at %RPC_URL%
+    echo Make sure the node is running with RPC enabled.
+    exit /b 2
+)
+
+REM Check for errors in response
+findstr /C:"\"error\"" "!TEMP_FILE!" | findstr /V /C:"null" >nul
+if not errorlevel 1 (
+    echo Error: RPC returned an error
+    type "!TEMP_FILE!"
+    del "!TEMP_FILE!"
+    exit /b 5
+)
+
+echo Response from node:
+type "!TEMP_FILE!"
+echo.
+echo.
+echo Note: For formatted output, install jq from https://stedolan.github.io/jq/
+
+REM Cleanup
+del "!TEMP_FILE!"
+endlocal
+goto :eof
+
+:cmd_newaddress
+echo Generating new address...
+echo.
+
+set "TEMP_FILE=%TEMP%\dilv-%RANDOM%%RANDOM%%TIME:~-5,5%.json"
+
+set "JSON={\"jsonrpc\":\"2.0\",\"method\":\"getnewaddress\",\"params\":{},\"id\":1}"
+"%CURL_CMD%" --max-time %CURL_TIMEOUT% -s -X POST "%RPC_URL%" -H "Content-Type: application/json" -H "X-Dilithion-RPC: 1" -d "%JSON%" > "!TEMP_FILE!"
+
+if not exist "!TEMP_FILE!" (
+    echo Error: Could not connect to DilV node at %RPC_URL%
+    exit /b 2
+)
+
+echo New Address:
+type "!TEMP_FILE!"
+echo.
+echo.
+echo You can receive DilV at this address.
+
+REM Cleanup
+del "!TEMP_FILE!"
+endlocal
+goto :eof
+
+:cmd_addresses
+echo Listing wallet addresses...
+echo.
+
+set "TEMP_FILE=%TEMP%\dilv-%RANDOM%%RANDOM%%TIME:~-5,5%.json"
+
+set "JSON={\"jsonrpc\":\"2.0\",\"method\":\"getaddresses\",\"params\":{},\"id\":1}"
+"%CURL_CMD%" --max-time %CURL_TIMEOUT% -s -X POST "%RPC_URL%" -H "Content-Type: application/json" -H "X-Dilithion-RPC: 1" -d "%JSON%" > "!TEMP_FILE!"
+
+if not exist "!TEMP_FILE!" (
+    echo Error: Could not connect to DilV node at %RPC_URL%
+    exit /b 2
+)
+
+echo Addresses:
+type "!TEMP_FILE!"
+echo.
+
+REM Cleanup
+del "!TEMP_FILE!"
+endlocal
+goto :eof
+
+:cmd_listunspent
+echo Listing unspent outputs...
+echo.
+
+set "TEMP_FILE=%TEMP%\dilv-%RANDOM%%RANDOM%%TIME:~-5,5%.json"
+
+set "JSON={\"jsonrpc\":\"2.0\",\"method\":\"listunspent\",\"params\":{},\"id\":1}"
+"%CURL_CMD%" --max-time %CURL_TIMEOUT% -s -X POST "%RPC_URL%" -H "Content-Type: application/json" -H "X-Dilithion-RPC: 1" -d "%JSON%" > "!TEMP_FILE!"
+
+if not exist "!TEMP_FILE!" (
+    echo Error: Could not connect to DilV node at %RPC_URL%
+    exit /b 2
+)
+
+echo Unspent Outputs:
+type "!TEMP_FILE!"
+echo.
+
+REM Cleanup
+del "!TEMP_FILE!"
+endlocal
+goto :eof
+
+:cmd_send
+if "%2"=="" (
+    echo Error: Missing arguments
+    echo Usage: dilv-wallet.bat send ^<address^> ^<amount^>
+    echo Example: dilv-wallet.bat send DLT1abc123... 10.5
+    exit /b 3
+)
+
+if "%3"=="" (
+    echo Error: Missing amount
+    echo Usage: dilv-wallet.bat send ^<address^> ^<amount^>
+    echo Example: dilv-wallet.bat send DLT1abc123... 10.5
+    exit /b 4
+)
+
+set ADDRESS=%2
+set AMOUNT=%3
+
+echo Validating transaction parameters...
+echo.
+
+REM Validate address (SECURITY: prevents sending to invalid addresses)
+call :validate_address "%ADDRESS%"
+if errorlevel 1 exit /b 3
+
+REM Validate amount (SECURITY: prevents invalid transactions)
+call :validate_amount "%AMOUNT%"
+if errorlevel 1 exit /b 4
+
+echo.
+echo ========================================================
+echo                  CONFIRM TRANSACTION
+echo ========================================================
+echo To:      %ADDRESS%
+echo Amount:  %AMOUNT% DilV
+echo ========================================================
+echo.
+echo WARNING: This action is PERMANENT and CANNOT be undone!
+echo WARNING: Verify the address is EXACTLY correct!
+echo.
+
+set /p CONFIRM="Type 'yes' to confirm, anything else to cancel: "
+
+REM Case-insensitive comparison
+if /i not "%CONFIRM%"=="yes" (
+    echo Transaction cancelled.
+    exit /b 0
+)
+
+echo.
+echo Sending transaction...
+
+REM Generate random temp files
+set "JSON_FILE=%TEMP%\dilv-req-%RANDOM%%RANDOM%%TIME:~-5,5%.json"
+set "TEMP_FILE=%TEMP%\dilv-res-%RANDOM%%RANDOM%%TIME:~-5,5%.json"
+
+REM Write JSON to temp file (SECURITY: prevents command injection)
+(
+    echo {"jsonrpc":"2.0","method":"sendtoaddress","params":{"address":"%ADDRESS%","amount":%AMOUNT%},"id":1}
+) > "!JSON_FILE!"
+
+"%CURL_CMD%" --max-time %CURL_TIMEOUT% -s -X POST "%RPC_URL%" -H "Content-Type: application/json" -H "X-Dilithion-RPC: 1" -d @"!JSON_FILE!" > "!TEMP_FILE!"
+
+if not exist "!TEMP_FILE!" (
+    echo Error: Could not connect to DilV node at %RPC_URL%
+    REM Cleanup
+    if exist "!JSON_FILE!" del "!JSON_FILE!"
+    exit /b 2
+)
+
+REM Check for errors
+findstr /C:"\"error\"" "!TEMP_FILE!" | findstr /V /C:"null" >nul
+if not errorlevel 1 (
+    echo Error: RPC returned an error
+    type "!TEMP_FILE!"
+    REM Cleanup
+    del "!JSON_FILE!"
+    del "!TEMP_FILE!"
+    exit /b 5
+)
+
+echo.
+echo [OK] Transaction sent successfully!
+echo.
+echo Transaction Response:
+type "!TEMP_FILE!"
+echo.
+echo Note: Transaction requires network confirmation
+
+REM Cleanup
+del "!JSON_FILE!"
+del "!TEMP_FILE!"
+endlocal
+goto :eof
+
+:cmd_version
+echo DilV CLI Wallet v%VERSION%
+echo Security: Production-grade with input validation
+endlocal
+goto :eof
+
+:show_help
+echo DilV CLI Wallet v%VERSION% (Windows)
+echo.
+echo Usage:
+echo   dilv-wallet.bat balance                  - Show wallet balance
+echo   dilv-wallet.bat newaddress               - Generate new receiving address
+echo   dilv-wallet.bat addresses                - List all wallet addresses
+echo   dilv-wallet.bat listunspent              - List unspent transaction outputs
+echo   dilv-wallet.bat send ^<address^> ^<amount^>  - Send DilV to address
+echo   dilv-wallet.bat help                     - Show this help message
+echo   dilv-wallet.bat version                  - Show version
+echo.
+echo Environment Variables:
+echo   DILV_RPC_HOST  - RPC host (default: localhost)
+echo   DILV_RPC_PORT  - RPC port (default: 9332 for DilV mainnet)
+echo.
+echo Examples:
+echo   # Check balance
+echo   dilv-wallet.bat balance
+echo.
+echo   # Generate new address
+echo   dilv-wallet.bat newaddress
+echo.
+echo   # Send 10.5 DilV
+echo   dilv-wallet.bat send DLT1abc123... 10.5
+echo.
+echo SECURITY: Always verify addresses before sending!
+echo See CLI-WALLET-GUIDE.md for important safety information
+echo.
+echo Note: For pretty-printed JSON output, install jq from https://stedolan.github.io/jq/
+echo.
+endlocal
+goto :eof

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -1,12 +1,17 @@
-# Dilithion Testnet Setup Guide
+# Dilithion — Getting Started
 
-**Version**: 1.0
-**Date**: October 26, 2025
-**Status**: Phase 3 - Multi-Node Testing
+**Applies to:** DIL mainnet and DilV mainnet (also covers DIL testnet — `--testnet`).
+**Renamed from `TESTNET-GUIDE.md` in v4.4.1.** Procedures below apply to both
+chains; where commands differ by chain, both forms are shown. The portions of
+this guide that still read as testnet-specific are scheduled for refresh in a
+follow-up docs PR — file an issue if a section is unclear in the meantime.
 
 ## Overview
 
-This guide walks you through setting up multiple Dilithion testnet nodes for local testing. The testnet uses easier difficulty (256x) and separate network infrastructure from mainnet.
+This guide walks you through setting up Dilithion nodes — DIL (RandomX PoW) and
+DilV (VDF) — on mainnet or testnet. The Dilithion testnet uses easier difficulty
+(256x) and separate network infrastructure from mainnet; the mainnet sections
+apply by default unless `--testnet` is shown.
 
 ## Current Implementation Status
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,7 @@ codebase. Marketing-facing content lives on [dilithion.org](https://dilithion.or
 | Read the whitepaper | [WHITEPAPER.md](WHITEPAPER.md) · [../Dilithion-Whitepaper-v1.0.pdf](../Dilithion-Whitepaper-v1.0.pdf) |
 | See the threat model | [THREAT-MODEL.md](THREAT-MODEL.md) |
 | Start mining | [mining/MINING_GUIDE_LINUX.md](mining/MINING_GUIDE_LINUX.md) · [mining/MINING_GUIDE_MACOS.md](mining/MINING_GUIDE_MACOS.md) · [mining/MINING_GUIDE_WINDOWS.md](mining/MINING_GUIDE_WINDOWS.md) · [mining/MINING_GUIDE_DILV.md](mining/MINING_GUIDE_DILV.md) |
-| Run a testnet node | [TESTNET-GUIDE.md](TESTNET-GUIDE.md) |
+| Set up and run a node | [GETTING-STARTED.md](GETTING-STARTED.md) |
 | Use the wallet | [HD_WALLET_USER_GUIDE.md](HD_WALLET_USER_GUIDE.md) · [USER-GUIDE.md](USER-GUIDE.md) |
 | Report a vulnerability | [../SECURITY.md](../SECURITY.md) |
 
@@ -71,7 +71,7 @@ codebase. Marketing-facing content lives on [dilithion.org](https://dilithion.or
 
 **Operations**
 - [SETUP.md](SETUP.md) — node setup
-- [TESTNET-GUIDE.md](TESTNET-GUIDE.md) — testnet node
+- [GETTING-STARTED.md](GETTING-STARTED.md) — set up and run a node (DIL or DilV)
 - [MAINTENANCE.md](MAINTENANCE.md) — ongoing maintenance
 - [MANUAL-PEER-SETUP.md](MANUAL-PEER-SETUP.md) — manual peering
 - [TROUBLESHOOTING-WINDOWS.md](TROUBLESHOOTING-WINDOWS.md) — Windows-specific issues

--- a/package-dilv-linux-release.sh
+++ b/package-dilv-linux-release.sh
@@ -59,10 +59,14 @@ chmod +x "${RELEASE_DIR}/run-node.sh"
 # Copy launcher scripts and documentation
 echo "[4/5] Copying launcher scripts and documentation..."
 cp start-dilv-mining.sh "${RELEASE_DIR}/" || { echo "ERROR: start-dilv-mining.sh not found."; exit 1; }
+cp start-dilv-miner-gui.sh "${RELEASE_DIR}/" || { echo "ERROR: start-dilv-miner-gui.sh not found."; exit 1; }
 cp setup-dilv.sh "${RELEASE_DIR}/" || { echo "ERROR: setup-dilv.sh not found."; exit 1; }
 chmod +x "${RELEASE_DIR}/start-dilv-mining.sh"
+chmod +x "${RELEASE_DIR}/start-dilv-miner-gui.sh"
 chmod +x "${RELEASE_DIR}/setup-dilv.sh"
 cp README-DILV-LINUX.txt "${RELEASE_DIR}/README.txt" || { echo "ERROR: README-DILV-LINUX.txt not found."; exit 1; }
+cp docs/GETTING-STARTED.md "${RELEASE_DIR}/GETTING-STARTED.md" || { echo "ERROR: docs/GETTING-STARTED.md not found."; exit 1; }
+cp website/wallet.html "${RELEASE_DIR}/wallet.html" || { echo "ERROR: website/wallet.html not found."; exit 1; }
 
 # Create archive
 echo "[5/5] Creating tar.gz archive..."

--- a/package-dilv-macos-release.sh
+++ b/package-dilv-macos-release.sh
@@ -49,10 +49,14 @@ bash "$(dirname "$0")/scripts/bundle-macos-dylibs.sh" "${RELEASE_DIR}" \
 # Copy launcher scripts and documentation
 echo "[3/4] Copying launcher scripts and documentation..."
 cp start-dilv-mining.sh "${RELEASE_DIR}/" || { echo "ERROR: start-dilv-mining.sh not found."; exit 1; }
+cp start-dilv-miner-gui.sh "${RELEASE_DIR}/" || { echo "ERROR: start-dilv-miner-gui.sh not found."; exit 1; }
 cp setup-dilv.sh "${RELEASE_DIR}/" || { echo "ERROR: setup-dilv.sh not found."; exit 1; }
 chmod +x "${RELEASE_DIR}/start-dilv-mining.sh"
+chmod +x "${RELEASE_DIR}/start-dilv-miner-gui.sh"
 chmod +x "${RELEASE_DIR}/setup-dilv.sh"
 cp README-DILV-MAC.txt "${RELEASE_DIR}/README.txt" || { echo "ERROR: README-DILV-MAC.txt not found."; exit 1; }
+cp docs/GETTING-STARTED.md "${RELEASE_DIR}/GETTING-STARTED.md" || { echo "ERROR: docs/GETTING-STARTED.md not found."; exit 1; }
+cp website/wallet.html "${RELEASE_DIR}/wallet.html" || { echo "ERROR: website/wallet.html not found."; exit 1; }
 
 # Create archive
 echo "[4/4] Creating tar.gz archive..."

--- a/package-dilv-windows-release-github.sh
+++ b/package-dilv-windows-release-github.sh
@@ -44,10 +44,12 @@ echo "   [SUCCESS] All 8 DLLs copied successfully"
 
 # Copy launcher scripts and documentation
 echo "[4/5] Copying launcher scripts and documentation..."
-cp SETUP-DILV.bat         "${RELEASE_DIR}/" || { echo "ERROR: SETUP-DILV.bat not found."; exit 1; }
-cp START-DILV-MINING.bat  "${RELEASE_DIR}/" || { echo "ERROR: START-DILV-MINING.bat not found."; exit 1; }
-cp README-DILV-WINDOWS.txt "${RELEASE_DIR}/README.txt" || { echo "ERROR: README-DILV-WINDOWS.txt not found."; exit 1; }
-cp website/wallet.html    "${RELEASE_DIR}/" || { echo "ERROR: website/wallet.html not found."; exit 1; }
+cp SETUP-DILV.bat              "${RELEASE_DIR}/" || { echo "ERROR: SETUP-DILV.bat not found."; exit 1; }
+cp START-DILV-MINING.bat       "${RELEASE_DIR}/" || { echo "ERROR: START-DILV-MINING.bat not found."; exit 1; }
+cp START-DILV-MINER-GUI.bat    "${RELEASE_DIR}/" || { echo "ERROR: START-DILV-MINER-GUI.bat not found."; exit 1; }
+cp dilv-wallet.bat             "${RELEASE_DIR}/" || { echo "ERROR: dilv-wallet.bat not found."; exit 1; }
+cp README-DILV-WINDOWS.txt     "${RELEASE_DIR}/README.txt" || { echo "ERROR: README-DILV-WINDOWS.txt not found."; exit 1; }
+cp website/wallet.html         "${RELEASE_DIR}/" || { echo "ERROR: website/wallet.html not found."; exit 1; }
 echo "   All scripts and documentation copied successfully"
 
 # Create ZIP archive

--- a/package-linux-release.sh
+++ b/package-linux-release.sh
@@ -72,7 +72,7 @@ chmod +x "${RELEASE_DIR}/setup-and-start.sh"
 
 # Copy documentation and wallet
 cp README-LINUX.txt "${RELEASE_DIR}/README.txt"
-cp docs/TESTNET-GUIDE.md "${RELEASE_DIR}/TESTNET-GUIDE.md"
+cp docs/GETTING-STARTED.md "${RELEASE_DIR}/GETTING-STARTED.md"
 cp website/wallet.html "${RELEASE_DIR}/wallet.html"
 
 # Create wrapper script that sets LD_LIBRARY_PATH

--- a/package-macos-release.sh
+++ b/package-macos-release.sh
@@ -64,7 +64,7 @@ chmod +x "${RELEASE_DIR}/setup-and-start.sh"
 
 # Copy documentation and wallet
 cp README-MAC.txt "${RELEASE_DIR}/README.txt"
-cp docs/TESTNET-GUIDE.md "${RELEASE_DIR}/TESTNET-GUIDE.md"
+cp docs/GETTING-STARTED.md "${RELEASE_DIR}/GETTING-STARTED.md"
 cp website/wallet.html "${RELEASE_DIR}/wallet.html"
 
 # Create the tar.gz archive

--- a/scripts/check-repo-hygiene.sh
+++ b/scripts/check-repo-hygiene.sh
@@ -77,14 +77,17 @@ ALLOWED_ROOT_FILES=(
   README-WINDOWS.txt
   SETUP-AND-START.bat
   SETUP-DILV.bat
+  START-DILV-MINER-GUI.bat
   START-DILV-MINING.bat
   START-MINER-GUI.bat
   START-MINING.bat
   build-randomx.bat
   dilithion-wallet
   dilithion-wallet.bat
+  dilv-wallet.bat
   setup-and-start.sh
   setup-dilv.sh
+  start-dilv-miner-gui.sh
   start-dilv-mining.sh
   start-miner-gui.sh
   start-mining.sh

--- a/start-dilv-miner-gui.sh
+++ b/start-dilv-miner-gui.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+#########################################################
+#  DILV MINER GUI - ONE-CLICK LAUNCH
+#########################################################
+#  Starts the dilv-node with VDF mining enabled and opens
+#  the miner dashboard in your default web browser.
+#########################################################
+
+# Colors
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+echo -e "${GREEN}"
+echo "  ================================================"
+echo "    DILV MINER GUI"
+echo "  ================================================"
+echo -e "${NC}"
+
+# Check if dilv-node exists
+if [ ! -f "dilv-node" ]; then
+    echo -e "${YELLOW}ERROR: dilv-node binary not found!${NC}"
+    echo "Make sure you extracted the complete release package."
+    exit 1
+fi
+
+chmod +x dilv-node 2>/dev/null
+
+# Detect RPC port (DilV mainnet default)
+RPC_PORT=9332
+
+# Function to open browser cross-platform
+open_browser() {
+    local url=$1
+    if command -v xdg-open &> /dev/null; then
+        xdg-open "$url" &> /dev/null &
+    elif command -v open &> /dev/null; then
+        open "$url"
+    elif command -v sensible-browser &> /dev/null; then
+        sensible-browser "$url" &> /dev/null &
+    else
+        echo -e "${YELLOW}Could not detect browser. Please open manually:${NC}"
+        echo "  $url"
+    fi
+}
+
+# Check if node is already running (DilV uses the same X-Dilithion-RPC header)
+if curl -s --user rpc:rpc -H 'X-Dilithion-RPC: 1' -H 'content-type:application/json' \
+    --data-binary '{"jsonrpc":"2.0","id":1,"method":"getblockchaininfo","params":[]}' \
+    http://127.0.0.1:${RPC_PORT}/ > /dev/null 2>&1; then
+    echo -e "${BLUE}Node is already running! Opening miner dashboard...${NC}"
+    open_browser "http://127.0.0.1:${RPC_PORT}/miner"
+    echo ""
+    echo -e "${GREEN}Dashboard opened in your browser.${NC}"
+    echo "URL: http://127.0.0.1:${RPC_PORT}/miner"
+    exit 0
+fi
+
+# Start node in background
+echo -e "${BLUE}Starting dilv-node with VDF mining enabled...${NC}"
+./dilv-node --mine &
+NODE_PID=$!
+
+# Wait for RPC to become available
+echo -e "${BLUE}Waiting for node to initialize...${NC}"
+for i in $(seq 1 30); do
+    sleep 2
+    if curl -s --user rpc:rpc -H 'X-Dilithion-RPC: 1' -H 'content-type:application/json' \
+        --data-binary '{"jsonrpc":"2.0","id":1,"method":"getblockchaininfo","params":[]}' \
+        http://127.0.0.1:${RPC_PORT}/ > /dev/null 2>&1; then
+        break
+    fi
+    echo "  Still waiting... ($i/30)"
+done
+
+echo ""
+echo -e "${GREEN}================================================${NC}"
+echo -e "${GREEN}  Node is running! Opening miner dashboard...${NC}"
+echo -e "${GREEN}================================================${NC}"
+echo ""
+echo "URL: http://127.0.0.1:${RPC_PORT}/miner"
+echo ""
+
+# Open browser
+open_browser "http://127.0.0.1:${RPC_PORT}/miner"
+
+echo "Press Ctrl+C to stop the node, or use the"
+echo "\"Shutdown Node\" button in the dashboard."
+echo ""
+
+# Handle Ctrl+C gracefully
+cleanup() {
+    echo ""
+    echo -e "${YELLOW}Shutting down node...${NC}"
+    curl -s --user rpc:rpc -H 'X-Dilithion-RPC: 1' -H 'content-type:application/json' \
+        --data-binary '{"jsonrpc":"2.0","id":1,"method":"stop","params":[]}' \
+        http://127.0.0.1:${RPC_PORT}/ > /dev/null 2>&1
+    wait $NODE_PID 2>/dev/null
+    echo "Done."
+    exit 0
+}
+
+trap cleanup SIGINT SIGTERM
+
+# Wait for node process to exit
+wait $NODE_PID
+echo ""
+echo -e "${YELLOW}Node has stopped.${NC}"


### PR DESCRIPTION
Closes **Phase 1** of the v4.4.1 cleanup plan (`.claude/contracts/v4_4_1_release_cleanup_plan_2026-05-11.md`) — DilV release packages were sparser than DIL on Linux + macOS.

## Added (new files)
| File | Purpose |
|------|---------|
| `start-dilv-miner-gui.sh` | DilV variant of `start-miner-gui.sh` |
| `START-DILV-MINER-GUI.bat` | DilV variant of `START-MINER-GUI.bat` |
| `dilv-wallet.bat` | DilV variant of `dilithion-wallet.bat` — port `9332`, `%AMOUNT% DilV`, env vars `DILV_RPC_HOST`/`DILV_RPC_PORT`. The `X-Dilithion-RPC` header is **intentionally** preserved — DilV nodes use the same header. |

## Renamed
- `docs/TESTNET-GUIDE.md` → `docs/GETTING-STARTED.md` (`git mv` — preserves history)
- Light intro edit noting it covers both chains; **bulk content rewrite is a deferred follow-up docs PR**.
- `docs/README.md` cross-references updated.

## Packaging scripts

**DilV (added missing files):**
- `package-dilv-linux-release.sh` — adds `wallet.html`, `start-dilv-miner-gui.sh`, `GETTING-STARTED.md`
- `package-dilv-macos-release.sh` — same
- `package-dilv-windows-release-github.sh` — adds `dilv-wallet.bat`, `START-DILV-MINER-GUI.bat`

**DIL (path rename only):**
- `package-linux-release.sh` — `TESTNET-GUIDE.md` → `GETTING-STARTED.md`
- `package-macos-release.sh` — same

## Deferred (intentionally NOT in this PR)

- Heavy rewrite of `GETTING-STARTED.md` body (still reads testnet-specific in places) — follow-up docs PR.
- Updates to historical audit/snapshot docs (`docs/security/GITHUB-PACKAGES-FINAL-AUDIT-REPORT.md` etc.) that reference the old filename — those are point-in-time records, intentionally left.
- **Reproducible-build work** (Phase 3 of the cleanup plan — open-ended investigation, separate PR per the plan itself).

No node code, no consensus, no test changes. Build-system / packaging / docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)