### PR TITLE
v4.4.3: RPC stability — fix the v4.4.2 PBKDF2 saturation regression

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -489,7 +489,7 @@ dilv-genesis-vdf: $(CORE_OBJECTS) $(OBJ_DIR)/tools/dilv_genesis_vdf.o $(DILITHIU
 # Test Binaries
 # ============================================================================
 
-tests: phase1_test miner_tests wallet_tests rpc_tests rpc_auth_tests timestamp_tests crypter_tests wallet_encryption_integration_tests wallet_persistence_tests integration_tests net_tests connman_tests tx_validation_tests tx_relay_tests mining_integration_tests bug_003_block_size_tests dfmp_mik_tests mik_registration_persistence_tests dna_propagation_tests test_passphrase_validator script_tests addrman_v2_tests peer_scorer_tests peer_scorer_banman_integration_tests header_proof_checker_tests chain_selector_tests getchaintips_equivalence_tests chain_case_2_5_equivalence_tests chain_work_smoke_tests reorg_wal_crash_injection_tests competing_sibling_below_checkpoint_tests headers_manager_to_chain_selector_wiring_tests fast_path_2_boundary_tests v4_1_checkpoint_enforcement_tests v4_1_chain_selector_suppression_tests auto_rebuild_marker_mode_symmetry_tests add_block_index_flag_merge_tests port_chain_selector_invariants_tests legacy_vs_port_differential_tests chainstate_integrity_tests
+tests: phase1_test miner_tests wallet_tests rpc_tests rpc_auth_tests ratelimiter_tests timestamp_tests crypter_tests wallet_encryption_integration_tests wallet_persistence_tests integration_tests net_tests connman_tests tx_validation_tests tx_relay_tests mining_integration_tests bug_003_block_size_tests dfmp_mik_tests mik_registration_persistence_tests dna_propagation_tests test_passphrase_validator script_tests addrman_v2_tests peer_scorer_tests peer_scorer_banman_integration_tests header_proof_checker_tests chain_selector_tests getchaintips_equivalence_tests chain_case_2_5_equivalence_tests chain_work_smoke_tests reorg_wal_crash_injection_tests competing_sibling_below_checkpoint_tests headers_manager_to_chain_selector_wiring_tests fast_path_2_boundary_tests v4_1_checkpoint_enforcement_tests v4_1_chain_selector_suppression_tests auto_rebuild_marker_mode_symmetry_tests add_block_index_flag_merge_tests port_chain_selector_invariants_tests legacy_vs_port_differential_tests chainstate_integrity_tests
 	@echo "$(COLOR_GREEN)✓ All tests built successfully$(COLOR_RESET)"
 
 phase1_test: $(CORE_OBJECTS) $(OBJ_DIR)/test/phase1_simple_test.o $(DILITHIUM_OBJECTS) $(CHIAVDF_OBJECTS)
@@ -509,6 +509,10 @@ rpc_tests: $(CORE_OBJECTS) $(OBJ_DIR)/test/rpc_tests.o $(DILITHIUM_OBJECTS) $(CH
 	@$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LIBS)
 
 rpc_auth_tests: $(CORE_OBJECTS) $(OBJ_DIR)/test/rpc_auth_tests.o $(DILITHIUM_OBJECTS) $(CHIAVDF_OBJECTS)
+	@echo "$(COLOR_BLUE)[LINK]$(COLOR_RESET) $@"
+	@$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LIBS)
+
+ratelimiter_tests: $(CORE_OBJECTS) $(OBJ_DIR)/test/ratelimiter_tests.o $(DILITHIUM_OBJECTS) $(CHIAVDF_OBJECTS)
 	@echo "$(COLOR_BLUE)[LINK]$(COLOR_RESET) $@"
 	@$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LIBS)
 
@@ -956,6 +960,9 @@ test: tests test_dilithion asert_test
 	@echo ""
 	@echo "$(COLOR_YELLOW)Running RPC authentication tests...$(COLOR_RESET)"
 	@./rpc_auth_tests
+	@echo ""
+	@echo "$(COLOR_YELLOW)Running rate limiter regression tests...$(COLOR_RESET)"
+	@./ratelimiter_tests
 	@echo ""
 	@echo "$(COLOR_YELLOW)Running timestamp validation tests...$(COLOR_RESET)"
 	@./timestamp_tests

--- a/docs/SEED-DECOMMISSIONING-SOP.md
+++ b/docs/SEED-DECOMMISSIONING-SOP.md
@@ -1,0 +1,54 @@
+# Seed Decommissioning SOP
+
+**Owner:** Operations · **Last updated:** 2026-05-22 (created during v4.4.3 hotfix red-team fold)
+
+This document describes the steps required when **decommissioning a mainnet seed node** — taking a seed permanently out of service. It exists primarily to close a security gap introduced in v4.4.3.
+
+## Why this exists (the gap being closed)
+
+v4.4.3 added an in-binary rate-limit exemption for the 4 mainnet seed IPs (sourced from `chainparams.seedAttestationIPs`). The exemption is at the **per-IP token bucket** layer only — per-method limits (e.g., `walletpassphrase`, `sendtoaddress`, `dumpprivkey`, `forcerebuild`) still apply. That contains the worst-case wallet-attack surface but does NOT eliminate the following risk:
+
+**The cloud-IP recycling problem.** If a DigitalOcean droplet is destroyed, the IP is recycled to other tenants. A binary that was built against a now-recycled seed IP will continue to exempt that IP from the per-IP rate limit until a new binary is released, built against an updated chainparams, and rolled. Anyone occupying that IP during that window gets the per-IP exemption "for free" — they can sustain higher request rates than a random outside IP can. Per-method limits still bound the wallet-tier methods, but the increase in budget for read methods can still be used (e.g., as a stronger reconnaissance vector or as part of a layered attack).
+
+## Decommissioning SOP (mandatory)
+
+When a seed is permanently taken offline (sold, destroyed, region-migrated, replaced with a different IP):
+
+1. **Update `chainparams.seedAttestationIPs`** on `main`:
+   - Remove the decommissioned IP.
+   - If replacing: add the new IP in the same commit.
+   - Commit message must include `seed-decommission:<old-ip>`.
+2. **Cut a binary release** that incorporates the chainparams change:
+   - This is a **release-blocker** event — must ship before the cloud provider can recycle the old IP. DigitalOcean's recycling window is typically days to weeks, so the binary release should ship within **7 days** of seed destruction.
+   - The release does NOT need to be a full feature release. A point-release with just the chainparams change is fine.
+   - Tag and ship per the normal release SOP (`docs/RELEASE-PROCESS.md` if present, or follow the most recent release for pattern).
+3. **Deploy the new binary to all remaining seeds** via the normal rolling-restart procedure.
+4. **Verify**: from one of the live seeds, send a high-rate burst from an outsider IP and confirm rate-limit kicks in. Then verify the same burst from one of the remaining live seed IPs is still allowed (no regression).
+5. **Update operational state files**:
+   - `dilithion-strategy/00-context/CURRENT_STATE.md` — update the seed-mesh table.
+   - `memory/snippets.md` (or local equivalent) — update any hardcoded seed-IP references.
+   - This README's "Active seeds" section below (keep in sync).
+
+## Active seeds (current)
+
+| Region | IP | P2P Port | RPC Port | Notes |
+|---|---|---|---|---|
+| NYC | 138.197.68.128 | 8444 | 8332 | Primary; bridge relayer + Explorer host |
+| LDN | 167.172.56.119 | 8444 | 8332 | Relay-only |
+| SGP | 165.22.103.114 | 8444 | 8332 | Relay-only |
+| SYD | 134.199.159.83 | 8444 | 8332 | Relay-only |
+
+When this table changes, the chainparams must also change. They are the single storage-of-record.
+
+## Backstop: tag-time check (planned)
+
+A future improvement (queued at `.claude/missions/release-blocker-gating/`) will add a check in the release-tag script that fails if any GitHub Issue labeled `release-blocker:vX.Y.Z` is open for that tag. Once that lands, this SOP can be enforced by adding a `release-blocker:vNEXT` issue at the moment a seed is decommissioned — the tag won't go out without the chainparams update.
+
+Until that's in place, this SOP relies on operator discipline. **Document seed decommissioning in `CURRENT_STATE.md` immediately so any session has the context.**
+
+## Related
+
+- `src/rpc/ratelimiter.cpp` — exemption implementation, sources IPs from `chainparams.seedAttestationIPs`
+- `src/core/chainparams.cpp` — single storage-of-record for seed IPs
+- `src/test/ratelimiter_tests.cpp` — regression tests; `TestEmptyChainparamsFailsClosed` validates fail-closed behavior
+- Red-team finding F-02 in `.claude/missions/cve-rpc-cors-wallet-drain/redteam_v4_4_3_b_and_c.md`

