### PR TITLE
Fix false peer banning for honest forks by correcting IsHeaderSyncInProgress()

### DIFF
--- a/src/net/headers_manager.cpp
+++ b/src/net/headers_manager.cpp
@@ -1326,7 +1326,6 @@ std::vector<CHeadersManager::HeaderTipInfo> CHeadersManager::GetCompetingHeaderT
 bool CHeadersManager::IsHeaderSyncInProgress() const
 {
     std::lock_guard<std::mutex> lock(cs_headers);
-    if (m_last_request_hash.IsNull()) return false;
 
     // Check if the last header request is stale (no response in HEADER_SYNC_STALE_SECS)
     auto now = std::chrono::steady_clock::now();


### PR DESCRIPTION
Fix a critical bug where honest peers sending blocks from a competing fork would be banned after sending just 10 orphan blocks, completely preventing fork resolution and chain reorganization.
Problem Description

When a node receives an orphan block (parent unknown), it calls RecordForkBlock() and bans the peer after 10 such blocks only if header sync is NOT in progress. However, IsHeaderSyncInProgress() incorrectly returns false during active GETHEADERS requests because it checks m_last_request_hash.IsNull() before checking the request timestamp.

The bug chain:
text

1. Peer sends orphan block (fork block at height 991, our tip is 1000)
2. IsHeaderSyncInProgress() checks: m_last_request_hash.IsNull() → true → returns false
3. RecordForkBlock() called → peer accumulates misbehavior score
4. RequestHeaders() sends GETHEADERS, updates m_last_header_request_time
   BUT m_last_request_hash remains null!
5. Peer sends next orphan block (height 992) before GETHEADERS response arrives
6. IsHeaderSyncInProgress() still returns false (m_last_request_hash still null)
7. Repeat steps 3-6 → peer banned after 10 blocks

Result: Honest peers with legitimate competing forks get banned. Fork headers never get stored, UpdateBestHeader() never sees the alternative chain, and reorganization becomes impossible.