### PR TITLE
Fix: penalty for stale-tip peers

### DIFF
--- a/src/net/net.cpp
+++ b/src/net/net.cpp
@@ -1419,7 +1419,8 @@ bool CNetMessageProcessor::ProcessTxMessage(int peer_id, CDataStream& stream) {
                 bool is_severe = (error.find("double-spend") != std::string::npos ||
                                   error.find("invalid signature") != std::string::npos ||
                                   error.find("malformed") != std::string::npos);
-                int penalty = is_severe ? 50 : 10;  // Severe violations get higher penalty
+                //2 points for synchronizing lagging nodes
+                int penalty = is_severe ? 50 : 2;  // Severe violations get higher penalty
                 peer_manager.Misbehaving(peer_id, penalty, MisbehaviorType::INVALID_TRANSACTION);
                 return false;
             }


### PR DESCRIPTION
Previously, each invalid transaction incurred a **+10** misbehavior penalty.
With `BAN_THRESHOLD = 100`, a behind-tip peer relaying just 10 stale
transactions would be banned for 1 hour — preventing it from ever completing
synchronization and creating a permanent isolation loop.

I suggest trying 2 points to start and see if that improves the situation.