### PR TITLE
fix(net): score peer eviction on live CNode::nLastRecv, not dead CPeer::last_recv (DilV peer-retention collapse)

### DIFF
--- a/src/net/peers.cpp
+++ b/src/net/peers.cpp
@@ -977,11 +977,22 @@ bool CPeerManager::EvictPeersIfNeeded() {
         // Phase 2 port: misbehavior score lives in CPeerScorer now.
         int score = GetMisbehaviorScore(peer_id);
 
-        // Prefer to evict peers with no recent activity (no messages in last 5 minutes)
-        if (peer->last_recv > 0 && (now - peer->last_recv) > 5 * 60) {
+        // Prefer to evict peers with no recent activity (no messages in last 5 minutes).
+        //
+        // ROOT-CAUSE FIX (2026-06-01 DilV peer-retention collapse): CPeer::last_recv has
+        // no write site anywhere in the tree — it is initialised to 0 and never updated —
+        // so this block previously scored EVERY peer +100 "never received anything". Once
+        // peers.size() reached MAX_TOTAL_CONNECTIONS the node evicted healthy, actively-
+        // receiving peers every maintenance tick, collapsing peer counts network-wide
+        // (verified: getpeerinfo lastrecv=0 while bytes_recv > 200 MB). Score on the live
+        // SSOT CNode::nLastRecv (updated in CConnman::ReceiveMsgBytes) instead. `node` is
+        // already fetched above for the fManual check; a peer with no live CNode is treated
+        // as inactive (eligible for eviction).
+        int64_t node_last_recv = node ? node->nLastRecv.load() : 0;
+        if (node_last_recv > 0 && (now - node_last_recv) > 5 * 60) {
             score += 50;  // Inactive peer
-        } else if (peer->last_recv == 0) {
-            score += 100;  // Never received anything
+        } else if (node_last_recv == 0) {
+            score += 100;  // Never received anything (or no live node)
         }
 
         // Prefer to evict peers that haven't completed handshake


### PR DESCRIPTION
## DilV peer-retention collapse — eviction-scoring root-cause fix

### Root cause (verified static + live + behavioral)
`CPeer::last_recv` has **no write site anywhere in `src/`** — defined (`peers.h:54`), initialised to `0`, read by eviction scoring (`peers.cpp:981/983`) and `getpeerinfo` (`rpc/server.cpp:5521`), and **never written**. So `EvictPeersIfNeeded` scored **every peer `+100` "never received anything"**; once `peers.size()` reached `MAX_TOTAL_CONNECTIONS` (125) the node evicted healthy, actively-receiving peers every maintenance tick → network-wide DilV peer collapse (~80 → ~0–18 across all 4 mainnet seeds, cliffing ~May 29 as inbound accumulated past the cap).

Verified:
- **Static:** grep — read-only field, no write site.
- **Live:** `getpeerinfo` showed `lastrecv=0` for every peer while `bytes_recv > 200 MB`; `tcpdump` showed 4,688 data-bearing inbound packets/150s from 55 peers (peers were NOT silent — the node ignored its own recv accounting in eviction). `ss` showed 64 ESTABLISHED sockets vs 0 counted peers.
- **Behavioral:** ~146 score-100 evictions per window, every ~30s.

The real recv path (`CNode::nLastRecv`, updated in `CConnman::ReceiveMsgBytes` at `connman.cpp:1495`) works correctly — only the peer-manager's eviction field was dead, which is why the chain stayed healthy throughout.

### Fix
Score eviction on the live SSOT `node->nLastRecv.load()` (the `CNode*` is already fetched in the same loop for the `fManual` check) instead of the dead `peer->last_recv`. Minimal, **P2P-only, no consensus/wire-format/serialization surface.**

### Reviews
- **red-team-validator:** GO — no HIGH/BLOCKER (units, thread-safety `cs_peers→cs_nodes`, null-case, consensus surface all verified).
- **Cursor close-readiness:** GO-WITH-REVISIONS — "no changes required in this commit before deploy"; revisions are deferred follow-ups (below).

### Deployed (hotfix-direct, 2026-06-01)
Rolled to all 4 DilV mainnet seeds (LDN canary → SGP → SYD → NYC). Peer counts recovered from ~0–18 to ~60+; eviction churn stopped; TCP-socket-vs-counted-peer gap closed. NYC verified bridge-safe (DIL node + relayer + explorer untouched). Per-seed backups: `dilv-node.PRE-EVICTIONFIX-20260601`.

### Deferred follow-ups (separate PRs — NOT in this hotfix)
- `getpeerinfo`/`getconnectioncount` read deprecated `CPeer` fields rather than the `CNode` SSOT (cosmetic; `getpeerinfo lastrecv` stays 0 until fixed — validation must use peer-count, not lastrecv).
- Eviction `RemovePeer` does not `MarkDisconnect`/close the socket (orphan-fd leak; benign once eviction is no longer firing constantly).
- Production inline-accept path enforces only a per-IP cap, no global cap (churn amplifier).
- `peers.cpp:999` handshake check uses the deprecated no-arg `IsHandshakeComplete()` (same SSOT-drift class).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
