### PR TITLE
fix(ibd): m_completed_heights liveness backstop — close F-013 M-2 divergent-hash-no-reorg stall (v4.4.4)

### DIFF
--- a/src/net/block_tracker.h
+++ b/src/net/block_tracker.h
@@ -49,6 +49,7 @@ public:
     static constexpr int MAX_PER_PEER = 128;           ///< Maximum in-flight blocks per peer
     static constexpr int MAX_TOTAL = 256;              ///< Maximum total in-flight blocks
     static constexpr int TIMEOUT_SECONDS = 120;        ///< Seconds before block times out
+    static constexpr int COMPLETED_HEIGHT_TTL_SECONDS = 120; ///< M-2: age out stuck completed heights after this (F-013 §M-2)
 
     CBlockTracker() = default;
 
@@ -366,7 +367,45 @@ public:
      */
     void MarkCompleted(int height) {
         std::lock_guard<std::mutex> lock(m_mutex);
-        m_completed_heights.insert(height);
+        // Record insert time so a stuck entry can be aged out (M-2 liveness backstop).
+        // Use insert (not operator[]=) so an existing entry keeps its ORIGINAL insert
+        // time -- re-marking a still-completed height must not refresh its age and
+        // postpone the age-out backstop indefinitely.
+        m_completed_heights.emplace(height, std::chrono::steady_clock::now());
+    }
+
+    /**
+     * @brief M-2 LIVENESS BACKSTOP: age out stale completed-height entries.
+     *
+     * A completed height is normally cleared by Clear() (reset) or ClearAboveHeight()
+     * (reorg). On the narrow divergent-hash-at-same-height-WITHOUT-reorg path
+     * (F-013 §M-2) neither fires, so AddBlock's completed-height reject (line 86)
+     * would permanently refuse the stall-recovery force-request and stall IBD silently.
+     * This method clears completed entries older than COMPLETED_HEIGHT_TTL_SECONDS so the
+     * next force-request's AddBlock succeeds and a GETDATA is pushed -- liveness restored.
+     * Called on the existing RetryTimeoutsAndStalls cadence (ibd_coordinator.cpp).
+     *
+     * Reorg-safe: this only DROPS completed flags; it never re-fetches, never touches
+     * m_heights, and is a strict superset of the existing ClearAboveHeight semantics
+     * (which still clears the same set above a fork point).
+     *
+     * @param ttl_seconds Entries older than this are cleared (default COMPLETED_HEIGHT_TTL_SECONDS)
+     * @return number of stale completed entries cleared
+     */
+    int RetryStaleCompleted(int ttl_seconds = COMPLETED_HEIGHT_TTL_SECONDS) {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        int cleared = 0;
+        auto now = std::chrono::steady_clock::now();
+        auto ttl = std::chrono::seconds(ttl_seconds);
+        for (auto it = m_completed_heights.begin(); it != m_completed_heights.end();) {
+            if (now - it->second > ttl) {
+                it = m_completed_heights.erase(it);
+                ++cleared;
+            } else {
+                ++it;
+            }
+        }
+        return cleared;
     }
 
     /**
@@ -421,7 +460,7 @@ public:
 
         // Also clear completed heights above fork_point
         for (auto it = m_completed_heights.begin(); it != m_completed_heights.end();) {
-            if (*it > fork_point) {
+            if (it->first > fork_point) {
                 it = m_completed_heights.erase(it);
             } else {
                 ++it;
@@ -451,8 +490,14 @@ private:
     //   corrected line numbers from initial PR10.2 commit). Don't.
     mutable std::mutex m_mutex;
 
-    // Heights that are already in DB (no need to request)
-    std::set<int> m_completed_heights;
+    // Heights that are already in DB (no need to request).
+    // M-2 LIVENESS FIX (F-013 §M-2): each completed height carries its insert time so
+    // RetryStaleCompleted() can age out an entry that got stuck on the divergent-hash
+    // no-reorg path (a completed height whose stored hash != IBD-expected hash, with no
+    // reorg/ClearAboveHeight ever firing). Without this, AddBlock's completed-height
+    // reject (line 86) permanently refuses the force-request at ibd_coordinator.cpp:2135,
+    // pushing no GETDATA -> silent IBD stall with no timeout that ever clears the entry.
+    std::map<int, std::chrono::steady_clock::time_point> m_completed_heights;
 
     // Per-height state
     struct BlockInfo {

--- a/src/node/ibd_coordinator.cpp
+++ b/src/node/ibd_coordinator.cpp
@@ -2167,6 +2167,23 @@ void CIbdCoordinator::RetryTimeoutsAndStalls() {
         return;
     }
 
+    // ============ M-2 LIVENESS BACKSTOP (F-013 §M-2) ============
+    // Age out completed-height entries that got stuck on the divergent-hash no-reorg
+    // path. The dedup fix's AddBlock rejects any height in m_completed_heights; that set
+    // is otherwise cleared ONLY by Clear()/ClearAboveHeight(). On a completed height
+    // whose stored hash diverges from the IBD-expected hash with no reorg, neither fires,
+    // so the stall-recovery force-request (below, via RequestBlockFromPeer->AddBlock) is
+    // permanently refused -> no GETDATA -> silent IBD stall. Aging out the stale entry
+    // here lets the next force-request's AddBlock succeed. Reorg-safe (only DROPS flags).
+    if (g_node_context.block_tracker) {
+        int aged = g_node_context.block_tracker->RetryStaleCompleted();
+        if (aged > 0 && g_verbose.load(std::memory_order_relaxed)) {
+            std::cout << "[IBD] M-2 liveness: aged out " << aged
+                      << " stale completed-height entr" << (aged == 1 ? "y" : "ies")
+                      << " (re-requestable now)" << std::endl;
+        }
+    }
+
     // ============ HARD TIMEOUT: Remove blocks stuck too long ============
     // Use shorter timeout when close to tip (only a few blocks behind) since blocks
     // should arrive quickly. Use longer timeout during bulk IBD where validation

--- a/src/test/ibd_functional_tests.cpp
+++ b/src/test/ibd_functional_tests.cpp
@@ -281,6 +281,91 @@ BOOST_AUTO_TEST_CASE(test_clear_above_height_reenables_completed_refetch_after_r
     g_node_context.block_tracker = std::move(old_tracker);
 }
 
+BOOST_AUTO_TEST_CASE(test_completed_height_ages_out_on_divergent_hash_no_reorg) {
+    // M-2 LIVENESS regression (F-013 §M-2, mission m2-liveness).
+    //
+    // THE BUG: the dedup fix's AddBlock rejects any height in m_completed_heights. That
+    // set is cleared ONLY by Clear() (reset) and ClearAboveHeight() (reorg). On the
+    // narrow divergent-hash-at-same-height-WITHOUT-reorg path, a completed height gets
+    // stuck:
+    //   - DB re-process (ibd_coordinator.cpp:2090) keys on the IBD-EXPECTED hash and
+    //     MISSES because the stored block's hash diverges from it (a fork at that height);
+    //   - GetTrackingAge(next) returns -1 (it consults m_heights only, NOT
+    //     m_completed_heights, block_tracker.h:345-351), so the stall-recovery branch
+    //     takes the FORCE-REQUEST path (ibd_coordinator.cpp:2132-2140);
+    //   - that path calls RequestBlockFromPeer -> AddBlock, which returns FALSE
+    //     (completed-height reject) -> no GETDATA pushed -> SILENT STALL.
+    //   No reorg => ClearAboveHeight never fires => the entry is stuck FOREVER. The old
+    //   ~1s re-request escape valve was removed and nothing replaced it for this path.
+    //
+    // THE FIX (option (a) — coarse age-out): MarkCompleted timestamps each entry, and the
+    // existing RetryTimeoutsAndStalls cadence calls RetryStaleCompleted() to drop entries
+    // older than the TTL. Once aged out, the next force-request's AddBlock SUCCEEDS and a
+    // GETDATA flows -> liveness restored. Option (b) was rejected: making GetTrackingAge
+    // consult m_completed_heights would change which branch is taken but the re-request at
+    // :2135 would STILL hit AddBlock's completed-height reject -> still no GETDATA, unless
+    // a force-clear is ALSO added -- which is exactly this age-out, just triggered
+    // elsewhere. (a) is self-contained in CBlockTracker + one call site and reorg-safe.
+    //
+    // RED on HEAD / GREEN after fix: the divergent-completed height is REFUSED by
+    // RequestBlockFromPeer (the stuck condition) and STAYS refused forever on HEAD --
+    // there is no API that clears it without a reorg. After the fix, RetryStaleCompleted()
+    // ages it out and the height becomes re-requestable. (This test references the new
+    // RetryStaleCompleted backstop, which does not exist on HEAD; see the mission report
+    // for the HEAD-compatible probe used to demonstrate the red state.)
+    CPeerManager peer_manager("");
+    CBlockFetcher fetcher(&peer_manager);
+
+    auto block_tracker = std::make_unique<CBlockTracker>();
+    auto old_tracker = std::move(g_node_context.block_tracker);
+    g_node_context.block_tracker = std::move(block_tracker);
+
+    const int H = 200;
+    // IBD-expected (header-canonical) hash for height H.
+    uint256 expected_hash; expected_hash.data[0] = 0xEE;
+    // The block actually stored/completed at height H is a DIVERGENT fork block: its hash
+    // differs from expected_hash. This is the M-2 precondition (fork at same height, no reorg).
+    uint256 divergent_hash; divergent_hash.data[0] = 0xDD;
+    const NodeId peer_id = 1;
+
+    // 1. Height H is MarkCompleted (orphan-with-data path: MarkCompleted(parent+1)).
+    //    The stored block diverges from the IBD-expected hash, and NO reorg occurs, so
+    //    ClearAboveHeight is never called.
+    g_node_context.block_tracker->MarkCompleted(H);
+    BOOST_CHECK(g_node_context.block_tracker->IsTracked(H));
+
+    // 2. STUCK STATE: the stall-recovery force-request for the IBD-expected hash is
+    //    REFUSED because H is completed (AddBlock completed-height reject). No GETDATA.
+    BOOST_CHECK(!fetcher.RequestBlockFromPeer(peer_id, H, expected_hash));
+    BOOST_CHECK_EQUAL(fetcher.GetInFlightCount(), 0);
+
+    // 3. No reorg fires. With a NON-zero TTL the entry is NOT yet stale, so the backstop
+    //    leaves it in place and the height is STILL refused -- proving the age-out is
+    //    time-gated and does not prematurely re-enable a freshly-completed height.
+    int aged_now = g_node_context.block_tracker->RetryStaleCompleted(/*ttl_seconds=*/3600);
+    BOOST_CHECK_EQUAL(aged_now, 0);
+    BOOST_CHECK(g_node_context.block_tracker->IsTracked(H));
+    BOOST_CHECK(!fetcher.RequestBlockFromPeer(peer_id, H, expected_hash));
+
+    // 4. THE FIX / THE RE-ENABLE: once the entry ages past the TTL (ttl=0 forces immediate
+    //    expiry of the already-inserted entry), RetryStaleCompleted clears it. The height
+    //    is no longer completed, so the force-request SUCCEEDS and a GETDATA would flow.
+    int aged = g_node_context.block_tracker->RetryStaleCompleted(/*ttl_seconds=*/0);
+    BOOST_CHECK_EQUAL(aged, 1);
+    BOOST_CHECK(!g_node_context.block_tracker->IsTracked(H));   // completed flag aged out
+    BOOST_CHECK(fetcher.RequestBlockFromPeer(peer_id, H, expected_hash));  // re-requestable!
+    BOOST_CHECK_EQUAL(fetcher.GetInFlightCount(), 1);
+    BOOST_CHECK(fetcher.IsHeightInFlight(H));
+
+    // 5. REORG-SAFETY is unaffected: ClearAboveHeight still clears the (now in-flight)
+    //    height above a fork point, same as before the age-out change.
+    fetcher.ClearAboveHeight(H - 1);
+    BOOST_CHECK(!fetcher.IsHeightInFlight(H));
+    BOOST_CHECK_EQUAL(fetcher.GetInFlightCount(), 0);
+
+    g_node_context.block_tracker = std::move(old_tracker);
+}
+
 BOOST_AUTO_TEST_CASE(test_headers_manager_basic) {
     // Test basic headers manager functionality
     if (!Dilithion::g_chainParams)


### PR DESCRIPTION
## What
Adds a coarse time-based liveness backstop to `CBlockTracker::m_completed_heights`, closing the F-013 §M-2 finding (a divergent-hash-at-same-height **without reorg** could silently stall IBD forever, since the dedup fix's `AddBlock` completed-height reject had no timeout backstop).

## How
- `m_completed_heights`: `std::set<int>` → `std::map<int, steady_clock::time_point>` (insert-time per entry).
- `RetryStaleCompleted(ttl)` drops entries older than `COMPLETED_HEIGHT_TTL_SECONDS=120`, called from the existing `RetryTimeoutsAndStalls()` cadence.
- `MarkCompleted` uses `emplace` (re-marking does NOT refresh age). `ClearAboveHeight`/`Clear` semantics preserved.

## Why it can't re-open the dedup storm
The storm re-requests heights completed ~1s ago; TTL is 120s (120× margin) — fresh entries are never aged out. And `GetNextBlocksToRequest` only iterates above the chain tip, so an aged-out below-tip height is never re-selected. Confirmed by red-team (F-001 GO).

## Validation
- **red→green proven**: RED on HEAD (probe), GREEN after fix.
- `ibd_functional_tests` 12 → **13**; reorg-safety + dedup-livelock regressions both pass.
- Fresh red-team **GO** (0 BLOCKER/CRIT/HIGH/MED, 3 LOW doc/test-hygiene).

Gates v4.4.4 (must merge before tag, per Will). Headers changed → seeds must `make clean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)