### PR TITLE
fix(ibd): DilV dedup-livelock — client AddBlock guard + seed rate-limited re-send (v4.4.4)

### DIFF
--- a/scripts/four_node_local.sh
+++ b/scripts/four_node_local.sh
@@ -31,6 +31,12 @@
 #   MIN_HEIGHT=20
 #   MAX_WAIT=180
 #
+# Scenarios: smoke | stress | delay | partition | dedup_ibd
+#   dedup_ibd — boots a ≥MIN_HEIGHT chain then a late-joining IBD client (Node E);
+#               asserts E completes sync AND its log is free of DEDUP-disconnect /
+#               skip-served tokens (dilv-dedup-livelock-fix regression-absence
+#               check). Run deep: `bash scripts/four_node_local.sh dedup_ibd 300`.
+#
 # Exit codes:
 #   0 — scenario passed
 #   1 — divergent (chain mismatch between nodes)
@@ -66,6 +72,7 @@ P2P_A=19444; RPC_A=19332
 P2P_B=19445; RPC_B=19333
 P2P_C=19446; RPC_C=19334
 P2P_D=19447; RPC_D=19335
+P2P_E=19448; RPC_E=19336   # late-joining IBD client (dedup_ibd scenario)
 
 # Stress scenario: Node D also mines (2-miner mainnet-topology mimic per
 # v0.1.3 PR8.3 reframe). Default smoke = single miner (Node A only).
@@ -87,7 +94,19 @@ fi
 TMPBASE="${TMPDIR:-/tmp}/four_node_$$"
 DA="$TMPBASE/nodeA"; DB="$TMPBASE/nodeB"
 DC="$TMPBASE/nodeC"; DD="$TMPBASE/nodeD"
-mkdir -p "$DA" "$DB" "$DC" "$DD"
+DE="$TMPBASE/nodeE"   # late-joining IBD client (dedup_ibd scenario only)
+mkdir -p "$DA" "$DB" "$DC" "$DD" "$DE"
+
+# dilv-dedup-livelock-fix (F-005 cookie-auth): pre-seed a deterministic
+# rpcuser/rpcpassword in each datadir's dilithion.conf BEFORE node start.
+# Without rpcuser/rpcpassword the node falls into the Bitcoin-Core .cookie model
+# (dilv-node.cpp:7088 — user "__cookie__" + random password) and rejects the
+# static `--user rpc:rpc` these helpers send, so getblockchaininfo/getconnectioncount
+# silently return nothing (auth 401). Seeding fixed creds makes RPC auth
+# deterministic for the whole harness, including Node E's IBD-progress poll.
+for d in "$DA" "$DB" "$DC" "$DD" "$DE"; do
+    printf 'rpcuser=rpc\nrpcpassword=rpc\n' > "$d/dilithion.conf"
+done
 
 cleanup() {
     set +e
@@ -95,11 +114,13 @@ cleanup() {
     [[ -n "${PID_B:-}" ]] && kill "$PID_B" 2>/dev/null
     [[ -n "${PID_C:-}" ]] && kill "$PID_C" 2>/dev/null
     [[ -n "${PID_D:-}" ]] && kill "$PID_D" 2>/dev/null
+    [[ -n "${PID_E:-}" ]] && kill "$PID_E" 2>/dev/null
     sleep 2
     [[ -n "${PID_A:-}" ]] && kill -9 "$PID_A" 2>/dev/null
     [[ -n "${PID_B:-}" ]] && kill -9 "$PID_B" 2>/dev/null
     [[ -n "${PID_C:-}" ]] && kill -9 "$PID_C" 2>/dev/null
     [[ -n "${PID_D:-}" ]] && kill -9 "$PID_D" 2>/dev/null
+    [[ -n "${PID_E:-}" ]] && kill -9 "$PID_E" 2>/dev/null
     if [[ "${PRESERVE_DATADIRS:-0}" = "1" ]]; then
         echo "PRESERVE_DATADIRS=1 — datadirs kept at $TMPBASE"
     fi
@@ -702,12 +723,76 @@ if [[ "$SCENARIO" = "delay" ]]; then
 fi
 
 # ============================================================================
+# dedup_ibd scenario: deep-tip IBD client regression
+# (dilv-dedup-livelock-fix: Part A + Part B integration smoke, F-003 §4.2)
+# Asserts a late-joining IBD client never sees DEDUP-disconnect / skip-served
+# logs and completes sync on a ≥300 block regtest chain.
+#
+# Run with: bash scripts/four_node_local.sh dedup_ibd 300
+# This is an ABSENCE check (the Part A/B fix prevents the storm, so the client
+# never re-requests). The positive "old-code-would-fail-here" deterministic
+# storm repro needs a DILITHION_DEBUG_VALIDATION_LAG_MS hook in
+# block_processing.cpp — deferred follow-up (board: dilv-ibd-lag-injection-harness),
+# NOT a v4.4.4 gate (Amendment 2 / F-008 gate decision).
+# ============================================================================
+DEDUP_IBD_FAIL=0
+if [[ "$SCENARIO" = "dedup_ibd" ]]; then
+    echo
+    echo "=== dedup_ibd: late-joining IBD client on ≥${MIN_HEIGHT} block chain ==="
+    if [[ "$MIN_HEIGHT" -lt 300 ]]; then
+        echo "  NOTE: dedup_ibd is intended for a deep chain (MIN_HEIGHT≥300);"
+        echo "        running against the current converged height $HA."
+    fi
+    echo "[E] Starting late-joining IBD client (connect only to Node A)..."
+    "$BIN" --regtest --datadir="$DE" --no-upnp --relay-only --yes \
+        --port=$P2P_E --rpcport=$RPC_E \
+        --addnode=127.0.0.1:$P2P_A \
+        >"$TMPBASE/nodeE.log" 2>&1 < /dev/null &
+    PID_E=$!
+    echo "[E] Running (PID $PID_E)"
+
+    # Poll for E to reach height >= (HA - 10) within the wait window.
+    TARGET=$(( HA - 10 ))
+    (( TARGET < 1 )) && TARGET=$HA
+    ibd_elapsed=0
+    HE=0
+    while (( ibd_elapsed < 120 )); do
+        sleep 5; ibd_elapsed=$(( ibd_elapsed + 5 ))
+        HE_NEW=$(rpc_height $RPC_E); HE=${HE_NEW:-$HE}
+        printf "  [%3ds] E=%s (target >= %s)\n" "$ibd_elapsed" "${HE:-?}" "$TARGET"
+        [[ -n "$HE" && "$HE" -ge "$TARGET" ]] && break
+    done
+
+    # Assert IBD client completed sync.
+    if [[ -z "$HE" || "$HE" -lt "$TARGET" ]]; then
+        echo "  FAIL: Node E did not complete IBD (E=${HE:-?} < $TARGET after 120s)"
+        DEDUP_IBD_FAIL=1
+    else
+        echo "  PASS: Node E synced to height $HE (target $TARGET)"
+    fi
+
+    # Assert zero dedup-disconnect / skip-all-served log tokens on the IBD client.
+    DEDUP_HITS=$(grep -c "DEDUP: Disconnecting\|Skipping GETDATA.*already served" \
+                     "$TMPBASE/nodeE.log" 2>/dev/null || true)
+    DEDUP_HITS=${DEDUP_HITS:-0}
+    if [[ "$DEDUP_HITS" -gt 0 ]] 2>/dev/null; then
+        echo "  FAIL: Node E log has $DEDUP_HITS dedup-disconnect/skip hits (pre-fix regression)"
+        DEDUP_IBD_FAIL=1
+    else
+        echo "  PASS: 0 dedup-livelock tokens in Node E log (IBD completed without seed disconnects)"
+    fi
+
+    kill "$PID_E" 2>/dev/null
+fi
+
+# ============================================================================
 # Final verdict
 # ============================================================================
 echo
 if [[ $SCENARIO_1_FAIL -eq 0 ]] && [[ $FORBIDDEN_TOKEN_GREP_FAIL -eq 0 ]] && [[ $CHAINTIPS_FAIL -eq 0 ]] \
    && [[ $STRESS_5_FAIL -eq 0 ]] && [[ $STRESS_6_FAIL -eq 0 ]] && [[ $STRESS_6B_FAIL -eq 0 ]] && [[ $STRESS_7_FAIL -eq 0 ]] \
-   && [[ $SCENARIO_2_M2_TAKEOVER_FAIL -eq 0 ]] && [[ $SCENARIO_2_RESYNC_FAIL -eq 0 ]]; then
+   && [[ $SCENARIO_2_M2_TAKEOVER_FAIL -eq 0 ]] && [[ $SCENARIO_2_RESYNC_FAIL -eq 0 ]] \
+   && [[ $DEDUP_IBD_FAIL -eq 0 ]]; then
     echo "RESULT: 4-node integration test PASSED ($SCENARIO scenario)"
     echo "  - Phase 1 (smoke): all 4 nodes lockstep on chain $HASH_A at height $HA"
     echo "  - Scenario 1 (connectivity): all ≥ 1 connection (regtest scope; full MAX_OUTBOUND requires N≥9)"
@@ -733,5 +818,6 @@ else
     echo "  Scenario 1 fail: $SCENARIO_1_FAIL"
     echo "  Scenario 4 fail (GREP): $FORBIDDEN_TOKEN_GREP_FAIL"
     echo "  Scenario 4b fail (getchaintips): $CHAINTIPS_FAIL"
+    echo "  dedup_ibd fail: $DEDUP_IBD_FAIL"
     exit 1
 fi

--- a/scripts/four_node_local.sh
+++ b/scripts/four_node_local.sh
@@ -100,7 +100,7 @@ mkdir -p "$DA" "$DB" "$DC" "$DD" "$DE"
 # dilv-dedup-livelock-fix (F-005 cookie-auth): pre-seed a deterministic
 # rpcuser/rpcpassword in each datadir's dilithion.conf BEFORE node start.
 # Without rpcuser/rpcpassword the node falls into the Bitcoin-Core .cookie model
-# (dilv-node.cpp:7088 — user "__cookie__" + random password) and rejects the
+# (the RPC-auth init in dilv-node — user "__cookie__" + random password) and rejects the
 # static `--user rpc:rpc` these helpers send, so getblockchaininfo/getconnectioncount
 # silently return nothing (auth 401). Seeding fixed creds makes RPC auth
 # deterministic for the whole harness, including Node E's IBD-progress poll.

--- a/src/net/block_tracker.h
+++ b/src/net/block_tracker.h
@@ -71,6 +71,22 @@ public:
             return false;
         }
 
+        // DEDUP-LIVELOCK FIX (mission dilv-dedup-livelock-fix, F-001):
+        // Also reject heights already marked completed. MarkCompleted means the block
+        // is already in the DB (orphan-with-data / blockInDb / reprocessed paths), so it
+        // must NOT be re-requested over the wire -- it resolves via parent-connection
+        // orphan processing once its parent connects. IsTracked() already consults
+        // m_completed_heights, so GetNextBlocksToRequest skips these; this closes the
+        // gap for DIRECT callers (stall-recovery ibd_coordinator.cpp:2135/2057/1657) that
+        // bypass selection and previously re-requested completed heights every ~1s,
+        // tripping the seed's 3-strike DEDUP disconnect and stalling IBD. Reorg-safe:
+        // ClearAboveHeight() clears m_completed_heights above a fork point before any
+        // legitimate post-reorg re-fetch. Restores the invariant that the dedup read
+        // tracks the MarkCompleted write (principle #3).
+        if (m_completed_heights.count(height) > 0) {
+            return false;
+        }
+
         // Check capacity
         if (GetPeerInFlightCountLocked(peer) >= MAX_PER_PEER) {
             return false;

--- a/src/net/connman.cpp
+++ b/src/net/connman.cpp
@@ -656,6 +656,15 @@ void CConnman::ThreadSocketHandler() {
     auto last_inactivity_check = std::chrono::steady_clock::now();
     static constexpr int INACTIVITY_CHECK_INTERVAL_SECONDS = 10;
 
+    // dilv-dedup-livelock-fix (F-007): track when we last swept the rate-limit /
+    // dedup maps. PeriodicRateLimitCleanup was DEAD (no caller), so the per-peer
+    // map-size cap (MAX_RATE_LIMIT_MAP_SIZE) never ran. Wire it on the same loop as
+    // the inactivity check, gated to ~every 60s. This is belt-and-suspenders behind
+    // NEW-1 (per-disconnect cleanup): with NEW-1 the maps already shrink on every
+    // disconnect, so this sweep is a backstop against any path that leaves residue.
+    auto last_ratelimit_cleanup = std::chrono::steady_clock::now();
+    static constexpr int RATELIMIT_CLEANUP_INTERVAL_SECONDS = 60;
+
     while (!interruptNet.load()) {
         DisconnectNodes();
         SocketHandler();
@@ -666,6 +675,15 @@ void CConnman::ThreadSocketHandler() {
                 >= INACTIVITY_CHECK_INTERVAL_SECONDS) {
             InactivityCheck();
             last_inactivity_check = now;
+        }
+
+        // Sweep stale rate-limit / dedup state periodically (every 60 seconds).
+        // Lock-safe here: this is OUTSIDE the cs_vNodes scope, and
+        // PeriodicRateLimitCleanup acquires only the rate-limit mutexes.
+        if (std::chrono::duration_cast<std::chrono::seconds>(now - last_ratelimit_cleanup).count()
+                >= RATELIMIT_CLEANUP_INTERVAL_SECONDS) {
+            PeriodicRateLimitCleanup();
+            last_ratelimit_cleanup = now;
         }
     }
 

--- a/src/net/net.cpp
+++ b/src/net/net.cpp
@@ -89,6 +89,49 @@ static const int MAX_DEDUP_BATCH_PENALTY = 20;      // Cap per-batch penalty so 
 static const int MAX_DEDUP_STRIKES = 3;             // Disconnect after this many duplicate GETDATA batches
 static std::map<int, int> g_peer_dedup_strikes;      // Per-peer strike counter
 
+// dilv-dedup-livelock-fix Part B (seed-side defense-in-depth).
+// The old behavior at the "Skip already-served blocks" continue was PERMANENT STARVATION:
+// a peer that re-requested an already-served block was never re-served and, after
+// MAX_DEDUP_STRIKES *monotonic* strikes, force-disconnected. That bit honest IBD clients
+// whose async validation lagged the wire by ~1s (the livelock this mission fixes) and the
+// legitimate VDF-divergence parent re-requests (ibd_coordinator.cpp:2057/1657). Part A fixes
+// the client root cause; Part B softens the seed so any residual re-request degrades to
+// BOUNDED wasted bandwidth, not a forced disconnect + IBD stall — while still bounding a
+// hostile peer that deliberately rotates hashes to amplify re-send bandwidth (red-team MED-2).
+static const int64_t RESEND_COOLDOWN_SECONDS = 2;    // <=1 re-send per (peer,blockhash) per this window
+static const int64_t RESEND_BUDGET_WINDOW_SECONDS = 60;
+static const int RESEND_MAX_PER_WINDOW = 16;         // contract: <=16 re-sends/60s, now byte-denominated below
+// MED-2: bound AGGREGATE re-send BYTES, not count — a hash-rotating attacker keeps every
+// per-hash cooldown at 1 while extracting up to 16 * 4MiB = 64 MiB/60s (~8.5 Mbit/s) under a
+// count bucket. Debit the WORST-CASE block size (Consensus::MAX_BLOCK_SIZE) per re-send so the
+// token bucket caps aggregate re-send bandwidth regardless of how many distinct hashes rotate.
+// Over-counting (real DilV blocks are far smaller) only throttles SOONER — the safe direction.
+static const int64_t RESEND_COST_BYTES = static_cast<int64_t>(MAX_BLOCK_VTX_BYTES);
+static const int64_t RESEND_BYTE_BUDGET_PER_WINDOW =
+    static_cast<int64_t>(RESEND_MAX_PER_WINDOW) * RESEND_COST_BYTES;  // 64 MiB / 60s aggregate cap
+// MED-3: this budget governs ONLY re-requests of already-served hashes. First-time block sends
+// never enter this branch, so honest deep-IBD (32 in-transit, first-time delivery) never touches
+// it; the only honest re-requests are the rare parent-recovery path — orders of magnitude under
+// 16 worst-case re-sends/60s. No honest-client throttle.
+// MED-4: the decaying strike counter alone lets a slow-drip attacker grief forever just under the
+// disconnect threshold, so retain an INDEPENDENT non-decaying "you've cost me too much total
+// re-send bandwidth on this connection" backstop that sustained abuse eventually trips regardless
+// of decay. Sized far above any honest re-send total over a full IBD.
+static const int64_t RESEND_BACKSTOP_TOTAL_BYTES = 512LL * RESEND_COST_BYTES;  // 2 GiB / connection
+static const int64_t STRIKE_DECAY_SECONDS = 60;     // MED-4: strikes decay -1 per 60s without duplicates
+
+// Per-(peer,blockhash) last re-send time — enforces RESEND_COOLDOWN_SECONDS.
+static std::map<int, std::map<uint256, int64_t>> g_peer_resend_times;
+// Per-peer byte token bucket (tokens in BYTES, refilled at RESEND_BYTE_BUDGET_PER_WINDOW/window).
+struct ResendBucket { int64_t tokens = 0; int64_t last_refill = 0; bool init = false; };
+static std::map<int, ResendBucket> g_peer_resend_bucket;
+// Per-peer last strike-affecting activity time — drives strike decay.
+static std::map<int, int64_t> g_peer_dedup_last_strike;
+// Per-peer MONOTONIC total re-sent bytes this connection — non-decaying disconnect backstop.
+static std::map<int, int64_t> g_peer_resend_total_bytes;
+// ALL of the above maps (plus g_peer_served_blocks / g_peer_dedup_strikes) are guarded by the
+// single cs_served_blocks mutex — one lock for all per-peer dedup/re-send state, no lock-ordering.
+
 // NET-013 FIX: Maximum size for rate limit maps to prevent memory exhaustion
 static const size_t MAX_RATE_LIMIT_MAP_SIZE = 1000;
 
@@ -143,6 +186,12 @@ void CleanupPeerRateLimitState(int peer_id) {
         std::lock_guard<std::mutex> lock(cs_served_blocks);
         g_peer_served_blocks.erase(peer_id);
         g_peer_dedup_strikes.erase(peer_id);
+        // dilv-dedup-livelock-fix Part B (LOW-2): release the per-peer re-send state on
+        // disconnect so it can't leak across connection churn.
+        g_peer_resend_times.erase(peer_id);
+        g_peer_resend_bucket.erase(peer_id);
+        g_peer_dedup_last_strike.erase(peer_id);
+        g_peer_resend_total_bytes.erase(peer_id);
     }
 }
 
@@ -207,6 +256,37 @@ void PeriodicRateLimitCleanup() {
             auto it = g_peer_served_blocks.begin();
             g_peer_dedup_strikes.erase(it->first);
             g_peer_served_blocks.erase(it);
+        }
+
+        // dilv-dedup-livelock-fix Part B (LOW-2): age out per-(peer,hash) re-send cooldown
+        // entries once the cooldown has elapsed (they carry no further meaning), drop emptied
+        // peers, and cap every per-peer re-send map at MAX_RATE_LIMIT_MAP_SIZE.
+        for (auto pit = g_peer_resend_times.begin(); pit != g_peer_resend_times.end(); ) {
+            auto& hashes = pit->second;
+            for (auto hit = hashes.begin(); hit != hashes.end(); ) {
+                if (now - hit->second > RESEND_COOLDOWN_SECONDS) {
+                    hit = hashes.erase(hit);
+                } else {
+                    ++hit;
+                }
+            }
+            if (hashes.empty()) {
+                pit = g_peer_resend_times.erase(pit);
+            } else {
+                ++pit;
+            }
+        }
+        while (g_peer_resend_times.size() > MAX_RATE_LIMIT_MAP_SIZE) {
+            g_peer_resend_times.erase(g_peer_resend_times.begin());
+        }
+        while (g_peer_resend_bucket.size() > MAX_RATE_LIMIT_MAP_SIZE) {
+            g_peer_resend_bucket.erase(g_peer_resend_bucket.begin());
+        }
+        while (g_peer_dedup_last_strike.size() > MAX_RATE_LIMIT_MAP_SIZE) {
+            g_peer_dedup_last_strike.erase(g_peer_dedup_last_strike.begin());
+        }
+        while (g_peer_resend_total_bytes.size() > MAX_RATE_LIMIT_MAP_SIZE) {
+            g_peer_resend_total_bytes.erase(g_peer_resend_total_bytes.begin());
         }
     }
 }