--- a/explorer/api/nodes.php
+++ b/explorer/api/nodes.php
@@ -5,6 +5,15 @@
  * Queries all 4 mainnet seed nodes directly via RPC.
  * NYC is local (127.0.0.1), others via direct HTTP.
  * Cached for 3 seconds to avoid overloading nodes.
+ *
+ * 2026-05-22: replaced 3 parallel per-node curl handles (12 HTTP requests
+ * total) with one JSON-RPC batch per node (4 HTTP requests total). The
+ * seed's per-IP token-bucket rate limiter costs 1 token per HTTP request,
+ * so the old pattern drained 3 tokens per seed per Explorer poll, which
+ * intermittently rejected one of the 3 calls (often getnetworkinfo or
+ * getblockchaininfo) and produced ghost "offline" flashes in the UI.
+ * Batch RPC: 1 HTTP request → 1 token → 1 auth check → 3 methods executed
+ * server-side. Auth is also cache-warm on the cache-hit path (v4.4.2+leakfix).
  */
 
 require_once __DIR__ . "/rpc.php";
@@ -37,44 +46,47 @@ $seedNodes = [
     ['id' => 'syd', 'ip' => '134.199.159.83', 'host' => '134.199.159.83', 'label' => 'Sydney',    'flag' => 'AU', 'primary' => false],
 ];
 
-// Query all nodes in parallel using curl_multi
+// Method id mapping for batch responses (id field on each sub-request).
+$batchMethods = [
+    1 => 'getblockchaininfo',
+    2 => 'getconnectioncount',
+    3 => 'getnetworkinfo',
+];
+
+// Build one curl handle per node carrying a JSON-RPC batch of all 3 methods.
 $multiHandle = curl_multi_init();
 $curlHandles = [];
 
-// For each node, create 3 requests: getblockchaininfo, getconnectioncount, getnetworkinfo
-$requests = [];
 foreach ($seedNodes as $i => $node) {
-    $methods = ['getblockchaininfo', 'getconnectioncount', 'getnetworkinfo'];
-    foreach ($methods as $j => $method) {
-        $ch = curl_init();
-        $url = "http://{$node['host']}:{$rpcPort}/";
-        $payload = json_encode(['jsonrpc' => '2.0', 'id' => 1, 'method' => $method, 'params' => []]);
-        curl_setopt($ch, CURLOPT_URL, $url);
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($ch, CURLOPT_POST, true);
-        curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);
-        curl_setopt($ch, CURLOPT_TIMEOUT, 3);
-        curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 2);
-        curl_setopt($ch, CURLOPT_HTTPHEADER, [
-            'Content-Type: application/json',
-            'X-Dilithion-RPC: 1',
-            'Authorization: Basic ' . base64_encode('rpc:rpc'),
-        ]);
-        curl_multi_add_handle($multiHandle, $ch);
-        $key = "{$i}_{$j}";
-        $curlHandles[$key] = $ch;
-        $requests[$key] = ['node' => $i, 'method' => $method];
+    $batch = [];
+    foreach ($batchMethods as $id => $method) {
+        $batch[] = ['jsonrpc' => '2.0', 'id' => $id, 'method' => $method, 'params' => []];
     }
+    $payload = json_encode($batch);
+
+    $ch = curl_init();
+    $url = "http://{$node['host']}:{$rpcPort}/";
+    curl_setopt($ch, CURLOPT_URL, $url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_POST, true);
+    curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);
+    curl_setopt($ch, CURLOPT_TIMEOUT, 10);
+    curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);
+    curl_setopt($ch, CURLOPT_HTTPHEADER, [
+        'Content-Type: application/json',
+        'X-Dilithion-RPC: 1',
+        'Authorization: Basic ' . base64_encode('rpc:rpc'),
+    ]);
+    curl_multi_add_handle($multiHandle, $ch);
+    $curlHandles[$i] = $ch;
 }
 
-// Execute all requests in parallel
 $running = null;
 do {
     curl_multi_exec($multiHandle, $running);
     curl_multi_select($multiHandle, 0.1);
 } while ($running > 0);
 
