### PR TITLE
fix(net): remove stale g_chain_height global, route through CChainState::GetHeight() (issue #83)

### DIFF
--- a/docs/TX-RELAY-PROTOCOL.md
+++ b/docs/TX-RELAY-PROTOCOL.md
@@ -501,7 +501,8 @@ extern CTxRelayManager* g_tx_relay_manager;
 extern CTxMemPool* g_mempool;
 extern CTransactionValidator* g_tx_validator;
 extern CUTXOSet* g_utxo_set;
-extern unsigned int g_chain_height;
+// Issue #83: g_chain_height removed — chain tip is read from g_chainstate.GetHeight()
+// (canonical accessor, updated atomically inside CChainState::SetTip under cs_main).
 ```
 
 #### Initialization
@@ -511,7 +512,7 @@ g_tx_relay_manager = new CTxRelayManager();
 g_mempool = &mempool;
 g_tx_validator = &validator;
 g_utxo_set = &utxo_set;
-g_chain_height = current_height;
+// No g_chain_height initialization — consumers read g_chainstate.GetHeight() live.
 ```
 
 #### Cleanup

--- a/src/net/net.cpp
+++ b/src/net/net.cpp
@@ -232,7 +232,8 @@ std::atomic<CTxRelayManager*> g_tx_relay_manager{nullptr};
 std::atomic<CTxMemPool*> g_mempool{nullptr};
 std::atomic<CTransactionValidator*> g_tx_validator{nullptr};
 std::atomic<CUTXOSet*> g_utxo_set{nullptr};
-std::atomic<unsigned int> g_chain_height{0};
+// Issue #83: g_chain_height removed — was only written at startup, causing
+// stale-height peer penalties post-IBD. Consumers now read g_chainstate.GetHeight().
 
 // Global pointers for P2P networking (NW-005)
 // Phase 5: Removed g_connection_manager - use CConnman via NodeContext instead
@@ -1384,7 +1385,16 @@ bool CNetMessageProcessor::ProcessTxMessage(int peer_id, CDataStream& stream) {
         auto* mempool = g_mempool.load();
         auto* tx_validator = g_tx_validator.load();
         auto* utxo_set = g_utxo_set.load();
-        unsigned int chain_height = g_chain_height.load();
+        // Issue #83: read live chain tip, not a stale startup-only global.
+        extern CChainState g_chainstate;
+        int chain_height_signed = g_chainstate.GetHeight();
+        if (chain_height_signed < 0) {
+            if (g_verbose.load(std::memory_order_relaxed))
+                std::cout << "[P2P] Dropping tx " << txid.GetHex().substr(0, 16)
+                          << "... from peer " << peer_id << ": no chain tip" << std::endl;
+            return true;  // No tip yet — not the peer's fault, don't penalise.
+        }
+        unsigned int chain_height = static_cast<unsigned int>(chain_height_signed);
 
         // Phase 5.3: Transaction relay processing
         if (tx_relay) {

--- a/src/net/net.h
+++ b/src/net/net.h
@@ -299,7 +299,7 @@ class CUTXOSet;
 extern std::atomic<CTxMemPool*> g_mempool;
 extern std::atomic<CTransactionValidator*> g_tx_validator;
 extern std::atomic<CUTXOSet*> g_utxo_set;
-extern std::atomic<unsigned int> g_chain_height;
+// Issue #83: g_chain_height removed — consumers read g_chainstate.GetHeight() (see consensus/chain.h).
 
 // Global P2P networking pointers (NW-005)
 // P0-5 FIX: Use std::atomic to prevent initialization race conditions

--- a/src/net/peers.cpp
+++ b/src/net/peers.cpp
@@ -13,6 +13,7 @@
 #include <net/net.h>
 #include <net/connman.h>
 #include <net/protocol.h>
+#include <consensus/chain.h>  // Issue #83: g_chainstate.GetHeight() (replaces g_chain_height)
 #include <net/port/addrman_v2.h>             // Phase 1 port: CAddrMan_v2 (default)
 #include <net/port/legacy_addrman_adapter.h> // Phase 1 port: legacy fallback
 #include <net/port/peer_scorer.h>             // Phase 2 port: CPeerScorer
@@ -997,7 +998,10 @@ bool CPeerManager::EvictPeersIfNeeded() {
 
     // Phase 4: Trust-based eviction bonus (only when active and not during IBD)
     {
-        int current_height = static_cast<int>(g_chain_height.load());
+        // Issue #83: read live chain tip via canonical accessor (GetHeight() returns
+        // -1 if no tip — comparison below naturally yields trust_active=false).
+        extern CChainState g_chainstate;
+        int current_height = g_chainstate.GetHeight();
         bool trust_active = Dilithion::g_chainParams &&
                             current_height >= Dilithion::g_chainParams->trustWeightedNetworkHeight;
         bool in_ibd = g_node_context.sync_coordinator &&

--- a/src/node/dilithion-node.cpp
+++ b/src/node/dilithion-node.cpp
@@ -2895,7 +2895,7 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                 // against tip's chainwork. Caused LDN tip-going-backwards /
                 // dual-hash deadlock 2026-05-04.
                 g_chainstate.RecomputeCandidates();
-                g_chain_height.store(static_cast<unsigned int>(pindexTip->nHeight));  // BUG #108 FIX: Set global height for TX validation
+                // Issue #83: g_chain_height.store removed — tx validation now reads g_chainstate.GetHeight() directly.
 
                 // BUG #270 FIX: Ensure all blocks on the active chain have BLOCK_VALID_CHAIN set.
                 // Bootstrap imports store blocks with only BLOCK_HAVE_DATA (status=8),

--- a/src/node/dilv-node.cpp
+++ b/src/node/dilv-node.cpp
@@ -2786,7 +2786,7 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                 // against tip's chainwork. Caused LDN tip-going-backwards /
                 // dual-hash deadlock 2026-05-04.
                 g_chainstate.RecomputeCandidates();
-                g_chain_height.store(static_cast<unsigned int>(pindexTip->nHeight));  // BUG #108 FIX: Set global height for TX validation
+                // Issue #83: g_chain_height.store removed — tx validation now reads g_chainstate.GetHeight() directly.
 
                 // BUG #270 FIX: Ensure all blocks on the active chain have BLOCK_VALID_CHAIN set.
                 // Bootstrap imports store blocks with only BLOCK_HAVE_DATA (status=8),


### PR DESCRIPTION
## Summary
Closes #83.

`g_chain_height` (a `std::atomic<unsigned int>` global in `src/net/net.cpp`) was written ONLY at node startup, never on tip advance. After a synced node had progressed past its startup tip, two consumers misbehaved:

- **Mempool admit** ([src/net/net.cpp:1387](https://github.com/dilithion/dilithion/blob/main/src/net/net.cpp#L1387)) — read stale height → coinbase-maturity check computed too-low `confirmations` → valid txs rejected → relaying seed penalised (penalty 10 per tx). This is the symptom in #83 — block 56567 had >100 confirmations but the gate still computed `current=56591, confirmations=24`.
- **Peer-eviction trust gate** ([src/net/peers.cpp:1000](https://github.com/dilithion/dilithion/blob/main/src/net/peers.cpp#L1000)) — same defect class, lower impact.

## Fix
- **Delete `g_chain_height` entirely.** Declaration in `src/net/net.h:302` and definition in `src/net/net.cpp:235` removed. Two redundant startup-time stores in `src/node/dilithion-node.cpp:2898` and `src/node/dilv-node.cpp:2789` removed.
- **Consumers read `g_chainstate.GetHeight()`** — already lock-free via `CChainState::m_cachedHeight`, atomically updated inside `CChainState::SetTip` under `cs_main` with `memory_order_release`. Storage-of-record invariant restored (one writer, one canonical reader).
- **Tx-admit path** guards the `-1` (no-tip) case: drops the tx without peer penalty, since we can't validate maturity against an empty chain (not the peer's fault).
- **Peer-eviction path** relies on the existing signed `>= trustWeightedNetworkHeight` comparison naturally yielding `false` for `-1` (`trustWeightedNetworkHeight` is `int`, no implicit sign promotion — verified).

Diff: ~14 source lines + 1 doc update across 6 files.

## Review history
- **red-team-validator Agent:** PASS. All 7 adversarial lenses cleared — concurrency / storage-of-record, missed-consumer (`grep -rn g_chain_height src/` returns only comment lines documenting the removal), inverse-adversarial framing, `-1` semantic correctness, sign-conversion (Bitcoin-Core-style burn does not apply), `extern CChainState g_chainstate` ODR, coinbase-maturity formula.
- **Cursor close-readiness (fresh-context second-layer):** APPROVE. No HIGH/MEDIUM/LOW. One pre-existing duplicate `#include <consensus/chain.h>` NIT in `net.cpp` (lines 10 + 25, predates this fix; out of scope).
- Build: clean on MSYS2, both `dilithion-node` and `dilv-node`, no new warnings on changed files.

## Test plan
- [ ] CI build passes.
- [ ] SYD canary on **both DIL + DilV mainnet** post-merge.
- [ ] Soak ≥1h with `getblockchaininfo` + `getpeerinfo` + log-tail confirming no spurious `Coinbase output not mature` penalties from peers.
- [ ] Verify the issue-#83 repro is fixed: a tx spending a coinbase UTXO at height H is accepted on the canary after chain has advanced past H+100 (pre-fix this was rejected; the originating peer was penalised).
- [ ] Rolling-restart remaining mainnet seeds on both networks: NYC → LDN → SGP, one at a time.
- [ ] Testnet skipped (deprecated, pending v5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)