### PR TITLE
security: close CVE-2026-RPC-CORS + CVE-2026-RPC-AUTH wallet drain (v4.4.2)

### DIFF
--- a/src/api/http_server.cpp
+++ b/src/api/http_server.cpp
@@ -34,8 +34,10 @@
 #endif
 
 // Constructor
-CHttpServer::CHttpServer(int port)
-    : m_port(port), m_num_threads(DEFAULT_HTTP_THREADS), m_work_queue(CHttpWorkQueue<SOCKET>::DEFAULT_HTTP_WORKQUEUE) {
+CHttpServer::CHttpServer(int port, bool public_api)
+    : m_port(port), m_public_api(public_api),
+      m_num_threads(DEFAULT_HTTP_THREADS),
+      m_work_queue(CHttpWorkQueue<SOCKET>::DEFAULT_HTTP_WORKQUEUE) {
 }
 
 // Destructor
@@ -75,10 +77,21 @@ bool CHttpServer::Start() {
     }
 #endif
 
-    // Create dual-stack listen socket (all interfaces for HTTP API)
+    // CVE-2026-RPC-CORS: Bind to 127.0.0.1 by default. Only seed nodes that
+    // opt in via --public-api (and have configured RPC auth) bind to all
+    // interfaces. Previously this server bound 0.0.0.0 unconditionally,
+    // exposing /api/v1/* + /wallet HTML + telemetry to any LAN attacker.
+    std::string bind_addr;
+    if (m_public_api) {
+        bind_addr = "";  // All interfaces (dual-stack IPv4+IPv6)
+        std::cout << "[HttpServer] Public API mode enabled - binding to all interfaces:" << m_port << std::endl;
+    } else {
+        bind_addr = "127.0.0.1";  // Localhost only
+    }
+
     socket_t http_sock;
     bool is_ipv6;
-    if (!CSock::CreateListenSocket(static_cast<uint16_t>(m_port), "", http_sock, is_ipv6)) {
+    if (!CSock::CreateListenSocket(static_cast<uint16_t>(m_port), bind_addr, http_sock, is_ipv6)) {
         std::cerr << "[HttpServer] Failed to create listen socket on port " << m_port << std::endl;
 #ifdef _WIN32
         WSACleanup();
@@ -262,16 +275,11 @@ void CHttpServer::HandleRequest(SOCKET client_socket) {
         return;
     }
 
-    // Handle OPTIONS preflight requests for CORS (browsers send this before cross-origin requests)
-    // Must be handled BEFORE REST API routing to allow light wallet browser access
+    // CVE-2026-RPC-CORS: No CORS. All OPTIONS preflights rejected.
+    // Same-origin requests do not preflight; cross-origin callers unsupported.
     if (method == "OPTIONS") {
-        // Build response with comprehensive CORS headers
         std::ostringstream response;
-        response << "HTTP/1.1 204 No Content\r\n";
-        response << "Access-Control-Allow-Origin: *\r\n";
-        response << "Access-Control-Allow-Methods: GET, POST, OPTIONS\r\n";
-        response << "Access-Control-Allow-Headers: Content-Type, Accept\r\n";
-        response << "Access-Control-Max-Age: 86400\r\n";  // Cache preflight for 24 hours
+        response << "HTTP/1.1 403 Forbidden\r\n";
         response << "Content-Length: 0\r\n";
         response << "Connection: close\r\n";
         response << "\r\n";
@@ -401,10 +409,7 @@ void CHttpServer::SendResponse(SOCKET client_socket,
     }
     response << "\r\n";
 
-    // CORS headers
-    response << "Access-Control-Allow-Origin: *\r\n";
-    response << "Access-Control-Allow-Methods: GET, OPTIONS\r\n";
-    response << "Access-Control-Allow-Headers: Content-Type\r\n";
+    // CVE-2026-RPC-CORS: NO CORS headers. Same-origin only.
 
     // Content headers
     response << "Content-Type: " << content_type << "\r\n";

--- a/src/api/http_server.h
+++ b/src/api/http_server.h
@@ -151,8 +151,12 @@ public:
     /**
      * Constructor
      * @param port Port to listen on (default: 8334 for testnet)
+     * @param public_api If true, bind to all interfaces (seed nodes / --public-api).
+     *                   If false (default), bind to 127.0.0.1 only.
+     *                   CVE-2026-RPC-CORS: prior default of all-interfaces exposed
+     *                   /api/v1/* + /wallet to LAN.
      */
-    explicit CHttpServer(int port = 8334);
+    explicit CHttpServer(int port = 8334, bool public_api = false);
 
     /**
      * Destructor - ensures server is stopped
@@ -263,6 +267,7 @@ private:
 
     // Configuration
     int m_port;                            // Server port
+    bool m_public_api;                     // CVE-2026: if false, bind 127.0.0.1 only
     int m_num_threads;                     // Number of worker threads
     StatsHandler m_stats_handler;          // Stats handler function
     MetricsHandler m_metrics_handler;      // Prometheus metrics handler

--- a/src/node/dilithion-node.cpp
+++ b/src/node/dilithion-node.cpp
@@ -71,6 +71,7 @@
 #include <wallet/wallet.h>
 #include <wallet/passphrase_validator.h>
 #include <rpc/server.h>
+#include <rpc/auth.h>      // CVE-2026-RPC-AUTH: RPCAuth::InitializeAuth
 #include <rpc/rest_api.h>  // REST API for light wallet
 #include <core/chainparams.h>
 #include <consensus/pow.h>
@@ -3726,7 +3727,8 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
         // Create and start HTTP API server for dashboard
         // Use port 18334 for testnet, 8334 for mainnet (Bitcoin convention)
         int api_port = config.testnet ? 18334 : 8334;
-        CHttpServer http_server(api_port);
+        // CVE-2026-RPC-CORS: gate all-interfaces bind on --public-api
+        CHttpServer http_server(api_port, config.public_api);
         g_node_state.http_server = &http_server;
 
         // STRESS TEST FIX: Create cached stats for lock-free API responses
@@ -7107,12 +7109,19 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
         std::string rpc_permissions_file = config.datadir + "/rpc_permissions.json";
 
         if (!rpcuser.empty() && !rpcpassword.empty()) {
-            // Initialize permissions system
+            // CVE-2026-RPC-AUTH: previously only InitializePermissions was called.
+            // The auth gate at server.cpp checks RPCAuth::IsAuthConfigured(),
+            // which is only set by RPCAuth::InitializeAuth — and that was never
+            // called in production. Wire both, and abort on either failure.
             if (!rpc_server.InitializePermissions(rpc_permissions_file, rpcuser, rpcpassword)) {
-                std::cerr << "WARNING: Failed to initialize RPC permissions, continuing without authentication" << std::endl;
-            } else {
-                std::cout << "  [AUTH] RPC authentication enabled" << std::endl;
+                std::cerr << "ERROR: Failed to initialize RPC permissions. Aborting startup." << std::endl;
+                return 1;
             }
+            if (!RPCAuth::InitializeAuth(rpcuser, rpcpassword)) {
+                std::cerr << "ERROR: Failed to initialize RPC authentication. Aborting startup." << std::endl;
+                return 1;
+            }
+            std::cout << "  [AUTH] RPC authentication enabled" << std::endl;
         } else if (config.public_api) {
             // v4.1-rc2 ISSUE-1 fix: auto-generate secure random RPC credentials
             // for --public-api when none configured, instead of refusing to start.
@@ -7173,47 +7182,80 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                 std::cerr << "ERROR: Failed to initialize RPC permissions with auto-generated credentials" << std::endl;
                 return 1;
             }
+            // CVE-2026-RPC-AUTH: wire RPCAuth so the auth gate actually runs.
+            if (!RPCAuth::InitializeAuth(rpcuser, rpcpassword)) {
+                std::cerr << "ERROR: Failed to initialize RPC authentication. Aborting startup." << std::endl;
+                return 1;
+            }
             std::cout << "  [AUTH] RPC authentication enabled (auto-generated)" << std::endl;
         } else {
-            // No credentials configured — generate a cookie file for local auth.
-            // This mirrors Bitcoin Core's .cookie mechanism: a random credential
-            // is written to <datadir>/.cookie on each startup. Local tools (relayer,
-            // CLI) can read it. The file is deleted on clean shutdown.
+            // CVE-2026-RPC-AUTH: previously this path could fail SILENTLY and
+            // leave the node serving RPC with NO authentication. Now any
+            // failure aborts startup. Bitcoin Core's .cookie model.
             std::string cookie_path = config.datadir + "/.cookie";
             std::vector<uint8_t> cookie_bytes(32);
             extern bool GenerateSalt(std::vector<uint8_t>&);
-            if (GenerateSalt(cookie_bytes)) {
-                // Convert to hex string for use as password
-                std::string cookie_password;
-                for (auto b : cookie_bytes) {
-                    char hex[3];
-                    snprintf(hex, sizeof(hex), "%02x", b);
-                    cookie_password += hex;
-                }
-                rpcuser = "__cookie__";
-                rpcpassword = cookie_password;
-
-                // Write cookie file (mode 0600 on Unix for owner-only access)
-                std::ofstream cookie_file(cookie_path);
-                if (cookie_file.is_open()) {
-                    cookie_file << rpcuser << ":" << rpcpassword;
-                    cookie_file.close();
-#ifndef _WIN32
-                    chmod(cookie_path.c_str(), 0600);
-#endif
-                    std::cout << "  [AUTH] RPC cookie authentication enabled (credentials in "
-                              << cookie_path << ")" << std::endl;
-
-                    // Initialize permissions with cookie credentials
-                    rpc_server.InitializePermissions(rpc_permissions_file, rpcuser, rpcpassword);
-                } else {
-                    std::cerr << "  [WARNING] Failed to write RPC cookie file. "
-                              << "RPC authentication disabled." << std::endl;
-                }
-            } else {
-                std::cerr << "  [WARNING] Failed to generate RPC cookie. "
-                          << "RPC authentication disabled." << std::endl;
+            if (!GenerateSalt(cookie_bytes)) {
+                std::cerr << "ERROR: Failed to generate RPC cookie (random source unavailable). "
+                          << "Aborting startup. Configure rpcuser/rpcpassword in "
+                          << config.datadir << "/dilithion.conf to bypass cookie generation."
+                          << std::endl;
+                return 1;
             }
+
+            // Convert to hex string for use as password
+            std::string cookie_password;
+            for (auto b : cookie_bytes) {
+                char hex[3];
+                snprintf(hex, sizeof(hex), "%02x", b);
+                cookie_password += hex;
+            }
+            rpcuser = "__cookie__";
+            rpcpassword = cookie_password;
+
+            // CVE-2026-RPC-AUTH (H-A2): write cookie file at mode 0600
+            // ATOMICALLY on Unix to close the race between ofstream creation
+            // (which uses umask-default, typically 0644) and the chmod 0600
+            // that previously fired only AFTER write+close. In that window
+            // the cookie was world-readable; on a shared host an attacker
+            // with `inotify` could win that race.
+            // Approach: tighten the process umask, write, restore. Belt and
+            // braces: explicit chmod 0600 after close (in case the FS / mount
+            // ignores umask).
+            // On Windows the per-user %APPDATA% datadir provides equivalent
+            // protection at the directory level (Windows ACLs are not
+            // affected by umask).
+#ifndef _WIN32
+            mode_t prev_umask = umask(077);
+#endif
+            std::ofstream cookie_file(cookie_path);
+            if (!cookie_file.is_open()) {
+#ifndef _WIN32
+                umask(prev_umask);
+#endif
+                std::cerr << "ERROR: Failed to write RPC cookie file at "
+                          << cookie_path << ". Aborting startup. "
+                          << "Check filesystem permissions or configure "
+                          << "rpcuser/rpcpassword in dilithion.conf." << std::endl;
+                return 1;
+            }
+            cookie_file << rpcuser << ":" << rpcpassword;
+            cookie_file.close();
+#ifndef _WIN32
+            umask(prev_umask);
+            chmod(cookie_path.c_str(), 0600);
+#endif
+
+            if (!rpc_server.InitializePermissions(rpc_permissions_file, rpcuser, rpcpassword)) {
+                std::cerr << "ERROR: Failed to initialize RPC permissions with cookie credentials. Aborting startup." << std::endl;
+                return 1;
+            }
+            if (!RPCAuth::InitializeAuth(rpcuser, rpcpassword)) {
+                std::cerr << "ERROR: Failed to initialize RPC authentication with cookie credentials. Aborting startup." << std::endl;
+                return 1;
+            }
+            std::cout << "  [AUTH] RPC cookie authentication enabled (credentials in "
+                      << cookie_path << ")" << std::endl;
         }
 
         // Phase 1: Initialize request logging

--- a/src/node/dilv-node.cpp
+++ b/src/node/dilv-node.cpp
@@ -71,6 +71,7 @@
 #include <wallet/wallet.h>
 #include <wallet/passphrase_validator.h>
 #include <rpc/server.h>
+#include <rpc/auth.h>      // CVE-2026-RPC-AUTH: RPCAuth::InitializeAuth
 #include <rpc/rest_api.h>  // REST API for light wallet
 #include <x402/facilitator.h>  // x402 payment facilitator
 #include <core/chainparams.h>
@@ -3582,7 +3583,8 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
         // Create and start HTTP API server for dashboard
         // Use port 18334 for testnet, 8334 for mainnet (Bitcoin convention)
         int api_port = 9334;  // DilV REST API port
-        CHttpServer http_server(api_port);
+        // CVE-2026-RPC-CORS: gate all-interfaces bind on --public-api
+        CHttpServer http_server(api_port, config.public_api);
         g_node_state.http_server = &http_server;
 
         // STRESS TEST FIX: Create cached stats for lock-free API responses
@@ -7006,12 +7008,17 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
         std::string rpc_permissions_file = config.datadir + "/rpc_permissions.json";
         
         if (!rpcuser.empty() && !rpcpassword.empty()) {
-            // Initialize permissions system
+            // CVE-2026-RPC-AUTH: wire both InitializePermissions AND RPCAuth so
+            // the auth gate at server.cpp:1105 actually runs. Abort on failure.
             if (!rpc_server.InitializePermissions(rpc_permissions_file, rpcuser, rpcpassword)) {
-                std::cerr << "WARNING: Failed to initialize RPC permissions, continuing without authentication" << std::endl;
-            } else {
-                std::cout << "  [AUTH] RPC authentication enabled" << std::endl;
+                std::cerr << "ERROR: Failed to initialize RPC permissions. Aborting startup." << std::endl;
+                return 1;
             }
+            if (!RPCAuth::InitializeAuth(rpcuser, rpcpassword)) {
+                std::cerr << "ERROR: Failed to initialize RPC authentication. Aborting startup." << std::endl;
+                return 1;
+            }
+            std::cout << "  [AUTH] RPC authentication enabled" << std::endl;
         } else if (config.public_api) {
             // v4.1-rc2 ISSUE-1 fix: auto-generate secure random RPC credentials
             // for --public-api when none configured, instead of refusing to start.
@@ -7072,40 +7079,69 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                 std::cerr << "ERROR: Failed to initialize RPC permissions with auto-generated credentials" << std::endl;
                 return 1;
             }
+            // CVE-2026-RPC-AUTH: wire RPCAuth so the auth gate actually runs.
+            if (!RPCAuth::InitializeAuth(rpcuser, rpcpassword)) {
+                std::cerr << "ERROR: Failed to initialize RPC authentication. Aborting startup." << std::endl;
+                return 1;
+            }
             std::cout << "  [AUTH] RPC authentication enabled (auto-generated)" << std::endl;
         } else {
-            // No credentials configured — generate a cookie file for local auth.
+            // CVE-2026-RPC-AUTH: previously this path could fail SILENTLY and
+            // leave the node serving RPC with NO authentication. Now any
+            // failure aborts startup. Bitcoin Core's .cookie model.
             std::string cookie_path = config.datadir + "/.cookie";
             std::vector<uint8_t> cookie_bytes(32);
             extern bool GenerateSalt(std::vector<uint8_t>&);
-            if (GenerateSalt(cookie_bytes)) {
-                std::string cookie_password;
-                for (auto b : cookie_bytes) {
-                    char hex[3];
-                    snprintf(hex, sizeof(hex), "%02x", b);
-                    cookie_password += hex;
-                }
-                rpcuser = "__cookie__";
-                rpcpassword = cookie_password;
-
-                std::ofstream cookie_file(cookie_path);
-                if (cookie_file.is_open()) {
-                    cookie_file << rpcuser << ":" << rpcpassword;
-                    cookie_file.close();
-#ifndef _WIN32
-                    chmod(cookie_path.c_str(), 0600);
-#endif
-                    std::cout << "  [AUTH] RPC cookie authentication enabled (credentials in "
-                              << cookie_path << ")" << std::endl;
-                    rpc_server.InitializePermissions(rpc_permissions_file, rpcuser, rpcpassword);
-                } else {
-                    std::cerr << "  [WARNING] Failed to write RPC cookie file. "
-                              << "RPC authentication disabled." << std::endl;
-                }
-            } else {
-                std::cerr << "  [WARNING] Failed to generate RPC cookie. "
-                          << "RPC authentication disabled." << std::endl;
+            if (!GenerateSalt(cookie_bytes)) {
+                std::cerr << "ERROR: Failed to generate RPC cookie (random source unavailable). "
+                          << "Aborting startup. Configure rpcuser/rpcpassword in "
+                          << config.datadir << "/dilithion.conf to bypass cookie generation."
+                          << std::endl;
+                return 1;
             }
+
+            std::string cookie_password;
+            for (auto b : cookie_bytes) {
+                char hex[3];
+                snprintf(hex, sizeof(hex), "%02x", b);
+                cookie_password += hex;
+            }
+            rpcuser = "__cookie__";
+            rpcpassword = cookie_password;
+
+            // CVE-2026-RPC-AUTH (H-A2): atomic mode-0600 cookie write on Unix.
+            // See dilithion-node.cpp for full rationale (umask race vs chmod).
+#ifndef _WIN32
+            mode_t prev_umask = umask(077);
+#endif
+            std::ofstream cookie_file(cookie_path);
+            if (!cookie_file.is_open()) {
+#ifndef _WIN32
+                umask(prev_umask);
+#endif
+                std::cerr << "ERROR: Failed to write RPC cookie file at "
+                          << cookie_path << ". Aborting startup. "
+                          << "Check filesystem permissions or configure "
+                          << "rpcuser/rpcpassword in dilithion.conf." << std::endl;
+                return 1;
+            }
+            cookie_file << rpcuser << ":" << rpcpassword;
+            cookie_file.close();
+#ifndef _WIN32
+            umask(prev_umask);
+            chmod(cookie_path.c_str(), 0600);
+#endif
+
+            if (!rpc_server.InitializePermissions(rpc_permissions_file, rpcuser, rpcpassword)) {
+                std::cerr << "ERROR: Failed to initialize RPC permissions with cookie credentials. Aborting startup." << std::endl;
+                return 1;
+            }
+            if (!RPCAuth::InitializeAuth(rpcuser, rpcpassword)) {
+                std::cerr << "ERROR: Failed to initialize RPC authentication with cookie credentials. Aborting startup." << std::endl;
+                return 1;
+            }
+            std::cout << "  [AUTH] RPC cookie authentication enabled (credentials in "
+                      << cookie_path << ")" << std::endl;
         }
 
         // Phase 1: Initialize request logging

--- a/src/rpc/permissions.cpp
+++ b/src/rpc/permissions.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license
 
 #include <rpc/permissions.h>
+#include <rpc/auth.h>  // CVE-2026-RPC-KDF: PBKDF2-HMAC-SHA3-256 (100k iters)
 #include <crypto/hmac_sha3.h>
 #include <fstream>
 #include <sstream>
@@ -153,11 +154,14 @@ void CRPCPermissions::InitializeMethodPermissions() {
     m_methodPermissions["savemempool"]        = adminServer;
 
     // ========================================================================
-    // Public Methods (no permission required)
+    // Public Methods (no permission required) — must be EXPLICITLY mapped
     // ========================================================================
-
-    // "help" - deliberately not added (returns 0 from GetMethodPermissions)
-    // Unknown methods also return 0, treated as public
+    // CVE-2026-RPC-PERMDEFAULT (H-A1): unknown methods now default to
+    // ROLE_ADMIN at the getter level (not just in CheckMethodPermission).
+    // Any method that should remain genuinely public MUST be added here
+    // with required=0. Previously "help" relied on the unknown-method
+    // sentinel; that sentinel is now fail-closed.
+    m_methodPermissions["help"] = 0;
 
     std::cout << "[RPC-PERMISSIONS] Initialized method permission map: "
               << m_methodPermissions.size() << " methods configured" << std::endl;
@@ -298,22 +302,21 @@ bool CRPCPermissions::InitializeLegacyMode(const std::string& username,
         return false;
     }
 
-    // Generate random salt (32 bytes)
-    std::vector<uint8_t> salt(32);
-    std::random_device rd;
-    std::mt19937 gen(rd());
-    std::uniform_int_distribution<> dis(0, 255);
-
-    for (size_t i = 0; i < salt.size(); i++) {
-        salt[i] = static_cast<uint8_t>(dis(gen));
+    // CVE-2026-RPC-KDF: generate salt with a cryptographic RNG (not mt19937)
+    // and hash with PBKDF2-HMAC-SHA3-256 (100k iterations). Previously this
+    // used mt19937 + single-round HMAC, which made a leaked rpc_permissions.json
+    // GPU-crackable in seconds.
+    std::vector<uint8_t> salt;
+    if (!RPCAuth::GenerateSalt(salt)) {
+        std::cerr << "[RPC-PERMISSIONS] ERROR: Failed to generate cryptographic salt" << std::endl;
+        return false;
     }
 
-    // Hash password with salt using PBKDF2-HMAC-SHA3
-    // For simplicity, use HMAC-SHA3 directly (production: use PBKDF2 with iterations)
-    std::vector<uint8_t> passwordHash(32);
-    HMAC_SHA3_256(salt.data(), salt.size(),
-                  reinterpret_cast<const uint8_t*>(password.c_str()), password.length(),
-                  passwordHash.data());
+    std::vector<uint8_t> passwordHash;
+    if (!RPCAuth::HashPassword(password, salt, passwordHash)) {
+        std::cerr << "[RPC-PERMISSIONS] ERROR: Failed to hash password (PBKDF2)" << std::endl;
+        return false;
+    }
 
     // Create admin user
     RPCUser user;
@@ -348,17 +351,23 @@ bool CRPCPermissions::AuthenticateUser(const std::string& username,
 
     const RPCUser& user = it->second;
 
-    // Hash provided password with stored salt
-    std::vector<uint8_t> computedHash(32);
-    HMAC_SHA3_256(user.passwordSalt.data(), user.passwordSalt.size(),
-                  reinterpret_cast<const uint8_t*>(password.c_str()), password.length(),
-                  computedHash.data());
-
-    // Constant-time comparison to prevent timing attacks
-    bool match = (user.passwordHash.size() == computedHash.size());
-    for (size_t i = 0; i < user.passwordHash.size() && i < computedHash.size(); i++) {
-        match = match && (user.passwordHash[i] == computedHash[i]);
+    // CVE-2026-RPC-KDF: PBKDF2-HMAC-SHA3-256 (100k iters), matching how
+    // legacy-mode credentials are now generated. Old rpc_permissions.json
+    // files written with the single-round HMAC will fail auth (by design)
+    // and must be regenerated — delete the file and restart, or configure
+    // rpcuser/rpcpassword in dilithion.conf.
+    std::vector<uint8_t> computedHash;
+    if (!RPCAuth::HashPassword(password, user.passwordSalt, computedHash)) {
+        return false;
     }
+
+    // Constant-time comparison to prevent timing attacks (length-mismatch safe)
+    if (user.passwordHash.size() != computedHash.size()) {
+        return false;
+    }
+    bool match = RPCAuth::SecureCompare(user.passwordHash.data(),
+                                        computedHash.data(),
+                                        computedHash.size());
 
     if (!match) {
         return false;  // Invalid password
@@ -395,23 +404,24 @@ bool CRPCPermissions::CheckMethodPermission(uint32_t userPermissions,
     // This avoids double lock when called from CheckMethodPermission(username, method)
     uint32_t required = GetMethodPermissionsUnlocked(method);
 
-    // If method not found (required = 0), allow (public method like "help")
-    if (required == 0) {
-        return true;
-    }
-
-    // Check if user has ALL required permissions (bitwise AND)
-    // Example: user has 0x003F (ROLE_WALLET), method requires 0x0010 (WRITE_WALLET)
-    //          (0x003F & 0x0010) = 0x0010, which equals required → TRUE
+    // CVE-2026-RPC-PERMDEFAULT: bitwise AND. `required == 0` means
+    // explicitly-public (in-map with required=0, e.g. "help"); the bitwise
+    // check returns true for any user. Unknown methods get ROLE_ADMIN from
+    // the getter itself (H-A1: single source of truth — see
+    // GetMethodPermissionsUnlocked below).
     return (userPermissions & required) == required;
 }
 
 // CID 1675190 FIX: Internal unlocked version - safe because m_methodPermissions
-// is only written in constructor and read-only afterwards
+// is only written in constructor and read-only afterwards.
+// CVE-2026-RPC-PERMDEFAULT (H-A1): fail-closed at the getter so EVERY caller
+// (including future external callers, RPC introspection endpoints, WebSocket
+// dispatch when B3 is fixed) inherits the safe default. Methods that must
+// remain public must be EXPLICITLY mapped with required=0 in the constructor.
 uint32_t CRPCPermissions::GetMethodPermissionsUnlocked(const std::string& method) const {
     auto it = m_methodPermissions.find(method);
     if (it == m_methodPermissions.end()) {
-        return 0;  // Unknown method, no permission required (public)
+        return static_cast<uint32_t>(RPCPermission::ROLE_ADMIN);
     }
 
     return it->second;

--- a/src/rpc/rest_api.cpp
+++ b/src/rpc/rest_api.cpp
@@ -583,9 +583,8 @@ std::string CRestAPI::BuildHTTPResponse(int statusCode, const std::string& body)
     response << "HTTP/1.1 " << statusCode << " " << statusText << "\r\n";
     response << "Content-Type: application/json\r\n";
     response << "Content-Length: " << body.size() << "\r\n";
-    response << "Access-Control-Allow-Origin: *\r\n";  // CORS for browser access
-    response << "Access-Control-Allow-Methods: GET, POST, OPTIONS\r\n";
-    response << "Access-Control-Allow-Headers: Content-Type\r\n";
+    // CVE-2026-RPC-CORS: NO CORS headers. Same-origin only. Browsers cannot
+    // read REST responses cross-origin, preventing drive-by data exfil.
     response << "Cache-Control: no-cache\r\n";
     response << "Connection: close\r\n";
     response << "\r\n";

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -419,6 +419,25 @@ bool CRPCServer::Start() {
         return false;
     }
 
+    // CVE-2026-RPC-AUTH (Cursor close-readiness nit): defense-in-depth
+    // invariant. If the production startup order ever changes such that
+    // RPCAuth::InitializeAuth() is not called before Start(), refuse to
+    // serve RPC. Belt-and-braces on the H1 wiring — the same class of
+    // bug as the never-wired-in-production failure that gave the original
+    // CVE its blast radius. CRPCServer::InitializePermissions() is the
+    // *other* required init; verified via m_permissions presence.
+    if (!RPCAuth::IsAuthConfigured()) {
+        std::cerr << "[RPC] CRITICAL: Start() called before RPCAuth::InitializeAuth(). "
+                  << "Refusing to serve RPC. Verify node startup order calls "
+                  << "RPCAuth::InitializeAuth() in every credential path." << std::endl;
+        return false;
+    }
+    if (!m_permissions) {
+        std::cerr << "[RPC] CRITICAL: Start() called before InitializePermissions(). "
+                  << "Refusing to serve RPC." << std::endl;
+        return false;
+    }
+
     // PR #38 red-team C5 follow-up: clear the cluster shutdown flag on
     // every Start(). Required because Boost test suites in this binary
     // run sequentially; a prior test's Stop() sets the flag, and without
@@ -898,7 +917,12 @@ void CRPCServer::HandleClient(int clientSocket) {
             }
             // If overflow would occur, searchStart remains 0 (search from beginning)
 
-            // Pre-compute max index where [i+3] is valid - bufSize >= 4 guaranteed above
+            // CVE-2026-RPC-PARSER (H-A4): RFC 7230 §3 requires CRLF line
+            // termination. Previously this accepted bare LF (`\n\n`) as a
+            // header terminator, but the Phase-2 header walker only splits
+            // on `\r\n` — meaning an LF-only request would have its entire
+            // header block treated as one line, bypassing Content-Length /
+            // Transfer-Encoding smuggling guards entirely. Strict CRLF only.
             const size_t maxIdx = bufSize - 4;
             for (size_t i = searchStart; i <= maxIdx; i++) {
                 if (buffer[i] == '\r' && buffer[i+1] == '\n' &&
@@ -907,37 +931,97 @@ void CRPCServer::HandleClient(int clientSocket) {
                     headerEndPos = i + 4;
                     break;
                 }
-                // Also check for \n\n (less common but valid) - [i+1] valid since i <= bufSize-4
-                if (buffer[i] == '\n' && buffer[i+1] == '\n') {
-                    requestComplete = true;
-                    headerEndPos = i + 2;
-                    break;
-                }
             }
         }
     }
 
-    // Phase 2: If headers found, check Content-Length and read remaining body
+    // Phase 2: If headers found, check Content-Length and read remaining body.
+    // CVE-2026-RPC-PARSER (surgical): line-anchored header parsing.
+    // Previously `headers.find("Content-Length:")` was a substring match that
+    // would have matched `X-Content-Length:` or any other header containing
+    // that substring. Also did not reject duplicate Content-Length or any
+    // Transfer-Encoding header, both classic HTTP-request-smuggling shapes.
+    // The full libevent migration is Phase B; this is the surgical guard.
     if (requestComplete && headerEndPos != std::string::npos) {
-        // Extract Content-Length from headers
         std::string headers(buffer.data(), headerEndPos);
+
+        auto ieq = [](char a, char b) {
+            if (a >= 'A' && a <= 'Z') a = static_cast<char>(a + 32);
+            if (b >= 'A' && b <= 'Z') b = static_cast<char>(b + 32);
+            return a == b;
+        };
+        auto starts_with_ci = [&ieq](const std::string& line, const char* name, size_t name_len) {
+            if (line.size() < name_len + 1) return false;
+            for (size_t i = 0; i < name_len; i++) {
+                if (!ieq(line[i], name[i])) return false;
+            }
+            return line[name_len] == ':';
+        };
+
+        // Walk header lines starting AFTER the request line.
+        size_t pos = headers.find("\r\n");
+        if (pos == std::string::npos) pos = 0; else pos += 2;
+
+        int clCount = 0;
+        bool teSeen = false;
         size_t contentLength = 0;
-        size_t clPos = headers.find("Content-Length:");
-        if (clPos == std::string::npos) {
-            clPos = headers.find("content-length:");
-        }
-        if (clPos != std::string::npos) {
-            size_t valStart = clPos + 15;  // strlen("Content-Length:")
-            while (valStart < headers.size() && headers[valStart] == ' ') valStart++;
-            size_t valEnd = headers.find("\r\n", valStart);
-            if (valEnd == std::string::npos) valEnd = headers.find("\n", valStart);
-            if (valEnd != std::string::npos) {
-                contentLength = std::stoul(headers.substr(valStart, valEnd - valStart));
+        bool malformed = false;
+
+        while (pos < headers.size()) {
+            size_t lineEnd = headers.find("\r\n", pos);
+            if (lineEnd == std::string::npos) lineEnd = headers.size();
+            if (lineEnd == pos) break;  // blank line: end of headers
+            std::string line = headers.substr(pos, lineEnd - pos);
+            pos = lineEnd + 2;
+
+            // Reject obs-fold (leading whitespace continuation lines)
+            if (!line.empty() && (line[0] == ' ' || line[0] == '\t')) {
+                malformed = true;
+                break;
+            }
+
+            if (starts_with_ci(line, "Content-Length", 14)) {
+                clCount++;
+                if (clCount > 1) { malformed = true; break; }
+                size_t v = 15;
+                while (v < line.size() && (line[v] == ' ' || line[v] == '\t')) v++;
+                // Value must be only digits and within sane range
+                if (v >= line.size()) { malformed = true; break; }
+                size_t end = line.size();
+                while (end > v && (line[end-1] == ' ' || line[end-1] == '\t')) end--;
+                if (end - v > 19) { malformed = true; break; }  // 64-bit decimal max ~19 digits
+                size_t cl = 0;
+                for (size_t k = v; k < end; k++) {
+                    if (line[k] < '0' || line[k] > '9') { malformed = true; break; }
+                    cl = cl * 10 + static_cast<size_t>(line[k] - '0');
+                    if (cl > MAX_REQUEST_SIZE) { malformed = true; break; }
+                }
+                if (malformed) break;
+                contentLength = cl;
+            } else if (starts_with_ci(line, "Transfer-Encoding", 17)) {
+                // CVE-2026-RPC-PARSER: refuse Transfer-Encoding entirely.
+                // Dilithion RPC speaks Content-Length-framed HTTP/1.1 only.
+                // TE creates ambiguity (TE.CL / CL.TE smuggling).
+                teSeen = true;
+                break;
             }
         }
 
+        if (malformed || teSeen) {
+            std::string body = "{\"error\":\"Malformed HTTP request (CVE-2026-RPC-PARSER)\",\"code\":-32700}";
+            std::ostringstream oss;
+            oss << "HTTP/1.1 400 Bad Request\r\n"
+                << "Content-Type: application/json\r\n"
+                << "Content-Length: " << body.size() << "\r\n"
+                << "Connection: close\r\n"
+                << "\r\n"
+                << body;
+            std::string resp = oss.str();
+            send_response_and_cleanup(resp);
+            return;
+        }
+
         // Read remaining body bytes if needed
-        size_t bodyBytesRead = buffer.size() - headerEndPos;
         size_t totalNeeded = headerEndPos + contentLength;
         if (totalNeeded > MAX_REQUEST_SIZE) totalNeeded = MAX_REQUEST_SIZE;
 
@@ -999,14 +1083,11 @@ void CRPCServer::HandleClient(int clientSocket) {
         return;
     }
 
-    // CORS: Handle OPTIONS preflight requests for web wallet and REST API
-    // Browsers send OPTIONS before cross-origin requests with custom headers
+    // CVE-2026-RPC-CORS: No CORS. All OPTIONS preflights rejected.
+    // Same-origin requests (bundled web wallet at /wallet) don't preflight.
+    // Cross-origin callers are unsupported — they cannot read RPC responses.
     if (request.find("OPTIONS ") == 0) {
-        std::string response = "HTTP/1.1 204 No Content\r\n"
-                               "Access-Control-Allow-Origin: *\r\n"
-                               "Access-Control-Allow-Methods: GET, POST, OPTIONS\r\n"
-                               "Access-Control-Allow-Headers: Content-Type, Authorization, X-Dilithion-RPC\r\n"
-                               "Access-Control-Max-Age: 86400\r\n"
+        std::string response = "HTTP/1.1 403 Forbidden\r\n"
                                "Content-Length: 0\r\n"
                                "Connection: close\r\n"
                                "\r\n";
@@ -1083,17 +1164,18 @@ void CRPCServer::HandleClient(int clientSocket) {
         }
 
         // RPC-004: Reject requests without CSRF protection header
-        std::string response = "HTTP/1.1 403 Forbidden\r\n"
-                               "Content-Type: application/json\r\n"
-                               "Content-Length: 108\r\n"
-                               "Connection: close\r\n"
-                               "X-Content-Type-Options: nosniff\r\n"
-                               "X-Frame-Options: DENY\r\n"
-                               "Access-Control-Allow-Origin: *\r\n"
-                               "Access-Control-Allow-Methods: POST, OPTIONS\r\n"
-                               "Access-Control-Allow-Headers: Content-Type, Authorization, X-Dilithion-RPC\r\n"
-                               "\r\n"
-                               "{\"error\":\"CSRF protection: Missing X-Dilithion-RPC header. Include 'X-Dilithion-RPC: 1' in request.\",\"code\":-32600}";
+        // CVE-2026-RPC-CORS: No CORS headers on 403 response either.
+        const std::string csrfBody = "{\"error\":\"CSRF protection: Missing X-Dilithion-RPC header. Include 'X-Dilithion-RPC: 1' in request.\",\"code\":-32600}";
+        std::ostringstream csrfOss;
+        csrfOss << "HTTP/1.1 403 Forbidden\r\n"
+                << "Content-Type: application/json\r\n"
+                << "Content-Length: " << csrfBody.size() << "\r\n"
+                << "Connection: close\r\n"
+                << "X-Content-Type-Options: nosniff\r\n"
+                << "X-Frame-Options: DENY\r\n"
+                << "\r\n"
+                << csrfBody;
+        std::string response = csrfOss.str();
         send_response_and_cleanup(response);
         return;
     }
@@ -1101,7 +1183,13 @@ void CRPCServer::HandleClient(int clientSocket) {
     // FIX-014: Declare username/password outside auth block for permission checking
     std::string username = "";
     std::string password = "";
-    uint32_t userPermissions = static_cast<uint32_t>(RPCPermission::ROLE_ADMIN);  // Default to admin if no auth
+    // CVE-2026-RPC-AUTH: previously defaulted to ROLE_ADMIN when the auth
+    // block was skipped (which it always was, because InitializeAuth was
+    // never wired in production). Defense in depth: default to 0 permissions
+    // so any future path that skips the auth block fails closed rather than
+    // open. Post-H1 the block always runs, so this default is normally
+    // never observed — but it must be safe if it ever is.
+    uint32_t userPermissions = 0;
 
     // Check authentication if configured
     if (RPCAuth::IsAuthConfigured()) {
@@ -1155,10 +1243,29 @@ void CRPCServer::HandleClient(int clientSocket) {
         // FIX-014: Get user permissions for authorization checking
         if (m_permissions) {
             if (!m_permissions->AuthenticateUser(username, password, userPermissions)) {
-                // Should not happen (already authenticated above), but handle gracefully
-                std::cerr << "[RPC-PERMISSIONS] ERROR: Permission lookup failed for user: "
-                          << username << std::endl;
-                std::string response = BuildHTTPUnauthorized();
+                // CVE-2026-RPC-AUTH (H-A5): RPCAuth said yes, permissions
+                // store says no. This is NOT an auth failure — both stores
+                // are supposed to agree (port_review row #17). Return 503
+                // so operators investigating a 401 spike don't dismiss it
+                // as bad creds when the real cause is a permissions-store
+                // divergence (the kind of bug that only surfaces during
+                // incidents).
+                std::cerr << "[RPC-PERMISSIONS] CRITICAL: Auth/permissions store divergence for user: "
+                          << username << " (RPCAuth accepted, CRPCPermissions rejected). "
+                          << "Investigate immediately." << std::endl;
+                if (m_logger) {
+                    m_logger->LogSecurityEvent("AUTH_STORE_DIVERGENCE", clientIP, username,
+                        "RPCAuth and CRPCPermissions disagree on credentials");
+                }
+                const std::string body = "{\"error\":\"Server misconfiguration: RPC permissions store inconsistent. See server log.\",\"code\":-32603}";
+                std::ostringstream oss;
+                oss << "HTTP/1.1 503 Service Unavailable\r\n"
+                    << "Content-Type: application/json\r\n"
+                    << "Content-Length: " << body.size() << "\r\n"
+                    << "Connection: close\r\n"
+                    << "\r\n"
+                    << body;
+                std::string response = oss.str();
                 send_response_and_cleanup(response);
                 return;
             }
@@ -1166,9 +1273,28 @@ void CRPCServer::HandleClient(int clientSocket) {
             std::cout << "[RPC-PERMISSIONS] User '" << username << "' has role: "
                       << CRPCPermissions::GetRoleName(userPermissions) << std::endl;
         } else {
-            // Permissions not initialized - allow (backwards compatibility)
-            std::cout << "[RPC-PERMISSIONS] WARNING: Permissions not initialized, allowing request" << std::endl;
-            userPermissions = static_cast<uint32_t>(RPCPermission::ROLE_ADMIN);  // Grant admin if not configured
+            // CVE-2026-RPC-AUTH (H-A5): m_permissions==nullptr means startup
+            // skipped permissions init — an init-invariant violation. Post-H1
+            // startup aborts if init fails, so this branch is dead under
+            // normal conditions. Return 503 (not 401) so an operator sees the
+            // real cause if the invariant is ever broken.
+            std::cerr << "[RPC-PERMISSIONS] CRITICAL: Permissions subsystem not initialized "
+                      << "but request reached permission check. Init invariant violated." << std::endl;
+            if (m_logger) {
+                m_logger->LogSecurityEvent("AUTH_INIT_INVARIANT", clientIP, username,
+                    "m_permissions==nullptr after successful auth — init order broken");
+            }
+            const std::string body = "{\"error\":\"Server misconfiguration: RPC permissions not initialized. See server log.\",\"code\":-32603}";
+            std::ostringstream oss;
+            oss << "HTTP/1.1 503 Service Unavailable\r\n"
+                << "Content-Type: application/json\r\n"
+                << "Content-Length: " << body.size() << "\r\n"
+                << "Connection: close\r\n"
+                << "\r\n"
+                << body;
+            std::string response = oss.str();
+            send_response_and_cleanup(response);
+            return;
         }
     }
 
@@ -1300,7 +1426,7 @@ void CRPCServer::HandleClient(int clientSocket) {
 
         // Phase 2: Execute batch requests
         auto batch_start = std::chrono::steady_clock::now();
-        std::vector<RPCResponse> batch_responses = ExecuteBatchRPC(batch_requests, clientIP, username);
+        std::vector<RPCResponse> batch_responses = ExecuteBatchRPC(batch_requests, clientIP, username, userPermissions);
         auto batch_end = std::chrono::steady_clock::now();
         auto batch_duration = std::chrono::duration_cast<std::chrono::milliseconds>(
             batch_end - batch_start);
@@ -1632,10 +1758,10 @@ std::string CRPCServer::BuildHTTPResponse(const std::string& body) {
     oss << "Strict-Transport-Security: max-age=31536000; includeSubDomains\r\n";  // Force HTTPS (future)
     oss << "Referrer-Policy: no-referrer\r\n";  // Don't leak referrer
 
-    // CORS headers for web wallet support
-    oss << "Access-Control-Allow-Origin: *\r\n";
-    oss << "Access-Control-Allow-Methods: POST, OPTIONS\r\n";
-    oss << "Access-Control-Allow-Headers: Content-Type, Authorization, X-Dilithion-RPC\r\n";
+    // CVE-2026-RPC-CORS: NO CORS headers. Bitcoin Core model: same-origin only.
+    // The bundled web wallet at /wallet works because it is same-origin (browsers
+    // don't enforce CORS for same-origin). Cross-origin callers (any third-party
+    // website) cannot read responses, eliminating drive-by wallet drain entirely.
 
     oss << "\r\n";
     oss << body;
@@ -1658,10 +1784,7 @@ std::string CRPCServer::BuildHTTPUnauthorized() {
     oss << "Content-Security-Policy: default-src 'none'\r\n";
     oss << "Referrer-Policy: no-referrer\r\n";
 
-    // CORS headers for web wallet support
-    oss << "Access-Control-Allow-Origin: *\r\n";
-    oss << "Access-Control-Allow-Methods: POST, OPTIONS\r\n";
-    oss << "Access-Control-Allow-Headers: Content-Type, Authorization, X-Dilithion-RPC\r\n";
+    // CVE-2026-RPC-CORS: NO CORS headers. See BuildHTTPResponse for rationale.
 
     oss << "\r\n";
     oss << body;
@@ -1930,17 +2053,11 @@ std::vector<RPCRequest> CRPCServer::ParseBatchRPCRequest(const std::string& json
 
 std::vector<RPCResponse> CRPCServer::ExecuteBatchRPC(const std::vector<RPCRequest>& requests,
                                                       const std::string& clientIP,
-                                                      const std::string& username) {
+                                                      const std::string& username,
+                                                      uint32_t userPermissions) {
     std::vector<RPCResponse> responses;
-
-    // Get user permissions once (if permissions enabled and user authenticated)
-    uint32_t userPermissions = static_cast<uint32_t>(RPCPermission::ROLE_ADMIN);
-    if (m_permissions && !username.empty()) {
-        // Note: We already authenticated in HandleClient, so we can't re-authenticate here
-        // Instead, we'll use a simplified permission check - in a real implementation,
-        // we'd cache the permissions from HandleClient
-        // For now, we'll check permissions per request (less efficient but correct)
-    }
+    (void)clientIP;
+    (void)username;
 
     for (const auto& request : requests) {
         // Handle invalid requests (from batch parsing)
@@ -1948,20 +2065,29 @@ std::vector<RPCResponse> CRPCServer::ExecuteBatchRPC(const std::vector<RPCReques
             RPCResponse error_resp = RPCResponse::ErrorStructured(-32600,
                 "Invalid Request", request.id, "RPC-INVALID-REQUEST",
                 {"Check JSON-RPC 2.0 format", "Verify request is a valid object"});
-            // Move error response (avoids unnecessary copy)
             responses.push_back(std::move(error_resp));
             continue;
         }
 
-        // Check method permission (if permissions enabled)
-        // Note: Permission checking was already done in HandleClient for the batch,
-        // but we check per-request here for granular control
-        // In a production system, we'd pass the userPermissions from HandleClient
-        // For now, we allow all requests in batch (permissions checked at batch level)
-        
+        // CVE-2026-RPC-AUTH: per-request permission check inside the batch
+        // loop. HandleClient pre-checks the whole batch before calling us,
+        // so this is defense in depth — if the pre-check is ever skipped
+        // or refactored away, we still fail closed per-request.
+        if (m_permissions &&
+            !m_permissions->CheckMethodPermission(userPermissions, request.method)) {
+            std::vector<std::string> recovery = {
+                "Contact administrator to grant required permissions",
+                "Verify you are using the correct user account"
+            };
+            RPCResponse denied = RPCResponse::ErrorStructured(-32000,
+                std::string("Insufficient permissions for method '") + request.method + "'",
+                request.id, "RPC-PERMISSION-DENIED", recovery);
+            responses.push_back(std::move(denied));
+            continue;
+        }
+
         // Execute request
         RPCResponse resp = ExecuteRPC(request);
-        // Move response (avoids unnecessary copy)
         responses.push_back(std::move(resp));
     }
 
@@ -3953,19 +4079,20 @@ std::string CRPCServer::RPC_WalletPassphrase(const std::string& params) {
         throw std::runtime_error("Passphrase too long (max " + std::to_string(MAX_PASSPHRASE_LENGTH) + " characters)");
     }
 
-    // Parse timeout (optional, default 60 seconds, max 24 hours, 0 = forever)
-    int64_t timeout = RPCUtil::GetOptionalInt64(j, "timeout", 60, 0, 86400);
+    // CVE-2026-RPC-AUTH (H-A3): require a positive timeout. Previously `0`
+    // was accepted, which the wallet maps to `time_point::max()` (unlock
+    // until process restart). That combined lethally with any RPC-level
+    // auth weakness — an attacker who reaches the wallet RPC surface could
+    // unlock forever and then call sendtoaddress without re-prompt. Min is
+    // now 1 second; max remains 24 hours.
+    int64_t timeout = RPCUtil::GetOptionalInt64(j, "timeout", 60, 1, 86400);
 
     if (!m_wallet->Unlock(passphrase, timeout)) {
         throw std::runtime_error("Error: The wallet passphrase entered was incorrect");
     }
 
     std::ostringstream oss;
-    oss << "\"Wallet unlocked";
-    if (timeout > 0) {
-        oss << " for " << timeout << " seconds";
-    }
-    oss << "\"";
+    oss << "\"Wallet unlocked for " << timeout << " seconds\"";
     return oss.str();
 }
 

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -278,11 +278,17 @@ private:
      * @param requests Vector of RPCRequest objects
      * @param clientIP Client IP address (for logging)
      * @param username Username (for logging)
+     * @param userPermissions Permissions of authenticated user (defense in depth;
+     *        HandleClient also pre-checks the whole batch).
+     *        CVE-2026-RPC-AUTH: previously this function defaulted to
+     *        ROLE_ADMIN and contained dead "check permissions per request"
+     *        comments without actually checking. Now enforced.
      * @return Vector of RPCResponse objects
      */
     std::vector<RPCResponse> ExecuteBatchRPC(const std::vector<RPCRequest>& requests,
                                             const std::string& clientIP,
-                                            const std::string& username);
+                                            const std::string& username,
+                                            uint32_t userPermissions);
 
     /**
      * Convert RPCResponse to JSON string

--- a/src/test/rpc_permissions_tests.cpp
+++ b/src/test/rpc_permissions_tests.cpp
@@ -209,10 +209,17 @@ TEST_F(RPCPermissionsMethodMappingTest, AdminServerMethods) {
 }
 
 TEST_F(RPCPermissionsMethodMappingTest, UnknownMethods) {
-    // Unknown methods return 0 (no permissions required, but logged as warning)
-    EXPECT_EQ(perms.GetMethodPermissions("unknownmethod"), 0);
-    EXPECT_EQ(perms.GetMethodPermissions(""), 0);
-    EXPECT_EQ(perms.GetMethodPermissions("getbalancetypo"), 0);
+    // CVE-2026-RPC-PERMDEFAULT (H-A1): unknown methods now require ROLE_ADMIN.
+    // Previously returned 0 (public), which silently exposed wallet-touching
+    // methods missing from the map (setminingaddress, claimhtlc, etc.).
+    EXPECT_EQ(perms.GetMethodPermissions("unknownmethod"),
+              static_cast<uint32_t>(RPCPermission::ROLE_ADMIN));
+    EXPECT_EQ(perms.GetMethodPermissions(""),
+              static_cast<uint32_t>(RPCPermission::ROLE_ADMIN));
+    EXPECT_EQ(perms.GetMethodPermissions("getbalancetypo"),
+              static_cast<uint32_t>(RPCPermission::ROLE_ADMIN));
+    // Methods explicitly mapped as public (required=0) remain public.
+    EXPECT_EQ(perms.GetMethodPermissions("help"), 0u);
 }
 
 /**

--- a/src/test/tx_index_integration_tests.cpp
+++ b/src/test/tx_index_integration_tests.cpp
@@ -19,6 +19,7 @@
 #include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <rpc/server.h>
+#include <rpc/auth.h>  // CVE-2026-RPC-AUTH: tests must init auth before Start()
 #include <uint256.h>
 
 #include <atomic>
@@ -204,10 +205,15 @@ std::string SendRPCRequest(uint16_t port, const std::string& method,
     std::string body_str = body.str();
 
     std::ostringstream req;
+    // CVE-2026-RPC-AUTH: tests must now send Basic Auth — base64("testuser:testpass")
+    // matches the fixture-installed credentials. Pre-H1 the server silently
+    // accepted unauth'd requests; that bug is closed, so the test client also
+    // needs to authenticate now.
     req << "POST / HTTP/1.1\r\n"
         << "Host: localhost\r\n"
         << "Content-Type: application/json\r\n"
         << "X-Dilithion-RPC: 1\r\n"
+        << "Authorization: Basic dGVzdHVzZXI6dGVzdHBhc3M=\r\n"
         << "Content-Length: " << body_str.size() << "\r\n\r\n"
         << body_str;
     std::string req_str = req.str();
@@ -332,6 +338,14 @@ struct IntegrationFixture {
         server->RegisterMempool(&mempool);
         server->RegisterBlockchain(&chain_db);
         server->RegisterChainState(&g_chainstate);
+        // CVE-2026-RPC-AUTH: Start() now requires auth + permissions
+        // configured (H1 + Cursor's defense-in-depth assert). Before the
+        // H1 fix, production silently skipped auth, so tests didn't need
+        // to init it. Now they must. Use a fixture-local InitializePermissions
+        // to populate m_permissions, and InitializeAuth to flip g_authConfigured.
+        std::string perms_file = idx_scope.path() + "/rpc_permissions.json";
+        BOOST_REQUIRE(server->InitializePermissions(perms_file, "testuser", "testpass"));
+        BOOST_REQUIRE(RPCAuth::InitializeAuth("testuser", "testpass"));
         BOOST_REQUIRE(server->Start());
         // Tiny pause so the listener is accepting before the first request.
         std::this_thread::sleep_for(std::chrono::milliseconds(50));

--- a/src/x402/facilitator.cpp
+++ b/src/x402/facilitator.cpp
@@ -672,9 +672,7 @@ std::string CFacilitator::BuildHTTPResponse(int statusCode, const std::string& b
 
     oss << "HTTP/1.1 " << statusCode << " " << statusText << "\r\n";
     oss << "Content-Type: application/json\r\n";
-    oss << "Access-Control-Allow-Origin: *\r\n";
-    oss << "Access-Control-Allow-Methods: GET, POST, OPTIONS\r\n";
-    oss << "Access-Control-Allow-Headers: Content-Type, PAYMENT-SIGNATURE, PAYMENT-REQUIRED\r\n";
+    // CVE-2026-RPC-CORS: NO CORS headers. Same-origin only.
     oss << "Content-Length: " << body.size() << "\r\n";
     oss << "\r\n";
     oss << body;


### PR DESCRIPTION
## Summary

**Critical security hardening of the RPC layer.** This release closes a class of vulnerabilities affecting all prior versions of Dilithion. Per coordinated-disclosure practice, full technical disclosure is deferred to a post-mortem published ~2 weeks after deploy gives the user base time to upgrade.

## Why minimal detail in this PR body

Releasing detailed vulnerability information simultaneously with the patch gives attackers a roadmap to exploit users who haven't yet upgraded. Following the practice of Bitcoin Core, OpenSSL, and the Linux kernel, this PR ships the fix immediately with minimal public detail. The full technical write-up, vulnerability classes, and post-mortem will be published once we have confidence the majority of nodes have upgraded.

Reviewers (Cursor / Zach) — the full close-readiness brief is at `.claude/contracts/cursor_review_cve_rpc_cors_wallet_drain.md` in the local working tree (gitignored). It contains the per-finding analysis, audit chain, and verification matrix.

## Scope

- 10 source files modified
- Net: +449/-214 lines plus 14 additional lines on top to harden the test suite
- 2 commits (security fix + test-fixture hygiene)
- Migration impact for users: see release notes draft at `.claude/missions/cve-rpc-cors-wallet-drain/release_notes_draft.md`

## Verification

PIPESTATUS-verified (no `make | tail` exit-code masking):

| Check | DIL | DilV |
|---|---|---|
| Clean build | ✓ | ✓ |
| `rpc_auth_tests` 26/26 | ✓ | n/a (shared) |
| `tx_index_integration_tests` | ✓ (No errors detected) | n/a (shared) |
| Live RPC functional E2E 9/9 | ✓ | ✓ |
| Raw-socket protocol-layer tests 4/4 | ✓ | n/a (shared parser) |

## Audit chain

- 4 × red-team-validator passes (fresh-context each)
- 1 × port-reviewer pass (upstream-equivalence comparison)
- 1 × independent close-readiness review: **APPROVE-WITH-NITS** (both nits folded into final commit)

## Test plan

- [ ] Reviewer pulls branch + runs `make dilithion-node dilv-node test_dilithion -j4` (PIPESTATUS-verified)
- [ ] Reviewer runs `./test_dilithion` (full Boost suite — expect `*** No errors detected` for `tx_index_integration_tests`)
- [ ] Linux CI build via NYC seed node (release SOP)
- [ ] After merge → tag `v4.4.2` → multi-platform builds (release SOP) → bootstrap → upload
- [ ] After upload → rolling seed-node deploy (NYC → LDN → SGP → SYD per release SOP)
- [ ] Each seed post-deploy → smoke RPC returns 401 to unauth POST
- [ ] After all 4 seeds green → publish minimal advisory to Discord + Telegram + website banner using release notes draft
- [ ] **~2 weeks post-deploy:** publish full technical post-mortem using `.claude/missions/cve-rpc-cors-wallet-drain/post_mortem_full_disclosure.md`

## Migration impact (one-line summary for users)

Single-admin users (default): zero impact. Custom `rpc_permissions.json` users + hosted PWA at `wallet.dilithion.org`: see release notes.

## Credit

External security researcher disclosed the initial finding via responsible-disclosure channel. Internal audit during fix development surfaced additional defense-in-depth items. Coordinated-disclosure timing by mutual agreement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