@@ -1151,54 +1231,155 @@ bool CNetMessageProcessor::ProcessGetDataMessage(int peer_id, CDataStream& strea
         }
 
         if (duplicate_count > 0) {
-            int penalty = std::min(duplicate_count * DUPLICATE_GETDATA_PENALTY, MAX_DEDUP_BATCH_PENALTY);
+            // dilv-dedup-livelock-fix Part B: rate-limited re-send instead of permanent starvation.
+            // Decide everything under ONE cs_served_blocks lock, then do all I/O (Misbehaving,
+            // DisconnectNode, on_getdata, logging) AFTER releasing it.
+            const int64_t now = GetTime();
+            std::set<uint256> resend_set;   // duplicate hashes approved for re-send this batch
+            int resend_count = 0;
+            int cooldown_skipped = 0;
+            bool budget_breached = false;
             int strikes = 0;
+            int64_t total_resent_bytes = 0;
             {
                 std::lock_guard<std::mutex> lock(cs_served_blocks);
-                strikes = ++g_peer_dedup_strikes[peer_id];
+
+                // --- MED-4: decay the strike counter (-1 per STRIKE_DECAY_SECONDS since last
+                //     strike-affecting activity) so honest long-lived connections don't strike out.
+                auto strike_it = g_peer_dedup_strikes.find(peer_id);
+                if (strike_it != g_peer_dedup_strikes.end() && strike_it->second > 0) {
+                    auto last_it = g_peer_dedup_last_strike.find(peer_id);
+                    if (last_it != g_peer_dedup_last_strike.end()) {
+                        int64_t elapsed = now - last_it->second;
+                        if (elapsed > 0) {
+                            int decay = static_cast<int>(elapsed / STRIKE_DECAY_SECONDS);
+                            if (decay > 0) {
+                                strike_it->second = std::max(0, strike_it->second - decay);
+                            }
+                        }
+                    }
+                }
+
+                // --- refill this peer's byte token bucket up to the per-window cap.
+                ResendBucket& bucket = g_peer_resend_bucket[peer_id];
+                if (!bucket.init) {
+                    bucket.tokens = RESEND_BYTE_BUDGET_PER_WINDOW;  // start full
+                    bucket.last_refill = now;
+                    bucket.init = true;
+                } else {
+                    int64_t elapsed = now - bucket.last_refill;
+                    if (elapsed > 0) {
+                        int64_t refill = elapsed * RESEND_BYTE_BUDGET_PER_WINDOW / RESEND_BUDGET_WINDOW_SECONDS;
+                        bucket.tokens = std::min(RESEND_BYTE_BUDGET_PER_WINDOW, bucket.tokens + refill);
+                        bucket.last_refill = now;
+                    }
+                }
+
+                // --- per duplicate hash: approve a re-send iff the per-(peer,hash) cooldown has
+                //     elapsed AND the byte budget has room. Cooldown-blocked dups are skipped
+                //     silently (could be honest impatience). Budget exhaustion is a breach.
+                auto& served = g_peer_served_blocks[peer_id];
+                auto& resend_times = g_peer_resend_times[peer_id];
+                for (const auto& inv : getdata) {
+                    if (inv.type != NetProtocol::MSG_BLOCK_INV) continue;
+                    if (!served.count(inv.hash)) continue;  // not a duplicate
+                    if (resend_set.count(inv.hash)) continue;  // already decided this hash in-batch
+                    auto rt = resend_times.find(inv.hash);
+                    if (rt != resend_times.end() && now - rt->second < RESEND_COOLDOWN_SECONDS) {
+                        ++cooldown_skipped;  // within cooldown — do not re-send, do not penalize
+                        continue;
+                    }
+                    if (bucket.tokens >= RESEND_COST_BYTES) {
+                        bucket.tokens -= RESEND_COST_BYTES;             // MED-2: debit worst-case bytes
+                        resend_times[inv.hash] = now;
+                        resend_set.insert(inv.hash);
+                        ++resend_count;
+                        total_resent_bytes = (g_peer_resend_total_bytes[peer_id] += RESEND_COST_BYTES);
+                    } else {
+                        budget_breached = true;  // out of budget — refuse re-send, penalize below
+                    }
+                }
+                // bound the per-(peer,hash) cooldown map (belt-and-suspenders; also swept periodically)
+                if (resend_times.size() > MAX_SERVED_BLOCKS_TRACK) {
+                    auto it = resend_times.begin();
+                    size_t to_remove = resend_times.size() - MAX_SERVED_BLOCKS_TRACK;
+                    for (size_t i = 0; i < to_remove; ++i) it = resend_times.erase(it);
+                }
+
+                // --- a budget BREACH (not a mere re-request) counts as one strike (post-decay).
+                //     Within-budget / cooldown-skipped re-requests are served (or quietly ignored)
+                //     FREE — no strike, no penalty — so honest low-rate parent-recovery re-requests
+                //     (ibd_coordinator.cpp:2057/1657; F-001 §3) are never disconnected. This keeps the
+                //     disconnect lever (strikes) gated identically to the penalty lever (Misbehaving),
+                //     which also fires only on breach below. re-send NEVER clears strikes.
+                if (budget_breached) {
+                    strikes = ++g_peer_dedup_strikes[peer_id];
+                    g_peer_dedup_last_strike[peer_id] = now;
+                } else {
+                    auto sit = g_peer_dedup_strikes.find(peer_id);
+                    strikes = (sit != g_peer_dedup_strikes.end()) ? sit->second : 0;  // report decayed value
+                }
+                if (total_resent_bytes == 0) {
+                    total_resent_bytes = g_peer_resend_total_bytes[peer_id];  // no re-send this batch
+                }
+            }
+
+            // --- MED-2/contract: Misbehaving penalty ONLY on budget breach (honest within-budget
+            //     re-requests are served free). Penalty scales with the batch, capped as before.
+            if (budget_breached) {
+                int penalty = std::min(duplicate_count * DUPLICATE_GETDATA_PENALTY, MAX_DEDUP_BATCH_PENALTY);
+                if (g_verbose.load(std::memory_order_relaxed))
+                    std::cout << "[P2P] DEDUP: Peer " << peer_id << " exceeded re-send byte budget (+"
+                              << penalty << " misbehavior, strike " << strikes << "/" << MAX_DEDUP_STRIKES
+                              << ")" << std::endl;
+                peer_manager.Misbehaving(peer_id, penalty, MisbehaviorType::GETDATA_RATE_EXCEEDED);
             }
             if (g_verbose.load(std::memory_order_relaxed))
-                std::cout << "[P2P] DEDUP: Peer " << peer_id << " re-requested "
-                          << duplicate_count << " already-served blocks (+"
-                          << penalty << " misbehavior, strike "
-                          << strikes << "/" << MAX_DEDUP_STRIKES << ")" << std::endl;
-            peer_manager.Misbehaving(peer_id, penalty, MisbehaviorType::GETDATA_RATE_EXCEEDED);
+                std::cout << "[P2P] DEDUP: Peer " << peer_id << " re-requested " << duplicate_count
+                          << " already-served blocks (re-send " << resend_count << ", cooldown-skip "
+                          << cooldown_skipped << ", strike " << strikes << "/" << MAX_DEDUP_STRIKES
+                          << ", total re-sent " << total_resent_bytes << "B)" << std::endl;
 
-            if (strikes >= MAX_DEDUP_STRIKES) {
+            // --- disconnect levers: (1) decaying strike counter for fast abuse; (2) MED-4
+            //     non-decaying total-re-sent-bytes backstop for slow-drip abuse under the strike
+            //     threshold. Honest clients trip neither (Part A removes the storm; residual
+            //     parent-recovery re-requests are orders of magnitude below both).
+            bool disconnect = (strikes >= MAX_DEDUP_STRIKES) ||
+                              (total_resent_bytes >= RESEND_BACKSTOP_TOTAL_BYTES);
+            if (disconnect) {
                 if (g_verbose.load(std::memory_order_relaxed))
                     std::cout << "[P2P] DEDUP: Disconnecting peer " << peer_id
-                              << " after " << strikes << " duplicate GETDATA batches (wasting bandwidth)" << std::endl;
+                              << " (strikes " << strikes << "/" << MAX_DEDUP_STRIKES
+                              << ", total re-sent " << total_resent_bytes << "B/"
+                              << RESEND_BACKSTOP_TOTAL_BYTES << "B)" << std::endl;
                 g_node_context.connman->DisconnectNode(peer_id);
-                {
-                    std::lock_guard<std::mutex> lock(cs_served_blocks);
-                    g_peer_served_blocks.erase(peer_id);
-                    g_peer_dedup_strikes.erase(peer_id);
-                }
+                CleanupPeerRateLimitState(peer_id);
                 return true;
             }
 
-            // Filter out already-served blocks, only serve new ones
-            std::vector<NetProtocol::CInv> new_items;
+            // --- serve: all non-duplicate items PLUS the duplicate items approved for re-send.
+            std::vector<NetProtocol::CInv> items_to_serve;
             {
                 std::lock_guard<std::mutex> lock(cs_served_blocks);
                 auto& served = g_peer_served_blocks[peer_id];
                 for (const auto& inv : getdata) {
-                    if (inv.type == NetProtocol::MSG_BLOCK_INV && served.count(inv.hash)) {
-                        continue;  // Skip already-served blocks
+                    bool is_dup = (inv.type == NetProtocol::MSG_BLOCK_INV) && served.count(inv.hash);
+                    if (!is_dup || resend_set.count(inv.hash)) {
+                        items_to_serve.push_back(inv);  // new item, or an approved re-send
                     }
-                    new_items.push_back(inv);
                 }
             }
-            if (!new_items.empty()) {
+            if (!items_to_serve.empty()) {
                 if (g_verbose.load(std::memory_order_relaxed))
-                    std::cout << "[P2P] Invoking GETDATA handler for " << new_items.size()
-                              << " NEW items from peer " << peer_id
-                              << " (skipped " << duplicate_count << " duplicates)" << std::endl;
-                on_getdata(peer_id, new_items);
+                    std::cout << "[P2P] Invoking GETDATA handler for " << items_to_serve.size()
+                              << " items from peer " << peer_id << " (" << resend_count
+                              << " rate-limited re-sends, " << cooldown_skipped << " cooldown-skipped)" << std::endl;
+                on_getdata(peer_id, items_to_serve);
             } else {
                 if (g_verbose.load(std::memory_order_relaxed))
                     std::cout << "[P2P] Skipping GETDATA for peer " << peer_id
-                              << " - all " << getdata.size() << " items already served" << std::endl;
+                              << " - all " << getdata.size() << " items already served, none re-sendable yet"
+                              << std::endl;
             }
         } else {
             // No duplicates - serve normally

--- a/src/net/net.cpp
+++ b/src/net/net.cpp
@@ -100,19 +100,24 @@ static std::map<int, int> g_peer_dedup_strikes;      // Per-peer strike counter
 // hostile peer that deliberately rotates hashes to amplify re-send bandwidth (red-team MED-2).
 static const int64_t RESEND_COOLDOWN_SECONDS = 2;    // <=1 re-send per (peer,blockhash) per this window
 static const int64_t RESEND_BUDGET_WINDOW_SECONDS = 60;
-static const int RESEND_MAX_PER_WINDOW = 16;         // contract: <=16 re-sends/60s, now byte-denominated below
+// L-b: this is the NUMBER OF WORST-CASE BLOCKS that fit in the per-window byte budget,
+// i.e. a budget-derivation input — NOT a re-send COUNT cap (more smaller real blocks may
+// re-send before the byte budget binds). Named accordingly.
+// L-a: lowered 16 -> 8, halving the aggregate re-send ceiling (64 -> 32 MiB/60s).
+static const int RESEND_BUDGET_BLOCK_EQUIV = 8;
 // MED-2: bound AGGREGATE re-send BYTES, not count — a hash-rotating attacker keeps every
-// per-hash cooldown at 1 while extracting up to 16 * 4MiB = 64 MiB/60s (~8.5 Mbit/s) under a
-// count bucket. Debit the WORST-CASE block size (Consensus::MAX_BLOCK_SIZE) per re-send so the
-// token bucket caps aggregate re-send bandwidth regardless of how many distinct hashes rotate.
-// Over-counting (real DilV blocks are far smaller) only throttles SOONER — the safe direction.
+// per-hash cooldown at 1 while extracting re-send bandwidth under a plain count bucket.
+// Debit the WORST-CASE block size (Consensus::MAX_BLOCK_SIZE = 4*1024*1024 = 4 MiB) per
+// re-send so the token bucket caps aggregate re-send bandwidth regardless of how many
+// distinct hashes rotate. Over-counting (real DilV blocks are far smaller) only throttles
+// SOONER — the safe direction. Aggregate ceiling: 8 * 4 MiB = 32 MiB/60s (~4.3 Mbit/s).
 static const int64_t RESEND_COST_BYTES = static_cast<int64_t>(MAX_BLOCK_VTX_BYTES);
 static const int64_t RESEND_BYTE_BUDGET_PER_WINDOW =
-    static_cast<int64_t>(RESEND_MAX_PER_WINDOW) * RESEND_COST_BYTES;  // 64 MiB / 60s aggregate cap
+    static_cast<int64_t>(RESEND_BUDGET_BLOCK_EQUIV) * RESEND_COST_BYTES;  // 32 MiB / 60s aggregate cap
 // MED-3: this budget governs ONLY re-requests of already-served hashes. First-time block sends
 // never enter this branch, so honest deep-IBD (32 in-transit, first-time delivery) never touches
 // it; the only honest re-requests are the rare parent-recovery path — orders of magnitude under
-// 16 worst-case re-sends/60s. No honest-client throttle.
+// 8 worst-case-block re-sends/60s. No honest-client throttle.
 // MED-4: the decaying strike counter alone lets a slow-drip attacker grief forever just under the
 // disconnect threshold, so retain an INDEPENDENT non-decaying "you've cost me too much total
 // re-send bandwidth on this connection" backstop that sustained abuse eventually trips regardless
@@ -249,18 +254,13 @@ void PeriodicRateLimitCleanup() {
         }
     }
 
-    // Clean up served blocks tracking (evict entries for large maps)
+    // Clean up the per-peer dedup / re-send state.
     {
         std::lock_guard<std::mutex> lock(cs_served_blocks);
-        while (g_peer_served_blocks.size() > MAX_RATE_LIMIT_MAP_SIZE) {
-            auto it = g_peer_served_blocks.begin();
-            g_peer_dedup_strikes.erase(it->first);
-            g_peer_served_blocks.erase(it);
-        }
 
         // dilv-dedup-livelock-fix Part B (LOW-2): age out per-(peer,hash) re-send cooldown
-        // entries once the cooldown has elapsed (they carry no further meaning), drop emptied
-        // peers, and cap every per-peer re-send map at MAX_RATE_LIMIT_MAP_SIZE.
+        // entries once the cooldown has elapsed (they carry no further meaning) and drop
+        // emptied peers. This is pure staleness reclamation, not capping.
         for (auto pit = g_peer_resend_times.begin(); pit != g_peer_resend_times.end(); ) {
             auto& hashes = pit->second;
             for (auto hit = hashes.begin(); hit != hashes.end(); ) {
@@ -276,17 +276,48 @@ void PeriodicRateLimitCleanup() {
                 ++pit;
             }
         }
-        while (g_peer_resend_times.size() > MAX_RATE_LIMIT_MAP_SIZE) {
-            g_peer_resend_times.erase(g_peer_resend_times.begin());
-        }
-        while (g_peer_resend_bucket.size() > MAX_RATE_LIMIT_MAP_SIZE) {
-            g_peer_resend_bucket.erase(g_peer_resend_bucket.begin());
-        }
-        while (g_peer_dedup_last_strike.size() > MAX_RATE_LIMIT_MAP_SIZE) {
-            g_peer_dedup_last_strike.erase(g_peer_dedup_last_strike.begin());
-        }
-        while (g_peer_resend_total_bytes.size() > MAX_RATE_LIMIT_MAP_SIZE) {
-            g_peer_resend_total_bytes.erase(g_peer_resend_total_bytes.begin());
+
+        // MED-2 / C-2: ATOMIC-UNIT capping. The six per-peer maps
+        // (g_peer_served_blocks, g_peer_dedup_strikes, g_peer_resend_times,
+        // g_peer_resend_bucket, g_peer_dedup_last_strike, g_peer_resend_total_bytes)
+        // describe ONE logical per-peer record. Capping them independently
+        // (the old `while(map.size()>cap) erase(begin())` per map) could half-evict a
+        // peer — e.g. drop its strikes/served set while keeping its
+        // resend_total_bytes — which would reset the non-decaying backstop or the
+        // dedup view for a still-live abuser. Instead, pick ONE victim set of
+        // peer_ids and erase those SAME peers from ALL six maps so no peer is ever
+        // half-present.
+        //
+        // The cap is keyed off g_peer_served_blocks (the largest / canonical
+        // per-peer record); after NEW-1 wires per-disconnect cleanup, this only
+        // fires under pathological churn beyond MAX_RATE_LIMIT_MAP_SIZE live peers.
+        //
+        // Eviction order: lowest peer_id first (std::map key order). Node IDs are
+        // monotonic and never reused (connman m_next_node_id), so lowest peer_id ==
+        // oldest connection. This is NOT attacker-gameable toward evicting a victim:
+        // an attacker cannot lower their own peer_id (IDs are server-assigned on
+        // connect), and evicting the oldest connections first is the desired LRU-ish
+        // behavior. Tradeoff (documented): we evict by connection age, not last
+        // activity — a cheap, monotonic, non-gameable proxy. A true last-activity
+        // timestamp isn't maintained for all peers (g_peer_dedup_last_strike only
+        // tracks strike events), so introducing one for ordering would add state for
+        // a path that is already a rare backstop behind NEW-1.
+        if (g_peer_served_blocks.size() > MAX_RATE_LIMIT_MAP_SIZE) {
+            size_t to_evict = g_peer_served_blocks.size() - MAX_RATE_LIMIT_MAP_SIZE;
+            std::vector<int> victims;
+            victims.reserve(to_evict);
+            for (auto it = g_peer_served_blocks.begin();
+                 it != g_peer_served_blocks.end() && victims.size() < to_evict; ++it) {
+                victims.push_back(it->first);
+            }
+            for (int victim : victims) {
+                g_peer_served_blocks.erase(victim);
+                g_peer_dedup_strikes.erase(victim);
+                g_peer_resend_times.erase(victim);
+                g_peer_resend_bucket.erase(victim);
+                g_peer_dedup_last_strike.erase(victim);
+                g_peer_resend_total_bytes.erase(victim);
+            }
         }
     }
 }
@@ -1234,6 +1265,11 @@ bool CNetMessageProcessor::ProcessGetDataMessage(int peer_id, CDataStream& strea
             // dilv-dedup-livelock-fix Part B: rate-limited re-send instead of permanent starvation.
             // Decide everything under ONE cs_served_blocks lock, then do all I/O (Misbehaving,
             // DisconnectNode, on_getdata, logging) AFTER releasing it.
+            // L-c (TOCTOU): the decide→release→serve split is safe because GETDATA for a given
+            // peer is processed by the SINGLE threadMessageHandler thread (connman.cpp:186), so no
+            // concurrent GETDATA from the same peer can interleave between the decision lock release
+            // and the serve. The lock guards only against unrelated threads touching the shared maps
+            // (e.g. the periodic sweep / disconnect cleanup), not against same-peer re-entrancy.
             const int64_t now = GetTime();
             std::set<uint256> resend_set;   // duplicate hashes approved for re-send this batch
             int resend_count = 0;
@@ -1344,9 +1380,31 @@ bool CNetMessageProcessor::ProcessGetDataMessage(int peer_id, CDataStream& strea
             //     non-decaying total-re-sent-bytes backstop for slow-drip abuse under the strike
             //     threshold. Honest clients trip neither (Part A removes the storm; residual
             //     parent-recovery re-requests are orders of magnitude below both).
-            bool disconnect = (strikes >= MAX_DEDUP_STRIKES) ||
-                              (total_resent_bytes >= RESEND_BACKSTOP_TOTAL_BYTES);
+            const bool backstop_tripped = (total_resent_bytes >= RESEND_BACKSTOP_TOTAL_BYTES);
+            bool disconnect = (strikes >= MAX_DEDUP_STRIKES) || backstop_tripped;
             if (disconnect) {
+                // MED-1/C-1: a backstop trip means this connection has cost us
+                // RESEND_BACKSTOP_TOTAL_BYTES (2 GiB) of re-sent block bandwidth — far
+                // above anything an honest IBD client (or rare parent-recovery re-request)
+                // could ever incur. That is PROVEN sustained abuse, so it is ban-worthy,
+                // not merely disconnect-worthy: a bare DisconnectNode lets the attacker
+                // reconnect with a fresh peer_id (node IDs are monotonic) and a reset
+                // budget, resuming the ~32 MiB/window drip indefinitely (this also closes
+                // C-3 slow-drip). Cross the misbehavior ban threshold (BAN_THRESHOLD = 100,
+                // peers.cpp:280 / peer_scorer m_ban_threshold) in ONE shot so banman.Ban
+                // records the IP persistently (checked at connect — survives reconnect).
+                // The strike-path disconnect (fast abuse) already routes through Misbehaving
+                // on each breach above, so it accumulates toward the same threshold; here we
+                // guarantee the slow-drip backstop also bans rather than just dropping.
+                if (backstop_tripped) {
+                    if (g_verbose.load(std::memory_order_relaxed))
+                        std::cout << "[P2P] DEDUP: Peer " << peer_id << " tripped re-send byte"
+                                  << " backstop (" << total_resent_bytes << "B/"
+                                  << RESEND_BACKSTOP_TOTAL_BYTES << "B) — banning (proven"
+                                  << " sustained abuse)" << std::endl;
+                    peer_manager.Misbehaving(peer_id, CPeerManager::BAN_THRESHOLD,
+                                             MisbehaviorType::GETDATA_RATE_EXCEEDED);
+                }
                 if (g_verbose.load(std::memory_order_relaxed))
                     std::cout << "[P2P] DEDUP: Disconnecting peer " << peer_id
                               << " (strikes " << strikes << "/" << MAX_DEDUP_STRIKES

--- a/src/net/net.cpp
+++ b/src/net/net.cpp
@@ -1146,6 +1146,7 @@ bool CNetMessageProcessor::ProcessGetDataMessage(int peer_id, CDataStream& strea
     try {
         // P2-1 FIX: Rate limiting for GETDATA messages
         // Prevents CPU exhaustion DoS via unlimited GETDATA requests
+        bool getdata_rate_breached = false;
         {
             std::lock_guard<std::mutex> lock(cs_getdata_rate);
             int64_t now = GetTime();
@@ -1161,10 +1162,21 @@ bool CNetMessageProcessor::ProcessGetDataMessage(int peer_id, CDataStream& strea
                 if (g_verbose.load(std::memory_order_relaxed))
                     std::cout << "[P2P] RATE LIMIT: Too many GETDATA from peer " << peer_id
                               << " (" << timestamps.size() << "/" << MAX_GETDATA_PER_SECOND << " per second)" << std::endl;
-                peer_manager.Misbehaving(peer_id, 2, MisbehaviorType::GETDATA_RATE_EXCEEDED);  // Reduced from 10 - IBD sync is legitimate
-                return false;
+                getdata_rate_breached = true;  // penalize AFTER releasing cs_getdata_rate (see below)
+            } else {
+                timestamps.push_back(now);
             }
-            timestamps.push_back(now);
+        }
+        // dilv-dedup-livelock-fix (F-009 BLOCKER-1): Misbehaving() takes cs_peers (via GetPeer),
+        // and the eviction/disconnect path takes cs_peers and then, via OnPeerDisconnected →
+        // CleanupPeerRateLimitState, the rate-limit mutexes. Calling Misbehaving WHILE holding
+        // cs_getdata_rate inverts that order → a reachable {cs_getdata_rate, cs_peers} AB-BA
+        // deadlock (GETDATA-storm peer + inbound-at-limit eviction). INVARIANT: never call
+        // Misbehaving (or anything that acquires cs_peers) while holding a rate-limit mutex —
+        // decide under the lock, penalize after release (the Part B dedup branch does the same).
+        if (getdata_rate_breached) {
+            peer_manager.Misbehaving(peer_id, 2, MisbehaviorType::GETDATA_RATE_EXCEEDED);  // Reduced from 10 - IBD sync is legitimate
+            return false;
         }
 
         // BUG #87 DEBUG: Log GETDATA processing
@@ -1265,6 +1277,12 @@ bool CNetMessageProcessor::ProcessGetDataMessage(int peer_id, CDataStream& strea
             // dilv-dedup-livelock-fix Part B: rate-limited re-send instead of permanent starvation.
             // Decide everything under ONE cs_served_blocks lock, then do all I/O (Misbehaving,
             // DisconnectNode, on_getdata, logging) AFTER releasing it.
+            // LOCK-ORDER INVARIANT (F-009 LOW-1): Misbehaving must stay OUTSIDE the cs_served_blocks
+            // scope below. Misbehaving→GetPeer takes cs_peers, and the disconnect path takes
+            // cs_peers then (via OnPeerDisconnected→CleanupPeerRateLimitState) cs_served_blocks;
+            // a Misbehaving call inside this lock would create a {cs_served_blocks, cs_peers} AB-BA
+            // deadlock (the same class F-009 BLOCKER-1 found+fixed for cs_getdata_rate). Do not move
+            // any Misbehaving/cs_peers-acquiring call into the locked region.
             // L-c (TOCTOU): the decide→release→serve split is safe because GETDATA for a given
             // peer is processed by the SINGLE threadMessageHandler thread (connman.cpp:186), so no
             // concurrent GETDATA from the same peer can interleave between the decision lock release

--- a/src/net/net.h
+++ b/src/net/net.h
@@ -329,4 +329,20 @@ static constexpr uint8_t REJECT_DUPLICATE   = 0x12;
 void SendRejectMessage(int peer_id, const std::string& command, const std::string& reason,
                        uint8_t code = REJECT_INVALID);
 
+// dilv-dedup-livelock-fix (NEW-1 / F-007): leak-class cleanups for the per-peer
+// GETDATA/HEADERS rate-limit + dedup/re-send maps. Declared here so the normal
+// disconnect path (CPeerManager::OnPeerDisconnected, peers.cpp) and the periodic
+// ThreadSocketHandler sweep (connman.cpp) can call them — they were previously
+// file-local to net.cpp and so were never wired to those paths.
+//
+// LOCK ORDER (verified, dilv-dedup-livelock NEW-1): CleanupPeerRateLimitState
+// acquires cs_getdata_rate → cs_headers_rate → cs_served_blocks. It is safe to
+// call from OnPeerDisconnected (which runs under CConnman::cs_vNodes), because no
+// code path acquires any of those three rate-limit mutexes and THEN cs_vNodes:
+// the dedup branch in ProcessGetDataMessage always releases cs_served_blocks
+// before any CConnman call (DisconnectNode/PushMessage/Misbehaving). Order is
+// therefore cs_vNodes → {rate-limit mutexes}, with no inversion.
+void CleanupPeerRateLimitState(int peer_id);
+void PeriodicRateLimitCleanup();
+
 #endif // DILITHION_NET_NET_H

--- a/src/net/net.h
+++ b/src/net/net.h
@@ -335,13 +335,22 @@ void SendRejectMessage(int peer_id, const std::string& command, const std::strin
 // ThreadSocketHandler sweep (connman.cpp) can call them — they were previously
 // file-local to net.cpp and so were never wired to those paths.
 //
-// LOCK ORDER (verified, dilv-dedup-livelock NEW-1): CleanupPeerRateLimitState
-// acquires cs_getdata_rate → cs_headers_rate → cs_served_blocks. It is safe to
-// call from OnPeerDisconnected (which runs under CConnman::cs_vNodes), because no
-// code path acquires any of those three rate-limit mutexes and THEN cs_vNodes:
-// the dedup branch in ProcessGetDataMessage always releases cs_served_blocks
-// before any CConnman call (DisconnectNode/PushMessage/Misbehaving). Order is
-// therefore cs_vNodes → {rate-limit mutexes}, with no inversion.
+// LOCK ORDER (dilv-dedup-livelock NEW-1 + F-009 BLOCKER-1 fix). The four relevant
+// mutex classes and their global acquisition order:
+//     cs_vNodes  →  cs_peers  →  {cs_getdata_rate, cs_headers_rate, cs_served_blocks}
+// CleanupPeerRateLimitState acquires the three rate-limit mutexes (last in the order),
+// so it is safe to call from OnPeerDisconnected even though the eviction/disconnect
+// callers hold cs_vNodes and/or cs_peers across the dispatch (AcceptConnection →
+// EvictPeersIfNeeded → DispatchPeerDisconnected → OnPeerDisconnected).
+// The ONLY way this inverts is if some path takes a rate-limit mutex and THEN cs_peers.
+// cs_peers is reached via CPeerManager::Misbehaving → GetPeer. INVARIANT (enforced):
+// no code calls Misbehaving (or otherwise acquires cs_peers) while holding any
+// rate-limit mutex — the GETDATA rate limiter (net.cpp) and the Part B dedup branch
+// both decide under the lock and penalize only after releasing it. F-009 BLOCKER-1
+// was exactly such an inversion (Misbehaving inside cs_getdata_rate) and was fixed by
+// hoisting that call out of the lock. cs_headers_rate never penalizes; cs_served_blocks
+// penalizes only after release. Do not reintroduce a Misbehaving call inside any of
+// these three scopes.
 void CleanupPeerRateLimitState(int peer_id);
 void PeriodicRateLimitCleanup();
 

--- a/src/net/peers.cpp
+++ b/src/net/peers.cpp
@@ -1658,6 +1658,19 @@ void CPeerManager::OnPeerDisconnected(int peer_id)
     connection_quality.RemovePeer(peer_id);
     m_peer_bandwidth_throttle.RemovePeer(peer_id);
 
+    // dilv-dedup-livelock-fix (NEW-1): next instance of the F19/F20/F21 leak class.
+    // CleanupPeerRateLimitState was previously called ONLY from the dedup self-
+    // disconnect branch (net.cpp); the normal disconnect path (timeout / eviction /
+    // graceful) left all six dedup/re-send maps behind. Node IDs are monotonic
+    // (never reused, connman m_next_node_id), so on a long-running seed serving
+    // IBD to churning peers the maps grew unbounded = slow memory-exhaustion DoS.
+    // Wiring it here releases that state on EVERY disconnect.
+    // Lock-order safety: this runs under CConnman::cs_vNodes (DisconnectNodes →
+    // DispatchPeerDisconnected); CleanupPeerRateLimitState takes the rate-limit
+    // mutexes only, and no path takes a rate-limit mutex then cs_vNodes — no
+    // inversion (see decl comment in net.h).
+    CleanupPeerRateLimitState(peer_id);
+
     // The actual peer removal is handled by RemovePeer()
 }
 

--- a/src/net/peers.cpp
+++ b/src/net/peers.cpp
@@ -1665,10 +1665,14 @@ void CPeerManager::OnPeerDisconnected(int peer_id)
     // (never reused, connman m_next_node_id), so on a long-running seed serving
     // IBD to churning peers the maps grew unbounded = slow memory-exhaustion DoS.
     // Wiring it here releases that state on EVERY disconnect.
-    // Lock-order safety: this runs under CConnman::cs_vNodes (DisconnectNodes →
-    // DispatchPeerDisconnected); CleanupPeerRateLimitState takes the rate-limit
-    // mutexes only, and no path takes a rate-limit mutex then cs_vNodes — no
-    // inversion (see decl comment in net.h).
+    // Lock-order safety (F-009 BLOCKER-1): this runs under the eviction/disconnect
+    // locks (cs_vNodes and/or cs_peers — e.g. EvictPeersIfNeeded holds cs_peers
+    // across DispatchPeerDisconnected). CleanupPeerRateLimitState takes only the
+    // rate-limit mutexes, which sit LAST in the global order
+    // (cs_vNodes → cs_peers → {rate-limit mutexes}). This is safe ONLY because the
+    // invariant "never call Misbehaving / acquire cs_peers while holding a rate-limit
+    // mutex" holds — F-009 found+fixed the one violation (Misbehaving inside the
+    // GETDATA rate limiter, now hoisted). See the full order note at net.h decl.
     CleanupPeerRateLimitState(peer_id);
 
     // The actual peer removal is handled by RemovePeer()

--- a/src/test/ibd_functional_tests.cpp
+++ b/src/test/ibd_functional_tests.cpp
@@ -376,4 +376,317 @@ BOOST_AUTO_TEST_CASE(test_clear_above_height) {
     g_node_context.block_tracker = std::move(old_tracker);
 }
 
+// ============================================================================
+// Part B seed-side rate-limited re-send test
+// (dilv-dedup-livelock-fix mission, LOW-1 deterministic proof)
+//
+// Seam: CNetMessageProcessor::ProcessMessage() (public) dispatches to the
+// private ProcessGetDataMessage which contains all the Part B logic.
+//
+// We drive the seam with serialized "getdata" CNetMessages. Pre-seeding the
+// served-block state is automatic: the code records every block hash served
+// via on_getdata in g_peer_served_blocks at the end of ProcessGetDataMessage.
+//
+// Time mocking: GetTime() is a thin inline over time(nullptr) with no mock
+// hook. Assertions that require wall-clock gaps (cooldown) use distinct hashes
+// so each gets its own per-(peer,hash) cooldown entry. Assertions that do NOT
+// require time mocking (budget breach, cleanup observable) work deterministically.
+//
+// Disconnect observable: CleanupPeerRateLimitState() erases g_peer_served_blocks
+// for the disconnected peer. We observe this by sending a post-disconnect GETDATA
+// with one of the previously-served hashes and checking on_getdata fires (meaning
+// the hash is no longer in the served set = cleanup occurred).
+// ============================================================================
+BOOST_AUTO_TEST_CASE(test_partb_seed_rate_limited_resend) {
+    if (!Dilithion::g_chainParams)
+        Dilithion::g_chainParams = new Dilithion::ChainParams();
+
+    // -----------------------------------------------------------------------
+    // Scaffold: a CPeerManager + CNetMessageProcessor with a minimal connman
+    // so DisconnectNode() doesn't crash when called with an unknown peer ID.
+    // CConnman::DisconnectNode iterates m_nodes and silently returns if the
+    // peer ID is not found — safe to call on a default-constructed connman.
+    // -----------------------------------------------------------------------
+    CPeerManager peer_manager("");
+    CNetMessageProcessor proc(peer_manager);
+
+    // Wire g_node_context.connman so the disconnect path in ProcessGetDataMessage
+    // doesn't dereference a null pointer.
+    auto connman = std::make_unique<CConnman>();
+    g_node_context.connman = std::move(connman);
+
+    // Counters / observables updated by the on_getdata callback.
+    std::atomic<int> getdata_call_count{0};
+    std::vector<uint256> served_hashes;
+    std::mutex served_mu;
+
+    proc.SetGetDataHandler([&](int /*peer_id*/, const std::vector<NetProtocol::CInv>& items) {
+        getdata_call_count.fetch_add(1, std::memory_order_relaxed);
+        std::lock_guard<std::mutex> lk(served_mu);
+        for (const auto& inv : items) {
+            if (inv.type == NetProtocol::MSG_BLOCK_INV)
+                served_hashes.push_back(inv.hash);
+        }
+    });
+
+    // Helper: build a serialized "getdata" CNetMessage for a list of CInv.
+    // Mirrors CNetMessageProcessor::SerializeInvMessage + CreateGetDataMessage.
+    auto make_getdata = [](const std::vector<NetProtocol::CInv>& invs) {
+        CDataStream s;
+        s.WriteCompactSize(invs.size());
+        for (const auto& inv : invs) {
+            s.WriteUint32(inv.type);
+            s.WriteUint256(inv.hash);
+        }
+        return CNetMessage("getdata", s.GetData());
+    };
+
+    // Helper: build a single-hash CInv (MSG_BLOCK_INV).
+    auto block_inv = [](uint8_t seed) {
+        NetProtocol::CInv inv;
+        inv.type = NetProtocol::MSG_BLOCK_INV;
+        inv.hash.data[0] = seed;
+        return inv;
+    };
+
+    // Pre-register test peer IDs with the peer manager so Misbehaving() is not
+    // a no-op (CPeerManager::Misbehaving returns early when GetPeer(id) returns
+    // null).  AddPeerWithId creates a minimal CPeer entry without requiring a
+    // live socket or address.
+    const int peer_a = 10, peer_b_id = 10, peer_c = 20, peer_d = 30, peer_e = 40;
+    peer_manager.AddPeerWithId(peer_a);
+    peer_manager.AddPeerWithId(peer_c);
+    peer_manager.AddPeerWithId(peer_d);
+    peer_manager.AddPeerWithId(peer_e);
+
+    // -----------------------------------------------------------------------
+    // (a) Re-send happens: a first GETDATA for an already-served block triggers
+    //     a re-send (via on_getdata), not a permanent skip.
+    //
+    // Peer 10 serves hash A (first time, no duplicate). Then re-requests hash A
+    // (now a duplicate). Under Part B, on_getdata should fire again (re-send
+    // approved, within budget, cooldown just started this instant).
+    //
+    // NOTE: cooldown is RESEND_COOLDOWN_SECONDS=2. The cooldown timer is only
+    // SET after a re-send is approved. Therefore the first re-request of a hash
+    // is ALWAYS approved (no prior cooldown entry for that hash). The second
+    // re-request of the SAME hash within 2s is what cooldown blocks (in (b)).
+    // -----------------------------------------------------------------------
+    {
+        uint256 hash_a; hash_a.data[0] = 0x01;
+
+        // First serve: non-duplicate, recorded in served set.
+        getdata_call_count = 0;
+        BOOST_CHECK(proc.ProcessMessage(peer_a, make_getdata({block_inv(0x01)})));
+        BOOST_CHECK_EQUAL(getdata_call_count.load(), 1);  // served first time
+
+        // Second send (duplicate): first re-request of this hash → no prior cooldown
+        // entry → approved for re-send.
+        int before = getdata_call_count.load();
+        BOOST_CHECK(proc.ProcessMessage(peer_a, make_getdata({block_inv(0x01)})));
+        // on_getdata must have fired again: re-send approved, not permanently skipped.
+        BOOST_CHECK_GT(getdata_call_count.load(), before);  // (a) PASS
+    }
+
+    // -----------------------------------------------------------------------
+    // (b) Cooldown: a second re-request for the SAME hash within 2s does NOT
+    //     trigger another re-send. The re-send timestamp was just set by (a)
+    //     above. We immediately re-request peer 10 hash 0x01 again — cooldown
+    //     should block it (no additional on_getdata call for that hash).
+    //
+    //     We also assert no Misbehaving was applied (cooldown skip is silent).
+    //     Misbehavior score remains at 0 because a cooldown-skipped re-request
+    //     is not a budget breach.
+    // -----------------------------------------------------------------------
+    {
+        // peer_b_id = 10 (same peer as (a), same hash — cooldown was just set above)
+        int before = getdata_call_count.load();
+        int score_before = peer_manager.GetMisbehaviorScore(peer_b_id);
+
+        BOOST_CHECK(proc.ProcessMessage(peer_b_id, make_getdata({block_inv(0x01)})));
+
+        // on_getdata must NOT have fired for the cooldown-blocked hash.
+        // We sent only one item so the batch is purely cooldown-blocked.
+        BOOST_CHECK_EQUAL(getdata_call_count.load(), before);  // (b) re-send count unchanged
+
+        // Misbehaving must not have been called (no budget breach).
+        BOOST_CHECK_EQUAL(peer_manager.GetMisbehaviorScore(peer_b_id), score_before);  // (b) no penalty
+    }
+
+    // -----------------------------------------------------------------------
+    // (c) Within-budget = FREE: an honest peer doing within-budget re-requests
+    //     (distinct hashes, each re-requested once) gets ZERO Misbehaving calls
+    //     and is NOT disconnected.
+    //
+    //     Budget = 16 re-sends * 4MiB = 64 MiB per 60s window.
+    //     We issue 15 distinct-hash re-requests (well under the 16-re-send limit)
+    //     using a fresh peer ID (peer 20) so the budget starts full.
+    //     Each hash is re-requested only once (no cooldown issue — each has
+    //     its own cooldown timer, and the timer is only set on re-send approval).
+    //
+    //     Assertion: misbehavior score stays 0 for the whole batch.
+    // -----------------------------------------------------------------------
+    {
+        const int peer_c = 20;
+        const int WITHIN_BUDGET_REQS = 15;  // 15 < 16 = budget capacity
+
+        // First: serve 15 distinct hashes to populate served set.
+        {
+            std::vector<NetProtocol::CInv> first_batch;
+            for (int i = 0; i < WITHIN_BUDGET_REQS; ++i) {
+                first_batch.push_back(block_inv(static_cast<uint8_t>(0x10 + i)));
+            }
+            BOOST_CHECK(proc.ProcessMessage(peer_c, make_getdata(first_batch)));
+        }
+
+        int score_before = peer_manager.GetMisbehaviorScore(peer_c);
+        BOOST_CHECK_EQUAL(score_before, 0);  // sanity: no prior misbehavior
+
+        // Re-request all 15 in a single batch (distinct hashes, each re-send
+        // is the FIRST re-send for its hash so no cooldown applies).
+        {
+            std::vector<NetProtocol::CInv> dup_batch;
+            for (int i = 0; i < WITHIN_BUDGET_REQS; ++i) {
+                dup_batch.push_back(block_inv(static_cast<uint8_t>(0x10 + i)));
+            }
+            BOOST_CHECK(proc.ProcessMessage(peer_c, make_getdata(dup_batch)));
+        }
+
+        // Misbehaving must be ZERO: within-budget re-requests are served free.
+        BOOST_CHECK_EQUAL(peer_manager.GetMisbehaviorScore(peer_c), 0);  // (c) PASS: no false positive
+    }
+
+    // -----------------------------------------------------------------------
+    // (d) Budget breach penalizes: a peer that exhausts the byte budget by
+    //     rotating distinct already-served hashes triggers a Misbehaving
+    //     penalty on the batch that exceeds the budget.
+    //
+    //     Budget capacity = RESEND_MAX_PER_WINDOW = 16 re-sends per window.
+    //     RESEND_COST_BYTES = MAX_BLOCK_SIZE = 4 MiB per re-send.
+    //     RESEND_BYTE_BUDGET_PER_WINDOW = 16 * 4 MiB = 64 MiB.
+    //
+    //     Strategy: serve 20 distinct hashes to peer 30 (so they're in served
+    //     set). Then re-request all 20 in a single batch. The first 16 are
+    //     approved (draining the budget), the 17th triggers budget_breached =
+    //     true → Misbehaving is called with a non-zero penalty.
+    //
+    //     We use a fresh peer (peer 30) so budget starts full.
+    // -----------------------------------------------------------------------
+    {
+        const int peer_d = 30;
+        const int OVER_BUDGET_HASHES = 20;  // 20 > 16 (budget capacity)
+
+        // First: serve 20 distinct hashes.
+        {
+            std::vector<NetProtocol::CInv> first_batch;
+            for (int i = 0; i < OVER_BUDGET_HASHES; ++i) {
+                first_batch.push_back(block_inv(static_cast<uint8_t>(0x30 + i)));
+            }
+            BOOST_CHECK(proc.ProcessMessage(peer_d, make_getdata(first_batch)));
+        }
+
+        int score_before = peer_manager.GetMisbehaviorScore(peer_d);
+        BOOST_CHECK_EQUAL(score_before, 0);  // no prior misbehavior
+
+        // Re-request all 20 (first 16 approved, 17th breaches budget).
+        {
+            std::vector<NetProtocol::CInv> dup_batch;
+            for (int i = 0; i < OVER_BUDGET_HASHES; ++i) {
+                dup_batch.push_back(block_inv(static_cast<uint8_t>(0x30 + i)));
+            }
+            BOOST_CHECK(proc.ProcessMessage(peer_d, make_getdata(dup_batch)));
+        }
+
+        // Misbehaving must have been called with a non-zero penalty.
+        BOOST_CHECK_GT(peer_manager.GetMisbehaviorScore(peer_d), score_before);  // (d) PASS
+    }
+
+    // -----------------------------------------------------------------------
+    // (e) Backstop disconnects on sustained abuse: 3 budget-breach batches
+    //     accumulate 3 strikes → disconnect fires (via MAX_DEDUP_STRIKES = 3).
+    //
+    //     Strategy: peer 40 serves 20 hashes. We re-request all 20 three times.
+    //     Each batch drains the budget past the breach threshold and increments
+    //     the strike counter. After 3 batches, strikes = 3 = MAX_DEDUP_STRIKES
+    //     → DisconnectNode() + CleanupPeerRateLimitState().
+    //
+    //     Observable: after disconnect, sending the same hash again must trigger
+    //     on_getdata (the served set was erased by cleanup, so the hash is no
+    //     longer a "known duplicate" and gets served as a first-time block).
+    //
+    //     NOTE: the byte token bucket refills at RESEND_BYTE_BUDGET_PER_WINDOW
+    //     / RESEND_BUDGET_WINDOW_SECONDS per second of elapsed time. Within the
+    //     same wall-clock second all three batches arrive, so the bucket stays
+    //     drained (no meaningful refill). Each batch re-sends 16 hashes (budget
+    //     exhausted), then reaches budget_breached on the 17th, incrementing the
+    //     strike counter once per batch. After 3 batches → 3 strikes → disconnect.
+    //
+    //     The second and third batches are NEW rotated hash sets (different
+    //     seeds 0x40+20..0x40+39 and 0x40+40..0x40+59) to avoid the cooldown
+    //     on hashes from the first batch that WERE approved for re-send.
+    //     Budget is already exhausted from the first batch regardless.
+    // -----------------------------------------------------------------------
+    {
+        const int peer_e = 40;
+        const int HASHES_PER_BATCH = 20;   // > 16 (triggers breach on each batch)
+        const int NUM_STRIKE_BATCHES = 3;  // = MAX_DEDUP_STRIKES
+
+        // First: serve HASHES_PER_BATCH * NUM_STRIKE_BATCHES distinct hashes
+        // so we have enough unique "already-served" hashes to rotate across batches.
+        {
+            std::vector<NetProtocol::CInv> first_serve;
+            for (int b = 0; b < NUM_STRIKE_BATCHES; ++b) {
+                for (int i = 0; i < HASHES_PER_BATCH; ++i) {
+                    NetProtocol::CInv inv;
+                    inv.type = NetProtocol::MSG_BLOCK_INV;
+                    inv.hash.data[0] = static_cast<uint8_t>(0x40 + b * HASHES_PER_BATCH + i);
+                    inv.hash.data[1] = 0xEE;  // distinguish from other test peers
+                    first_serve.push_back(inv);
+                }
+            }
+            BOOST_CHECK(proc.ProcessMessage(peer_e, make_getdata(first_serve)));
+        }
+
+        // Three breach batches — one per strike.
+        for (int b = 0; b < NUM_STRIKE_BATCHES; ++b) {
+            std::vector<NetProtocol::CInv> dup_batch;
+            for (int i = 0; i < HASHES_PER_BATCH; ++i) {
+                NetProtocol::CInv inv;
+                inv.type = NetProtocol::MSG_BLOCK_INV;
+                inv.hash.data[0] = static_cast<uint8_t>(0x40 + b * HASHES_PER_BATCH + i);
+                inv.hash.data[1] = 0xEE;
+                dup_batch.push_back(inv);
+            }
+            proc.ProcessMessage(peer_e, make_getdata(dup_batch));
+        }
+
+        // After 3 strike batches the code calls DisconnectNode(peer_e) then
+        // CleanupPeerRateLimitState(peer_e), which erases g_peer_served_blocks[peer_e].
+        // Observable: a now-"served" hash sent again must be treated as a first-time
+        // request (no longer in the served set), so on_getdata fires.
+        // Use hash data[0]=0x40, data[1]=0xEE which was in the first_serve batch.
+        int before = getdata_call_count.load();
+        {
+            NetProtocol::CInv inv;
+            inv.type = NetProtocol::MSG_BLOCK_INV;
+            inv.hash.data[0] = 0x40;
+            inv.hash.data[1] = 0xEE;
+            BOOST_CHECK(proc.ProcessMessage(peer_e, make_getdata({inv})));
+        }
+        // If cleanup happened (disconnect fired), the hash is unknown → on_getdata fired.
+        // If cleanup did NOT happen, the hash is in served set → duplicate path → no re-send.
+        // (Well, the budget may be exhausted too, but clean state = on_getdata fires.)
+        BOOST_CHECK_GT(getdata_call_count.load(), before);  // (e) PASS: cleanup confirms disconnect fired
+
+        // Document which lever fired: the strike counter is the primary lever here.
+        // MAX_DEDUP_STRIKES = 3. Each breach batch increments strikes by 1.
+        // 3 batches → strikes = 3 = MAX_DEDUP_STRIKES → disconnect.
+        // The RESEND_BACKSTOP_TOTAL_BYTES lever (2 GiB = 512 re-sends * 4MiB) would
+        // require ~512 re-sends to trip alone; with 3*16=48 re-sends we are far below it.
+    }
+
+    // Teardown: restore g_node_context.connman to avoid leaking into other tests.
+    g_node_context.connman.reset();
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/ibd_functional_tests.cpp
+++ b/src/test/ibd_functional_tests.cpp
@@ -235,6 +235,52 @@ BOOST_AUTO_TEST_CASE(test_addblock_rejects_completed_height_dedup_livelock) {
     g_node_context.block_tracker = std::move(old_tracker);
 }
 
+BOOST_AUTO_TEST_CASE(test_clear_above_height_reenables_completed_refetch_after_reorg) {
+    // Reorg-safety regression for Part A (mission dilv-dedup-livelock-fix, L-e / F-004 LOW-4).
+    //
+    // Part A's AddBlock rejects any height in m_completed_heights so the direct
+    // stall-recovery path can't re-request a height already in the DB
+    // (test_addblock_rejects_completed_height_dedup_livelock proves the reject).
+    // The LOAD-BEARING-BUT-UNTESTED other half of that invariant is reorg safety:
+    // after a reorg, ClearAboveHeight(fork_point) MUST clear m_completed_heights
+    // above the fork point so the orphaned-then-completed height becomes
+    // re-requestable again. If ClearAboveHeight did NOT clear m_completed_heights,
+    // a height completed on the losing fork would be permanently un-fetchable on
+    // the winning fork = a stall. This test exercises that clear-and-re-enable path
+    // end to end through the public CBlockFetcher API.
+    CPeerManager peer_manager("");
+    CBlockFetcher fetcher(&peer_manager);
+
+    auto block_tracker = std::make_unique<CBlockTracker>();
+    auto old_tracker = std::move(g_node_context.block_tracker);
+    g_node_context.block_tracker = std::move(block_tracker);
+
+    const int H = 150;
+    uint256 hash; hash.data[0] = 0xCD;
+    const NodeId peer_id = 1;
+
+    // 1. Mark height H completed (orphan-with-data path: MarkCompleted(parent+1)).
+    g_node_context.block_tracker->MarkCompleted(H);
+    BOOST_CHECK(g_node_context.block_tracker->IsTracked(H));
+
+    // 2. AddBlock(H) is REFUSED while H is completed (Part A guard).
+    BOOST_CHECK(!fetcher.RequestBlockFromPeer(peer_id, H, hash));
+    BOOST_CHECK_EQUAL(fetcher.GetInFlightCount(), 0);
+
+    // 3. A reorg clears everything above the fork point H-1. This MUST drop the
+    //    completed flag for H (ClearAboveHeight clears m_completed_heights > fork_point).
+    fetcher.ClearAboveHeight(H - 1);
+    BOOST_CHECK(!g_node_context.block_tracker->IsTracked(H));  // completed flag gone
+
+    // 4. THE RE-ENABLE: AddBlock(H) now SUCCEEDS — the height is re-requestable on
+    //    the winning fork. Pre-clear it was permanently refused; post-clear it is fetchable.
+    BOOST_CHECK(fetcher.RequestBlockFromPeer(peer_id, H, hash));
+    BOOST_CHECK_EQUAL(fetcher.GetInFlightCount(), 1);
+    BOOST_CHECK(fetcher.IsHeightInFlight(H));
+
+    g_node_context.block_tracker = std::move(old_tracker);
+}
+
 BOOST_AUTO_TEST_CASE(test_headers_manager_basic) {
     // Test basic headers manager functionality
     if (!Dilithion::g_chainParams)
@@ -489,27 +535,38 @@ BOOST_AUTO_TEST_CASE(test_partb_seed_rate_limited_resend) {
     }
 
     // -----------------------------------------------------------------------
-    // (b) Cooldown: a second re-request for the SAME hash within 2s does NOT
-    //     trigger another re-send. The re-send timestamp was just set by (a)
-    //     above. We immediately re-request peer 10 hash 0x01 again — cooldown
-    //     should block it (no additional on_getdata call for that hash).
+    // (b) Cooldown: a re-request for a hash whose re-send was approved earlier in
+    //     THIS test, within RESEND_COOLDOWN_SECONDS (2s), does NOT trigger another
+    //     re-send and is NOT penalized (cooldown skip is silent).
     //
-    //     We also assert no Misbehaving was applied (cooldown skip is silent).
-    //     Misbehavior score remains at 0 because a cooldown-skipped re-request
-    //     is not a budget breach.
+    //     L-d (wall-clock robustness): rather than rely on the (a)->(b) gap being
+    //     < 2s (whole-second GetTime() with no mock hook — a stalled CI box could
+    //     in principle straddle a 2s boundary), we make the cooldown set-and-test
+    //     a single tight pair on a FRESH hash inside this block: approve a re-send
+    //     for hash 0x02 (sets its cooldown at GetTime()=T), then IMMEDIATELY
+    //     re-request 0x02 again. The two ProcessMessage calls are adjacent
+    //     statements (microseconds apart), so the second is guaranteed to fall in
+    //     [T, T+1] << 2s regardless of scheduling jitter. This removes the
+    //     dependency on when (a) ran. peer_b_id = 10 (same peer as (a)).
     // -----------------------------------------------------------------------
     {
-        // peer_b_id = 10 (same peer as (a), same hash — cooldown was just set above)
+        // Serve a fresh hash 0x02 first (non-duplicate), so the next request is its
+        // FIRST re-request → re-send approved → cooldown timer set at GetTime()=T.
+        BOOST_CHECK(proc.ProcessMessage(peer_b_id, make_getdata({block_inv(0x02)})));   // serve
+        int after_serve = getdata_call_count.load();
+        BOOST_CHECK(proc.ProcessMessage(peer_b_id, make_getdata({block_inv(0x02)})));   // 1st re-request: approved
+        BOOST_CHECK_GT(getdata_call_count.load(), after_serve);  // re-send happened, cooldown now set at T
+
         int before = getdata_call_count.load();
         int score_before = peer_manager.GetMisbehaviorScore(peer_b_id);
 
-        BOOST_CHECK(proc.ProcessMessage(peer_b_id, make_getdata({block_inv(0x01)})));
+        // 2nd re-request of 0x02, adjacent statement → within [T, T+1] << 2s cooldown.
+        BOOST_CHECK(proc.ProcessMessage(peer_b_id, make_getdata({block_inv(0x02)})));
 
-        // on_getdata must NOT have fired for the cooldown-blocked hash.
-        // We sent only one item so the batch is purely cooldown-blocked.
+        // on_getdata must NOT have fired: the single-item batch is purely cooldown-blocked.
         BOOST_CHECK_EQUAL(getdata_call_count.load(), before);  // (b) re-send count unchanged
 
-        // Misbehaving must not have been called (no budget breach).
+        // Misbehaving must not have been called (cooldown skip is not a budget breach).
         BOOST_CHECK_EQUAL(peer_manager.GetMisbehaviorScore(peer_b_id), score_before);  // (b) no penalty
     }
 
@@ -518,8 +575,9 @@ BOOST_AUTO_TEST_CASE(test_partb_seed_rate_limited_resend) {
     //     (distinct hashes, each re-requested once) gets ZERO Misbehaving calls
     //     and is NOT disconnected.
     //
-    //     Budget = 16 re-sends * 4MiB = 64 MiB per 60s window.
-    //     We issue 15 distinct-hash re-requests (well under the 16-re-send limit)
+    //     Budget = RESEND_BUDGET_BLOCK_EQUIV (8) worst-case-block re-sends * 4 MiB
+    //     = 32 MiB per 60s window.
+    //     We issue 7 distinct-hash re-requests (under the 8 worst-case-block budget)
     //     using a fresh peer ID (peer 20) so the budget starts full.
     //     Each hash is re-requested only once (no cooldown issue — each has
     //     its own cooldown timer, and the timer is only set on re-send approval).
@@ -528,7 +586,7 @@ BOOST_AUTO_TEST_CASE(test_partb_seed_rate_limited_resend) {
     // -----------------------------------------------------------------------
     {
         const int peer_c = 20;
-        const int WITHIN_BUDGET_REQS = 15;  // 15 < 16 = budget capacity
+        const int WITHIN_BUDGET_REQS = 7;  // 7 < 8 = budget capacity (block-equiv)
 
         // First: serve 15 distinct hashes to populate served set.
         {
@@ -561,20 +619,20 @@ BOOST_AUTO_TEST_CASE(test_partb_seed_rate_limited_resend) {
     //     rotating distinct already-served hashes triggers a Misbehaving
     //     penalty on the batch that exceeds the budget.
     //
-    //     Budget capacity = RESEND_MAX_PER_WINDOW = 16 re-sends per window.
+    //     Budget capacity = RESEND_BUDGET_BLOCK_EQUIV = 8 worst-case-block re-sends/window.
     //     RESEND_COST_BYTES = MAX_BLOCK_SIZE = 4 MiB per re-send.
-    //     RESEND_BYTE_BUDGET_PER_WINDOW = 16 * 4 MiB = 64 MiB.
+    //     RESEND_BYTE_BUDGET_PER_WINDOW = 8 * 4 MiB = 32 MiB.
     //
     //     Strategy: serve 20 distinct hashes to peer 30 (so they're in served
-    //     set). Then re-request all 20 in a single batch. The first 16 are
-    //     approved (draining the budget), the 17th triggers budget_breached =
+    //     set). Then re-request all 20 in a single batch. The first 8 are
+    //     approved (draining the budget), the 9th triggers budget_breached =
     //     true → Misbehaving is called with a non-zero penalty.
     //
     //     We use a fresh peer (peer 30) so budget starts full.
     // -----------------------------------------------------------------------
     {
         const int peer_d = 30;
-        const int OVER_BUDGET_HASHES = 20;  // 20 > 16 (budget capacity)
+        const int OVER_BUDGET_HASHES = 20;  // 20 > 8 (budget capacity, block-equiv)
 
         // First: serve 20 distinct hashes.
         {
@@ -617,9 +675,11 @@ BOOST_AUTO_TEST_CASE(test_partb_seed_rate_limited_resend) {
     //     NOTE: the byte token bucket refills at RESEND_BYTE_BUDGET_PER_WINDOW
     //     / RESEND_BUDGET_WINDOW_SECONDS per second of elapsed time. Within the
     //     same wall-clock second all three batches arrive, so the bucket stays
-    //     drained (no meaningful refill). Each batch re-sends 16 hashes (budget
-    //     exhausted), then reaches budget_breached on the 17th, incrementing the
-    //     strike counter once per batch. After 3 batches → 3 strikes → disconnect.
+    //     drained (no meaningful refill). The first batch re-sends 8 hashes
+    //     (budget exhausted), then reaches budget_breached, incrementing the
+    //     strike counter once per batch (subsequent batches breach immediately
+    //     since the budget is already drained). After 3 batches → 3 strikes →
+    //     disconnect.
     //
     //     The second and third batches are NEW rotated hash sets (different
     //     seeds 0x40+20..0x40+39 and 0x40+40..0x40+59) to avoid the cooldown
@@ -628,7 +688,7 @@ BOOST_AUTO_TEST_CASE(test_partb_seed_rate_limited_resend) {
     // -----------------------------------------------------------------------
     {
         const int peer_e = 40;
-        const int HASHES_PER_BATCH = 20;   // > 16 (triggers breach on each batch)
+        const int HASHES_PER_BATCH = 20;   // > 8 (triggers breach on each batch)
         const int NUM_STRIKE_BATCHES = 3;  // = MAX_DEDUP_STRIKES
 
         // First: serve HASHES_PER_BATCH * NUM_STRIKE_BATCHES distinct hashes
@@ -681,8 +741,9 @@ BOOST_AUTO_TEST_CASE(test_partb_seed_rate_limited_resend) {
         // Document which lever fired: the strike counter is the primary lever here.
         // MAX_DEDUP_STRIKES = 3. Each breach batch increments strikes by 1.
         // 3 batches → strikes = 3 = MAX_DEDUP_STRIKES → disconnect.
-        // The RESEND_BACKSTOP_TOTAL_BYTES lever (2 GiB = 512 re-sends * 4MiB) would
-        // require ~512 re-sends to trip alone; with 3*16=48 re-sends we are far below it.
+        // The RESEND_BACKSTOP_TOTAL_BYTES lever (2 GiB = 512 re-sends * 4 MiB) would
+        // require ~512 re-sends to trip alone; only the FIRST batch re-sends (8, then
+        // budget drained), so we are far below the backstop — the strike lever fires.
     }
 
     // Teardown: restore g_node_context.connman to avoid leaking into other tests.

--- a/src/test/ibd_functional_tests.cpp
+++ b/src/test/ibd_functional_tests.cpp
@@ -33,6 +33,7 @@
 #include <primitives/block.h>
 #include <core/chainparams.h>
 #include <iostream>
+#include <algorithm>
 
 BOOST_AUTO_TEST_SUITE(ibd_functional_tests)
 
@@ -167,6 +168,70 @@ BOOST_AUTO_TEST_CASE(test_block_fetcher_receive) {
     BOOST_CHECK_EQUAL(fetcher.GetInFlightCount(), 0);
 
     // Restore previous tracker
+    g_node_context.block_tracker = std::move(old_tracker);
+}
+
+BOOST_AUTO_TEST_CASE(test_addblock_rejects_completed_height_dedup_livelock) {
+    // Regression for the DilV IBD dedup-livelock (mission dilv-dedup-livelock-fix, F-001).
+    //
+    // ROOT CAUSE: CBlockTracker::AddBlock (block_tracker.h:70) deduplicates ONLY against
+    // m_heights (in-flight), never m_completed_heights -- while IsTracked checks BOTH.
+    // During async IBD a received-but-unconnected block is an orphan whose height is
+    // MarkCompleted'd (block_processing.cpp:1257). So:
+    //   - GetNextBlocksToRequest (selection) skips it via IsTracked  -> the per-block
+    //     request site ibd_coordinator.cpp:1674 never fires (so A2/A1 selection-layer
+    //     fixes are INERT), BUT
+    //   - the stall-recovery DIRECT path (ibd_coordinator.cpp:2135/2057/1657) calls
+    //     RequestBlockFromPeer -> AddBlock directly, which checks only m_heights and
+    //     RE-REQUESTS the completed height every ~1s -> duplicate-GETDATA storm ->
+    //     the seed force-disconnects after 3 monotonic strikes -> IBD stalls.
+    //
+    // This test reproduces the exact tracker state and asserts the direct re-request is
+    // REFUSED. It FAILS today (AddBlock returns true) and PASSES after the one-line
+    // m_completed_heights guard in AddBlock.
+    CPeerManager peer_manager("");
+    CBlockFetcher fetcher(&peer_manager);
+
+    auto block_tracker = std::make_unique<CBlockTracker>();
+    auto old_tracker = std::move(g_node_context.block_tracker);
+    g_node_context.block_tracker = std::move(block_tracker);
+
+    const int H = 100;
+    uint256 hash; hash.data[0] = 0xAB;
+    const NodeId peer_id = 1;
+
+    // 1. Request + receive the block (mirrors the async receive path: OnBlockReceived
+    //    erases the in-flight tracker entry, so H leaves m_heights).
+    BOOST_CHECK(fetcher.RequestBlockFromPeer(peer_id, H, hash));
+    BOOST_CHECK(fetcher.OnBlockReceived(peer_id, H, hash));
+    BOOST_CHECK(!fetcher.IsHeightInFlight(H));  // no longer in-flight
+
+    // 2. Mark the orphan height completed (the orphan receive path does exactly this
+    //    via MarkCompleted(parent_height + 1) in block_processing.cpp:1257).
+    g_node_context.block_tracker->MarkCompleted(H);
+
+    // 3. Selection-layer suppression WORKS: IsTracked sees m_completed_heights, so
+    //    GetNextBlocksToRequest skips H. (This is precisely why the selection-layer
+    //    A2/A1 designs are inert for this bug.)
+    BOOST_CHECK(g_node_context.block_tracker->IsTracked(H));
+    {
+        // GetNextBlocksToRequest must not re-select a completed height.
+        auto sel = fetcher.GetNextBlocksToRequest(/*max_blocks=*/8, /*chain_height=*/H - 1,
+                                                  /*header_height=*/H + 5);
+        BOOST_CHECK(std::find(sel.begin(), sel.end(), H) == sel.end());
+    }
+
+    // 4. THE BUG / THE FIX: the DIRECT stall-recovery re-request must be REFUSED for a
+    //    completed height. Pre-fix AddBlock checks only m_heights and ALLOWS it
+    //    (returns true) -> duplicate GETDATA -> disconnect. This assertion FAILS today
+    //    (red) and PASSES after the AddBlock m_completed_heights guard (green).
+    BOOST_CHECK(!fetcher.RequestBlockFromPeer(peer_id, H, hash));
+    // And the refused request must not have re-entered the IN-FLIGHT set as a side effect.
+    // NOTE: use GetInFlightCount() (delegates to GetTotalInFlight() = m_heights only), NOT
+    // IsHeightInFlight() -- the latter delegates to IsTracked(), which is true for
+    // m_completed_heights entries too, so it is the wrong API for an "in-flight only" check.
+    BOOST_CHECK_EQUAL(fetcher.GetInFlightCount(), 0);
+
     g_node_context.block_tracker = std::move(old_tracker);
 }
 


### PR DESCRIPTION
## Fix the DilV IBD dedup filter-starvation livelock (v4.4.4)

**Confirmed DilV-mainnet bug:** IBD clients cannot complete sync. A client re-requests a received-but-async-unconnected block ~1/s; the seed refuses to re-serve and force-disconnects after 3 monotonic strikes → IBD stalls for all new nodes.

### Part A — client root cause (load-bearing)
`CBlockTracker::AddBlock` deduplicated only against `m_heights` (in-flight) while `IsTracked` checks both `m_heights` **and** `m_completed_heights`. So a completed orphan height was re-requestable by the stall-recovery **direct** path (`ibd_coordinator.cpp:2135/2057/1657`) that bypasses selection. Fix: `AddBlock` also rejects `m_completed_heights`. Reorg-safe via `ClearAboveHeight`. Proven red→green (`test_addblock_rejects_completed_height_dedup_livelock`).

### Part B — seed defense-in-depth
Replaces permanent GETDATA starvation + monotonic 3-strike disconnect with **rate-limited re-send**: per-(peer,hash) 2s cooldown + per-peer **byte** token bucket (32 MiB/60s, worst-case-block debit). Penalty + strike fire **only on byte-budget breach**, so honest low-rate parent-recovery re-requests are never disconnected. Two disconnect levers: decaying strikes (fast abuse) + non-decaying 2 GiB/connection backstop → **persistent IP ban** (survives reconnect). Per-peer state cleaned on **every** disconnect + a periodic sweep.

### Review trail (all artifacts in `dilithion-strategy/missions/dilv-dedup-livelock-fix/`)
- Diagnosis: Cursor pre-impl + F-001 escape-path trace (orchestrator-verified).
- Part B: fresh red-team (F-004) + behavioral mesh (F-005) + **external consensus, 6 models** (F-006) + Cursor close-readiness (F-008) — **7 reviewers, unanimous GO-WITH-REVISIONS**. All findings folded (reconnect-amplification→ban-score, atomic map capping, leak fix, LOWs).
- Re-review of the fold round caught a **reachable `{cs_getdata_rate, cs_peers}` deadlock** introduced by the leak-fix wiring (F-009) — fixed by hoisting `Misbehaving` out of the rate-limit lock; fresh lock-trace re-review confirms the cycle is broken (F-011 GO).
- Tests: `ibd_functional_tests` **12/12** (incl. a reorg-safety test + a seed-adversarial Part B test); 4-node mesh converges with zero forbidden DEDUP tokens.

### Deferred follow-ups (tracked as board rows; not blockers per Amendment 2)
- `dilv-ibd-lag-injection-harness` — deterministic deep-tip + validation-lag-hook integration test (needs a debug hook; absence-check scenario committed in the meantime).
- `four_node_local.sh` localhost-loopback + cookie-auth harness fixes.

### Status
**DRAFT** — not for merge until Gate B. Bundles into **v4.4.4** with the peer-eviction fix (`fix/dilv-peer-eviction-recv-accounting`). Deploy is separately Will-gated (LDN canary → rolling, dual-validation vs current seed behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
