### PR TITLE
chore(gitignore): leftover agent-comms review-clone dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -680,3 +680,8 @@ docs/WALLET-INTEGRATION-QUESTIONS-FOR-ZACH.md
 /test-isolation2/
 /test-iso3/
 /test-dll-check/
+
+# Leftover review/scratch clones — never check these in
+# (relocated to c:/tmp/ archive 2026-05-25 to keep them out of Cursor's index)
+_agent_comms_review/
+_review_agent_comms/


### PR DESCRIPTION
## Summary

Adds `_agent_comms_review/` and `_review_agent_comms/` to `.gitignore`.

## Why

Both directories were leftover full clones of `agent-comms` inside the `dilithion` repo root from prior review sessions. Cursor's indexer treated them as in-scope dilithion code, polluting findings and burning Cursor's context budget on duplicate content.

Both clones were relocated then deleted 2026-05-25; all commits in them were verified reachable on canonical `agent-comms` `origin/main` before deletion (0 truly-unpushed commits). Guardrail prevents future review-clones into the dilithion root from being tracked or indexed.

## Test plan

- [x] `git status` no longer shows `_agent_comms_review/` or `_review_agent_comms/` as untracked (the directories are gone anyway, but the pattern catches re-creation)
- [x] No actual code or build artifacts affected
- [x] Sub-PR class: 2-line `.gitignore` addition, reversible

🤖 Generated with [Claude Code](https://claude.com/claude-code)