-// Collect results
 $nodeData = [];
 foreach ($seedNodes as $i => $node) {
     $nodeData[$i] = [
@@ -92,30 +104,39 @@ foreach ($seedNodes as $i => $node) {
     ];
 }
 
-foreach ($curlHandles as $key => $ch) {
+foreach ($curlHandles as $i => $ch) {
     $response = curl_multi_getcontent($ch);
     $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
     curl_multi_remove_handle($multiHandle, $ch);
     curl_close($ch);
 
     if ($httpCode !== 200 || !$response) continue;
-    $data = json_decode($response, true);
-    if (!$data || isset($data['error']) && $data['error'] !== null) continue;
-    $result = $data['result'] ?? null;
-    if ($result === null) continue;
+    $parsed = json_decode($response, true);
+    if (!is_array($parsed)) continue;
 
-    $nodeIdx = $requests[$key]['node'];
-    $method = $requests[$key]['method'];
+    // JSON-RPC batch response is an array; single-response shape is also
+    // tolerated (defensive — should not happen here, but the server may
+    // return a single error object on a malformed batch).
+    $entries = (isset($parsed[0]) && is_array($parsed[0])) ? $parsed : [$parsed];
 
-    if ($method === 'getblockchaininfo') {
-        $nodeData[$nodeIdx]['online'] = true;
-        $nodeData[$nodeIdx]['height'] = $result['blocks'] ?? 0;
-        $nodeData[$nodeIdx]['chain'] = $result['chain'] ?? null;
-        $nodeData[$nodeIdx]['difficulty'] = $result['difficulty'] ?? null;
-    } elseif ($method === 'getconnectioncount') {
-        $nodeData[$nodeIdx]['peers'] = $result;
-    } elseif ($method === 'getnetworkinfo') {
-        $nodeData[$nodeIdx]['version'] = $result['subversion'] ?? null;
+    foreach ($entries as $entry) {
+        if (!is_array($entry)) continue;
+        if (isset($entry['error']) && $entry['error'] !== null) continue;
+        $id = $entry['id'] ?? null;
+        $result = $entry['result'] ?? null;
+        if ($result === null || !isset($batchMethods[$id])) continue;
+
+        $method = $batchMethods[$id];
+        if ($method === 'getblockchaininfo') {
+            $nodeData[$i]['online'] = true;
+            $nodeData[$i]['height'] = $result['blocks'] ?? 0;
+            $nodeData[$i]['chain'] = $result['chain'] ?? null;
+            $nodeData[$i]['difficulty'] = $result['difficulty'] ?? null;
+        } elseif ($method === 'getconnectioncount') {
+            $nodeData[$i]['peers'] = $result;
+        } elseif ($method === 'getnetworkinfo') {
+            $nodeData[$i]['version'] = $result['subversion'] ?? null;
+        }
     }
 }
 

--- a/src/rpc/auth.cpp
+++ b/src/rpc/auth.cpp
@@ -4,7 +4,10 @@
 #include <rpc/auth.h>
 #include <crypto/sha3.h>
 
+#include <array>
+#include <chrono>
 #include <cstring>
+#include <deque>
 #include <mutex>
 #include <algorithm>
 
@@ -30,6 +33,97 @@ static std::vector<uint8_t> g_passwordSalt;
 static std::vector<uint8_t> g_passwordHash;
 static bool g_authConfigured = false;
 static std::mutex g_authMutex;
+
+// =============================================================================
+// Auth credential cache
+// =============================================================================
+// PBKDF2-HMAC-SHA3-256 with 100,000 iterations costs ~50–100 ms CPU per call,
+// and was being invoked TWICE per request (RPCAuth::AuthenticateRequest plus
+// CRPCPermissions::AuthenticateUser). On a 2-vCPU host sustaining Explorer +
+// bridge-relayer + external RPC traffic against localhost, this saturated the
+// worker pool, the request queue grew, clients (curl with 3–10 s timeouts) sent
+// FIN before the server responded, and the resulting CLOSE-WAITs accumulated
+// faster than they could be closed. Cache hits skip both PBKDF2 calls.
+//
+// Cache key: SHA3-256(user || 0x00 || password). Plaintext is never stored.
+// TTL: success 60 s, failure 5 s. Bounded at 256 entries, FIFO eviction.
+//
+// Lockout / rate-limit checks are NOT bypassed: TryCachedAuth callers MUST
+// check m_rateLimiter.IsLockedOut BEFORE consulting the cache.
+
+namespace {
+
+constexpr size_t  AUTH_CACHE_MAX_ENTRIES   = 256;
+constexpr int64_t AUTH_CACHE_TTL_OK_MS     = 60 * 1000;
+constexpr int64_t AUTH_CACHE_TTL_FAIL_MS   = 5 * 1000;
+
+struct AuthCacheEntry {
+    std::array<uint8_t, 32> key;
+    std::chrono::steady_clock::time_point expiry;
+    uint32_t permissions;
+    bool success;
+};
+
+static std::mutex g_authCacheMutex;
+static std::deque<AuthCacheEntry> g_authCache;  // FIFO
+
+// Derive the cache key from (username, password). The output is a 32-byte
+// SHA3-256 digest. The plaintext credentials are zeroed from the local
+// intermediate buffer before return.
+void DeriveCacheKey(const std::string& username,
+                    const std::string& password,
+                    std::array<uint8_t, 32>& keyOut) {
+    std::vector<uint8_t> buf;
+    buf.reserve(username.size() + 1 + password.size());
+    buf.insert(buf.end(), username.begin(), username.end());
+    buf.push_back(0x00);
+    buf.insert(buf.end(), password.begin(), password.end());
+    SHA3_256(buf.data(), buf.size(), keyOut.data());
+    // Zero the intermediate buffer (best-effort; std::vector growth elsewhere
+    // may have left earlier copies behind, but new data only flowed through
+    // this single buffer).
+    if (!buf.empty()) {
+        std::memset(buf.data(), 0, buf.size());
+    }
+}
+
+// Internal helper: scan the cache with constant-time key comparison.
+// Returns iterator to a matching, non-expired entry, or g_authCache.end().
+// Caller MUST hold g_authCacheMutex.
+std::deque<AuthCacheEntry>::iterator FindLive(
+    const std::array<uint8_t, 32>& key,
+    std::chrono::steady_clock::time_point now)
+{
+    for (auto it = g_authCache.begin(); it != g_authCache.end(); ++it) {
+        if (it->expiry <= now) continue;
+        if (RPCAuth::SecureCompare(it->key.data(), key.data(), 32)) {
+            return it;
+        }
+    }
+    return g_authCache.end();
+}
+
+// Evict any entries whose expiry has passed. Caller MUST hold mutex.
+void EvictExpired(std::chrono::steady_clock::time_point now) {
+    while (!g_authCache.empty() && g_authCache.front().expiry <= now) {
+        // Wipe key before pop (defense in depth — no plaintext in here, but
+        // a digest of plaintext is still sensitive).
+        std::memset(g_authCache.front().key.data(), 0, 32);
+        g_authCache.pop_front();
+    }
+}
+
+// Insert a new entry. If the cache is full, evict the oldest entry. Caller
+// MUST hold mutex.
+void InsertEntry(const AuthCacheEntry& entry) {
+    if (g_authCache.size() >= AUTH_CACHE_MAX_ENTRIES) {
+        std::memset(g_authCache.front().key.data(), 0, 32);
+        g_authCache.pop_front();
+    }
+    g_authCache.push_back(entry);
+}
+
+} // namespace
 
 // Base64 encoding table
 static const char* BASE64_CHARS =
@@ -380,6 +474,11 @@ bool InitializeAuth(const std::string& configUser,
         return false;
     }
 
+    // v4.4.2 leak fix: drop any stale cached entries from a prior init
+    // so a credential rotation (re-init with new password) takes effect
+    // immediately rather than after the 60 s success-TTL elapses.
+    ClearAuthCache();
+
     g_authConfigured = true;
     return true;
 }
@@ -444,6 +543,86 @@ bool SecureCompare(const uint8_t* a, const uint8_t* b, size_t len) {
 
     // Return true only if all bytes matched (result == 0)
     return result == 0;
+}
+
+CachedAuthResult TryCachedAuth(const std::string& username,
+                               const std::string& password,
+                               uint32_t& permissionsOut) {
+    std::array<uint8_t, 32> key;
+    DeriveCacheKey(username, password, key);
+
+    const auto now = std::chrono::steady_clock::now();
+
+    std::lock_guard<std::mutex> lock(g_authCacheMutex);
+    EvictExpired(now);
+
+    auto it = FindLive(key, now);
+    if (it == g_authCache.end()) {
+        // Wipe stack key before return.
+        std::memset(key.data(), 0, key.size());
+        return CachedAuthResult::Miss;
+    }
+
+    bool ok = it->success;
+    if (ok) {
+        permissionsOut = it->permissions;
+    }
+
+    std::memset(key.data(), 0, key.size());
+    return ok ? CachedAuthResult::HitSuccess : CachedAuthResult::HitFail;
+}
+
+void CacheAuthSuccess(const std::string& username,
+                      const std::string& password,
+                      uint32_t permissions) {
+    AuthCacheEntry e;
+    DeriveCacheKey(username, password, e.key);
+    e.expiry = std::chrono::steady_clock::now() +
+               std::chrono::milliseconds(AUTH_CACHE_TTL_OK_MS);
+    e.permissions = permissions;
+    e.success = true;
+
+    std::lock_guard<std::mutex> lock(g_authCacheMutex);
+    // Drop any prior entry for this key first (avoid duplicates that would
+    // delay eviction of the most-recently-verified entry).
+    for (auto it = g_authCache.begin(); it != g_authCache.end(); ) {
+        if (SecureCompare(it->key.data(), e.key.data(), 32)) {
+            std::memset(it->key.data(), 0, 32);
+            it = g_authCache.erase(it);
+        } else {
+            ++it;
+        }
+    }
+    InsertEntry(e);
+}
+
+void CacheAuthFail(const std::string& username,
+                   const std::string& password) {
+    AuthCacheEntry e;
+    DeriveCacheKey(username, password, e.key);
+    e.expiry = std::chrono::steady_clock::now() +
+               std::chrono::milliseconds(AUTH_CACHE_TTL_FAIL_MS);
+    e.permissions = 0;
+    e.success = false;
+
+    std::lock_guard<std::mutex> lock(g_authCacheMutex);
+    for (auto it = g_authCache.begin(); it != g_authCache.end(); ) {
+        if (SecureCompare(it->key.data(), e.key.data(), 32)) {
+            std::memset(it->key.data(), 0, 32);
+            it = g_authCache.erase(it);
+        } else {
+            ++it;
+        }
+    }
+    InsertEntry(e);
+}
+
+void ClearAuthCache() {
+    std::lock_guard<std::mutex> lock(g_authCacheMutex);
+    for (auto& e : g_authCache) {
+        std::memset(e.key.data(), 0, 32);
+    }
+    g_authCache.clear();
 }
 
 } // namespace RPCAuth

--- a/src/rpc/auth.h
+++ b/src/rpc/auth.h
@@ -190,6 +190,74 @@ bool Base64Decode(const std::string& encoded, std::vector<uint8_t>& decoded);
  */
 bool SecureCompare(const uint8_t* a, const uint8_t* b, size_t len);
 
+/**
+ * @brief Result of a cached auth lookup.
+ */
+enum class CachedAuthResult {
+    HitSuccess,   ///< cache hit, credentials previously verified OK
+    HitFail,      ///< cache hit, credentials previously verified BAD
+    Miss          ///< no cache entry — caller must run full PBKDF2 path
+};
+
+/**
+ * @brief Try to satisfy an auth request from the in-memory credential cache.
+ *
+ * Cache key is SHA3-256(username || 0x00 || password). The cache is bounded
+ * (256 entries, FIFO eviction), thread-safe, and TTL-bounded
+ * (success: 60s, failure: 5s). The cache prevents repeated PBKDF2-HMAC-SHA3
+ * (100k iters, ~50–100 ms CPU per call) for high-rate same-credential
+ * traffic — without the cache, sustained Explorer load on the same RPC
+ * credential saturates a 2-vCPU host and produces a CLOSE-WAIT socket leak
+ * because clients FIN before the server finishes PBKDF2 on a dead request.
+ *
+ * On HitSuccess: permissionsOut is populated with the cached permissions
+ * bitmask (as stored by CacheAuthSuccess).
+ *
+ * @param username Plaintext username from Basic auth.
+ * @param password Plaintext password from Basic auth.
+ * @param permissionsOut Output: permissions bitmask if HitSuccess.
+ * @return CachedAuthResult — HitSuccess, HitFail, or Miss.
+ *
+ * @note On Miss, callers must run the full RPCAuth::AuthenticateRequest +
+ *       CRPCPermissions::AuthenticateUser path and call CacheAuthSuccess /
+ *       CacheAuthFail to populate the cache.
+ * @note Lockout / rate-limit checks are NOT bypassed: callers must check
+ *       lockout BEFORE consulting the cache.
+ */
+CachedAuthResult TryCachedAuth(const std::string& username,
+                               const std::string& password,
+                               uint32_t& permissionsOut);
+
+/**
+ * @brief Insert a verified-good credential into the auth cache.
+ *
+ * TTL: 60 seconds. Inserts evict the oldest entry if the cache is full.
+ *
+ * @param username Plaintext username.
+ * @param password Plaintext password.
+ * @param permissions Permissions bitmask resolved via CRPCPermissions.
+ */
+void CacheAuthSuccess(const std::string& username,
+                      const std::string& password,
+                      uint32_t permissions);
+
+/**
+ * @brief Insert a verified-bad credential into the auth cache.
+ *
+ * TTL: 5 seconds (shorter window: limits negative-cache abuse vector
+ * for legitimate user typos).
+ *
+ * @param username Plaintext username.
+ * @param password Plaintext password.
+ */
+void CacheAuthFail(const std::string& username,
+                   const std::string& password);
+
+/**
+ * @brief Clear all cached credentials. Used by tests and on credential rotation.
+ */
+void ClearAuthCache();
+
 } // namespace RPCAuth
 
 #endif // DILITHION_RPC_AUTH_H

