### PR TITLE
chore(gitignore): harden against repo-root scratch (autonomy-lane first-fire output)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -685,3 +685,27 @@ docs/WALLET-INTEGRATION-QUESTIONS-FOR-ZACH.md
 # (relocated to c:/tmp/ archive 2026-05-25 to keep them out of Cursor's index)
 _agent_comms_review/
 _review_agent_comms/
+
+# Per-session scratch convention: _tmp_*.{sh,js,md} files at repo root.
+# These are session-local working files (mock harnesses, behavioral validator
+# scratch, red-team scratch notes). Pattern established + 7 instances cleaned
+# 2026-05-29 (autonomy-lane proposal dilithion-repo-audit-tmp-cruft).
+/_tmp_*.sh
+/_tmp_*.js
+/_tmp_*.md
+
+# Loose cursor close-readiness review snapshots at repo root. Authoritative
+# copies live in the corresponding mission dir under .claude/missions/ (or
+# the closed archive in dilithion-strategy/missions/_closed/<mission>_DATE/).
+# Cleaned 2026-05-29.
+/cursor_close_readiness_*.md
+
+# Local MCP server config. Written by agent_comms_sync (entry: seedrpc shims +
+# extreview). Not source-controlled — local machine config only.
+/.mcp.json
+
+# Sibling repo working clones under dilithion/ (not submodules — bind-mount-style
+# Will workflow: `cd ~/dilithion && cd agent-comms` to cross-edit without
+# leaving the IDE workspace).
+/agent-comms/
+/dilithion-strategy/


### PR DESCRIPTION
## Summary

`.gitignore` hardening surfaced by **autonomy-lane first-fire shadow test** against OPERATIONS_BOARD row 41. Patterns added:

- `/_tmp_*.{sh,js,md}` — per-session scratch convention (7 instances cleaned)
- `/cursor_close_readiness_*.md` — loose review snapshots (mirrored in mission archives)
- `/.mcp.json` — local agent_comms_sync MCP config
- `/agent-comms/`, `/dilithion-strategy/` — Will's sibling working clones

Untracked working-tree files deleted as side-effect (not in diff — they were never committed):
- 6× `_tmp_*` files from closed seedrpc-seed-targeting mission
- `cursor_close_readiness_F-003_disposition_enforcement.md`
- `.claude/missions/seedrpc-seed-targeting/` stale orphan

All deletes verified to have authoritative archive copies before action.

## Autonomy-lane verification (end-to-end)

| Metric | Value |
|---|---|
| Cycle elapsed | 322s (well under 30min cap) |
| Exit code | 0 |
| Candidates | 1 |
| Spawned | 1 |
| New proposals | 1 |
| Stuck count | 0 |
| Abort reason | (none) |
| Forbidden surfaces touched | 0 |

Proposal: `dilithion-strategy/inbox/yoda/reviewed/20260529T080917Z-dilithion-repo-audit-tmp-cruft.md` (commit `0bc444b` in dilithion-strategy).

## Out of scope (separate PRs)

- `depends/libzmq` + `depends/randomx` submodule pointer drift
- `.mcp.json` deletion (load-bearing live config; only gitignored here)
- Archive of remaining unarchived missions in `dilithion/.claude/missions/`
- Caps-bump for autonomy lane (separate PR in agent-comms)

## Test plan

- [ ] `git status` in clean working tree shows no `_tmp_*` / `cursor_close_readiness_*` / `.mcp.json` / `agent-comms/` / `dilithion-strategy/` entries
- [ ] `git check-ignore .mcp.json` returns the new rule (line 705 in this PR)
- [ ] No tracked files removed (this is a `.gitignore`-only diff; verify with `git show --stat HEAD`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)