### PR TITLE
ci: clean-room smoke-test gate on all release builds (prove package RUNS on a clean box before upload)

### DIFF
--- a/.github/workflows/build-dilv-linux.yml
+++ b/.github/workflows/build-dilv-linux.yml
@@ -144,10 +144,15 @@ jobs:
           if ldd ./dilv-node | grep -q "not found"; then
             echo "CLEAN-ROOM FAIL: unresolved deps"; ldd ./dilv-node | grep "not found"; exit 1
           fi
-          # Must actually start (prints usage banner; --help/--version exit non-zero by design).
-          out=$(timeout 20 ./dilv-node --version 2>&1 || timeout 20 ./dilv-node --help 2>&1 || true)
+          # Must actually start VIA THE REAL run-node.sh WRAPPER (unset LD_LIBRARY_PATH so the
+          # wrapper's own lib-path setup is what's tested). Assert on the post-main() banner
+          # string only the RUNNING binary prints — a loader error echoes the binary PATH
+          # (contains "dilv") to stderr BEFORE main, so matching the name would false-pass a
+          # binary that never started. "Quantum-Resistant VDF Payment Chain" is printed by
+          # PrintUsage() after main, so it cannot appear in a pre-main loader error.
+          out=$(env -u LD_LIBRARY_PATH timeout 20 ./run-node.sh --help 2>&1 || true)
           echo "$out" | head -3
-          echo "$out" | grep -qiE "dilithion|dilv|version|usage" || { echo "CLEAN-ROOM FAIL: binary did not start"; exit 1; }
+          echo "$out" | grep -q "Quantum-Resistant VDF Payment Chain" || { echo "CLEAN-ROOM FAIL: binary did not start (no post-main banner)"; exit 1; }
           echo "CLEAN-ROOM PASS"
         '
 

--- a/.github/workflows/build-dilv-linux.yml
+++ b/.github/workflows/build-dilv-linux.yml
@@ -119,6 +119,38 @@ jobs:
         done
         echo "All required libraries bundled."
 
+    - name: Clean-room smoke test (BLOCKING)
+      # Run the JUST-PACKAGED tarball inside a pristine ubuntu:22.04 container
+      # that has NONE of the runtime deps installed. Proves the package actually
+      # STARTS using only its bundled libs — a binary can pass the file-present
+      # checks above yet still fail to launch (wrong lib version / bad rpath /
+      # broken wrapper). This gate blocks the upload steps below on failure.
+      env:
+        VERSION: ${{ steps.get_version.outputs.version }}
+      run: |
+        RELEASE_NAME="dilv-${VERSION}-mainnet-linux-x64"
+        docker run --rm -v "$PWD/releases:/r:ro" ubuntu:22.04 bash -c '
+          set -e
+          RELEASE_NAME="'"${RELEASE_NAME}"'"
+          cd /tmp && tar xzf "/r/${RELEASE_NAME}.tar.gz" && cd "${RELEASE_NAME}"
+          # Manifest assertion: key files must be present in the package.
+          for f in dilv-node run-node.sh lib; do
+            [ -e "$f" ] || { echo "CLEAN-ROOM FAIL: missing $f in package"; exit 1; }
+          done
+          # Sanity: prove the clean box lacks the bundled libs system-wide.
+          ! ldconfig -p | grep -qE "libleveldb|libminiupnpc|libsnappy" || echo "warn: clean box unexpectedly has bundled libs"
+          export LD_LIBRARY_PATH="$PWD/lib"
+          # Must resolve every dependency using the bundled libs.
+          if ldd ./dilv-node | grep -q "not found"; then
+            echo "CLEAN-ROOM FAIL: unresolved deps"; ldd ./dilv-node | grep "not found"; exit 1
+          fi
+          # Must actually start (prints usage banner; --help/--version exit non-zero by design).
+          out=$(timeout 20 ./dilv-node --version 2>&1 || timeout 20 ./dilv-node --help 2>&1 || true)
+          echo "$out" | head -3
+          echo "$out" | grep -qiE "dilithion|dilv|version|usage" || { echo "CLEAN-ROOM FAIL: binary did not start"; exit 1; }
+          echo "CLEAN-ROOM PASS"
+        '
+
     - name: Upload artifact
       uses: actions/upload-artifact@v7
       with:

