### PR TITLE
ci(macos): fix retired macos-13 Intel runner (-> macos-15-intel)

### DIFF
--- a/.github/workflows/build-dilv-macos.yml
+++ b/.github/workflows/build-dilv-macos.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: macos-13   # Intel x86_64
+          - runner: macos-15-intel   # Intel x86_64 (macos-13 retired Dec 2025; macos-15-intel is GitHub's Intel image, available until ~Aug 2027)
             arch: x64
           - runner: macos-14   # Apple Silicon arm64
             arch: arm64

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: macos-13   # Intel x86_64
+          - runner: macos-15-intel   # Intel x86_64 (macos-13 retired Dec 2025; macos-15-intel is GitHub's Intel image, available until ~Aug 2027)
             arch: x64
           - runner: macos-14   # Apple Silicon arm64
             arch: arm64


### PR DESCRIPTION
The `macos-13` Intel runner image was **deprecated 2025-09-22 / retired ~Dec 2025** ([GitHub changelog](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/)). x64 jobs targeting it queue indefinitely — our v4.4.4 Intel builds sat ~19h while arm64 (`macos-14`) succeeded. Switches the x64 matrix leg to `macos-15-intel` (GitHub's supported Intel image, available until ~Aug 2027; x86_64 macOS sunsets Fall 2027). arm64 unchanged. Dispatch-tested on this branch (also first real run of the #97 macOS clean-room gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)