--- a/src/rpc/ratelimiter.cpp
+++ b/src/rpc/ratelimiter.cpp
@@ -3,6 +3,8 @@
 
 #include <rpc/ratelimiter.h>
 
+#include <core/chainparams.h>  // for g_chainParams->seedAttestationIPs (red-team F-01)
+
 // Configuration constants
 const std::chrono::seconds CRateLimiter::WINDOW_DURATION(60);  // 1 minute
 const std::chrono::seconds CRateLimiter::AUTH_LOCKOUT_BASE(60);  // 1 minute base
@@ -93,16 +95,32 @@ const std::map<std::string, CRateLimiter::MethodRateLimit> CRateLimiter::METHOD_
     {"waitforblockheight",     {10.0, 0.167, 1.0}},
 };
 
-// Mainnet seed-mesh IPs exempt from per-IP rate limiting. Same trust model
-// as the 127.0.0.1 exemption — these hosts mutually trust each other for
-// status polling (Explorer-on-NYC fan-out to LDN/SGP/SYD; cross-seed health
-// checks). Listed inline rather than in chainparams to keep the exemption
-// surface tightly scoped and easy to audit. 2026-05-22.
+// Seed-mesh IPs exempt from the per-IP request token bucket. Same trust
+// model as the 127.0.0.1 exemption — these hosts mutually trust each other
+// for status polling (Explorer-on-NYC fan-out to LDN/SGP/SYD; cross-seed
+// health checks). The list comes from the chain params seed-attestation
+// IP list — Dilithion::g_chainParams->seedAttestationIPs — which is the
+// single storage-of-record for "who is a seed". When a seed rotates IP,
+// chainparams updates and this exemption follows automatically.
+//
+// IPv4-only string compare is acceptable today because the network-layer
+// ExtractAddress unwraps IPv4-mapped IPv6 ("::ffff:138.197.68.128" → the
+// IPv4 literal) before the IP reaches the rate limiter (see the IPv6
+// smoke tests). If seeds ever get AAAA records this helper needs to be
+// extended; chain params is the right place to add the parallel v6 list.
+//
+// Defense in depth: if g_chainParams is not yet initialized (call path
+// before InitChainParams), the helper returns false — meaning no IP is
+// exempted — so we never accidentally over-grant under a missing-init
+// invariant violation.
 static bool IsSeedMeshIP(const std::string& ip) {
-    return ip == "138.197.68.128"   // NYC
-        || ip == "167.172.56.119"   // LDN
-        || ip == "165.22.103.114"   // SGP
-        || ip == "134.199.159.83";  // SYD
+    if (ip.empty()) return false;
+    const auto* cp = Dilithion::g_chainParams;
+    if (!cp) return false;
+    for (const auto& seedIP : cp->seedAttestationIPs) {
+        if (seedIP == ip) return true;
+    }
+    return false;
 }
 
 bool CRateLimiter::AllowRequest(const std::string& ipAddress) {
@@ -157,9 +175,16 @@ bool CRateLimiter::AllowMethodRequest(const std::string& ipAddress, const std::s
     if (ipAddress == "127.0.0.1" || ipAddress == "::1") {
         return true;
     }
-    if (IsSeedMeshIP(ipAddress)) {
-        return true;
-    }
+    // NOTE: seed-mesh exemption is INTENTIONALLY NOT extended to per-method
+    // rate limits. Cross-seed polling only needs the low-tier methods
+    // (getblockchaininfo, getconnectioncount, getnetworkinfo) — well inside
+    // every per-method default. Exempting seed IPs at the per-method layer
+    // too would broaden the wallet-method attack surface (walletpassphrase,
+    // dumpprivkey, sendtoaddress, forcerebuild) in a recycled-IP scenario
+    // where a deprovisioned seed IP gets handed to a new cloud tenant. The
+    // per-IP bucket exemption in AllowRequest already covers the legitimate
+    // fan-out cost; per-method buckets stay enforced as a defense-in-depth
+    // layer (red-team F-03, 2026-05-22).
 
     std::lock_guard<std::mutex> lock(m_mutex);
 

--- a/src/rpc/ratelimiter.cpp
+++ b/src/rpc/ratelimiter.cpp
@@ -93,9 +93,24 @@ const std::map<std::string, CRateLimiter::MethodRateLimit> CRateLimiter::METHOD_
     {"waitforblockheight",     {10.0, 0.167, 1.0}},
 };
 
+// Mainnet seed-mesh IPs exempt from per-IP rate limiting. Same trust model
+// as the 127.0.0.1 exemption — these hosts mutually trust each other for
+// status polling (Explorer-on-NYC fan-out to LDN/SGP/SYD; cross-seed health
+// checks). Listed inline rather than in chainparams to keep the exemption
+// surface tightly scoped and easy to audit. 2026-05-22.
+static bool IsSeedMeshIP(const std::string& ip) {
+    return ip == "138.197.68.128"   // NYC
+        || ip == "167.172.56.119"   // LDN
+        || ip == "165.22.103.114"   // SGP
+        || ip == "134.199.159.83";  // SYD
+}
+
 bool CRateLimiter::AllowRequest(const std::string& ipAddress) {
     // Exempt localhost from rate limiting (local services like block explorer)
     if (ipAddress == "127.0.0.1" || ipAddress == "::1") {
+        return true;
+    }
+    if (IsSeedMeshIP(ipAddress)) {
         return true;
     }
 
@@ -140,6 +155,9 @@ bool CRateLimiter::AllowRequest(const std::string& ipAddress) {
 bool CRateLimiter::AllowMethodRequest(const std::string& ipAddress, const std::string& method) {
     // Exempt localhost from rate limiting (local services like block explorer)
     if (ipAddress == "127.0.0.1" || ipAddress == "::1") {
+        return true;
+    }
+    if (IsSeedMeshIP(ipAddress)) {
         return true;
     }
 

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -1209,40 +1209,80 @@ void CRPCServer::HandleClient(int clientSocket) {
             return;
         }
 
-        // Authenticate
-        if (!RPCAuth::AuthenticateRequest(username, password)) {
-            // RPC-016 FIX: Audit log failed authentication attempt
-            std::cout << "[RPC-SECURITY] Failed authentication from " << clientIP
-                      << " (user: " << username << ")" << std::endl;
+        // v4.4.2 NYC socket-leak fix: short-TTL credential cache. Sustained
+        // same-credential traffic (Explorer + bridge relayer + miners all
+        // hitting 127.0.0.1:8332 with the same rpc:rpc creds) would otherwise
+        // run PBKDF2-HMAC-SHA3 100k iterations TWICE per request (~200 ms CPU
+        // on a 2-vCPU host), saturate the worker pool, and produce CLOSE-WAIT
+        // accumulation as clients FIN'd before responses landed. The cache
+        // bypass is keyed on SHA3-256(user || 0x00 || pass), TTL 60 s on
+        // success / 5 s on failure, bounded at 256 entries.
+        //
+        // IMPORTANT ordering: lockout/rate-limit checks already ran above
+        // (lines for IsLockedOut and AllowRequest), so a cache hit cannot
+        // bypass them. Cache hits also intentionally bypass the
+        // RecordAuthSuccess / RecordAuthFailure counters — the original
+        // outcome was already recorded when the entry was inserted on miss.
+        uint32_t cachedPermissions = 0;
+        RPCAuth::CachedAuthResult cacheRes =
+            RPCAuth::TryCachedAuth(username, password, cachedPermissions);
 
-            // Phase 1: Log security event
+        if (cacheRes == RPCAuth::CachedAuthResult::HitFail) {
+            // Cached known-bad creds. Same response as a live failure, and
+            // also increment the per-IP failure counter so the rate-limiter
+            // lockout reflects sustained-bad-credentials traffic — without
+            // this, a same-bad-cred flood would desync the lockout count
+            // from reality (red-team M-1).
+            m_rateLimiter.RecordAuthFailure(clientIP);
             if (m_logger) {
                 m_logger->LogSecurityEvent("AUTH_FAILURE", clientIP, username,
-                    "Invalid credentials provided");
+                    "Invalid credentials (cache hit)");
             }
-
-            // Invalid credentials - record failure
-            m_rateLimiter.RecordAuthFailure(clientIP);
             std::string response = BuildHTTPUnauthorized();
             send_response_and_cleanup(response);
             return;
         }
 
-        // RPC-016 FIX: Audit log successful authentication
-        std::cout << "[RPC-AUDIT] Successful authentication from " << clientIP
-                  << " (user: " << username << ")" << std::endl;
-        
-        // Phase 1: Log security event
-        if (m_logger) {
-            m_logger->LogSecurityEvent("AUTH_SUCCESS", clientIP, username, "Authentication successful");
-        }
+        if (cacheRes == RPCAuth::CachedAuthResult::HitSuccess) {
+            // Fast path: skip BOTH PBKDF2 calls. permissions resolved from cache.
+            userPermissions = cachedPermissions;
+        } else {
+            // Cache miss — full PBKDF2 path.
+            if (!RPCAuth::AuthenticateRequest(username, password)) {
+                // RPC-016 FIX: Audit log failed authentication attempt
+                std::cout << "[RPC-SECURITY] Failed authentication from " << clientIP
+                          << " (user: " << username << ")" << std::endl;
 
-        // Authentication successful - reset failure counter
-        m_rateLimiter.RecordAuthSuccess(clientIP);
+                // Phase 1: Log security event
+                if (m_logger) {
+                    m_logger->LogSecurityEvent("AUTH_FAILURE", clientIP, username,
+                        "Invalid credentials provided");
+                }
 
-        // FIX-014: Get user permissions for authorization checking
-        if (m_permissions) {
-            if (!m_permissions->AuthenticateUser(username, password, userPermissions)) {
+                // Invalid credentials - record failure + cache the failure to
+                // prevent flooding the PBKDF2 path with the same bad creds.
+                m_rateLimiter.RecordAuthFailure(clientIP);
+                RPCAuth::CacheAuthFail(username, password);
+                std::string response = BuildHTTPUnauthorized();
+                send_response_and_cleanup(response);
+                return;
+            }
+
+            // RPC-016 FIX: Audit log successful authentication
+            std::cout << "[RPC-AUDIT] Successful authentication from " << clientIP
+                      << " (user: " << username << ")" << std::endl;
+
+            // Phase 1: Log security event
+            if (m_logger) {
+                m_logger->LogSecurityEvent("AUTH_SUCCESS", clientIP, username, "Authentication successful");
+            }
+
+            // Authentication successful - reset failure counter
+            m_rateLimiter.RecordAuthSuccess(clientIP);
+
+            // FIX-014: Get user permissions for authorization checking
+            if (m_permissions) {
+                if (!m_permissions->AuthenticateUser(username, password, userPermissions)) {
                 // CVE-2026-RPC-AUTH (H-A5): RPCAuth said yes, permissions
                 // store says no. This is NOT an auth failure — both stores
                 // are supposed to agree (port_review row #17). Return 503
@@ -1270,32 +1310,40 @@ void CRPCServer::HandleClient(int clientSocket) {
                 return;
             }
 
-            std::cout << "[RPC-PERMISSIONS] User '" << username << "' has role: "
-                      << CRPCPermissions::GetRoleName(userPermissions) << std::endl;
-        } else {
-            // CVE-2026-RPC-AUTH (H-A5): m_permissions==nullptr means startup
-            // skipped permissions init — an init-invariant violation. Post-H1
-            // startup aborts if init fails, so this branch is dead under
-            // normal conditions. Return 503 (not 401) so an operator sees the
-            // real cause if the invariant is ever broken.
-            std::cerr << "[RPC-PERMISSIONS] CRITICAL: Permissions subsystem not initialized "
-                      << "but request reached permission check. Init invariant violated." << std::endl;
-            if (m_logger) {
-                m_logger->LogSecurityEvent("AUTH_INIT_INVARIANT", clientIP, username,
-                    "m_permissions==nullptr after successful auth — init order broken");
+                std::cout << "[RPC-PERMISSIONS] User '" << username << "' has role: "
+                          << CRPCPermissions::GetRoleName(userPermissions) << std::endl;
+
+                // Cache the resolved permissions for subsequent same-credential
+                // requests within the success TTL (60 s). Bypass-safe: lockout
+                // and rate-limit checks ran above this block, and divergence
+                // (H-A5) is NEVER cached (we don't reach this point on
+                // divergence; the 503 branch returns earlier).
+                RPCAuth::CacheAuthSuccess(username, password, userPermissions);
+            } else {
+                // CVE-2026-RPC-AUTH (H-A5): m_permissions==nullptr means startup
+                // skipped permissions init — an init-invariant violation. Post-H1
+                // startup aborts if init fails, so this branch is dead under
+                // normal conditions. Return 503 (not 401) so an operator sees the
+                // real cause if the invariant is ever broken.
+                std::cerr << "[RPC-PERMISSIONS] CRITICAL: Permissions subsystem not initialized "
+                          << "but request reached permission check. Init invariant violated." << std::endl;
+                if (m_logger) {
+                    m_logger->LogSecurityEvent("AUTH_INIT_INVARIANT", clientIP, username,
+                        "m_permissions==nullptr after successful auth — init order broken");
+                }
+                const std::string body = "{\"error\":\"Server misconfiguration: RPC permissions not initialized. See server log.\",\"code\":-32603}";
+                std::ostringstream oss;
+                oss << "HTTP/1.1 503 Service Unavailable\r\n"
+                    << "Content-Type: application/json\r\n"
+                    << "Content-Length: " << body.size() << "\r\n"
+                    << "Connection: close\r\n"
+                    << "\r\n"
+                    << body;
+                std::string response = oss.str();
+                send_response_and_cleanup(response);
+                return;
             }
-            const std::string body = "{\"error\":\"Server misconfiguration: RPC permissions not initialized. See server log.\",\"code\":-32603}";
-            std::ostringstream oss;
-            oss << "HTTP/1.1 503 Service Unavailable\r\n"
-                << "Content-Type: application/json\r\n"
-                << "Content-Length: " << body.size() << "\r\n"
-                << "Connection: close\r\n"
-                << "\r\n"
-                << body;
-            std::string response = oss.str();
-            send_response_and_cleanup(response);
-            return;
-        }
+        }  // end cache-miss (full PBKDF2) branch
     }
 
     // Parse HTTP request

--- a/src/test/ratelimiter_tests.cpp
+++ b/src/test/ratelimiter_tests.cpp
@@ -1,0 +1,204 @@
+// Copyright (c) 2026 The Dilithion Core developers
+// Distributed under the MIT software license
+//
+// Regression tests for CRateLimiter — added 2026-05-22 per red-team F-05
+// during v4.4.3 hotfix work. The fix changed two surfaces:
+//   1. Auth credential cache (commit a) — covered by rpc_auth_tests + live
+//      behavioral checks.
+//   2. Per-IP rate limit exemption for seed-mesh IPs (commit b) — this file.
+//
+// What we lock in:
+//   - 127.0.0.1 / ::1 stay exempt (no regression in localhost behavior).
+//   - Seed-mesh IPs are exempt at the PER-IP layer (AllowRequest) — read
+//     from chainparams.seedAttestationIPs.
+//   - Seed-mesh IPs are NOT exempt at the PER-METHOD layer (AllowMethodRequest)
+//     — defense-in-depth against recycled-IP attack on wallet-tier methods.
+//   - Non-seed, non-localhost IPs drain after the 10-token burst capacity.
+//   - Non-seed IPs recover after a refill window.
+//
+// Per memory/feedback_fold_dont_defer_test_infra.md, the test infra was
+// folded into the same PR as the production fix rather than queued.
+
+#include <rpc/ratelimiter.h>
+#include <core/chainparams.h>
+
+#include <cassert>
+#include <chrono>
+#include <iostream>
+#include <thread>
+
+namespace {
+
+// Minimal in-memory ChainParams shim for tests. The production
+// g_chainParams is normally initialized by InitChainParams at node
+// startup; tests need to populate seedAttestationIPs without dragging in
+// the full chainparams init path. We allocate a ChainParams on the heap
+// and point g_chainParams at it for the duration of the test.
+struct TestParamsHandle {
+    Dilithion::ChainParams* m_owned;
+    Dilithion::ChainParams* m_prev;
+
+    TestParamsHandle(std::vector<std::string> seedIPs) {
+        m_owned = new Dilithion::ChainParams();
+        m_owned->seedAttestationIPs = std::move(seedIPs);
+        m_prev = Dilithion::g_chainParams;
+        Dilithion::g_chainParams = m_owned;
+    }
+    ~TestParamsHandle() {
+        Dilithion::g_chainParams = m_prev;
+        delete m_owned;
+    }
+};
+
+const std::string SEED_NYC = "138.197.68.128";
+const std::string SEED_LDN = "167.172.56.119";
+const std::string SEED_SGP = "165.22.103.114";
+const std::string SEED_SYD = "134.199.159.83";
+const std::string OUTSIDER = "203.0.113.42";  // RFC 5737 TEST-NET-3
+
+} // namespace
+
+void TestLocalhostAlwaysExempt() {
+    std::cout << "Testing 127.0.0.1 / ::1 stay exempt..." << std::endl;
+    TestParamsHandle params({SEED_NYC, SEED_LDN, SEED_SGP, SEED_SYD});
+
+    CRateLimiter limiter;
+    // 100 rapid calls — would drain the 10-token bucket twice over for a
+    // non-exempt IP. Exempt IPs must never return false.
+    for (int i = 0; i < 100; i++) {
+        assert(limiter.AllowRequest("127.0.0.1"));
+        assert(limiter.AllowRequest("::1"));
+    }
+    std::cout << "  ✓ 127.0.0.1 and ::1 never rate-limited" << std::endl;
+}
+
+void TestSeedMeshIPsExemptInAllowRequest() {
+    std::cout << "\nTesting seed-mesh IPs exempt from per-IP token bucket..." << std::endl;
+    TestParamsHandle params({SEED_NYC, SEED_LDN, SEED_SGP, SEED_SYD});
+
+    CRateLimiter limiter;
+    for (const auto& seedIP : {SEED_NYC, SEED_LDN, SEED_SGP, SEED_SYD}) {
+        for (int i = 0; i < 50; i++) {
+            assert(limiter.AllowRequest(seedIP));
+        }
+    }
+    std::cout << "  ✓ All 4 seed IPs from chainparams exempt at AllowRequest layer" << std::endl;
+}
+
+void TestNonSeedIPDrains() {
+    std::cout << "\nTesting non-seed IP drains after 10-burst capacity..." << std::endl;
+    TestParamsHandle params({SEED_NYC, SEED_LDN, SEED_SGP, SEED_SYD});
+
+    CRateLimiter limiter;
+
+    // Bucket capacity is 10; refill 1/sec. Burst 10 requests fast → all
+    // should pass, the 11th should fail (no time for any refill in a tight
+    // loop).
+    int allowed = 0;
+    for (int i = 0; i < 11; i++) {
+        if (limiter.AllowRequest(OUTSIDER)) allowed++;
+    }
+    assert(allowed >= 10 && allowed <= 11);
+    // 11th call could squeak through if a millisecond of refill happened
+    // between calls (very tight margin). The invariant we care about: not
+    // all 11 pass when sustained — verify by a 12th call after no sleep.
+    bool eleventh_or_twelfth_blocked = false;
+    for (int i = 0; i < 3 && !eleventh_or_twelfth_blocked; i++) {
+        if (!limiter.AllowRequest(OUTSIDER)) eleventh_or_twelfth_blocked = true;
+    }
+    assert(eleventh_or_twelfth_blocked);
+    std::cout << "  ✓ Outsider IP (" << OUTSIDER << ") rate-limited after burst" << std::endl;
+}
+
+void TestNonSeedIPRefills() {
+    std::cout << "\nTesting non-seed IP recovers after refill window..." << std::endl;
+    TestParamsHandle params({SEED_NYC, SEED_LDN, SEED_SGP, SEED_SYD});
+
+    CRateLimiter limiter;
+    const std::string ip = "198.51.100.7";  // RFC 5737 TEST-NET-2
+
+    // Drain the bucket.
+    while (limiter.AllowRequest(ip)) { /* drain */ }
+
+    // Sleep ~1.2 seconds — should refill at least 1 token.
+    std::this_thread::sleep_for(std::chrono::milliseconds(1200));
+    assert(limiter.AllowRequest(ip));
+    std::cout << "  ✓ Drained outsider IP recovers after refill interval" << std::endl;
+}
+
+void TestSeedMeshNOTExemptPerMethod() {
+    std::cout << "\nTesting seed-mesh IPs are NOT exempt at per-method layer..." << std::endl;
+    TestParamsHandle params({SEED_NYC, SEED_LDN, SEED_SGP, SEED_SYD});
+
+    CRateLimiter limiter;
+    // 'walletpassphrase' has a strict per-method limit. Drain it from a
+    // seed IP; it MUST eventually rate-limit. If seed IPs were exempt at
+    // the per-method layer, this loop would never terminate.
+    int allowed = 0;
+    for (int i = 0; i < 200 && limiter.AllowMethodRequest(SEED_NYC, "walletpassphrase"); i++) {
+        allowed++;
+    }
+    assert(allowed < 200);  // must hit the limit
+    bool blocked = !limiter.AllowMethodRequest(SEED_NYC, "walletpassphrase");
+    assert(blocked);
+    std::cout << "  ✓ Seed IP " << SEED_NYC << " rate-limited on walletpassphrase ("
+              << "allowed " << allowed << " then blocked) — recycled-IP wallet "
+              << "attack surface stays bounded" << std::endl;
+}
+
+void TestEmptyChainparamsFailsClosed() {
+    std::cout << "\nTesting g_chainParams=nullptr falls closed (no IP exempt)..." << std::endl;
+    // Clear g_chainParams to simulate pre-init state. IsSeedMeshIP must
+    // return false → no over-grant.
+    Dilithion::ChainParams* saved = Dilithion::g_chainParams;
+    Dilithion::g_chainParams = nullptr;
+
+    CRateLimiter limiter;
+    // Drain a "seed" IP — under nullptr params, it's no longer exempt,
+    // so the 10-token bucket must drain.
+    int allowed = 0;
+    for (int i = 0; i < 15 && limiter.AllowRequest(SEED_NYC); i++) {
+        allowed++;
+    }
+
+    Dilithion::g_chainParams = saved;
+    assert(allowed <= 11);
+    std::cout << "  ✓ Missing chainparams → no IP gets exempt status" << std::endl;
+}
+
+void TestEmptyIPRejected() {
+    std::cout << "\nTesting empty IP string is not exempt..." << std::endl;
+    TestParamsHandle params({SEED_NYC, SEED_LDN, SEED_SGP, SEED_SYD});
+
+    CRateLimiter limiter;
+    int allowed = 0;
+    for (int i = 0; i < 15 && limiter.AllowRequest(""); i++) {
+        allowed++;
+    }
+    assert(allowed <= 11);
+    std::cout << "  ✓ Empty IP string drained by bucket like any other non-exempt source" << std::endl;
+}
+
+int main() {
+    std::cout << "========================================" << std::endl;
+    std::cout << "CRateLimiter Regression Tests (v4.4.3)" << std::endl;
+    std::cout << "========================================" << std::endl;
+
+    try {
+        TestLocalhostAlwaysExempt();
+        TestSeedMeshIPsExemptInAllowRequest();
+        TestNonSeedIPDrains();
+        TestNonSeedIPRefills();
+        TestSeedMeshNOTExemptPerMethod();
+        TestEmptyChainparamsFailsClosed();
+        TestEmptyIPRejected();
+
+        std::cout << "\n========================================" << std::endl;
+        std::cout << "All CRateLimiter regression tests PASSED" << std::endl;
+        std::cout << "========================================" << std::endl;
+        return 0;
+    } catch (const std::exception& e) {
+        std::cerr << "❌ Test failed: " << e.what() << std::endl;
+        return 1;
+    }
+}


### PR DESCRIPTION
## Summary

Hotfix for two stacked production regressions surfaced after v4.4.2 shipped:

1. **NYC RPC death under sustained Explorer load** (2026-05-21): v4.4.2's PBKDF2 (100k iters) is invoked twice per request, ~200 ms CPU on a 2-vCPU host. Sustained same-credential traffic saturated the worker pool and produced CLOSE-WAIT socket accumulation as clients FIN'd mid-PBKDF2.
2. **DIL Explorer "flashing offline"** (2026-05-22): cross-seed Explorer polls from NYC drained the remote seeds' per-IP token-bucket rate limit (which exempted only `127.0.0.1`), producing intermittent 429s that surfaced as ghost offline flashes in the nodes panel.

## What's in this PR

Three commits, each a self-contained fix:

- **`32dac0a` perf(rpc): cache verified credentials for 60s** — RPCAuth-level credential cache (SHA3-256 keyed, 60s success / 5s fail TTL, 256-entry FIFO, mutex-guarded). HandleClient consults it before the existing two-stage auth. On hit, both PBKDF2 calls are skipped.
- **`2bc21eb` perf(rpc): exempt seed-mesh IPs from per-IP rate limit** — extends the existing `127.0.0.1` exemption to the 4 mainnet seed IPs. Same trust model.
- **`077c11e` fix(explorer): nodes.php uses one JSON-RPC batch per seed** — drops the per-poll HTTP-request count from 12 → 4. Server-side `ExecuteBatchRPC` runs all 3 methods within one auth + one network round-trip.

## Production state

All 4 seeds are running v4.4.2 + these patches **pre-PR-merge** as an emergency rolling deploy (NYC since 2026-05-21 12:26 UTC; LDN/SGP/SYD since 2026-05-22 21:18–21:24 UTC). Binaries on disk are backed up at `/root/dilithion/dilithion-node.PRE-V2-20260522` on each. Soak as of report: 12 samples / 2 min / both chains × 4 seeds = all stable.

NYC `dilv-node` rebuilt with same source-tree fix; serving Explorer DilV panel locally. SYD + NYC DilV restored from v4.4.0 `bootstrap-dilv-54809.tar.gz` after LevelDB corruption (separate incident, not in this PR).

## Test plan

- [x] Layer-3 red-team-validator review of commit (a) on 2026-05-21: GO-WITH-REVISIONS, 1 HIGH + 1 MEDIUM applied, no BLOCKERs. See `.claude/missions/cve-rpc-cors-wallet-drain/redteam_v4_4_2_leakfix.md`.
- [ ] Layer-3 red-team-validator review of commits (b) + (c) — pending pre-merge.
- [x] Live behavioral validation:
  - NYC pre-fix CPU 99% saturated, 738+ CLOSE-WAIT, RPC unresponsive
  - NYC post-fix CPU 33–46%, 0 CLOSE-WAIT, 50 sequential RPCs in 1s
  - Cross-seed latency pre-fix: 0.13–1.79s spread (10× variance)
  - Cross-seed latency post-fix: 0.13s / 0.47s / 0.43s flat for LDN / SGP / SYD
- [x] 2-min stability soak — 12 samples × 4 seeds × 2 chains all `online: true`.
- [ ] `/evaluate` to clear the deploy/tag gate before tagging v4.4.3.

## Followups (separate PRs)

- NYC `dilithion-node` + `dilv-node` upgrade to this PR's binary (consistency only — NYC's local Explorer is exempt via `127.0.0.1` already; the seed-mesh exemption benefits NYC only when OTHER seeds poll it).
- DilV `dilv-node` upgrade on LDN/SGP/SYD (their older DilV releases don't have the PBKDF2 leak, so they're not bleeding — but consistency desirable).
- Post-mortem disclosure doc update with the symptom-2 cross-seed flashing root cause.

## Files changed

```
 explorer/api/nodes.php  | 107 +++++++++++++++++------------
 src/rpc/auth.cpp        | 179 ++++++++++++++++++++++++++++++++++++++++++++++++
 src/rpc/auth.h          |  68 ++++++++++++++++++
 src/rpc/ratelimiter.cpp |  18 +++++
 src/rpc/server.cpp      | 146 ++++++++++++++++++++++++++-------------
 5 files changed, 426 insertions(+), 92 deletions(-)
```

No Tx-index port surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)