--- a/.github/workflows/build-dilv-macos.yml
+++ b/.github/workflows/build-dilv-macos.yml
@@ -82,6 +82,53 @@ jobs:
         chmod +x package-dilv-macos-release.sh
         ./package-dilv-macos-release.sh
 
+    - name: Clean-room smoke test (BLOCKING)
+      # Run the JUST-PACKAGED binary and prove it is self-contained. The macOS
+      # runner is NOT a clean machine (Homebrew is installed), so the real
+      # isolation proof is the otool dependency check: every non-system dylib
+      # the binary links MUST be bundled under the package's lib/ (the packager
+      # rewrites refs to @executable_path/lib/<name>). We also actually launch
+      # the binary. This gate blocks the upload steps below on failure.
+      env:
+        VERSION: ${{ steps.get_version.outputs.version }}
+        ARCH: ${{ matrix.arch }}
+      run: |
+        set -e
+        RELEASE_NAME="dilv-${VERSION}-mainnet-macos-${ARCH}"
+        PKG="releases/${RELEASE_NAME}"
+        BIN="${PKG}/dilv-node"
+        # Manifest assertion: key files present.
+        for f in "${BIN}" "${PKG}/lib" "${PKG}/README.txt"; do
+          [ -e "$f" ] || { echo "CLEAN-ROOM FAIL: missing $f in package"; exit 1; }
+        done
+        # Strip quarantine so a fresh download would launch.
+        xattr -dr com.apple.quarantine "${PKG}" || true
+        # Every non-system dylib (not under /usr/lib or /System) must be bundled.
+        echo "otool -L dilv-node:"
+        otool -L "${BIN}"
+        FAIL=0
+        while read -r dep; do
+          case "$dep" in
+            /usr/lib/*|/System/*|@executable_path/*|@loader_path/*|@rpath/*) ;;
+            "") ;;
+            *)
+              base=$(basename "$dep")
+              if [ ! -f "${PKG}/lib/${base}" ]; then
+                echo "CLEAN-ROOM FAIL: non-system dylib not bundled: $dep"
+                FAIL=1
+              fi
+              ;;
+          esac
+        done < <(otool -L "${BIN}" | tail -n +2 | awk '{print $1}')
+        [ "$FAIL" -eq 0 ] || exit 1
+        # Must actually start (prints usage banner; --help/--version exit non-zero by design).
+        # macOS lacks GNU `timeout`; use a perl alarm watchdog (always present).
+        run_guarded() { perl -e 'alarm shift; exec @ARGV' 20 "$@"; }
+        out=$(run_guarded "${BIN}" --version 2>&1 || run_guarded "${BIN}" --help 2>&1 || true)
+        echo "$out" | head -3
+        echo "$out" | grep -qiE "dilithion|dilv|version|usage" || { echo "CLEAN-ROOM FAIL: binary did not start"; exit 1; }
+        echo "CLEAN-ROOM PASS"
+
     - name: Upload artifact
       uses: actions/upload-artifact@v7
       with:

--- a/.github/workflows/build-dilv-macos.yml
+++ b/.github/workflows/build-dilv-macos.yml
@@ -124,9 +124,11 @@ jobs:
         # Must actually start (prints usage banner; --help/--version exit non-zero by design).
         # macOS lacks GNU `timeout`; use a perl alarm watchdog (always present).
         run_guarded() { perl -e 'alarm shift; exec @ARGV' 20 "$@"; }
-        out=$(run_guarded "${BIN}" --version 2>&1 || run_guarded "${BIN}" --help 2>&1 || true)
+        out=$(run_guarded "${BIN}" --help 2>&1 || true)
         echo "$out" | head -3
-        echo "$out" | grep -qiE "dilithion|dilv|version|usage" || { echo "CLEAN-ROOM FAIL: binary did not start"; exit 1; }
+        # Assert on the post-main() banner only the RUNNING binary prints; a dyld error echoes
+        # the binary path (contains "dilv") to stderr before main and must NOT count as start.
+        echo "$out" | grep -q "Quantum-Resistant VDF Payment Chain" || { echo "CLEAN-ROOM FAIL: binary did not start (no post-main banner)"; exit 1; }
         echo "CLEAN-ROOM PASS"
 
     - name: Upload artifact

--- a/.github/workflows/build-dilv-windows.yml
+++ b/.github/workflows/build-dilv-windows.yml
@@ -107,9 +107,11 @@ jobs:
         [ "$FAIL" -eq 0 ] || exit 1
         # Must actually start (prints usage banner; --help/--version exit non-zero by design).
         cd "${PKG}"
-        out=$(timeout 20 ./"${BIN}" --version 2>&1 || timeout 20 ./"${BIN}" --help 2>&1 || true)
+        out=$(timeout 20 ./"${BIN}" --help 2>&1 || true)
         echo "$out" | head -3
-        echo "$out" | grep -qiE "dilithion|dilv|version|usage" || { echo "CLEAN-ROOM FAIL: exe did not start"; exit 1; }
+        # Assert on the post-main() banner only the RUNNING exe prints; a "loading shared
+        # libraries"/path error echoes the exe name (contains "dilv") and must NOT count as start.
+        echo "$out" | grep -q "Quantum-Resistant VDF Payment Chain" || { echo "CLEAN-ROOM FAIL: exe did not start (no post-main banner)"; exit 1; }
         echo "CLEAN-ROOM PASS"
 
     - name: Upload artifact

--- a/.github/workflows/build-dilv-windows.yml
+++ b/.github/workflows/build-dilv-windows.yml
@@ -65,6 +65,53 @@ jobs:
         chmod +x package-dilv-windows-release-github.sh
         ./package-dilv-windows-release-github.sh
 
+    - name: Clean-room smoke test (BLOCKING)
+      # Prove the packaged .exe actually RUNS using only bundled DLLs, and that
+      # every non-system DLL it imports is bundled. The windows-latest runner is
+      # NOT a clean machine (MSYS2/mingw DLLs are on PATH), so the real isolation
+      # proof is the PE-import completeness check via objdump: any non-system DLL
+      # that is NOT shipped in the package would silently load from MSYS2 here but
+      # be MISSING on a user's machine. We also launch the exe from the package
+      # dir (Windows resolves the application directory first, so bundled DLLs
+      # win). This gate blocks the upload steps below on failure.
+      shell: msys2 {0}
+      env:
+        VERSION: ${{ steps.get_version.outputs.version }}
+      run: |
+        set -e
+        RELEASE_NAME="dilv-${VERSION}-mainnet-windows-x64"
+        PKG="releases/${RELEASE_NAME}"
+        BIN="dilv-node.exe"
+        # Manifest assertion: exe + a couple of key DLLs present.
+        for f in "${BIN}" libstdc++-6.dll libssl-3-x64.dll; do
+          [ -f "${PKG}/${f}" ] || { echo "CLEAN-ROOM FAIL: missing ${f} in package"; exit 1; }
+        done
+        # System DLL allowlist (case-insensitive). Anything imported but not on
+        # this list MUST be bundled in the package, else it fails on user machines.
+        SYS_DLLS=" kernel32.dll user32.dll advapi32.dll ws2_32.dll msvcrt.dll shell32.dll bcrypt.dll dbghelp.dll iphlpapi.dll ntdll.dll gdi32.dll ole32.dll oleaut32.dll shlwapi.dll crypt32.dll secur32.dll winmm.dll setupapi.dll version.dll userenv.dll psapi.dll wininet.dll dnsapi.dll mswsock.dll rpcrt4.dll comdlg32.dll imm32.dll powrprof.dll "
+        FAIL=0
+        echo "PE imports for ${BIN}:"
+        objdump -p "${PKG}/${BIN}" | grep -i 'DLL Name' | awk '{print $3}' | while read -r dll; do echo "  $dll"; done
+        for dll in $(objdump -p "${PKG}/${BIN}" | grep -i 'DLL Name' | awk '{print $3}'); do
+          lc=$(echo "$dll" | tr 'A-Z' 'a-z')
+          case "$SYS_DLLS" in
+            *" $lc "*) ;;  # system DLL, fine
+            *)
+              if [ ! -f "${PKG}/${dll}" ]; then
+                echo "CLEAN-ROOM FAIL: imported DLL not bundled and not system: $dll"
+                FAIL=1
+              fi
+              ;;
+          esac
+        done
+        [ "$FAIL" -eq 0 ] || exit 1
+        # Must actually start (prints usage banner; --help/--version exit non-zero by design).
+        cd "${PKG}"
+        out=$(timeout 20 ./"${BIN}" --version 2>&1 || timeout 20 ./"${BIN}" --help 2>&1 || true)
+        echo "$out" | head -3
+        echo "$out" | grep -qiE "dilithion|dilv|version|usage" || { echo "CLEAN-ROOM FAIL: exe did not start"; exit 1; }
+        echo "CLEAN-ROOM PASS"
+
     - name: Upload artifact
       uses: actions/upload-artifact@v7
       with:

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -108,6 +108,38 @@ jobs:
         done
         echo "All required libraries bundled."
 
+    - name: Clean-room smoke test (BLOCKING)
+      # Run the JUST-PACKAGED tarball inside a pristine ubuntu:22.04 container
+      # that has NONE of the runtime deps installed. Proves the package actually
+      # STARTS using only its bundled libs — a binary can pass the file-present
+      # checks above yet still fail to launch (wrong lib version / bad rpath /
+      # broken wrapper). This gate blocks the upload steps below on failure.
+      env:
+        VERSION: ${{ steps.get_version.outputs.version }}
+      run: |
+        RELEASE_NAME="dilithion-${VERSION}-mainnet-linux-x64"
+        docker run --rm -v "$PWD/releases:/r:ro" ubuntu:22.04 bash -c '
+          set -e
+          RELEASE_NAME="'"${RELEASE_NAME}"'"
+          cd /tmp && tar xzf "/r/${RELEASE_NAME}.tar.gz" && cd "${RELEASE_NAME}"
+          # Manifest assertion: key files must be present in the package.
+          for f in dilithion-node run-node.sh lib; do
+            [ -e "$f" ] || { echo "CLEAN-ROOM FAIL: missing $f in package"; exit 1; }
+          done
+          # Sanity: prove the clean box lacks the bundled libs system-wide.
+          ! ldconfig -p | grep -qE "libleveldb|libminiupnpc|libsnappy" || echo "warn: clean box unexpectedly has bundled libs"
+          export LD_LIBRARY_PATH="$PWD/lib"
+          # Must resolve every dependency using the bundled libs.
+          if ldd ./dilithion-node | grep -q "not found"; then
+            echo "CLEAN-ROOM FAIL: unresolved deps"; ldd ./dilithion-node | grep "not found"; exit 1
+          fi
+          # Must actually start (prints usage banner; --help/--version exit non-zero by design).
+          out=$(timeout 20 ./dilithion-node --version 2>&1 || timeout 20 ./dilithion-node --help 2>&1 || true)
+          echo "$out" | head -3
+          echo "$out" | grep -qiE "dilithion|version|usage" || { echo "CLEAN-ROOM FAIL: binary did not start"; exit 1; }
+          echo "CLEAN-ROOM PASS"
+        '
+
     - name: Upload artifact
       uses: actions/upload-artifact@v7
       with:

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -133,10 +133,15 @@ jobs:
           if ldd ./dilithion-node | grep -q "not found"; then
             echo "CLEAN-ROOM FAIL: unresolved deps"; ldd ./dilithion-node | grep "not found"; exit 1
           fi
-          # Must actually start (prints usage banner; --help/--version exit non-zero by design).
-          out=$(timeout 20 ./dilithion-node --version 2>&1 || timeout 20 ./dilithion-node --help 2>&1 || true)
+          # Must actually start VIA THE REAL run-node.sh WRAPPER (unset LD_LIBRARY_PATH so the
+          # wrapper's own lib-path setup is what's tested). Assert on the post-main() banner
+          # string only the RUNNING binary prints — a loader/dyld error echoes the binary PATH
+          # (contains "dilithion"/"version") to stderr BEFORE main, so matching the name/path
+          # would false-pass a binary that never started. "Post-Quantum Cryptocurrency" is
+          # printed by PrintUsage() after main, so it cannot appear in a pre-main loader error.
+          out=$(env -u LD_LIBRARY_PATH timeout 20 ./run-node.sh --help 2>&1 || true)
           echo "$out" | head -3
-          echo "$out" | grep -qiE "dilithion|version|usage" || { echo "CLEAN-ROOM FAIL: binary did not start"; exit 1; }
+          echo "$out" | grep -q "Post-Quantum Cryptocurrency" || { echo "CLEAN-ROOM FAIL: binary did not start (no post-main banner)"; exit 1; }
           echo "CLEAN-ROOM PASS"
         '
 

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -127,9 +127,11 @@ jobs:
         # Must actually start (prints usage banner; --help/--version exit non-zero by design).
         # macOS lacks GNU `timeout`; use a perl alarm watchdog (always present).
         run_guarded() { perl -e 'alarm shift; exec @ARGV' 20 "$@"; }
-        out=$(run_guarded "${BIN}" --version 2>&1 || run_guarded "${BIN}" --help 2>&1 || true)
+        out=$(run_guarded "${BIN}" --help 2>&1 || true)
         echo "$out" | head -3
-        echo "$out" | grep -qiE "dilithion|version|usage" || { echo "CLEAN-ROOM FAIL: binary did not start"; exit 1; }
+        # Assert on the post-main() banner only the RUNNING binary prints; a dyld error echoes
+        # the binary path (contains "dilithion") to stderr before main and must NOT count as start.
+        echo "$out" | grep -q "Post-Quantum Cryptocurrency" || { echo "CLEAN-ROOM FAIL: binary did not start (no post-main banner)"; exit 1; }
         echo "CLEAN-ROOM PASS"
 
     - name: Upload artifact

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -85,6 +85,53 @@ jobs:
         chmod +x package-macos-release.sh
         ./package-macos-release.sh
 
+    - name: Clean-room smoke test (BLOCKING)
+      # Run the JUST-PACKAGED binary and prove it is self-contained. The macOS
+      # runner is NOT a clean machine (Homebrew is installed), so the real
+      # isolation proof is the otool dependency check: every non-system dylib
+      # the binary links MUST be bundled under the package's lib/ (the packager
+      # rewrites refs to @executable_path/lib/<name>). We also actually launch
+      # the binary. This gate blocks the upload steps below on failure.
+      env:
+        VERSION: ${{ steps.get_version.outputs.version }}
+        ARCH: ${{ matrix.arch }}
+      run: |
+        set -e
+        RELEASE_NAME="dilithion-${VERSION}-mainnet-macos-${ARCH}"
+        PKG="releases/${RELEASE_NAME}"
+        BIN="${PKG}/dilithion-node"
+        # Manifest assertion: key files present.
+        for f in "${BIN}" "${PKG}/lib" "${PKG}/README.txt"; do
+          [ -e "$f" ] || { echo "CLEAN-ROOM FAIL: missing $f in package"; exit 1; }
+        done
+        # Strip quarantine so a fresh download would launch.
+        xattr -dr com.apple.quarantine "${PKG}" || true
+        # Every non-system dylib (not under /usr/lib or /System) must be bundled.
+        echo "otool -L dilithion-node:"
+        otool -L "${BIN}"
+        FAIL=0
+        while read -r dep; do
+          case "$dep" in
+            /usr/lib/*|/System/*|@executable_path/*|@loader_path/*|@rpath/*) ;;
+            "") ;;
+            *)
+              base=$(basename "$dep")
+              if [ ! -f "${PKG}/lib/${base}" ]; then
+                echo "CLEAN-ROOM FAIL: non-system dylib not bundled: $dep"
+                FAIL=1
+              fi
+              ;;
+          esac
+        done < <(otool -L "${BIN}" | tail -n +2 | awk '{print $1}')
+        [ "$FAIL" -eq 0 ] || exit 1
+        # Must actually start (prints usage banner; --help/--version exit non-zero by design).
+        # macOS lacks GNU `timeout`; use a perl alarm watchdog (always present).
+        run_guarded() { perl -e 'alarm shift; exec @ARGV' 20 "$@"; }
+        out=$(run_guarded "${BIN}" --version 2>&1 || run_guarded "${BIN}" --help 2>&1 || true)
+        echo "$out" | head -3
+        echo "$out" | grep -qiE "dilithion|version|usage" || { echo "CLEAN-ROOM FAIL: binary did not start"; exit 1; }
+        echo "CLEAN-ROOM PASS"
+
     - name: Upload artifact
       uses: actions/upload-artifact@v7
       with:

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -65,6 +65,53 @@ jobs:
         chmod +x package-windows-release-github.sh
         ./package-windows-release-github.sh
 
+    - name: Clean-room smoke test (BLOCKING)
+      # Prove the packaged .exe actually RUNS using only bundled DLLs, and that
+      # every non-system DLL it imports is bundled. The windows-latest runner is
+      # NOT a clean machine (MSYS2/mingw DLLs are on PATH), so the real isolation
+      # proof is the PE-import completeness check via objdump: any non-system DLL
+      # that is NOT shipped in the package would silently load from MSYS2 here but
+      # be MISSING on a user's machine. We also launch the exe from the package
+      # dir (Windows resolves the application directory first, so bundled DLLs
+      # win). This gate blocks the upload steps below on failure.
+      shell: msys2 {0}
+      env:
+        VERSION: ${{ steps.get_version.outputs.version }}
+      run: |
+        set -e
+        RELEASE_NAME="dilithion-${VERSION}-mainnet-windows-x64"
+        PKG="releases/${RELEASE_NAME}"
+        BIN="dilithion-node.exe"
+        # Manifest assertion: exe + a couple of key DLLs present.
+        for f in "${BIN}" libstdc++-6.dll libssl-3-x64.dll; do
+          [ -f "${PKG}/${f}" ] || { echo "CLEAN-ROOM FAIL: missing ${f} in package"; exit 1; }
+        done
+        # System DLL allowlist (case-insensitive). Anything imported but not on
+        # this list MUST be bundled in the package, else it fails on user machines.
+        SYS_DLLS=" kernel32.dll user32.dll advapi32.dll ws2_32.dll msvcrt.dll shell32.dll bcrypt.dll dbghelp.dll iphlpapi.dll ntdll.dll gdi32.dll ole32.dll oleaut32.dll shlwapi.dll crypt32.dll secur32.dll winmm.dll setupapi.dll version.dll userenv.dll psapi.dll wininet.dll dnsapi.dll mswsock.dll rpcrt4.dll comdlg32.dll imm32.dll powrprof.dll "
+        FAIL=0
+        echo "PE imports for ${BIN}:"
+        objdump -p "${PKG}/${BIN}" | grep -i 'DLL Name' | awk '{print $3}' | while read -r dll; do echo "  $dll"; done
+        for dll in $(objdump -p "${PKG}/${BIN}" | grep -i 'DLL Name' | awk '{print $3}'); do
+          lc=$(echo "$dll" | tr 'A-Z' 'a-z')
+          case "$SYS_DLLS" in
+            *" $lc "*) ;;  # system DLL, fine
+            *)
+              if [ ! -f "${PKG}/${dll}" ]; then
+                echo "CLEAN-ROOM FAIL: imported DLL not bundled and not system: $dll"
+                FAIL=1
+              fi
+              ;;
+          esac
+        done
+        [ "$FAIL" -eq 0 ] || exit 1
+        # Must actually start (prints usage banner; --help/--version exit non-zero by design).
+        cd "${PKG}"
+        out=$(timeout 20 ./"${BIN}" --version 2>&1 || timeout 20 ./"${BIN}" --help 2>&1 || true)
+        echo "$out" | head -3
+        echo "$out" | grep -qiE "dilithion|version|usage" || { echo "CLEAN-ROOM FAIL: exe did not start"; exit 1; }
+        echo "CLEAN-ROOM PASS"
+
     - name: Upload artifact
       uses: actions/upload-artifact@v7
       with:

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -107,9 +107,11 @@ jobs:
         [ "$FAIL" -eq 0 ] || exit 1
         # Must actually start (prints usage banner; --help/--version exit non-zero by design).
         cd "${PKG}"
-        out=$(timeout 20 ./"${BIN}" --version 2>&1 || timeout 20 ./"${BIN}" --help 2>&1 || true)
+        out=$(timeout 20 ./"${BIN}" --help 2>&1 || true)
         echo "$out" | head -3
-        echo "$out" | grep -qiE "dilithion|version|usage" || { echo "CLEAN-ROOM FAIL: exe did not start"; exit 1; }
+        # Assert on the post-main() banner only the RUNNING exe prints; a "loading shared
+        # libraries"/path error echoes the exe name (contains "dilithion") and must NOT count as start.
+        echo "$out" | grep -q "Post-Quantum Cryptocurrency" || { echo "CLEAN-ROOM FAIL: exe did not start (no post-main banner)"; exit 1; }
         echo "CLEAN-ROOM PASS"
 
     - name: Upload artifact


### PR DESCRIPTION
## What
Adds a **BLOCKING \"Clean-room smoke test\"** step to all 6 release-build workflows (DIL + DilV × Linux/Windows/macOS), placed after the package/verify steps and **strictly before the upload steps** — so a package that can't actually start on a clean machine **fails the release**.

## Why
CI previously verified runtime libs were *present as files* but never **ran the packaged binary on a clean target**. A package can have every file yet still fail to launch (wrong lib version / broken `run-node.sh` wrapper / missing rpath) and CI would pass it. This closes that gap and makes \"the shipped package actually runs\" a permanent, machine-enforced gate (a standing role, not a remembered step).

## Mechanism per platform
- **Linux / DilV Linux:** extract the just-built tarball in a pristine `ubuntu:22.04` container (none of the deps installed), set `LD_LIBRARY_PATH=lib`, assert `ldd` has no `not found`, launch the binary, assert the usage banner prints. A genuine clean-box test.
- **macOS / DilV macOS:** `otool -L` — every non-system dylib must be bundled in `lib/`; strip quarantine; launch. (macOS hosted runners have Homebrew, so the *dep-completeness* check is the isolation proof, not a clean-box run — flagged below.)
- **Windows / DilV Windows:** `objdump -p` PE-import completeness vs a system-DLL allowlist (every non-system DLL bundled); launch the exe from the package dir. (Windows hosted runners have MSYS DLLs on PATH — same limitation; objdump completeness is the proof.)

## Validated (load-bearing, not vacuous)
Ran the Linux gate logic locally in Docker:
- Good v4.4.4 package → **CLEAN-ROOM PASS**.
- Same package with `libminiupnpc.so.17` removed → **CLEAN-ROOM FAIL: libminiupnpc.so.17 => not found** (gate `exit 1`, would block upload).

## Honest limitation (decision welcome)
Only **Linux** runs in a truly clean container. macOS/Windows hosted runners aren't pristine, so for those the gate relies on `otool`/`objdump` dependency-completeness (every non-system lib bundled) + a launch — strong, but not a clean-box run. A truly clean macOS/Windows test would need a container/fresh runner. The v4.4.4 Windows + Linux packages were already verified self-contained by hand.

## Notes
- `--help`/`--version` exit non-zero by design, so the gate asserts on **printed output**, not exit code (do not \"fix\" to assert exit 0). Bare-invocation auto-starts mining, so the gate only ever runs `--help`/`--version`.
- Additive only — no existing steps changed; all 6 YAMLs validated parseable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)