### PR TITLE
fix(rpc): restore node-wallet login + close DNS-rebinding/admin-token surface (wallet Option A)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -296,7 +296,8 @@ RPC_SOURCES := src/rpc/server.cpp \
                src/rpc/logger.cpp \
                src/rpc/ssl_wrapper.cpp \
                src/rpc/websocket.cpp \
-               src/rpc/rest_api.cpp
+               src/rpc/rest_api.cpp \
+               src/rpc/host_validator.cpp
 
 API_SOURCES := src/api/http_server.cpp \
                src/api/cached_stats.cpp
@@ -381,6 +382,7 @@ MINER_TEST_SOURCE := src/test/miner_tests.cpp
 WALLET_TEST_SOURCE := src/test/wallet_tests.cpp
 RPC_TEST_SOURCE := src/test/rpc_tests.cpp
 RPC_AUTH_TEST_SOURCE := src/test/rpc_auth_tests.cpp
+RPC_HOST_HEADER_TEST_SOURCE := src/test/rpc_host_header_tests.cpp
 RPC_HD_WALLET_TEST_SOURCE := src/test/rpc_hd_wallet_tests.cpp
 RPC_SSL_TEST_SOURCE := src/test/rpc_ssl_tests.cpp
 RPC_WEBSOCKET_TEST_SOURCE := src/test/rpc_websocket_tests.cpp
@@ -489,7 +491,7 @@ dilv-genesis-vdf: $(CORE_OBJECTS) $(OBJ_DIR)/tools/dilv_genesis_vdf.o $(DILITHIU
 # Test Binaries
 # ============================================================================
 
-tests: phase1_test miner_tests wallet_tests rpc_tests rpc_auth_tests ratelimiter_tests timestamp_tests crypter_tests wallet_encryption_integration_tests wallet_persistence_tests integration_tests net_tests connman_tests tx_validation_tests tx_relay_tests mining_integration_tests bug_003_block_size_tests dfmp_mik_tests mik_registration_persistence_tests dna_propagation_tests test_passphrase_validator script_tests addrman_v2_tests peer_scorer_tests peer_scorer_banman_integration_tests header_proof_checker_tests chain_selector_tests getchaintips_equivalence_tests chain_case_2_5_equivalence_tests chain_work_smoke_tests reorg_wal_crash_injection_tests competing_sibling_below_checkpoint_tests headers_manager_to_chain_selector_wiring_tests fast_path_2_boundary_tests v4_1_checkpoint_enforcement_tests v4_1_chain_selector_suppression_tests auto_rebuild_marker_mode_symmetry_tests add_block_index_flag_merge_tests port_chain_selector_invariants_tests legacy_vs_port_differential_tests chainstate_integrity_tests
+tests: phase1_test miner_tests wallet_tests rpc_tests rpc_auth_tests rpc_host_header_tests ratelimiter_tests timestamp_tests crypter_tests wallet_encryption_integration_tests wallet_persistence_tests integration_tests net_tests connman_tests tx_validation_tests tx_relay_tests mining_integration_tests bug_003_block_size_tests dfmp_mik_tests mik_registration_persistence_tests dna_propagation_tests test_passphrase_validator script_tests addrman_v2_tests peer_scorer_tests peer_scorer_banman_integration_tests header_proof_checker_tests chain_selector_tests getchaintips_equivalence_tests chain_case_2_5_equivalence_tests chain_work_smoke_tests reorg_wal_crash_injection_tests competing_sibling_below_checkpoint_tests headers_manager_to_chain_selector_wiring_tests fast_path_2_boundary_tests v4_1_checkpoint_enforcement_tests v4_1_chain_selector_suppression_tests auto_rebuild_marker_mode_symmetry_tests add_block_index_flag_merge_tests port_chain_selector_invariants_tests legacy_vs_port_differential_tests chainstate_integrity_tests
 	@echo "$(COLOR_GREEN)✓ All tests built successfully$(COLOR_RESET)"
 
 phase1_test: $(CORE_OBJECTS) $(OBJ_DIR)/test/phase1_simple_test.o $(DILITHIUM_OBJECTS) $(CHIAVDF_OBJECTS)
@@ -511,6 +513,13 @@ rpc_tests: $(CORE_OBJECTS) $(OBJ_DIR)/test/rpc_tests.o $(DILITHIUM_OBJECTS) $(CH
 rpc_auth_tests: $(CORE_OBJECTS) $(OBJ_DIR)/test/rpc_auth_tests.o $(DILITHIUM_OBJECTS) $(CHIAVDF_OBJECTS)
 	@echo "$(COLOR_BLUE)[LINK]$(COLOR_RESET) $@"
 	@$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LIBS)
+
+# wallet-rpc-login-restore: Host-header allowlist + session-token unit tests.
+# Self-contained — links ONLY host_validator.o, so it builds and runs WITHOUT
+# the node's depends/ (libzmq/randomx/chiavdf). No CORE_OBJECTS dependency.
+rpc_host_header_tests: $(OBJ_DIR)/rpc/host_validator.o $(OBJ_DIR)/test/rpc_host_header_tests.o
+	@echo "$(COLOR_BLUE)[LINK]$(COLOR_RESET) $@"
+	@$(CXX) $(CXXFLAGS) -o $@ $^
 
 ratelimiter_tests: $(CORE_OBJECTS) $(OBJ_DIR)/test/ratelimiter_tests.o $(DILITHIUM_OBJECTS) $(CHIAVDF_OBJECTS)
 	@echo "$(COLOR_BLUE)[LINK]$(COLOR_RESET) $@"
@@ -960,6 +969,9 @@ test: tests test_dilithion asert_test
 	@echo ""
 	@echo "$(COLOR_YELLOW)Running RPC authentication tests...$(COLOR_RESET)"
 	@./rpc_auth_tests
+	@echo ""
+	@echo "$(COLOR_YELLOW)Running RPC Host-header allowlist + session-token tests...$(COLOR_RESET)"
+	@./rpc_host_header_tests
 	@echo ""
 	@echo "$(COLOR_YELLOW)Running rate limiter regression tests...$(COLOR_RESET)"
 	@./ratelimiter_tests

--- a/docs/RPC-AUTHENTICATION.md
+++ b/docs/RPC-AUTHENTICATION.md
@@ -493,6 +493,85 @@ bool valid = RPCAuth::AuthenticateRequest(username, password);
 
 ---
 
+## Anti-DNS-Rebinding Host-Header Allowlist (v4.4.4+)
+
+The RPC/HTTP server enforces a **Host-header allowlist** as the FIRST check on
+every request, before any path dispatch (wallet HTML, OPTIONS, REST `/api/v1/*`,
+or JSON-RPC). This mirrors `geth --http.vhosts` and is the canonical defense
+against DNS-rebinding attacks (Geth-2018 account-drain, Sia-2019 seed-theft):
+a malicious web page that rebinds its DNS name to `127.0.0.1` is rejected because
+the browser still sends `Host: evil.com`, which is not in the allowlist.
+
+**Default policy (desktop / mining node, no `--public-api`):** only loopback Host
+headers are accepted — `127.0.0.1`, `[::1]`, `localhost` (with or without the
+correct `:port`). Everything else is rejected with `403 Forbidden`.
+
+**`--public-api` policy (seed nodes):** loopback PLUS:
+- any host you add with `--rpcallowhost=<host>` (repeatable; also `rpcallowhost=`
+  in `dilithion.conf`), AND
+- the node's own external IP **by default** when `--externalip=<ip>` is set, so
+  existing remote light-wallet REST clients (which send `Host: <seed-ip>`) keep
+  working after upgrade.
+
+> **Migration note:** if you run a `--public-api` seed and your remote clients
+> connect using a **DNS name** (not the raw IP), add it explicitly:
+> `--rpcallowhost=seed.example.org`. A `--public-api` node with NO `--rpcallowhost`
+> and no `--externalip` accepts only loopback Host headers and will reject remote
+> clients — the node prints a WARNING at startup in that case.
+
+The Host parser does an **exact host-token match** (port stripped, IPv6 brackets
+removed, case-insensitive) — NOT a substring search. Rejected forms include
+absent/empty Host (default-deny), duplicate Host headers (smuggling), wrong port,
+and suffix tricks such as `localhost.evil.com` / `127.0.0.1.evil.com` / `localhostX`.
+
+**Residual (documented, matches the geth `--http.vhosts` residual):** a raw-IP
+literal (`127.0.0.1`) is, by design, always allowed. A non-browser local process
+(curl, a script, a malicious process already on the box) can therefore reach the
+RPC server with `Host: 127.0.0.1`. This is acceptable because it is outside the
+browser-DNS-rebinding threat model (such a process can already open a loopback
+socket directly); the allowlist defends specifically against a victim's browser
+being weaponized via rebinding.
+
+## Same-origin wallet login (node-injected session token)
+
+When the bundled web wallet is **served by the node** (`GET /` or `GET /wallet`),
+the node mints a fresh, short-lived, server-validated **session token** and
+injects it into the page (`<meta name="dilithion-rpc-token">`). The wallet uses
+this token as its RPC credential (`Authorization: Basic base64("__token__:<tok>")`)
+instead of any hardcoded username/password — so a default node (cookie auth) logs
+in with **no credential paste required**.
+
+Security properties:
+- The token is a **real credential**, validated server-side (constant-time) on
+  every fund-capable call. It is NOT the CSRF header (which accepts any value).
+- A valid token resolves server-side to the configured cookie/`rpcuser`
+  credentials and runs through the **existing** `RPCAuth` + permissions path —
+  it never bypasses auth (`sendtoaddress` / `dumpprivkey` stay protected).
+- Short-lived (12h TTL) and **rotated on every page load**; bound to the node
+  process. The token is held in browser memory only — never written to
+  `localStorage`, never logged.
+- The token-bearing page is served with `X-Frame-Options: DENY`, a restrictive
+  `Content-Security-Policy` (`frame-ancestors 'none'`), `Referrer-Policy:
+  no-referrer`, and `Cache-Control: no-store` to prevent framing / referrer /
+  cache leakage of the token.
+
+**Opening `wallet.html` directly from disk** (not served by a node) leaves the
+token placeholder unfilled; the wallet then falls back to the manual
+`rpcuser`/`rpcpassword` fields (in-memory only — no guessable `rpc:rpc` default).
+
+## Credential model summary
+
+| Mode | Server credential | Wallet login |
+|------|-------------------|--------------|
+| Default node | random `.cookie` (`__cookie__:<hex>`) | node-injected session token |
+| `rpcuser`/`rpcpassword` set | your configured creds | session token (served) or manual entry |
+| `--public-api` (seed) | auto-generated `dilithion:<hex>` (in `dilithion.conf`) | session token (served) or manual entry |
+
+There is **no guessable static credential** anywhere in this model. The old
+`rpc:rpc` default has been removed from the bundled wallet client.
+
+---
+
 ## References
 
 - **HTTP Basic Auth:** RFC 7617

--- a/docs/RPC-AUTHENTICATION.md
+++ b/docs/RPC-AUTHENTICATION.md
@@ -506,31 +506,59 @@ the browser still sends `Host: evil.com`, which is not in the allowlist.
 headers are accepted — `127.0.0.1`, `[::1]`, `localhost` (with or without the
 correct `:port`). Everything else is rejected with `403 Forbidden`.
 
-**`--public-api` policy (seed nodes):** loopback PLUS:
-- any host you add with `--rpcallowhost=<host>` (repeatable; also `rpcallowhost=`
-  in `dilithion.conf`), AND
-- the node's own external IP **by default** when `--externalip=<ip>` is set, so
-  existing remote light-wallet REST clients (which send `Host: <seed-ip>`) keep
-  working after upgrade.
+**`--public-api` policy (seed nodes), RPC/REST surface:** loopback PLUS any host
+you add **explicitly** with `--rpcallowhost=<host>` (repeatable; also
+`rpcallowhost=` in `dilithion.conf`).
 
-> **Migration note:** if you run a `--public-api` seed and your remote clients
-> connect using a **DNS name** (not the raw IP), add it explicitly:
-> `--rpcallowhost=seed.example.org`. A `--public-api` node with NO `--rpcallowhost`
-> and no `--externalip` accepts only loopback Host headers and will reject remote
-> clients — the node prints a WARNING at startup in that case.
+> **The node does NOT auto-allow its own `--externalip`.** (Security hardening,
+> F-002 C-01.) Auto-allowing the public IP converted an operator opt-in into a
+> default remote exposure, and — combined with the token-minting wallet page —
+> issued an admin session token to any remote client that knew the seed IP. A
+> `--public-api` operator who genuinely wants remote light-wallet REST on the raw
+> IP must now list it explicitly: `--rpcallowhost=<this node's public IP>`. If
+> your remote clients connect by **DNS name**, add that instead:
+> `--rpcallowhost=seed.example.org`. A `--public-api` node with NO
+> `--rpcallowhost` accepts only loopback Host headers for RPC/REST and prints a
+> WARNING at startup.
+
+**The token-minting wallet UI is ALWAYS loopback-only.** `GET /` and
+`GET /wallet` (which serve the admin-token-bearing wallet HTML) are served ONLY
+to a loopback Host (`127.0.0.1` / `localhost` / `[::1]`), **regardless of
+`--public-api` / `--rpcallowhost` / `--externalip`**. Even a host you allowlist
+for RPC/REST will receive `403 Forbidden` on `GET /wallet`. Remote operators must
+reach the wallet UI over an SSH tunnel (`ssh -L 8332:127.0.0.1:8332 ...`). This
+is a separate, stricter gate than the RPC/REST allowlist — the session-token
+login is a same-origin desktop affordance, never a seed feature.
 
 The Host parser does an **exact host-token match** (port stripped, IPv6 brackets
 removed, case-insensitive) — NOT a substring search. Rejected forms include
 absent/empty Host (default-deny), duplicate Host headers (smuggling), wrong port,
 and suffix tricks such as `localhost.evil.com` / `127.0.0.1.evil.com` / `localhostX`.
 
-**Residual (documented, matches the geth `--http.vhosts` residual):** a raw-IP
-literal (`127.0.0.1`) is, by design, always allowed. A non-browser local process
-(curl, a script, a malicious process already on the box) can therefore reach the
-RPC server with `Host: 127.0.0.1`. This is acceptable because it is outside the
-browser-DNS-rebinding threat model (such a process can already open a loopback
-socket directly); the allowlist defends specifically against a victim's browser
-being weaponized via rebinding.
+**Residual — raw-IP literal (documented, matches the geth `--http.vhosts`
+residual):** a raw-IP literal (`127.0.0.1`) is, by design, always allowed. A
+non-browser local process (curl, a script, a malicious process already on the
+box) can therefore reach the RPC server with `Host: 127.0.0.1`. This is
+acceptable because it is outside the browser-DNS-rebinding threat model (such a
+process can already open a loopback socket directly); the allowlist defends
+specifically against a victim's browser being weaponized via rebinding.
+
+**Residual — `localhost` name allowlisting (M-01, matches geth's
+`--http.vhosts localhost` residual):** the *name* `localhost` is accepted, not
+only the literal `127.0.0.1`. A non-browser middlebox / dev proxy that rewrites
+the `Host` header to `localhost` would pass the gate. Browsers send the *origin*
+hostname as `Host`, so a rebinding payload cannot set `Host: localhost` for an
+off-origin page — the residual is confined to local tooling that deliberately
+rewrites Host, which is outside the rebinding threat model. (To run strictly
+IP-only, an operator can front the node with a proxy that rejects the `localhost`
+name; the node defaults to accepting it for desktop ergonomics.)
+
+**Residual — IPv6 loopback canonicalization is not exhaustive (L-01):** common
+loopback spellings (`::1`, fully-expanded `0:0:...:1`, dotted IPv4-mapped
+`::ffff:127.0.0.1`, hex IPv4-mapped `::ffff:7f00:1`) canonicalize to `::1` and
+are accepted. Any *other* IPv6 spelling of loopback is **rejected**
+(fail-closed / over-restrictive, never over-permissive) — a denied loopback
+spelling is safe; a wrongly-accepted one would not be.
 
 ## Same-origin wallet login (node-injected session token)
 
@@ -547,13 +575,31 @@ Security properties:
 - A valid token resolves server-side to the configured cookie/`rpcuser`
   credentials and runs through the **existing** `RPCAuth` + permissions path —
   it never bypasses auth (`sendtoaddress` / `dumpprivkey` stay protected).
-- Short-lived (12h TTL) and **rotated on every page load**; bound to the node
-  process. The token is held in browser memory only — never written to
-  `localStorage`, never logged.
+- Short-lived (**1h TTL**, F-002 M-02) and **rotated on every page load**; bound
+  to the node process. The token is held in browser memory only — never written
+  to `localStorage`, never logged. The short TTL bounds the exposure of a leaked
+  token (it is a pure bearer credential, not bound to client IP/UA); an active
+  desktop session self-heals because each page load re-mints.
+- Served **loopback-only** (F-002 C-01): the token-minting `GET /` / `GET /wallet`
+  page is never served to a non-loopback Host, even one allowlisted for RPC/REST.
 - The token-bearing page is served with `X-Frame-Options: DENY`, a restrictive
   `Content-Security-Policy` (`frame-ancestors 'none'`), `Referrer-Policy:
   no-referrer`, and `Cache-Control: no-store` to prevent framing / referrer /
   cache leakage of the token.
+
+**Reserved usernames (M-03):** `__token__` (session-token sentinel) and
+`__cookie__` (cookie-auth user) are reserved on the auth surface. Configuring
+`rpcuser=__token__` or `rpcuser=__cookie__` is rejected at startup (the node
+aborts) so an operator cannot create a username that collides with the internal
+sentinel branches.
+
+**Residual — CSP `'unsafe-inline'` (L-02, tracked):** the served wallet HTML uses
+inline `<script>`, so its CSP retains `script-src 'self' 'unsafe-inline'`. The
+page now embeds a session token in the DOM, making it the highest-value XSS
+target on the node. Tracked follow-up: move the wallet JS to an external `'self'`
+file so the inline allowance can be dropped. Mitigations already in place:
+loopback-only serving (no remote XSS vector), `no-store` caching, and the token
+living only in browser memory.
 
 **Opening `wallet.html` directly from disk** (not served by a node) leaves the
 token placeholder unfilled; the wallet then falls back to the manual

--- a/src/api/wallet_html.h
+++ b/src/api/wallet_html.h
@@ -15,6 +15,14 @@ inline const std::string& GetWalletHTML() {
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <!-- wallet-rpc-login-restore: same-origin RPC session token.
+         When this page is served BY a Dilithion node, the node replaces the
+         placeholder below with a freshly-minted, server-validated session token.
+         The wallet uses it as its RPC credential (replacing the old rpc:rpc).
+         If the file is opened directly (not served by a node), the placeholder
+         stays as the literal sentinel and the wallet falls back to the
+         user-supplied rpcuser/rpcpassword fields. -->
+    <meta name="dilithion-rpc-token" content="__DILITHION_RPC_SESSION_TOKEN__">
     <title>Dilithion Web Wallet</title>
     <link rel="icon" type="image/x-icon" href="favicon.ico">
     <!-- PWA -->
@@ -1888,12 +1896,12 @@ inline const std::string& GetWalletHTML() {
                     <small style="color: var(--text-muted); font-size: 0.75rem;">DIL: 8332, DilV: 9332, Testnet: 18332</small>
                 </div>
                 <div class="form-group">
-                    <label class="form-label">RPC Username</label>
-                    <input type="text" class="form-input" id="rpcUser" value="rpc" placeholder="Default: rpc">
+                    <label class="form-label">RPC Username <small style="color: var(--text-muted); font-weight: normal;">(only if not served by your node)</small></label>
+                    <input type="text" class="form-input" id="rpcUser" value="" placeholder="from dilithion.conf / .cookie" autocomplete="off">
                 </div>
                 <div class="form-group">
                     <label class="form-label">RPC Password</label>
-                    <input type="password" class="form-input" id="rpcPass" value="rpc" placeholder="Default: rpc">
+                    <input type="password" class="form-input" id="rpcPass" value="" placeholder="from dilithion.conf / .cookie" autocomplete="off">
                 </div>
                 <button class="btn btn-primary" onclick="saveSettings()">Save & Connect</button>
             </div>
@@ -2187,9 +2195,27 @@ inline const std::string& GetWalletHTML() {
         let rpcConfig = {
             host: '127.0.0.1',
             port: 8332,  // Mainnet RPC port (testnet: 18332)
-            user: 'rpc',
-            pass: 'rpc'
+            user: '',    // wallet-rpc-login-restore: no guessable default (was 'rpc')
+            pass: ''     // populated only via manual override when not served by a node
         };
+
+        // wallet-rpc-login-restore: same-origin RPC session token.
+        // When this page is served BY a Dilithion node, the node injects a fresh
+        // server-validated token into the <meta name="dilithion-rpc-token"> tag.
+        // We use it as the RPC credential (Authorization: Basic __token__:<tok>)
+        // INSTEAD of a username/password. This is the supported same-origin login
+        // path on a default node — no credential paste required. The token is
+        // held in memory only (never localStorage) and re-read on each call so a
+        // freshly-served page always uses the latest minted token.
+        function getSessionToken() {
+            const m = document.querySelector('meta[name="dilithion-rpc-token"]');
+            if (!m) return '';
+            const v = (m.getAttribute('content') || '').trim();
+            // The literal sentinel means the page was NOT served by a node
+            // (opened from disk) — no token available, fall back to manual creds.
+            if (!v || v === '__DILITHION_RPC_SESSION_TOKEN__') return '';
+            return v;
+        }
 
         // Active chain: 'dil' or 'dilv'
         let activeChain = 'dil';  // Always start on DIL
@@ -2235,7 +2261,10 @@ inline const std::string& GetWalletHTML() {
             // Switch RPC port and reconnect
             rpcConfig.port = chainPorts[chain];
             document.getElementById('rpcPort').value = rpcConfig.port;
-            localStorage.setItem('dilithionWalletConfig', JSON.stringify(rpcConfig));
+            // wallet-rpc-login-restore: persist host/port ONLY — never credentials.
+            localStorage.setItem('dilithionWalletConfig', JSON.stringify({
+                host: rpcConfig.host, port: rpcConfig.port
+            }));
             // Update chain ID for transaction signing (DIL=1, DilV=2)
             if (txBuilder) txBuilder.chainId = chain === 'dilv' ? 2 : 1;
             // Update connection manager chain for API routing
@@ -2359,20 +2388,22 @@ inline const std::string& GetWalletHTML() {
         }
 
         // Load saved settings
+        // wallet-rpc-login-restore: only host/port are persisted. RPC credentials
+        // are NEVER written to localStorage (MED-1): on a node-served page the
+        // session token supplies auth; for a from-disk page the user re-enters
+        // manual creds each session (in-memory only).
         function loadSettings() {
             const saved = localStorage.getItem('dilithionWalletConfig');
             if (saved) {
                 try {
-                    rpcConfig = JSON.parse(saved);
+                    const savedCfg = JSON.parse(saved);
+                    rpcConfig.host = savedCfg.host || rpcConfig.host;
+                    rpcConfig.port = savedCfg.port || rpcConfig.port;
                     // Prefer per-chain port for current activeChain over the last-saved port
                     if (chainPorts[activeChain]) rpcConfig.port = chainPorts[activeChain];
                     document.getElementById('rpcHost').value = rpcConfig.host;
                     document.getElementById('rpcPort').value = rpcConfig.port;
-                    document.getElementById('rpcUser').value = rpcConfig.user || 'rpc';
-                    document.getElementById('rpcPass').value = rpcConfig.pass || 'rpc';
-                    // Ensure defaults are set even for old saved configs
-                    if (!rpcConfig.user) rpcConfig.user = 'rpc';
-                    if (!rpcConfig.pass) rpcConfig.pass = 'rpc';
+                    // Do NOT restore user/pass from storage — no guessable defaults.
                 } catch(e) {}
             }
         }
@@ -2381,11 +2412,15 @@ inline const std::string& GetWalletHTML() {
         function saveSettings() {
             rpcConfig.host = document.getElementById('rpcHost').value;
             rpcConfig.port = parseInt(document.getElementById('rpcPort').value);
+            // Manual-override credentials are kept in memory only (not persisted).
             rpcConfig.user = document.getElementById('rpcUser').value;
             rpcConfig.pass = document.getElementById('rpcPass').value;
             chainPorts[activeChain] = rpcConfig.port;
             localStorage.setItem('dilithionChainPorts', JSON.stringify(chainPorts));
-            localStorage.setItem('dilithionWalletConfig', JSON.stringify(rpcConfig));
+            // wallet-rpc-login-restore: persist host/port ONLY — never credentials.
+            localStorage.setItem('dilithionWalletConfig', JSON.stringify({
+                host: rpcConfig.host, port: rpcConfig.port
+            }));
             showNotification('Settings saved. Connecting...', 'info');
             connect();
         }
@@ -2429,10 +2464,18 @@ inline const std::string& GetWalletHTML() {
             const url = `http://${rpcConfig.host}:${rpcConfig.port}/`;
             const headers = {
                 'Content-Type': 'application/json',
-                'X-Dilithion-RPC': '1'  // Required for CSRF protection
+                'X-Dilithion-RPC': '1'  // Required for CSRF protection (presence-only)
             };
 
-            if (rpcConfig.user && rpcConfig.pass) {
+            // wallet-rpc-login-restore: prefer the node-injected same-origin
+            // session token. It is a REAL server-validated credential — the node
+            // maps "__token__:<token>" to the configured cookie/rpcuser creds and
+            // runs the existing auth + permissions path. Falls back to manual
+            // rpcuser/rpcpassword only when the page was not served by a node.
+            const sessionToken = getSessionToken();
+            if (sessionToken) {
+                headers['Authorization'] = 'Basic ' + btoa('__token__:' + sessionToken);
+            } else if (rpcConfig.user && rpcConfig.pass) {
                 headers['Authorization'] = 'Basic ' + btoa(rpcConfig.user + ':' + rpcConfig.pass);
             }
 

--- a/src/node/dilithion-node.cpp
+++ b/src/node/dilithion-node.cpp
@@ -568,6 +568,7 @@ struct NodeConfig {
     int max_connections = 0;         // --maxconnections: Maximum peer connections (0 = default 125)
     int max_connections_per_ip = 2;  // --max-connections-per-ip: Max inbound per IP (default 2, range 1-64)
     int attestation_rate_limit = 1;  // --attestation-rate-limit: Max attestations per /24 subnet per day
+    std::vector<std::string> rpc_allow_hosts;  // --rpcallowhost: extra allowed Host headers (anti-DNS-rebinding allowlist)
     bool shared_heat = true;         // Phase 3b: shared cluster heat (default ON)
     // use_new_peerman field removed in v4.3.4 cut Block 8 with the --usenewpeerman
     // flag retirement (port::CPeerManager class deleted in Block 7; flag was a no-op
@@ -758,6 +759,15 @@ struct NodeConfig {
                 // Public REST API: bind to 0.0.0.0 for light wallet access (seed nodes only)
                 public_api = true;
             }
+            else if (arg.find("--rpcallowhost=") == 0) {
+                // wallet-rpc-login-restore: add an allowed Host header to the
+                // anti-DNS-rebinding allowlist. Repeatable. Loopback
+                // (127.0.0.1/::1/localhost) is always allowed implicitly; use
+                // this to allow a node's public IP / DNS name so remote
+                // light-wallet REST clients keep working under --public-api.
+                std::string h = arg.substr(15);
+                if (!h.empty()) rpc_allow_hosts.push_back(h);
+            }
             else if (arg == "--no-shared-heat") {
                 // Disable Phase 3b shared cluster heat penalty
                 shared_heat = false;
@@ -875,6 +885,12 @@ struct NodeConfig {
         std::cout << "                          Add --yes to skip the confirmation prompt." << std::endl;
         std::cout << "  --relay-only          Relay-only mode: skip wallet (for seed nodes)" << std::endl;
         std::cout << "  --public-api          Enable public REST API for light wallets (seed nodes)" << std::endl;
+        std::cout << "  --rpcallowhost=<host> Allow this Host header on the RPC/HTTP server" << std::endl;
+        std::cout << "                          (anti-DNS-rebinding allowlist; repeatable)." << std::endl;
+        std::cout << "                          Loopback (127.0.0.1/::1/localhost) is always" << std::endl;
+        std::cout << "                          allowed. MIGRATION: under --public-api the node's" << std::endl;
+        std::cout << "                          own external IP is allowed by default, but remote" << std::endl;
+        std::cout << "                          clients using a DNS name must be added here." << std::endl;
         std::cout << "  --no-shared-heat      Disable shared cluster heat penalty" << std::endl;
         std::cout << "  --upnp                Enable automatic port mapping (UPnP)" << std::endl;
         std::cout << "  --no-upnp             Disable UPnP (don't prompt)" << std::endl;
@@ -2093,6 +2109,12 @@ int main(int argc, char* argv[]) {
     // Verbose mode (only if not set via command-line)
     if (!config.verbose) {
         config.verbose = config_parser.GetBool("verbose", false);
+
+        // wallet-rpc-login-restore: merge conf-file rpcallowhost entries with CLI
+        // --rpcallowhost. CLI entries already populated config.rpc_allow_hosts.
+        for (const auto& h : config_parser.GetList("rpcallowhost")) {
+            if (!h.empty()) config.rpc_allow_hosts.push_back(h);
+        }
     }
 
     // Set global verbose flag for debug output
@@ -7256,6 +7278,27 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
             }
             std::cout << "  [AUTH] RPC cookie authentication enabled (credentials in "
                       << cookie_path << ")" << std::endl;
+        }
+
+        // wallet-rpc-login-restore: register the REAL configured credentials so a
+        // valid same-origin session token can resolve to them and run through the
+        // existing RPCAuth + permissions path (token = credential alias, never a
+        // skip-auth bypass). rpcuser/rpcpassword now hold the final creds from
+        // whichever auth branch ran above (configured / public-api auto / cookie).
+        rpc_server.SetSessionAuthCredentials(rpcuser, rpcpassword);
+
+        // wallet-rpc-login-restore: populate the anti-DNS-rebinding Host allowlist.
+        // Loopback is always allowed by the validator itself; here we add operator
+        // --rpcallowhost / rpcallowhost= entries, plus — under --public-api — the
+        // node's own external IP by default so EXISTING remote light-wallet REST
+        // clients (which send Host: <seed-ip>) keep working after upgrade.
+        for (const auto& h : config.rpc_allow_hosts) {
+            rpc_server.AddRpcAllowHost(h);
+        }
+        if (config.public_api && !config.external_ip.empty()) {
+            rpc_server.AddRpcAllowHost(config.external_ip);
+            std::cout << "  [RPC] --public-api: allowing own external IP in Host "
+                         "allowlist: " << config.external_ip << std::endl;
         }
 
         // Phase 1: Initialize request logging

--- a/src/node/dilithion-node.cpp
+++ b/src/node/dilithion-node.cpp
@@ -888,9 +888,9 @@ struct NodeConfig {
         std::cout << "  --rpcallowhost=<host> Allow this Host header on the RPC/HTTP server" << std::endl;
         std::cout << "                          (anti-DNS-rebinding allowlist; repeatable)." << std::endl;
         std::cout << "                          Loopback (127.0.0.1/::1/localhost) is always" << std::endl;
-        std::cout << "                          allowed. MIGRATION: under --public-api the node's" << std::endl;
-        std::cout << "                          own external IP is allowed by default, but remote" << std::endl;
-        std::cout << "                          clients using a DNS name must be added here." << std::endl;
+        std::cout << "                          allowed. Under --public-api, remote REST/RPC clients" << std::endl;
+        std::cout << "                          must be added here EXPLICITLY (by IP or DNS name) —" << std::endl;
+        std::cout << "                          the node's own external IP is NOT auto-allowed." << std::endl;
         std::cout << "  --no-shared-heat      Disable shared cluster heat penalty" << std::endl;
         std::cout << "  --upnp                Enable automatic port mapping (UPnP)" << std::endl;
         std::cout << "  --no-upnp             Disable UPnP (don't prompt)" << std::endl;

--- a/src/node/dilithion-node.cpp
+++ b/src/node/dilithion-node.cpp
@@ -7130,6 +7130,18 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
         std::string rpcpassword = config_parser.GetString("rpcpassword", "");
         std::string rpc_permissions_file = config.datadir + "/rpc_permissions.json";
 
+        // M-03 (F-002): __token__ and __cookie__ are RESERVED usernames on the
+        // auth surface — __token__ is the session-token sentinel (server.cpp) and
+        // __cookie__ is the cookie-auth user. Reject them at config time so an
+        // operator cannot configure a real rpcuser that collides with the
+        // sentinel branch (which would hijack/lock-out their login).
+        if (rpcuser == "__token__" || rpcuser == "__cookie__") {
+            std::cerr << "ERROR: rpcuser '" << rpcuser << "' is a reserved username "
+                      << "(used internally for session-token / cookie auth). "
+                      << "Choose a different rpcuser. Aborting startup." << std::endl;
+            return 1;
+        }
+
         if (!rpcuser.empty() && !rpcpassword.empty()) {
             // CVE-2026-RPC-AUTH: previously only InitializePermissions was called.
             // The auth gate at server.cpp checks RPCAuth::IsAuthConfigured(),
@@ -7287,18 +7299,38 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
         // whichever auth branch ran above (configured / public-api auto / cookie).
         rpc_server.SetSessionAuthCredentials(rpcuser, rpcpassword);
 
-        // wallet-rpc-login-restore: populate the anti-DNS-rebinding Host allowlist.
-        // Loopback is always allowed by the validator itself; here we add operator
-        // --rpcallowhost / rpcallowhost= entries, plus — under --public-api — the
-        // node's own external IP by default so EXISTING remote light-wallet REST
-        // clients (which send Host: <seed-ip>) keep working after upgrade.
+        // wallet-rpc-login-restore: populate the anti-DNS-rebinding Host allowlist
+        // for RPC/REST. Loopback is ALWAYS allowed by the validator itself; here
+        // we add ONLY operator-explicit --rpcallowhost / rpcallowhost= entries.
+        //
+        // C-01 (F-002): we DELIBERATELY do NOT auto-add the node's own
+        // --externalip. Auto-allowing the public IP is the line that converts
+        // "operator opt-in" into "default remote exposure" — and combined with
+        // the wallet-HTML token mint it issued an admin token to any remote
+        // client that knew the seed IP. A --public-api operator who genuinely
+        // wants remote light-wallet REST on the raw IP must list it explicitly
+        // (--rpcallowhost=<ip>); even then it only governs RPC/REST and NEVER
+        // the loopback-only wallet-HTML/token path (see server.cpp GET /wallet).
         for (const auto& h : config.rpc_allow_hosts) {
+            // L-03 (F-002): a bare (unbracketed) IPv6 literal with a trailing
+            // ":port" is silently mis-parsed by the allowlist (the port is not
+            // stripped, so a dead entry is inserted that never matches a real
+            // request). Warn the operator to use the bracketless+portless form.
+            if (h.find("::") != std::string::npos && h.find('[') == std::string::npos) {
+                size_t lastColon = h.rfind(':');
+                if (lastColon != std::string::npos && lastColon + 1 < h.size()) {
+                    bool tail_digits = true;
+                    for (size_t i = lastColon + 1; i < h.size(); ++i)
+                        if (h[i] < '0' || h[i] > '9') { tail_digits = false; break; }
+                    if (tail_digits) {
+                        std::cerr << "WARNING: --rpcallowhost='" << h << "' looks like a "
+                                  << "bare IPv6 literal with a port. Pass IPv6 hosts "
+                                  << "bracketless AND portless (e.g. 2001:db8::5) or this "
+                                  << "entry will never match a request." << std::endl;
+                    }
+                }
+            }
             rpc_server.AddRpcAllowHost(h);
-        }
-        if (config.public_api && !config.external_ip.empty()) {
-            rpc_server.AddRpcAllowHost(config.external_ip);
-            std::cout << "  [RPC] --public-api: allowing own external IP in Host "
-                         "allowlist: " << config.external_ip << std::endl;
         }
 
         // Phase 1: Initialize request logging

--- a/src/node/dilv-node.cpp
+++ b/src/node/dilv-node.cpp
@@ -564,6 +564,7 @@ struct NodeConfig {
     int max_connections = 0;         // --maxconnections: Maximum peer connections (0 = default 125)
     int max_connections_per_ip = 2;  // --max-connections-per-ip: Max inbound per IP (default 2, range 1-64)
     int attestation_rate_limit = 1;  // --attestation-rate-limit: Max attestations per /24 subnet per day (Sybil defense)
+    std::vector<std::string> rpc_allow_hosts;  // --rpcallowhost: extra allowed Host headers (anti-DNS-rebinding allowlist)
     // use_new_peerman field removed in v4.3.4 cut Block 8 with the --usenewpeerman
     // flag retirement (port::CPeerManager class deleted in Block 7; flag was a no-op
     // since Block 7).
@@ -750,6 +751,12 @@ struct NodeConfig {
                 // Public REST API: bind to 0.0.0.0 for light wallet access (seed nodes only)
                 public_api = true;
             }
+            else if (arg.find("--rpcallowhost=") == 0) {
+                // wallet-rpc-login-restore: anti-DNS-rebinding Host allowlist.
+                // Repeatable. Loopback is always allowed implicitly.
+                std::string h = arg.substr(15);
+                if (!h.empty()) rpc_allow_hosts.push_back(h);
+            }
             else if (arg == "--upnp") {
                 // Enable UPnP automatic port mapping
                 upnp_enabled = true;
@@ -853,6 +860,11 @@ struct NodeConfig {
         std::cout << "                          Add --yes to skip the confirmation prompt." << std::endl;
         std::cout << "  --relay-only          Relay-only mode: skip wallet (for seed nodes)" << std::endl;
         std::cout << "  --public-api          Enable public REST API for light wallets (seed nodes)" << std::endl;
+        std::cout << "  --rpcallowhost=<host> Allow this Host header on the RPC/HTTP server" << std::endl;
+        std::cout << "                          (anti-DNS-rebinding allowlist; repeatable)." << std::endl;
+        std::cout << "                          Loopback is always allowed. Under --public-api" << std::endl;
+        std::cout << "                          the node's own external IP is allowed by default;" << std::endl;
+        std::cout << "                          add DNS names of remote clients here." << std::endl;
         std::cout << "  --upnp                Enable automatic port mapping (UPnP)" << std::endl;
         std::cout << "  --no-upnp             Disable UPnP (don't prompt)" << std::endl;
         std::cout << "  --externalip=<ip>     Your public IP (for manual port forwarding)" << std::endl;
@@ -2010,6 +2022,12 @@ int main(int argc, char* argv[]) {
         }
     }
     
+    // wallet-rpc-login-restore: merge conf-file rpcallowhost entries with CLI
+    // --rpcallowhost (anti-DNS-rebinding allowlist; loopback always allowed).
+    for (const auto& h : config_parser.GetList("rpcallowhost")) {
+        if (!h.empty()) config.rpc_allow_hosts.push_back(h);
+    }
+
     // Add nodes from config file (append to command-line nodes)
     std::vector<std::string> conf_addnodes = config_parser.GetList("addnode");
     for (const auto& node : conf_addnodes) {
@@ -7142,6 +7160,23 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
             }
             std::cout << "  [AUTH] RPC cookie authentication enabled (credentials in "
                       << cookie_path << ")" << std::endl;
+        }
+
+        // wallet-rpc-login-restore: register the REAL configured credentials so a
+        // valid same-origin session token resolves to them and runs through the
+        // existing RPCAuth + permissions path (token = credential alias).
+        rpc_server.SetSessionAuthCredentials(rpcuser, rpcpassword);
+
+        // wallet-rpc-login-restore: populate the anti-DNS-rebinding Host allowlist
+        // (loopback always allowed by the validator; add operator hosts + own
+        // external IP under --public-api so existing remote REST clients work).
+        for (const auto& h : config.rpc_allow_hosts) {
+            rpc_server.AddRpcAllowHost(h);
+        }
+        if (config.public_api && !config.external_ip.empty()) {
+            rpc_server.AddRpcAllowHost(config.external_ip);
+            std::cout << "  [RPC] --public-api: allowing own external IP in Host "
+                         "allowlist: " << config.external_ip << std::endl;
         }
 
         // Phase 1: Initialize request logging

--- a/src/node/dilv-node.cpp
+++ b/src/node/dilv-node.cpp
@@ -862,9 +862,10 @@ struct NodeConfig {
         std::cout << "  --public-api          Enable public REST API for light wallets (seed nodes)" << std::endl;
         std::cout << "  --rpcallowhost=<host> Allow this Host header on the RPC/HTTP server" << std::endl;
         std::cout << "                          (anti-DNS-rebinding allowlist; repeatable)." << std::endl;
-        std::cout << "                          Loopback is always allowed. Under --public-api" << std::endl;
-        std::cout << "                          the node's own external IP is allowed by default;" << std::endl;
-        std::cout << "                          add DNS names of remote clients here." << std::endl;
+        std::cout << "                          Loopback is always allowed. Under --public-api," << std::endl;
+        std::cout << "                          remote REST/RPC clients must be added here EXPLICITLY" << std::endl;
+        std::cout << "                          (by IP or DNS name) — the node's own external IP is" << std::endl;
+        std::cout << "                          NOT auto-allowed." << std::endl;
         std::cout << "  --upnp                Enable automatic port mapping (UPnP)" << std::endl;
         std::cout << "  --no-upnp             Disable UPnP (don't prompt)" << std::endl;
         std::cout << "  --externalip=<ip>     Your public IP (for manual port forwarding)" << std::endl;

--- a/src/node/dilv-node.cpp
+++ b/src/node/dilv-node.cpp
@@ -7024,7 +7024,15 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
         std::string rpcuser = config_parser.GetString("rpcuser", "");
         std::string rpcpassword = config_parser.GetString("rpcpassword", "");
         std::string rpc_permissions_file = config.datadir + "/rpc_permissions.json";
-        
+
+        // M-03 (F-002): reject the reserved __token__ / __cookie__ usernames.
+        if (rpcuser == "__token__" || rpcuser == "__cookie__") {
+            std::cerr << "ERROR: rpcuser '" << rpcuser << "' is a reserved username "
+                      << "(used internally for session-token / cookie auth). "
+                      << "Choose a different rpcuser. Aborting startup." << std::endl;
+            return 1;
+        }
+
         if (!rpcuser.empty() && !rpcpassword.empty()) {
             // CVE-2026-RPC-AUTH: wire both InitializePermissions AND RPCAuth so
             // the auth gate at server.cpp:1105 actually runs. Abort on failure.
@@ -7168,15 +7176,13 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
         rpc_server.SetSessionAuthCredentials(rpcuser, rpcpassword);
 
         // wallet-rpc-login-restore: populate the anti-DNS-rebinding Host allowlist
-        // (loopback always allowed by the validator; add operator hosts + own
-        // external IP under --public-api so existing remote REST clients work).
+        // for RPC/REST with ONLY operator-explicit --rpcallowhost entries.
+        // C-01 (F-002): do NOT auto-add the node's own --externalip — that turned
+        // the wallet-HTML token mint into remote admin-token issuance. Loopback is
+        // always allowed by the validator; the wallet-HTML/token path is loopback
+        // only regardless of this allowlist (see server.cpp GET /wallet).
         for (const auto& h : config.rpc_allow_hosts) {
             rpc_server.AddRpcAllowHost(h);
-        }
-        if (config.public_api && !config.external_ip.empty()) {
-            rpc_server.AddRpcAllowHost(config.external_ip);
-            std::cout << "  [RPC] --public-api: allowing own external IP in Host "
-                         "allowlist: " << config.external_ip << std::endl;
         }
 
         // Phase 1: Initialize request logging

--- a/src/rpc/host_validator.cpp
+++ b/src/rpc/host_validator.cpp
@@ -248,6 +248,79 @@ bool HostValidator::IsRequestLoopbackHost(const std::string& rawRequest) const {
     return IsLoopbackHost(host);
 }
 
+// wallet-rpc-login-restore C-01b: classify a SOCKET-PEER IP literal (from
+// getpeername / GetClientIP) as loopback. Unlike IsLoopbackHost, this takes NO
+// Host header and accepts NO names — only numeric IP literals. The peer address
+// is kernel-reported and cannot be spoofed by a remote client, so it is the
+// correct basis for the "is this request loopback-origin" decision on the
+// token-minting wallet path. Default-deny: anything not recognised as loopback
+// returns false (including "unknown" from a failed getpeername).
+//
+// Accepted forms:
+//   - 127.0.0.0/8        : any 127.x.x.x (the whole loopback /8, not just .1)
+//   - ::1                : IPv6 loopback (canonical and fully-expanded spellings)
+//   - ::ffff:127.x.x.x   : IPv4-mapped loopback in textual form (defense in depth;
+//                          GetClientIP already unwraps these to dotted 127.x, but
+//                          accept the literal form too so the classifier is correct
+//                          regardless of the caller's unwrapping behaviour)
+bool HostValidator::IsLoopbackIP(const std::string& ip) {
+    if (ip.empty()) return false;
+    std::string s = ToLower(Trim(ip));
+    // Strip surrounding IPv6 brackets if a caller passed them.
+    if (s.size() >= 2 && s.front() == '[' && s.back() == ']') {
+        s = s.substr(1, s.size() - 2);
+    }
+    // Strip an IPv6 zone id (%eth0) if present.
+    size_t pct = s.find('%');
+    if (pct != std::string::npos) s = s.substr(0, pct);
+    if (s.empty()) return false;
+
+    // IPv6 loopback (canonical + fully-expanded). CanonicalizeIPv6 also collapses
+    // the IPv4-mapped-loopback spellings (::ffff:127.0.0.1, ::ffff:7f00:1, ...) to
+    // "::1", so this single compare covers those literal forms too.
+    if (s.find(':') != std::string::npos) {
+        std::string canon = CanonicalizeIPv6(s);
+        if (canon == "::1") return true;
+        // IPv4-mapped loopback for the general 127.x range (e.g. ::ffff:127.1.2.3)
+        // that CanonicalizeIPv6 does not enumerate: peel the mapped IPv4 tail.
+        const std::string mapped = "::ffff:";
+        if (s.compare(0, mapped.size(), mapped) == 0) {
+            std::string tail = s.substr(mapped.size());
+            // Only treat as loopback if the tail is a dotted-quad in 127.0.0.0/8.
+            if (tail.find('.') != std::string::npos) return IsLoopbackIP(tail);
+        }
+        return false;
+    }
+
+    // IPv4 dotted-quad: loopback is the entire 127.0.0.0/8 block.
+    // Parse the first octet and require it to be exactly 127, with a well-formed
+    // 4-octet a.b.c.d shape (each octet 0..255). Default-deny on any malformation.
+    int octets[4] = {0, 0, 0, 0};
+    int idx = 0;
+    size_t i = 0;
+    while (i < s.size()) {
+        if (idx >= 4) return false;            // too many octets
+        size_t start = i;
+        int val = 0;
+        size_t digits = 0;
+        while (i < s.size() && s[i] >= '0' && s[i] <= '9') {
+            val = val * 10 + (s[i] - '0');
+            if (val > 255) return false;        // octet out of range
+            ++i; ++digits;
+        }
+        if (digits == 0 || digits > 3) return false;  // empty/oversized octet
+        (void)start;
+        octets[idx++] = val;
+        if (i < s.size()) {
+            if (s[i] != '.') return false;      // unexpected char
+            ++i;                                 // consume '.'
+            if (i == s.size()) return false;     // trailing dot
+        }
+    }
+    if (idx != 4) return false;                 // not exactly 4 octets
+    return octets[0] == 127;                    // 127.0.0.0/8
+}
+
 // ---------------------------------------------------------------------------
 // SessionTokenStore
 // ---------------------------------------------------------------------------

--- a/src/rpc/host_validator.cpp
+++ b/src/rpc/host_validator.cpp
@@ -33,11 +33,16 @@ static bool IsAllDigits(const std::string& s) {
 }
 
 // Canonicalize an IPv6 numeric address (already de-bracketed, lowercased) so
-// the various spellings of loopback collapse to "::1". Only loopback forms are
-// canonicalized here; any other IPv6 is returned lowercased unchanged (and will
-// only match if explicitly allowlisted). This deliberately covers the bypass
-// matrix forms [::1], [0:0:0:0:0:0:0:1], and the IPv4-mapped loopback
-// ::ffff:127.0.0.1 (which is loopback semantically).
+// COMMON spellings of loopback collapse to "::1". Only the loopback forms listed
+// below are canonicalized; any other IPv6 is returned lowercased unchanged (and
+// will only match if explicitly allowlisted).
+//
+// L-01 (F-002): this is NOT an exhaustive IPv6 canonicalizer. Spellings NOT
+// listed here (e.g. the hex IPv4-mapped form ::ffff:7f00:1, or other zero-run
+// compressions) are returned unchanged and therefore REJECTED (fail-closed —
+// over-restrictive, never over-permissive). That is safe: an un-canonicalized
+// loopback spelling is denied, not allowed. We canonicalize the forms a browser
+// actually emits as a same-origin Host (decimal ::1 / dotted IPv4-mapped).
 static std::string CanonicalizeIPv6(const std::string& v6) {
     std::string s = v6;
     // Strip a zone id (%eth0) if present.
@@ -46,8 +51,13 @@ static std::string CanonicalizeIPv6(const std::string& v6) {
 
     // Fully-expanded loopback.
     if (s == "0:0:0:0:0:0:0:1") return "::1";
-    // IPv4-mapped loopback: ::ffff:127.0.0.1 (and a couple of equivalent spellings).
-    if (s == "::ffff:127.0.0.1" || s == "0:0:0:0:0:ffff:127.0.0.1") return "::1";
+    // IPv4-mapped loopback (dotted form): ::ffff:127.0.0.1 and equivalents,
+    // plus the hex-encoded IPv4-mapped loopback ::ffff:7f00:1 / 7f00:0001.
+    if (s == "::ffff:127.0.0.1" || s == "0:0:0:0:0:ffff:127.0.0.1" ||
+        s == "::ffff:7f00:1" || s == "::ffff:7f00:0001" ||
+        s == "0:0:0:0:0:ffff:7f00:1" || s == "0:0:0:0:0:ffff:7f00:0001") {
+        return "::1";
+    }
     return s;
 }
 
@@ -217,6 +227,25 @@ bool HostValidator::IsRequestHostAllowed(const std::string& rawRequest) const {
     if (r != ParseResult::Ok) return false;     // default-deny on any parse failure
     if (!portMatched) return false;              // present-but-wrong port -> reject
     return IsHostAllowed(host);
+}
+
+// wallet-rpc-login-restore C-01: loopback predicate, independent of the operator
+// allowlist. ParseHostHeader already canonicalizes the various loopback
+// spellings ([::1], [0:0:0:0:0:0:0:1], ::ffff:127.0.0.1, localhost.) to one of
+// these three tokens, so an exact compare here covers the bypass matrix.
+bool HostValidator::IsLoopbackHost(const std::string& canonicalHost) {
+    return canonicalHost == "127.0.0.1" ||
+           canonicalHost == "::1" ||
+           canonicalHost == "localhost";
+}
+
+bool HostValidator::IsRequestLoopbackHost(const std::string& rawRequest) const {
+    std::string host;
+    bool portMatched = false;
+    ParseResult r = ParseHostHeader(rawRequest, host, portMatched);
+    if (r != ParseResult::Ok) return false;     // default-deny on any parse failure
+    if (!portMatched) return false;              // present-but-wrong port -> reject
+    return IsLoopbackHost(host);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/rpc/host_validator.cpp
+++ b/src/rpc/host_validator.cpp
@@ -1,0 +1,293 @@
+// Copyright (c) 2026 The Dilithion Core developers
+// Distributed under the MIT software license
+
+#include <rpc/host_validator.h>
+
+#include <algorithm>
+#include <cctype>
+
+namespace rpc {
+
+// ---------------------------------------------------------------------------
+// small helpers (file-local)
+// ---------------------------------------------------------------------------
+
+static std::string ToLower(const std::string& s) {
+    std::string out;
+    out.reserve(s.size());
+    for (char c : s) out.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(c))));
+    return out;
+}
+
+static std::string Trim(const std::string& s) {
+    size_t b = 0, e = s.size();
+    while (b < e && (s[b] == ' ' || s[b] == '\t')) b++;
+    while (e > b && (s[e - 1] == ' ' || s[e - 1] == '\t' || s[e - 1] == '\r' || s[e - 1] == '\n')) e--;
+    return s.substr(b, e - b);
+}
+
+static bool IsAllDigits(const std::string& s) {
+    if (s.empty()) return false;
+    for (char c : s) if (c < '0' || c > '9') return false;
+    return true;
+}
+
+// Canonicalize an IPv6 numeric address (already de-bracketed, lowercased) so
+// the various spellings of loopback collapse to "::1". Only loopback forms are
+// canonicalized here; any other IPv6 is returned lowercased unchanged (and will
+// only match if explicitly allowlisted). This deliberately covers the bypass
+// matrix forms [::1], [0:0:0:0:0:0:0:1], and the IPv4-mapped loopback
+// ::ffff:127.0.0.1 (which is loopback semantically).
+static std::string CanonicalizeIPv6(const std::string& v6) {
+    std::string s = v6;
+    // Strip a zone id (%eth0) if present.
+    size_t pct = s.find('%');
+    if (pct != std::string::npos) s = s.substr(0, pct);
+
+    // Fully-expanded loopback.
+    if (s == "0:0:0:0:0:0:0:1") return "::1";
+    // IPv4-mapped loopback: ::ffff:127.0.0.1 (and a couple of equivalent spellings).
+    if (s == "::ffff:127.0.0.1" || s == "0:0:0:0:0:ffff:127.0.0.1") return "::1";
+    return s;
+}
+
+// ---------------------------------------------------------------------------
+// HostValidator
+// ---------------------------------------------------------------------------
+
+void HostValidator::Configure(uint16_t port, const std::vector<std::string>& extraAllowedHosts) {
+    m_port = port;
+    m_allowed.clear();
+    // Loopback names are ALWAYS allowed (default/desktop posture).
+    m_allowed.insert("127.0.0.1");
+    m_allowed.insert("::1");
+    m_allowed.insert("localhost");
+    for (const auto& h : extraAllowedHosts) {
+        AddAllowedHost(h);
+    }
+}
+
+void HostValidator::AddAllowedHost(const std::string& host) {
+    std::string h = Trim(host);
+    if (h.empty()) return;
+    // Strip surrounding IPv6 brackets if present.
+    if (h.size() >= 2 && h.front() == '[' && h.back() == ']') {
+        h = h.substr(1, h.size() - 2);
+    }
+    h = ToLower(h);
+    // If an operator passed host:port, strip the port for IPv4/hostnames.
+    // (We do NOT strip ':' inside an IPv6 literal — but operator IPv6 entries
+    //  should be passed bracketless and portless; document this.)
+    if (h.find(':') != std::string::npos && h.find("::") == std::string::npos) {
+        // Looks like host:port (single colon, not IPv6) -> drop the port part.
+        size_t c = h.rfind(':');
+        std::string maybePort = h.substr(c + 1);
+        if (IsAllDigits(maybePort)) h = h.substr(0, c);
+    }
+    if (h.find(':') != std::string::npos) {
+        h = CanonicalizeIPv6(h);
+    }
+    // Reject trailing-dot FQDN ambiguity by normalizing "localhost." -> "localhost".
+    if (!h.empty() && h.back() == '.') h.pop_back();
+    if (!h.empty()) m_allowed.insert(h);
+}
+
+std::set<std::string> HostValidator::AllowedHosts() const {
+    return m_allowed;
+}
+
+bool HostValidator::IsHostAllowed(const std::string& canonicalHost) const {
+    return m_allowed.find(canonicalHost) != m_allowed.end();
+}
+
+HostValidator::ParseResult HostValidator::ParseHostHeader(const std::string& rawRequest,
+                                                          std::string& hostOut,
+                                                          bool& portMatched) const {
+    hostOut.clear();
+    portMatched = true;  // portless is acceptable; only a present-but-wrong port flips this
+
+    // Locate the end of the request line and the end of the header block.
+    size_t lineEnd = rawRequest.find("\r\n");
+    if (lineEnd == std::string::npos) {
+        // No CRLF at all — also accept a bare-LF terminated request line for
+        // robustness, but if there's no line terminator there are no headers.
+        lineEnd = rawRequest.find('\n');
+        if (lineEnd == std::string::npos) return ParseResult::Missing;
+    }
+
+    // Header section ends at the first blank line (CRLFCRLF or LFLF).
+    size_t headerEnd = rawRequest.find("\r\n\r\n");
+    if (headerEnd == std::string::npos) {
+        headerEnd = rawRequest.find("\n\n");
+    }
+    if (headerEnd == std::string::npos) headerEnd = rawRequest.size();
+
+    // Walk header lines (only within [afterRequestLine, headerEnd)).
+    size_t pos = lineEnd;
+    // advance past the line terminator
+    if (pos + 1 < rawRequest.size() && rawRequest[pos] == '\r' && rawRequest[pos + 1] == '\n') pos += 2;
+    else if (pos < rawRequest.size() && rawRequest[pos] == '\n') pos += 1;
+
+    int hostCount = 0;
+    std::string rawValue;
+
+    while (pos < headerEnd) {
+        size_t eol = rawRequest.find('\n', pos);
+        if (eol == std::string::npos || eol > headerEnd) eol = headerEnd;
+        size_t lineLen = eol - pos;
+        // strip a trailing '\r'
+        if (lineLen > 0 && rawRequest[pos + lineLen - 1] == '\r') lineLen--;
+        std::string line = rawRequest.substr(pos, lineLen);
+        pos = eol + 1;
+
+        if (line.empty()) break;  // end of headers (defensive)
+
+        // Case-insensitive "host:" prefix match on the header NAME.
+        // Header name is everything before the first ':'.
+        size_t colon = line.find(':');
+        if (colon == std::string::npos) continue;
+        std::string name = Trim(line.substr(0, colon));
+        if (ToLower(name) != "host") continue;
+
+        hostCount++;
+        if (hostCount > 1) return ParseResult::Duplicate;  // smuggling defense
+        rawValue = Trim(line.substr(colon + 1));
+    }
+
+    if (hostCount == 0) return ParseResult::Missing;   // default-deny
+    if (rawValue.empty()) return ParseResult::Empty;   // default-deny
+
+    // ---- Split host token from optional port. ----
+    std::string host = rawValue;
+    std::string portStr;
+
+    if (!host.empty() && host.front() == '[') {
+        // IPv6 literal: "[....]" optionally followed by ":port".
+        size_t rb = host.find(']');
+        if (rb == std::string::npos) return ParseResult::Malformed;  // unterminated
+        std::string inner = host.substr(1, rb - 1);
+        std::string rest = host.substr(rb + 1);
+        if (!rest.empty()) {
+            if (rest[0] != ':') return ParseResult::Malformed;
+            portStr = rest.substr(1);
+        }
+        host = inner;
+        host = ToLower(host);
+        host = CanonicalizeIPv6(host);
+    } else {
+        // IPv4 or hostname. A single ':' separates host:port. Bare IPv6 without
+        // brackets (multiple colons) is not a valid HTTP Host authority -> reject.
+        size_t firstColon = host.find(':');
+        size_t lastColon = host.rfind(':');
+        if (firstColon != std::string::npos && firstColon != lastColon) {
+            // multiple colons, no brackets -> malformed authority
+            return ParseResult::Malformed;
+        }
+        if (firstColon != std::string::npos) {
+            portStr = host.substr(firstColon + 1);
+            host = host.substr(0, firstColon);
+        }
+        host = ToLower(host);
+        // Normalize trailing-dot FQDN ("localhost." -> "localhost").
+        if (!host.empty() && host.back() == '.') host.pop_back();
+    }
+
+    if (host.empty()) return ParseResult::Empty;
+
+    // ---- Port validation. ----
+    if (!portStr.empty()) {
+        if (!IsAllDigits(portStr)) return ParseResult::Malformed;
+        // Compare numerically against the configured RPC port.
+        long p = 0;
+        for (char c : portStr) {
+            p = p * 10 + (c - '0');
+            if (p > 65535) { p = -1; break; }
+        }
+        portMatched = (p == static_cast<long>(m_port));
+    }
+
+    hostOut = host;
+    return ParseResult::Ok;
+}
+
+bool HostValidator::IsRequestHostAllowed(const std::string& rawRequest) const {
+    std::string host;
+    bool portMatched = false;
+    ParseResult r = ParseHostHeader(rawRequest, host, portMatched);
+    if (r != ParseResult::Ok) return false;     // default-deny on any parse failure
+    if (!portMatched) return false;              // present-but-wrong port -> reject
+    return IsHostAllowed(host);
+}
+
+// ---------------------------------------------------------------------------
+// SessionTokenStore
+// ---------------------------------------------------------------------------
+
+std::string SessionTokenStore::Mint(const std::vector<uint8_t>& randomBytes, int64_t nowUnix) {
+    if (randomBytes.size() < 16) return std::string();
+    static const char* hexd = "0123456789abcdef";
+    std::string token;
+    token.reserve(randomBytes.size() * 2);
+    for (uint8_t b : randomBytes) {
+        token.push_back(hexd[(b >> 4) & 0xF]);
+        token.push_back(hexd[b & 0xF]);
+    }
+
+    std::lock_guard<std::mutex> lock(m_mutex);
+    // Opportunistic prune of expired entries.
+    {
+        std::vector<Entry> live;
+        live.reserve(m_tokens.size());
+        for (auto& e : m_tokens) if (e.expiresAt > nowUnix) live.push_back(e);
+        m_tokens.swap(live);
+    }
+    // Bound the store: drop oldest if at capacity.
+    if (m_tokens.size() >= kMaxTokens) {
+        m_tokens.erase(m_tokens.begin(),
+                       m_tokens.begin() + (m_tokens.size() - kMaxTokens + 1));
+    }
+    m_tokens.push_back(Entry{token, nowUnix + m_ttl});
+    return token;
+}
+
+bool SessionTokenStore::Validate(const std::string& token, int64_t nowUnix) const {
+    if (token.empty()) return false;
+    std::lock_guard<std::mutex> lock(m_mutex);
+    bool ok = false;
+    // Walk ALL entries (no early return) so timing does not leak which token,
+    // if any, matched. ConstantTimeEquals handles per-token constant time.
+    for (const auto& e : m_tokens) {
+        if (e.expiresAt > nowUnix && ConstantTimeEquals(e.token, token)) {
+            ok = true;
+        }
+    }
+    return ok;
+}
+
+void SessionTokenStore::PruneExpired(int64_t nowUnix) {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    std::vector<Entry> live;
+    live.reserve(m_tokens.size());
+    for (auto& e : m_tokens) if (e.expiresAt > nowUnix) live.push_back(e);
+    m_tokens.swap(live);
+}
+
+size_t SessionTokenStore::Size() const {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_tokens.size();
+}
+
+bool SessionTokenStore::ConstantTimeEquals(const std::string& a, const std::string& b) {
+    // Length mismatch is itself a non-match. Compare against the longer length
+    // so the loop count does not depend on where the first differing byte is.
+    size_t n = std::max(a.size(), b.size());
+    unsigned char diff = static_cast<unsigned char>(a.size() ^ b.size());
+    for (size_t i = 0; i < n; i++) {
+        unsigned char ca = i < a.size() ? static_cast<unsigned char>(a[i]) : 0;
+        unsigned char cb = i < b.size() ? static_cast<unsigned char>(b[i]) : 0;
+        diff |= static_cast<unsigned char>(ca ^ cb);
+    }
+    return diff == 0;
+}
+
+} // namespace rpc

--- a/src/rpc/host_validator.h
+++ b/src/rpc/host_validator.h
@@ -1,0 +1,171 @@
+// Copyright (c) 2026 The Dilithion Core developers
+// Distributed under the MIT software license
+
+#ifndef DILITHION_RPC_HOST_VALIDATOR_H
+#define DILITHION_RPC_HOST_VALIDATOR_H
+
+#include <cstdint>
+#include <mutex>
+#include <set>
+#include <string>
+#include <vector>
+
+// ----------------------------------------------------------------------------
+// Anti-DNS-rebinding Host-header allowlist + same-origin session token.
+//
+// Both classes are intentionally dependency-free (only <string>/<set>/<mutex>/
+// <vector>) so they can be unit-tested WITHOUT linking the full node (which
+// needs depends/{libzmq,randomx,chiavdf}). server.cpp wires these into the
+// HTTP request path; the security logic lives here as a single source of truth.
+//
+// SECURITY MODEL (mirrors geth --http.vhosts; see contract
+// wallet-rpc-login-restore):
+//   - The Host-header check is the FIRST gate in HandleRequest, strictly above
+//     the wallet-HTML / OPTIONS / REST /api/v1/* branches. It blocks DNS
+//     rebinding (Geth-2018 / Sia-2019 class fund-drain) before any other
+//     processing.
+//   - Default-deny: an absent/empty/duplicate/unknown Host is REJECTED.
+//   - Exact host-token match after stripping the port — NOT substring search,
+//     so localhost.evil.com / 127.0.0.1.evil.com / localhostX are all rejected.
+// ----------------------------------------------------------------------------
+
+namespace rpc {
+
+/**
+ * Host-header allowlist validator (anti-DNS-rebinding).
+ *
+ * Construct with the RPC port and the set of operator-configured extra hosts
+ * (empty on a default/desktop node). Loopback names (127.0.0.1, ::1, localhost)
+ * are ALWAYS allowed. Call ParseHostHeader() to extract+normalize the Host
+ * from a raw HTTP request, then IsHostAllowed() / IsRequestHostAllowed().
+ */
+class HostValidator {
+public:
+    enum class ParseResult {
+        Ok,            ///< exactly one well-formed Host header found
+        Missing,       ///< no Host header present  -> default-deny REJECT
+        Empty,         ///< Host header present but empty -> REJECT
+        Duplicate,     ///< more than one Host header -> REJECT (smuggling)
+        Malformed      ///< unparseable (e.g. unterminated IPv6 literal) -> REJECT
+    };
+
+    HostValidator() : m_port(0) {}
+
+    /**
+     * @param port              RPC port (used to accept "<host>:<port>" forms).
+     * @param extraAllowedHosts Operator-configured extra hostnames/IPs
+     *                          (lowercased, port-stripped). Loopback names are
+     *                          added implicitly and need not be listed.
+     */
+    void Configure(uint16_t port, const std::vector<std::string>& extraAllowedHosts);
+
+    /** Add a single allowed host at runtime (lowercased internally). */
+    void AddAllowedHost(const std::string& host);
+
+    /**
+     * Extract the canonical host token (lowercased, port-stripped, IPv6
+     * brackets removed) from a raw HTTP request string.
+     *
+     * Enforces: exactly one Host header (duplicate -> Duplicate), reads only
+     * from the header section (stops at the blank line), case-insensitive
+     * header-name match, trims surrounding whitespace, validates the port
+     * matches the configured RPC port when a port is present.
+     *
+     * @param rawRequest Full raw HTTP request (request line + headers [+ body]).
+     * @param hostOut    Output: canonical host token (only valid on Ok).
+     * @param portMatched Output: true if a port was present AND matched m_port,
+     *                    or no port was present (portless is acceptable).
+     *                    false if a port was present but mismatched.
+     * @return ParseResult
+     */
+    ParseResult ParseHostHeader(const std::string& rawRequest,
+                                std::string& hostOut,
+                                bool& portMatched) const;
+
+    /**
+     * True iff @p canonicalHost (already lowercased + port-stripped + IPv6
+     * de-bracketed) is in the allowlist. Exact match only.
+     */
+    bool IsHostAllowed(const std::string& canonicalHost) const;
+
+    /**
+     * End-to-end check on a raw HTTP request: parse the Host header and confirm
+     * it is allowed AND (if a port was present) the port matched. Any parse
+     * failure (missing/empty/duplicate/malformed) returns false (default-deny).
+     */
+    bool IsRequestHostAllowed(const std::string& rawRequest) const;
+
+    /** For diagnostics/tests: the current allowlist (lowercased). */
+    std::set<std::string> AllowedHosts() const;
+
+private:
+    uint16_t m_port;
+    std::set<std::string> m_allowed;  // lowercased canonical hosts
+};
+
+/**
+ * Same-origin session token store.
+ *
+ * The node mints a token, embeds it in the served wallet HTML, and the wallet
+ * uses it as its RPC credential. The token is a REAL credential: validated
+ * server-side (constant-time) on every request. It is NOT the CSRF header
+ * (which accepts any value) and does NOT bypass the auth gate — server.cpp maps
+ * a valid token to the configured cookie credentials and runs them through the
+ * existing RPCAuth + permissions path.
+ *
+ * Lifetime: tokens are bound to this process (the store is created per
+ * CRPCServer instance) and expire after a TTL. A fresh token is minted on each
+ * served wallet-HTML page load (rotation), and stale tokens are pruned. The
+ * authoritative value lives ONLY here (SSoT) — the HTML carries a copy that is
+ * validated back against this store.
+ */
+class SessionTokenStore {
+public:
+    // Default TTL: 12h. Long enough for a wallet session, short enough that a
+    // leaked token does not live for the process lifetime. Each page load mints
+    // a fresh token, so practical exposure is per-session.
+    static constexpr int64_t kDefaultTtlSeconds = 12 * 60 * 60;
+    // Bound the store so an attacker who can trigger page loads cannot grow it
+    // without limit. Oldest entries are pruned first.
+    static constexpr size_t kMaxTokens = 512;
+
+    explicit SessionTokenStore(int64_t ttlSeconds = kDefaultTtlSeconds)
+        : m_ttl(ttlSeconds) {}
+
+    /**
+     * Mint a fresh token from caller-supplied cryptographically-strong random
+     * bytes (server.cpp passes GetStrongRandBytes output). The token is the
+     * lowercase hex of @p randomBytes. Returns the hex token and records it.
+     *
+     * @param randomBytes >=16 bytes of CSPRNG output (32 recommended).
+     * @param nowUnix      Current unix time (injected for testability).
+     * @return hex token string, or "" if randomBytes too short.
+     */
+    std::string Mint(const std::vector<uint8_t>& randomBytes, int64_t nowUnix);
+
+    /**
+     * Validate a presented token in constant time against the live store and
+     * confirm it has not expired. Expired/pruned tokens return false.
+     */
+    bool Validate(const std::string& token, int64_t nowUnix) const;
+
+    /** Remove expired entries (called opportunistically). */
+    void PruneExpired(int64_t nowUnix);
+
+    /** Number of live (un-pruned) tokens — for tests. */
+    size_t Size() const;
+
+private:
+    // Constant-time string compare (length-independent leak avoided by comparing
+    // a fixed accumulator; mismatched lengths fail without early-return on content).
+    static bool ConstantTimeEquals(const std::string& a, const std::string& b);
+
+    mutable std::mutex m_mutex;
+    int64_t m_ttl;
+    struct Entry { std::string token; int64_t expiresAt; };
+    std::vector<Entry> m_tokens;  // insertion-ordered; prune from front
+};
+
+} // namespace rpc
+
+#endif // DILITHION_RPC_HOST_VALIDATOR_H

--- a/src/rpc/host_validator.h
+++ b/src/rpc/host_validator.h
@@ -95,6 +95,28 @@ public:
      */
     bool IsRequestHostAllowed(const std::string& rawRequest) const;
 
+    /**
+     * True iff @p canonicalHost (already lowercased + port-stripped + IPv6
+     * de-bracketed) is a LOOPBACK host — i.e. 127.0.0.1, ::1, or localhost.
+     *
+     * This is INDEPENDENT of the operator allowlist: even on a --public-api
+     * seed that allowlists its own external IP / a DNS name for RPC+REST, those
+     * non-loopback hosts are NOT loopback. Used to gate the token-minting
+     * wallet-HTML serving so an admin-bearing page is never served to a remote
+     * (but RPC-allowlisted) origin. (wallet-rpc-login-restore C-01.)
+     */
+    static bool IsLoopbackHost(const std::string& canonicalHost);
+
+    /**
+     * End-to-end LOOPBACK check on a raw HTTP request: parse the Host header and
+     * confirm it is a loopback host (127.0.0.1 / ::1 / localhost) AND (if a port
+     * was present) the port matched. Any parse failure returns false
+     * (default-deny). This is the SSoT gate for serving the token-bearing wallet
+     * HTML — it must pass REGARDLESS of --public-api / --rpcallowhost / the
+     * general allowlist. (wallet-rpc-login-restore C-01.)
+     */
+    bool IsRequestLoopbackHost(const std::string& rawRequest) const;
+
     /** For diagnostics/tests: the current allowlist (lowercased). */
     std::set<std::string> AllowedHosts() const;
 
@@ -121,10 +143,12 @@ private:
  */
 class SessionTokenStore {
 public:
-    // Default TTL: 12h. Long enough for a wallet session, short enough that a
-    // leaked token does not live for the process lifetime. Each page load mints
-    // a fresh token, so practical exposure is per-session.
-    static constexpr int64_t kDefaultTtlSeconds = 12 * 60 * 60;
+    // Default TTL: 1h (M-02, F-002). The token is a pure bearer credential not
+    // bound to client IP/UA, so a shorter window bounds the blast radius of a
+    // leaked token. Each wallet page load mints a fresh token (rotation), so an
+    // active desktop session self-heals well within an hour; a reload re-mints.
+    // (Previously 12h — shortened to reduce the leaked-token exposure window.)
+    static constexpr int64_t kDefaultTtlSeconds = 60 * 60;
     // Bound the store so an attacker who can trigger page loads cannot grow it
     // without limit. Oldest entries are pruned first.
     static constexpr size_t kMaxTokens = 512;

--- a/src/rpc/host_validator.h
+++ b/src/rpc/host_validator.h
@@ -108,6 +108,22 @@ public:
     static bool IsLoopbackHost(const std::string& canonicalHost);
 
     /**
+     * True iff @p ip is a LOOPBACK IP **literal** — i.e. an address in
+     * 127.0.0.0/8, ::1, or an IPv4-mapped loopback (::ffff:127.x.x.x).
+     *
+     * CRITICAL — this is an IP-LITERAL classifier, NOT a Host-header parser. It
+     * is meant to be fed the KERNEL-reported socket peer (getpeername /
+     * GetClientIP), never a client-supplied Host header. The Host header is
+     * attacker-controlled on a --public-api (all-interfaces) bind; the socket
+     * peer is not. The token-minting wallet-HTML origin decision MUST rest on
+     * this predicate applied to the real peer, never on IsLoopbackHost (which
+     * trusts the header). The literal name "localhost" is deliberately NOT
+     * accepted here — a peer address is always a numeric IP, never a name.
+     * (wallet-rpc-login-restore C-01b.)
+     */
+    static bool IsLoopbackIP(const std::string& ip);
+
+    /**
      * End-to-end LOOPBACK check on a raw HTTP request: parse the Host header and
      * confirm it is a loopback host (127.0.0.1 / ::1 / localhost) AND (if a port
      * was present) the port matched. Any parse failure returns false

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -528,9 +528,17 @@ bool CRPCServer::Start() {
             first = false;
         }
         std::cout << std::endl;
-        std::cout << "[RPC] Wallet UI (GET / and GET /wallet) is served on LOOPBACK "
-                     "Host ONLY (127.0.0.1/localhost), regardless of --rpcallowhost."
-                  << std::endl;
+        if (m_publicAPI) {
+            std::cout << "[RPC] Wallet UI (GET / and GET /wallet) is DISABLED on this "
+                         "--public-api node (no page, no admin-token minting). "
+                         "SSH-tunnel to a loopback RPC to use the wallet."
+                      << std::endl;
+        } else {
+            std::cout << "[RPC] Wallet UI (GET / and GET /wallet) is served to LOOPBACK "
+                         "SOCKET PEERS ONLY (127.0.0.0/8, ::1); the Host header is not "
+                         "trusted for this decision."
+                      << std::endl;
+        }
         if (m_publicAPI && m_rpcAllowHosts.empty()) {
             std::cout << "[RPC] WARNING: --public-api with no --rpcallowhost: only "
                          "loopback Host headers are accepted for RPC/REST. Remote "
@@ -1149,16 +1157,85 @@ void CRPCServer::HandleClient(int clientSocket) {
     // Serve web wallet at GET /wallet or GET /wallet.html (or GET /).
     if (request.find("GET /wallet") == 0 || request.find("GET / HTTP") == 0) {
         // ====================================================================
+        // C-01b (F-003) — HARD SAFETY NET: the wallet UI is a desktop affordance,
+        // not a seed feature. On a --public-api node (all-interfaces bind) it is
+        // DISABLED ENTIRELY — no page, no token minting — REGARDLESS of socket
+        // peer. This structurally removes the entire remote-admin-token class on
+        // network-bound nodes (belt-and-suspenders with the socket-peer gate
+        // below). Operators who need the wallet on such a node SSH-tunnel to a
+        // loopback RPC. Checked FIRST so a public-API node never even classifies
+        // the peer.
+        // ====================================================================
+        if (m_publicAPI) {
+            if (m_logger) {
+                m_logger->LogSecurityEvent("WALLET_HTML_REJECTED", clientIP, "",
+                    "Wallet UI disabled on a --public-api node (token-minting page "
+                    "not served on a network-bound bind)");
+            }
+            const std::string body =
+                "{\"error\":\"Forbidden: the wallet UI is disabled on a public-API node. "
+                "SSH-tunnel to a loopback RPC to use the wallet.\",\"code\":-32600}";
+            std::ostringstream oss;
+            oss << "HTTP/1.1 403 Forbidden\r\n"
+                << "Content-Type: application/json\r\n"
+                << "Content-Length: " << body.size() << "\r\n"
+                << "Connection: close\r\n"
+                << "X-Content-Type-Options: nosniff\r\n"
+                << "X-Frame-Options: DENY\r\n"
+                << "\r\n"
+                << body;
+            std::string resp_str = oss.str();
+            send_response_and_cleanup(resp_str);
+            return;
+        }
+
+        // ====================================================================
+        // C-01b (F-003) — the ORIGIN decision rests on the KERNEL-REPORTED SOCKET
+        // PEER, never on the Host header. The wallet HTML mints an ADMIN-bearing
+        // session token; it MUST be served ONLY to a genuine loopback origin.
+        //
+        // The previous fold (C-01/F-002) gated on IsRequestLoopbackHost, which
+        // parses the **Host header** — attacker-controlled on a --public-api
+        // (all-interfaces) bind. A remote attacker sending `Host: localhost`
+        // defeated that gate and scraped a remote ROLE_ADMIN token. The fix:
+        // require the REAL peer (clientIP, from getpeername at GetClientIP above)
+        // to be a loopback IP literal (127.0.0.0/8 / ::1 / IPv4-mapped loopback)
+        // via IsLoopbackIP — which takes NO header and accepts NO names.
+        //
+        // Defense-in-depth: we ALSO keep the Host gate (IsRequestLoopbackHost)
+        // for anti-rebinding, but the loopback ORIGIN decision is the socket
+        // peer. Both must pass; either failing rejects, fail-closed if the
+        // validator is unready.
+        // ====================================================================
+        if (!rpc::HostValidator::IsLoopbackIP(clientIP)) {
+            if (m_logger) {
+                m_logger->LogSecurityEvent("WALLET_HTML_REJECTED", clientIP, "",
+                    "Wallet HTML (token-minting) requested from a NON-LOOPBACK socket "
+                    "peer; served to loopback peers only (Host header is not trusted "
+                    "for this decision)");
+            }
+            const std::string body =
+                "{\"error\":\"Forbidden: the wallet UI is served to loopback connections "
+                "only. Use an SSH tunnel for remote access.\",\"code\":-32600}";
+            std::ostringstream oss;
+            oss << "HTTP/1.1 403 Forbidden\r\n"
+                << "Content-Type: application/json\r\n"
+                << "Content-Length: " << body.size() << "\r\n"
+                << "Connection: close\r\n"
+                << "X-Content-Type-Options: nosniff\r\n"
+                << "X-Frame-Options: DENY\r\n"
+                << "\r\n"
+                << body;
+            std::string resp_str = oss.str();
+            send_response_and_cleanup(resp_str);
+            return;
+        }
+
+        // ====================================================================
         // C-01 (F-002): the wallet HTML mints an ADMIN-bearing session token.
-        // It MUST be served ONLY to a LOOPBACK Host — ALWAYS, regardless of
-        // --public-api / --rpcallowhost / --externalip. The general Host gate
-        // above may have allowlisted a non-loopback Host for RPC/REST (e.g. a
-        // seed's own external IP), but the token-minting page must never be
-        // served to that remote origin, or a remote client could scrape the
-        // admin token and call sendtoaddress/dumpprivkey. The session-token
-        // login is a same-origin desktop affordance; it has no business firing
-        // for a remote REST client. This is a SEPARATE, stricter check than the
-        // RPC/REST allowlist — loopback-only, fail-closed if validator unready.
+        // The Host header is ALSO checked (anti-DNS-rebinding) — but this is now
+        // SECONDARY to the socket-peer gate above, which is the load-bearing
+        // loopback-origin assertion. Fail-closed if validator unready.
         // ====================================================================
         if (!m_hostValidatorReady || !m_hostValidator.IsRequestLoopbackHost(request)) {
             if (m_logger) {

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -191,7 +191,8 @@ CRPCServer::CRPCServer(uint16_t port)
       m_blockchain(nullptr), m_utxo_set(nullptr), m_chainstate(nullptr),
       m_serverSocket(INVALID_SOCKET), m_permissions(nullptr), m_logger(nullptr),
       m_ssl_wrapper(nullptr), m_ssl_enabled(false), m_websocket_server(nullptr),
-      m_restAPI(std::make_unique<CRestAPI>()), m_publicAPI(false)
+      m_restAPI(std::make_unique<CRestAPI>()), m_publicAPI(false),
+      m_sessionTokens(std::make_unique<rpc::SessionTokenStore>())
 {
     // Register RPC handlers - Wallet information
     m_handlers["getnewaddress"] = [this](const std::string& p) { return RPC_GetNewAddress(p); };
@@ -509,6 +510,31 @@ bool CRPCServer::Start() {
         std::cout << "[RPC] Server bound to 127.0.0.1:" << m_port << " (localhost only)" << std::endl;
     }
     std::cout << "[RPC] SECURITY: For remote access, use SSH tunneling" << std::endl;
+
+    // wallet-rpc-login-restore: configure the anti-DNS-rebinding Host allowlist.
+    // Loopback (127.0.0.1 / ::1 / localhost) is always allowed. Operator-set
+    // --rpcallowhost entries (+ on --public-api the node's own external IP/host,
+    // registered by the node at startup) are added so legitimate remote
+    // light-wallet REST clients keep working. This is checked as the FIRST gate
+    // in HandleClient, strictly above the wallet-HTML/OPTIONS/REST branches.
+    m_hostValidator.Configure(static_cast<uint16_t>(m_port), m_rpcAllowHosts);
+    m_hostValidatorReady = true;
+    {
+        std::cout << "[RPC] Host-header allowlist active (anti-DNS-rebinding): ";
+        bool first = true;
+        for (const auto& h : m_hostValidator.AllowedHosts()) {
+            std::cout << (first ? "" : ", ") << h;
+            first = false;
+        }
+        std::cout << std::endl;
+        if (m_publicAPI && m_rpcAllowHosts.empty()) {
+            std::cout << "[RPC] WARNING: --public-api with no --rpcallowhost: only "
+                         "loopback Host headers are accepted. Remote light-wallet REST "
+                         "clients that send Host: <seed-ip/name> will be rejected. Set "
+                         "--rpcallowhost=<this node's public IP or DNS name> to allow them."
+                      << std::endl;
+        }
+    }
 
     // Initialize REST API with component references
     if (m_restAPI) {
@@ -1051,6 +1077,42 @@ void CRPCServer::HandleClient(int clientSocket) {
     buffer.push_back('\0');
     std::string request(buffer.data());
 
+    // ========================================================================
+    // wallet-rpc-login-restore — ANTI-DNS-REBINDING HOST-HEADER ALLOWLIST.
+    //
+    // ORDERING INVARIANT (F-001 BLOCKER-1): this MUST be the first dispatch
+    // check, strictly ABOVE the GET /miner, GET / & GET /wallet, OPTIONS, and
+    // REST /api/v1/* branches below — every one of which otherwise serves a
+    // response with no Host check (REST even bypasses auth+CSRF). A DNS-rebound
+    // page (evil.com -> 127.0.0.1) is blocked here before it can read the
+    // token-bearing wallet HTML or POST /api/v1/broadcast into the mempool.
+    //
+    // Default-deny: a missing / empty / duplicate / wrong-port / non-allowlisted
+    // Host is rejected with 403. Mirrors geth --http.vhosts. Loopback names are
+    // always allowed; --public-api seeds add operator --rpcallowhost entries.
+    // ========================================================================
+    if (m_hostValidatorReady && !m_hostValidator.IsRequestHostAllowed(request)) {
+        if (m_logger) {
+            m_logger->LogSecurityEvent("HOST_REJECTED", clientIP, "",
+                "Host header not in allowlist (possible DNS rebinding)");
+        }
+        const std::string body =
+            "{\"error\":\"Forbidden: Host header not allowed (DNS-rebinding protection). "
+            "Connect via 127.0.0.1/localhost or configure --rpcallowhost.\",\"code\":-32600}";
+        std::ostringstream oss;
+        oss << "HTTP/1.1 403 Forbidden\r\n"
+            << "Content-Type: application/json\r\n"
+            << "Content-Length: " << body.size() << "\r\n"
+            << "Connection: close\r\n"
+            << "X-Content-Type-Options: nosniff\r\n"
+            << "X-Frame-Options: DENY\r\n"
+            << "\r\n"
+            << body;
+        std::string resp_str = oss.str();
+        send_response_and_cleanup(resp_str);
+        return;
+    }
+
     // Serve miner dashboard at GET /miner
     if (request.find("GET /miner") == 0) {
         const std::string& miner_html = GetMinerHTML();
@@ -1068,14 +1130,54 @@ void CRPCServer::HandleClient(int clientSocket) {
     }
 
     // Serve web wallet at GET /wallet or GET /wallet.html
+    // (Host gate above already confirmed a same-origin loopback/allowlisted Host.)
     if (request.find("GET /wallet") == 0 || request.find("GET / HTTP") == 0) {
-        const std::string& wallet_html = GetWalletHTML();
+        // wallet-rpc-login-restore: mint a fresh same-origin session token and
+        // inject it into the served HTML, replacing the hardcoded rpc:rpc creds.
+        // The token is a REAL credential validated server-side on each RPC call
+        // (see the auth block below). Rotated per page load; bound to this
+        // process via m_sessionTokens. Only injected when auth is configured
+        // (cookie/rpcuser model) AND we captured the real creds to resolve to.
+        std::string wallet_html = GetWalletHTML();
+        if (RPCAuth::IsAuthConfigured() && !m_sessionAuthPass.empty() && m_sessionTokens) {
+            extern bool GetStrongRandBytes(uint8_t* buf, size_t len);
+            std::vector<uint8_t> tok_bytes(32);
+            std::string token;
+            if (GetStrongRandBytes(tok_bytes.data(), tok_bytes.size())) {
+                token = m_sessionTokens->Mint(tok_bytes, static_cast<int64_t>(time(nullptr)));
+            }
+            // Replace the placeholder regardless: if minting failed, the empty
+            // string leaves the wallet to fall back to manual credentials rather
+            // than shipping a guessable default.
+            const std::string placeholder = "__DILITHION_RPC_SESSION_TOKEN__";
+            size_t ph = wallet_html.find(placeholder);
+            if (ph != std::string::npos) {
+                wallet_html.replace(ph, placeholder.size(), token);
+            }
+        } else {
+            // No auth configured (or creds not captured): blank the placeholder
+            // so the literal sentinel never leaks into the page.
+            const std::string placeholder = "__DILITHION_RPC_SESSION_TOKEN__";
+            size_t ph = wallet_html.find(placeholder);
+            if (ph != std::string::npos) wallet_html.replace(ph, placeholder.size(), "");
+        }
+
         std::ostringstream response;
         response << "HTTP/1.1 200 OK\r\n"
                  << "Content-Type: text/html; charset=utf-8\r\n"
                  << "Content-Length: " << wallet_html.length() << "\r\n"
                  << "Connection: close\r\n"
-                 << "Cache-Control: no-cache\r\n"
+                 // wallet-rpc-login-restore: the page now embeds a session token,
+                 // so harden it against framing / referrer / cache leaks.
+                 << "Cache-Control: no-store, no-cache, must-revalidate\r\n"
+                 << "Pragma: no-cache\r\n"
+                 << "X-Frame-Options: DENY\r\n"
+                 << "X-Content-Type-Options: nosniff\r\n"
+                 << "Referrer-Policy: no-referrer\r\n"
+                 << "Content-Security-Policy: default-src 'self'; "
+                    "script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; "
+                    "img-src 'self' data:; connect-src 'self'; "
+                    "frame-ancestors 'none'; base-uri 'none'; form-action 'none'\r\n"
                  << "\r\n"
                  << wallet_html;
         std::string resp_str = response.str();
@@ -1207,6 +1309,39 @@ void CRPCServer::HandleClient(int clientSocket) {
             std::string response = BuildHTTPUnauthorized();
             send_response_and_cleanup(response);
             return;
+        }
+
+        // wallet-rpc-login-restore: same-origin session-token credential.
+        // The bundled wallet sends Authorization: Basic base64("__token__:<tok>").
+        // If the username is the sentinel and the token validates server-side
+        // (constant-time, TTL-bounded), substitute the REAL configured
+        // credentials and let the rest of the auth path (cache, PBKDF2,
+        // permissions) run UNCHANGED. The token is a credential ALIAS, never a
+        // skip-auth bypass — defense in depth from F-001 HIGH-2 is preserved:
+        // sendtoaddress/dumpprivkey still flow through RPCAuth + permissions.
+        if (username == "__token__") {
+            bool tokenOk = false;
+            if (m_sessionTokens && !m_sessionAuthPass.empty()) {
+                tokenOk = m_sessionTokens->Validate(password,
+                                                    static_cast<int64_t>(time(nullptr)));
+            }
+            if (!tokenOk) {
+                // Invalid/expired session token. Treat exactly like bad creds:
+                // record the failure and return 401. Never log the token value.
+                m_rateLimiter.RecordAuthFailure(clientIP);
+                if (m_logger) {
+                    m_logger->LogSecurityEvent("AUTH_FAILURE", clientIP, "__token__",
+                        "Invalid or expired session token");
+                }
+                std::string response = BuildHTTPUnauthorized();
+                send_response_and_cleanup(response);
+                return;
+            }
+            // Resolve to the real configured credentials. Downstream auth +
+            // permissions validate these — the token is never the auth secret
+            // for the credential store itself.
+            username = m_sessionAuthUser;
+            password = m_sessionAuthPass;
         }
 
         // v4.4.2 NYC socket-leak fix: short-TTL credential cache. Sustained

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -511,27 +511,34 @@ bool CRPCServer::Start() {
     }
     std::cout << "[RPC] SECURITY: For remote access, use SSH tunneling" << std::endl;
 
-    // wallet-rpc-login-restore: configure the anti-DNS-rebinding Host allowlist.
-    // Loopback (127.0.0.1 / ::1 / localhost) is always allowed. Operator-set
-    // --rpcallowhost entries (+ on --public-api the node's own external IP/host,
-    // registered by the node at startup) are added so legitimate remote
-    // light-wallet REST clients keep working. This is checked as the FIRST gate
-    // in HandleClient, strictly above the wallet-HTML/OPTIONS/REST branches.
+    // wallet-rpc-login-restore: configure the anti-DNS-rebinding Host allowlist
+    // for RPC/REST. Loopback (127.0.0.1 / ::1 / localhost) is always allowed.
+    // ONLY operator-explicit --rpcallowhost entries are added (C-01: the node's
+    // own --externalip is NOT auto-added). This allowlist governs RPC/REST only;
+    // the token-minting wallet-HTML path (GET / and GET /wallet) is served on
+    // LOOPBACK Host ONLY, independent of this allowlist. Checked as the FIRST
+    // gate in HandleClient, strictly above the wallet-HTML/OPTIONS/REST branches.
     m_hostValidator.Configure(static_cast<uint16_t>(m_port), m_rpcAllowHosts);
     m_hostValidatorReady = true;
     {
-        std::cout << "[RPC] Host-header allowlist active (anti-DNS-rebinding): ";
+        std::cout << "[RPC] Host-header allowlist active (anti-DNS-rebinding, RPC/REST): ";
         bool first = true;
         for (const auto& h : m_hostValidator.AllowedHosts()) {
             std::cout << (first ? "" : ", ") << h;
             first = false;
         }
         std::cout << std::endl;
+        std::cout << "[RPC] Wallet UI (GET / and GET /wallet) is served on LOOPBACK "
+                     "Host ONLY (127.0.0.1/localhost), regardless of --rpcallowhost."
+                  << std::endl;
         if (m_publicAPI && m_rpcAllowHosts.empty()) {
             std::cout << "[RPC] WARNING: --public-api with no --rpcallowhost: only "
-                         "loopback Host headers are accepted. Remote light-wallet REST "
-                         "clients that send Host: <seed-ip/name> will be rejected. Set "
-                         "--rpcallowhost=<this node's public IP or DNS name> to allow them."
+                         "loopback Host headers are accepted for RPC/REST. Remote "
+                         "light-wallet REST clients that send Host: <seed-ip/name> "
+                         "will be rejected. To allow them, set --rpcallowhost=<this "
+                         "node's public IP or DNS name> EXPLICITLY (the node no longer "
+                         "auto-allows its --externalip). This grants RPC/REST only — "
+                         "the admin-token wallet UI stays loopback-only."
                       << std::endl;
         }
     }
@@ -1091,10 +1098,20 @@ void CRPCServer::HandleClient(int clientSocket) {
     // Host is rejected with 403. Mirrors geth --http.vhosts. Loopback names are
     // always allowed; --public-api seeds add operator --rpcallowhost entries.
     // ========================================================================
-    if (m_hostValidatorReady && !m_hostValidator.IsRequestHostAllowed(request)) {
+    // H-01 (F-002): FAIL-CLOSED. If the validator is not yet configured
+    // (m_hostValidatorReady == false), REJECT rather than skip the gate. The
+    // ready flag must never be a reason to *bypass* the anti-rebinding check on
+    // this fund-drain surface — an un-configured validator denies all requests.
+    // In production the flag is always true by the time worker threads accept
+    // requests (Configure() runs before thread spawn in Start()), so this is a
+    // no-op there; the point is to remove the open-by-omission failure mode so a
+    // future reorder of Start() cannot silently disable rebinding protection.
+    if (!m_hostValidatorReady || !m_hostValidator.IsRequestHostAllowed(request)) {
         if (m_logger) {
             m_logger->LogSecurityEvent("HOST_REJECTED", clientIP, "",
-                "Host header not in allowlist (possible DNS rebinding)");
+                m_hostValidatorReady
+                    ? "Host header not in allowlist (possible DNS rebinding)"
+                    : "Host validator not ready (fail-closed reject)");
         }
         const std::string body =
             "{\"error\":\"Forbidden: Host header not allowed (DNS-rebinding protection). "
@@ -1129,9 +1146,42 @@ void CRPCServer::HandleClient(int clientSocket) {
         return;
     }
 
-    // Serve web wallet at GET /wallet or GET /wallet.html
-    // (Host gate above already confirmed a same-origin loopback/allowlisted Host.)
+    // Serve web wallet at GET /wallet or GET /wallet.html (or GET /).
     if (request.find("GET /wallet") == 0 || request.find("GET / HTTP") == 0) {
+        // ====================================================================
+        // C-01 (F-002): the wallet HTML mints an ADMIN-bearing session token.
+        // It MUST be served ONLY to a LOOPBACK Host — ALWAYS, regardless of
+        // --public-api / --rpcallowhost / --externalip. The general Host gate
+        // above may have allowlisted a non-loopback Host for RPC/REST (e.g. a
+        // seed's own external IP), but the token-minting page must never be
+        // served to that remote origin, or a remote client could scrape the
+        // admin token and call sendtoaddress/dumpprivkey. The session-token
+        // login is a same-origin desktop affordance; it has no business firing
+        // for a remote REST client. This is a SEPARATE, stricter check than the
+        // RPC/REST allowlist — loopback-only, fail-closed if validator unready.
+        // ====================================================================
+        if (!m_hostValidatorReady || !m_hostValidator.IsRequestLoopbackHost(request)) {
+            if (m_logger) {
+                m_logger->LogSecurityEvent("WALLET_HTML_REJECTED", clientIP, "",
+                    "Wallet HTML (token-minting) requested with non-loopback Host; "
+                    "served loopback-only regardless of --rpcallowhost");
+            }
+            const std::string body =
+                "{\"error\":\"Forbidden: the wallet UI is served on loopback only "
+                "(127.0.0.1/localhost). Use an SSH tunnel for remote access.\",\"code\":-32600}";
+            std::ostringstream oss;
+            oss << "HTTP/1.1 403 Forbidden\r\n"
+                << "Content-Type: application/json\r\n"
+                << "Content-Length: " << body.size() << "\r\n"
+                << "Connection: close\r\n"
+                << "X-Content-Type-Options: nosniff\r\n"
+                << "X-Frame-Options: DENY\r\n"
+                << "\r\n"
+                << body;
+            std::string resp_str = oss.str();
+            send_response_and_cleanup(resp_str);
+            return;
+        }
         // wallet-rpc-login-restore: mint a fresh same-origin session token and
         // inject it into the served HTML, replacing the hardcoded rpc:rpc creds.
         // The token is a REAL credential validated server-side on each RPC call

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -13,6 +13,7 @@
 #include <rpc/ssl_wrapper.h>
 #include <rpc/websocket.h>
 #include <rpc/rest_api.h>
+#include <rpc/host_validator.h>
 
 // Forward declarations
 namespace x402 { class CFacilitator; }
@@ -196,6 +197,21 @@ private:
     // Phase 5: REST API for light wallets
     std::unique_ptr<CRestAPI> m_restAPI;
     bool m_publicAPI{false};  // --public-api flag: bind to 0.0.0.0 instead of 127.0.0.1
+
+    // wallet-rpc-login-restore: anti-DNS-rebinding Host-header allowlist.
+    // Configured at Start() from m_port + operator --rpcallowhost entries.
+    // Checked as the FIRST gate in HandleClient, above wallet-HTML/OPTIONS/REST.
+    rpc::HostValidator m_hostValidator;
+    bool m_hostValidatorReady{false};
+    std::vector<std::string> m_rpcAllowHosts;  // operator-configured extra hosts
+
+    // wallet-rpc-login-restore: same-origin session token store. The node mints
+    // a fresh token into the served wallet HTML; the wallet uses it as its RPC
+    // credential. A valid token maps to the configured cookie credentials and
+    // runs through the EXISTING RPCAuth + permissions path (no skip-auth).
+    std::unique_ptr<rpc::SessionTokenStore> m_sessionTokens;
+    std::string m_sessionAuthUser;  // real configured user the token resolves to
+    std::string m_sessionAuthPass;  // real configured pass the token resolves to
 
     // Seed attestation (Phase 2+3): only active on seed nodes (--relay-only + DilV)
     Attestation::CSeedAttestationKey* m_seedAttestationKey{nullptr};
@@ -578,6 +594,27 @@ public:
      * SECURITY: Only enable on seed nodes, not home mining nodes.
      */
     void SetPublicAPI(bool publicAPI) { m_publicAPI = publicAPI; }
+
+    /**
+     * wallet-rpc-login-restore: register an operator-configured allowed Host for
+     * the anti-DNS-rebinding allowlist (--rpcallowhost / rpcallowhost= conf).
+     * Loopback (127.0.0.1 / ::1 / localhost) is always allowed implicitly.
+     * On a --public-api node the node's own external IP/host should also be
+     * registered here so existing remote light-wallet REST clients keep working.
+     */
+    void AddRpcAllowHost(const std::string& host) { m_rpcAllowHosts.push_back(host); }
+
+    /**
+     * wallet-rpc-login-restore: register the REAL configured RPC credentials
+     * that a valid same-origin session token resolves to server-side. Called at
+     * startup with the same user/pass passed to RPCAuth::InitializeAuth so the
+     * token flows through the EXISTING auth + permissions path (defense in depth:
+     * the token is a credential alias, never a skip-auth bypass).
+     */
+    void SetSessionAuthCredentials(const std::string& user, const std::string& pass) {
+        m_sessionAuthUser = user;
+        m_sessionAuthPass = pass;
+    }
 
     /**
      * Register seed attestation components (Phase 2+3).

--- a/src/test/rpc_host_header_tests.cpp
+++ b/src/test/rpc_host_header_tests.cpp
@@ -1,0 +1,265 @@
+// Copyright (c) 2026 The Dilithion Core developers
+// Distributed under the MIT software license
+//
+// Unit tests for the anti-DNS-rebinding Host-header allowlist and the
+// same-origin session-token store (mission wallet-rpc-login-restore).
+//
+// These tests are deliberately self-contained: they link ONLY against
+// rpc/host_validator.{h,cpp} and the C++ stdlib, so they build and run WITHOUT
+// the node's depends/ (libzmq/randomx/chiavdf). They exercise the full Host
+// bypass matrix from F-001 HIGH-1, the token round-trip, and the rebinding/
+// REST-bypass rejection cases from the contract acceptance criteria.
+
+#include <rpc/host_validator.h>
+
+#include <cassert>
+#include <iostream>
+#include <string>
+#include <vector>
+
+using rpc::HostValidator;
+using rpc::SessionTokenStore;
+
+static int g_checks = 0;
+#define CHECK(cond) do { \
+    g_checks++; \
+    if (!(cond)) { \
+        std::cerr << "  FAIL: " #cond " (line " << __LINE__ << ")" << std::endl; \
+        std::exit(1); \
+    } \
+} while (0)
+
+// Build a minimal raw HTTP request with a given Host header literal.
+// `hostHeader` is the full header line value (may be empty to omit).
+static std::string MakeRequest(const std::string& method,
+                               const std::string& path,
+                               const std::string& hostHeader,
+                               bool includeHost = true,
+                               const std::string& body = "") {
+    std::string r = method + " " + path + " HTTP/1.1\r\n";
+    if (includeHost) r += "Host: " + hostHeader + "\r\n";
+    r += "X-Dilithion-RPC: 1\r\n";
+    r += "Content-Type: application/json\r\n";
+    r += "\r\n";
+    r += body;
+    return r;
+}
+
+// ---------------------------------------------------------------------------
+// Host bypass matrix (default/desktop node: loopback only)
+// ---------------------------------------------------------------------------
+static void TestHostBypassMatrix() {
+    std::cout << "Host bypass matrix (loopback-only node)..." << std::endl;
+    HostValidator hv;
+    hv.Configure(8332, {});  // default node: no extra hosts
+
+    // --- Allowed loopback forms ---
+    CHECK(hv.IsRequestHostAllowed(MakeRequest("POST", "/", "127.0.0.1:8332")));
+    CHECK(hv.IsRequestHostAllowed(MakeRequest("POST", "/", "127.0.0.1")));        // portless OK
+    CHECK(hv.IsRequestHostAllowed(MakeRequest("POST", "/", "localhost:8332")));
+    CHECK(hv.IsRequestHostAllowed(MakeRequest("POST", "/", "localhost")));
+    CHECK(hv.IsRequestHostAllowed(MakeRequest("POST", "/", "[::1]:8332")));
+    CHECK(hv.IsRequestHostAllowed(MakeRequest("POST", "/", "[::1]")));
+    CHECK(hv.IsRequestHostAllowed(MakeRequest("POST", "/", "LOCALHOST")));         // case-insensitive value
+    CHECK(hv.IsRequestHostAllowed(MakeRequest("POST", "/", "localhost.")));        // trailing-dot FQDN
+
+    // --- IPv6 spelling variants of loopback ---
+    CHECK(hv.IsRequestHostAllowed(MakeRequest("POST", "/", "[0:0:0:0:0:0:0:1]:8332")));
+    CHECK(hv.IsRequestHostAllowed(MakeRequest("POST", "/", "[::ffff:127.0.0.1]"))); // IPv4-mapped loopback
+
+    // --- Rebinding / suffix / substring bypass attempts: ALL rejected ---
+    CHECK(!hv.IsRequestHostAllowed(MakeRequest("POST", "/", "evil.com")));
+    CHECK(!hv.IsRequestHostAllowed(MakeRequest("POST", "/", "evil.com:8332")));
+    CHECK(!hv.IsRequestHostAllowed(MakeRequest("POST", "/", "localhost.evil.com")));   // suffix trick
+    CHECK(!hv.IsRequestHostAllowed(MakeRequest("POST", "/", "127.0.0.1.evil.com")));   // suffix trick
+    CHECK(!hv.IsRequestHostAllowed(MakeRequest("POST", "/", "evil-localhost.com")));
+    CHECK(!hv.IsRequestHostAllowed(MakeRequest("POST", "/", "localhostX")));
+    CHECK(!hv.IsRequestHostAllowed(MakeRequest("POST", "/", "notlocalhost")));
+    CHECK(!hv.IsRequestHostAllowed(MakeRequest("POST", "/", "0.0.0.0")));              // not browser-reachable loopback
+    CHECK(!hv.IsRequestHostAllowed(MakeRequest("POST", "/", "[::]")));
+    CHECK(!hv.IsRequestHostAllowed(MakeRequest("POST", "/", "169.254.169.254")));      // cloud metadata, not loopback
+
+    // --- Port mismatch: present but wrong port -> reject ---
+    CHECK(!hv.IsRequestHostAllowed(MakeRequest("POST", "/", "127.0.0.1:9999")));
+    CHECK(!hv.IsRequestHostAllowed(MakeRequest("POST", "/", "localhost:1")));
+    CHECK(!hv.IsRequestHostAllowed(MakeRequest("POST", "/", "[::1]:9999")));
+
+    // --- Absent / empty Host: default-deny ---
+    CHECK(!hv.IsRequestHostAllowed(MakeRequest("POST", "/", "", /*includeHost=*/false)));
+    CHECK(!hv.IsRequestHostAllowed(MakeRequest("POST", "/", "")));   // present but empty value
+
+    // --- Duplicate Host header: reject (smuggling ambiguity) ---
+    {
+        std::string dup = "POST / HTTP/1.1\r\nHost: 127.0.0.1:8332\r\nHost: evil.com\r\n\r\n";
+        CHECK(!hv.IsRequestHostAllowed(dup));
+        std::string dup2 = "POST / HTTP/1.1\r\nHost: evil.com\r\nHost: 127.0.0.1:8332\r\n\r\n";
+        CHECK(!hv.IsRequestHostAllowed(dup2));  // pick-first/pick-last must not let evil through
+    }
+
+    // --- Host appearing only in the BODY must not be read as the Host header ---
+    {
+        std::string sneaky = "POST / HTTP/1.1\r\nHost: evil.com\r\n\r\nHost: 127.0.0.1\r\n";
+        CHECK(!hv.IsRequestHostAllowed(sneaky));  // header Host is evil.com -> reject
+    }
+
+    // --- Case-insensitive header NAME ---
+    {
+        std::string lc = "POST / HTTP/1.1\r\nhost: 127.0.0.1:8332\r\n\r\n";
+        CHECK(hv.IsRequestHostAllowed(lc));
+        std::string uc = "POST / HTTP/1.1\r\nHOST: 127.0.0.1:8332\r\n\r\n";
+        CHECK(hv.IsRequestHostAllowed(uc));
+    }
+
+    // --- Whitespace around value tolerated ---
+    {
+        std::string ws = "POST / HTTP/1.1\r\nHost:    127.0.0.1:8332   \r\n\r\n";
+        CHECK(hv.IsRequestHostAllowed(ws));
+    }
+
+    // --- Multi-colon bare IPv6 (no brackets) -> malformed authority -> reject ---
+    CHECK(!hv.IsRequestHostAllowed(MakeRequest("POST", "/", "::1")));        // bare, no brackets
+    CHECK(!hv.IsRequestHostAllowed(MakeRequest("POST", "/", "fe80::1")));
+
+    std::cout << "  ok" << std::endl;
+}
+
+// ---------------------------------------------------------------------------
+// Path coverage: the gate is path-agnostic (wallet HTML, REST, OPTIONS)
+// ---------------------------------------------------------------------------
+static void TestAppliesToAllPaths() {
+    std::cout << "Host gate applies across all HTTP entry paths..." << std::endl;
+    HostValidator hv;
+    hv.Configure(8332, {});
+
+    // wallet HTML serving paths
+    CHECK(hv.IsRequestHostAllowed(MakeRequest("GET", "/", "127.0.0.1:8332")));
+    CHECK(hv.IsRequestHostAllowed(MakeRequest("GET", "/wallet", "127.0.0.1:8332")));
+    CHECK(!hv.IsRequestHostAllowed(MakeRequest("GET", "/", "evil.com")));
+    CHECK(!hv.IsRequestHostAllowed(MakeRequest("GET", "/wallet", "evil.com")));
+
+    // OPTIONS preflight (rebound) -> rejected by Host gate before the 403 path
+    CHECK(!hv.IsRequestHostAllowed(MakeRequest("OPTIONS", "/wallet", "evil.com")));
+
+    // REST /api/v1/broadcast (the pre-auth/pre-CSRF mempool-write path):
+    // a rebound page hitting it with a bad Host must be rejected.
+    CHECK(!hv.IsRequestHostAllowed(MakeRequest("POST", "/api/v1/broadcast", "evil.com",
+                                               true, "{\"rawtx\":\"deadbeef\"}")));
+    // ... but legitimate loopback REST still allowed on a default node.
+    CHECK(hv.IsRequestHostAllowed(MakeRequest("POST", "/api/v1/broadcast", "127.0.0.1:8332",
+                                              true, "{\"rawtx\":\"deadbeef\"}")));
+
+    std::cout << "  ok" << std::endl;
+}
+
+// ---------------------------------------------------------------------------
+// --public-api node: loopback + operator-configured host(s) + own external IP
+// ---------------------------------------------------------------------------
+static void TestPublicApiAllowlist() {
+    std::cout << "--public-api allowlist (loopback + operator hosts)..." << std::endl;
+    HostValidator hv;
+    // Simulates a seed: own external IP added by default + an operator DNS name.
+    hv.Configure(8332, {"203.0.113.7", "seed.dilithion.org"});
+
+    // Loopback still allowed.
+    CHECK(hv.IsRequestHostAllowed(MakeRequest("POST", "/api/v1/broadcast", "127.0.0.1:8332")));
+    // The seed's own external IP allowed (legacy remote light-wallet REST clients).
+    CHECK(hv.IsRequestHostAllowed(MakeRequest("POST", "/api/v1/broadcast", "203.0.113.7:8332")));
+    CHECK(hv.IsRequestHostAllowed(MakeRequest("POST", "/api/v1/broadcast", "203.0.113.7")));
+    // Operator-configured DNS name allowed.
+    CHECK(hv.IsRequestHostAllowed(MakeRequest("POST", "/api/v1/broadcast", "seed.dilithion.org:8332")));
+    CHECK(hv.IsRequestHostAllowed(MakeRequest("POST", "/api/v1/broadcast", "SEED.DILITHION.ORG")));  // case
+    // An unrelated rebinding host still rejected even on a public-api node.
+    CHECK(!hv.IsRequestHostAllowed(MakeRequest("POST", "/api/v1/broadcast", "evil.com")));
+    CHECK(!hv.IsRequestHostAllowed(MakeRequest("POST", "/api/v1/broadcast", "seed.dilithion.org.evil.com")));
+
+    std::cout << "  ok" << std::endl;
+}
+
+// ---------------------------------------------------------------------------
+// AddAllowedHost normalization (host:port and brackets)
+// ---------------------------------------------------------------------------
+static void TestAddAllowedHostNormalization() {
+    std::cout << "AddAllowedHost normalization..." << std::endl;
+    HostValidator hv;
+    hv.Configure(8332, {});
+    hv.AddAllowedHost("MyNode.LAN:8332");     // mixed case + port
+    hv.AddAllowedHost("[2001:db8::5]");        // bracketed IPv6
+    hv.AddAllowedHost("trailing.example.");    // trailing dot
+
+    CHECK(hv.IsRequestHostAllowed(MakeRequest("POST", "/", "mynode.lan:8332")));
+    CHECK(hv.IsRequestHostAllowed(MakeRequest("POST", "/", "mynode.lan")));
+    CHECK(hv.IsRequestHostAllowed(MakeRequest("POST", "/", "trailing.example")));
+    CHECK(hv.IsRequestHostAllowed(MakeRequest("POST", "/", "[2001:db8::5]:8332")));
+
+    std::cout << "  ok" << std::endl;
+}
+
+// ---------------------------------------------------------------------------
+// Session token store: mint -> validate round-trip, TTL, rotation, constant-time
+// ---------------------------------------------------------------------------
+static void TestSessionToken() {
+    std::cout << "session token mint/validate round-trip..." << std::endl;
+    SessionTokenStore store(/*ttlSeconds=*/100);
+    int64_t now = 1000;
+
+    std::vector<uint8_t> rnd(32, 0xAB);
+    std::string tok = store.Mint(rnd, now);
+    CHECK(!tok.empty());
+    CHECK(tok.size() == 64);  // 32 bytes -> 64 hex chars
+
+    // Valid within TTL.
+    CHECK(store.Validate(tok, now));
+    CHECK(store.Validate(tok, now + 99));
+    // Expired after TTL.
+    CHECK(!store.Validate(tok, now + 101));
+    // Wrong/empty token rejected.
+    CHECK(!store.Validate("", now));
+    CHECK(!store.Validate("deadbeef", now));
+    CHECK(!store.Validate(tok + "0", now));     // length mismatch
+    CHECK(!store.Validate(tok.substr(0, 63), now));
+
+    // Too-short random input rejected.
+    CHECK(store.Mint(std::vector<uint8_t>(8, 0x01), now).empty());
+
+    // Rotation: a second token coexists; both valid until each expires.
+    std::vector<uint8_t> rnd2(32, 0xCD);
+    std::string tok2 = store.Mint(rnd2, now + 10);
+    CHECK(tok2 != tok);
+    CHECK(store.Validate(tok, now + 20));
+    CHECK(store.Validate(tok2, now + 20));
+
+    // Prune drops expired only.
+    store.PruneExpired(now + 105);            // tok (exp 1100) gone, tok2 (exp 1110) lives
+    CHECK(!store.Validate(tok, now + 105));
+    CHECK(store.Validate(tok2, now + 105));
+
+    std::cout << "  ok" << std::endl;
+}
+
+// Capacity bound: store never exceeds kMaxTokens live entries.
+static void TestSessionTokenCapacity() {
+    std::cout << "session token capacity bound..." << std::endl;
+    SessionTokenStore store(/*ttlSeconds=*/1000000);
+    int64_t now = 0;
+    for (size_t i = 0; i < SessionTokenStore::kMaxTokens + 50; i++) {
+        std::vector<uint8_t> rnd(16, static_cast<uint8_t>(i & 0xFF));
+        // vary bytes so tokens differ
+        rnd[0] = static_cast<uint8_t>(i & 0xFF);
+        rnd[1] = static_cast<uint8_t>((i >> 8) & 0xFF);
+        store.Mint(rnd, now);
+    }
+    CHECK(store.Size() <= SessionTokenStore::kMaxTokens);
+    std::cout << "  ok" << std::endl;
+}
+
+int main() {
+    std::cout << "=== rpc_host_header_tests ===" << std::endl;
+    TestHostBypassMatrix();
+    TestAppliesToAllPaths();
+    TestPublicApiAllowlist();
+    TestAddAllowedHostNormalization();
+    TestSessionToken();
+    TestSessionTokenCapacity();
+    std::cout << "ALL PASSED (" << g_checks << " checks)" << std::endl;
+    return 0;
+}

--- a/src/test/rpc_host_header_tests.cpp
+++ b/src/test/rpc_host_header_tests.cpp
@@ -157,12 +157,14 @@ static void TestAppliesToAllPaths() {
 static void TestPublicApiAllowlist() {
     std::cout << "--public-api allowlist (loopback + operator hosts)..." << std::endl;
     HostValidator hv;
-    // Simulates a seed: own external IP added by default + an operator DNS name.
+    // Simulates a seed where the operator EXPLICITLY allowlisted its external IP
+    // and a DNS name via --rpcallowhost (C-01: the node no longer auto-adds
+    // --externalip; these are present only because the operator opted in).
     hv.Configure(8332, {"203.0.113.7", "seed.dilithion.org"});
 
     // Loopback still allowed.
     CHECK(hv.IsRequestHostAllowed(MakeRequest("POST", "/api/v1/broadcast", "127.0.0.1:8332")));
-    // The seed's own external IP allowed (legacy remote light-wallet REST clients).
+    // The operator-allowlisted external IP is accepted for RPC/REST.
     CHECK(hv.IsRequestHostAllowed(MakeRequest("POST", "/api/v1/broadcast", "203.0.113.7:8332")));
     CHECK(hv.IsRequestHostAllowed(MakeRequest("POST", "/api/v1/broadcast", "203.0.113.7")));
     // Operator-configured DNS name allowed.
@@ -252,6 +254,236 @@ static void TestSessionTokenCapacity() {
     std::cout << "  ok" << std::endl;
 }
 
+// ===========================================================================
+// INTEGRATION TEST (H-02, F-002): drive the REAL dispatch decision functions
+// in the REAL order CRPCServer::HandleClient uses, asserting:
+//   (a) gate-first ordering: a bad-Host request is rejected BEFORE any
+//       GET /wallet / OPTIONS / REST branch is reached;
+//   (b) the served-HTML -> authenticated-RPC round-trip on loopback (token mint
+//       -> __token__ auth resolves to the configured creds);
+//   (c) the C-01 regression: a NON-loopback Host that IS allowlisted for
+//       RPC/REST does NOT get served the wallet page / a token.
+//
+// This is NOT a re-implementation of HandleClient: it calls the SAME security
+// primitives server.cpp calls (HostValidator::IsRequestHostAllowed for the
+// first gate, HostValidator::IsRequestLoopbackHost for the wallet-HTML gate,
+// SessionTokenStore::Mint/Validate for the token round-trip) in the SAME
+// ordering, so a future reorder or a regression in those functions is caught.
+// ===========================================================================
+
+// Outcome of the dispatch up to (and including) the wallet-HTML / auth decision.
+enum class Dispatched {
+    HostRejected,       // first gate rejected (403) — nothing else ran
+    WalletHtmlServed,   // GET / or /wallet served WITH a minted token
+    WalletHtmlRejected, // GET / or /wallet hit but non-loopback Host -> 403 (C-01)
+    RestHandled,        // REST /api/v1/* path handled (Host gate passed)
+    RpcAuthPath,        // fell through to the JSON-RPC auth path
+};
+
+// Faithful model of the server.cpp HandleClient ordering. Returns what the
+// dispatch did and, for WalletHtmlServed, the token that would be embedded in
+// the served HTML (so the test can round-trip it through the auth path).
+static Dispatched SimulateDispatch(const HostValidator& hv,
+                                   bool hostValidatorReady,
+                                   SessionTokenStore& tokens,
+                                   bool authConfigured,
+                                   const std::string& request,
+                                   int64_t now,
+                                   std::string& servedTokenOut) {
+    servedTokenOut.clear();
+
+    // --- GATE 1 (server.cpp:1094): FAIL-CLOSED Host allowlist, FIRST. ---
+    if (!hostValidatorReady || !hv.IsRequestHostAllowed(request)) {
+        return Dispatched::HostRejected;
+    }
+
+    // --- GET /miner (skipped: irrelevant to token surface) ---
+
+    // --- GET / or GET /wallet (server.cpp:1134): token-minting wallet HTML. ---
+    if (request.find("GET /wallet") == 0 || request.find("GET / HTTP") == 0) {
+        // C-01: loopback-Host ONLY, regardless of the RPC/REST allowlist.
+        if (!hostValidatorReady || !hv.IsRequestLoopbackHost(request)) {
+            return Dispatched::WalletHtmlRejected;
+        }
+        // Mint + embed a token (only when auth is configured), exactly as
+        // server.cpp does.
+        if (authConfigured) {
+            std::vector<uint8_t> rnd(32, 0x5A);
+            // Vary so repeated mints differ in the test.
+            rnd[0] = static_cast<uint8_t>(now & 0xFF);
+            rnd[1] = static_cast<uint8_t>((now >> 8) & 0xFF);
+            servedTokenOut = tokens.Mint(rnd, now);
+        }
+        return Dispatched::WalletHtmlServed;
+    }
+
+    // --- OPTIONS (rejected) — but Host gate already ran above. ---
+    if (request.find("OPTIONS ") == 0) {
+        return Dispatched::HostRejected;  // 403, but post-gate
+    }
+
+    // --- REST /api/v1/* ---
+    if (request.find("POST /api/v1/") == 0 || request.find("GET /api/v1/") == 0) {
+        return Dispatched::RestHandled;
+    }
+
+    // --- Fell through to JSON-RPC auth path. ---
+    return Dispatched::RpcAuthPath;
+}
+
+// Model of the server.cpp __token__ auth resolution (server.cpp:1322-1345):
+// a presented "__token__:<tok>" resolves to the configured creds iff the token
+// validates; otherwise 401. Returns true if the RPC call would be authorized.
+static bool SimulateTokenAuth(SessionTokenStore& tokens,
+                              const std::string& presentedUser,
+                              const std::string& presentedToken,
+                              int64_t now) {
+    if (presentedUser != "__token__") return false;  // (other creds tested elsewhere)
+    return tokens.Validate(presentedToken, now);
+}
+
+static void TestHandleClientIntegration() {
+    std::cout << "integration: real dispatch ordering + token round-trip + C-01..." << std::endl;
+    const int64_t now = 100000;
+
+    // ---- Default/desktop node: loopback only, auth configured (cookie). ----
+    {
+        HostValidator hv;
+        hv.Configure(8332, {});  // no operator hosts
+        SessionTokenStore tokens(/*ttl=*/3600);
+        std::string tok;
+
+        // (a) GATE-FIRST: a rebound GET /wallet with evil.com is HostRejected,
+        //     never reaching the wallet-HTML branch.
+        Dispatched d = SimulateDispatch(hv, true, tokens, true,
+            MakeRequest("GET", "/wallet", "evil.com"), now, tok);
+        CHECK(d == Dispatched::HostRejected);
+        CHECK(tok.empty());  // no token minted for a rejected Host
+
+        // Same for the REST mempool-write path (pre-auth surface).
+        d = SimulateDispatch(hv, true, tokens, true,
+            MakeRequest("POST", "/api/v1/broadcast", "evil.com", true, "{\"rawtx\":\"de\"}"),
+            now, tok);
+        CHECK(d == Dispatched::HostRejected);
+
+        // (b) SERVED-HTML -> RPC ROUND-TRIP on loopback: GET /wallet mints a
+        //     token; presenting __token__:<tok> authorizes; expired/garbage 401s.
+        d = SimulateDispatch(hv, true, tokens, true,
+            MakeRequest("GET", "/wallet", "127.0.0.1:8332"), now, tok);
+        CHECK(d == Dispatched::WalletHtmlServed);
+        CHECK(!tok.empty());
+        CHECK(tok.size() == 64);
+        CHECK(SimulateTokenAuth(tokens, "__token__", tok, now));          // valid
+        CHECK(SimulateTokenAuth(tokens, "__token__", tok, now + 3500));   // still valid
+        CHECK(!SimulateTokenAuth(tokens, "__token__", tok, now + 3601));  // expired (TTL 1h)
+        CHECK(!SimulateTokenAuth(tokens, "__token__", "deadbeef", now));  // wrong token
+        CHECK(!SimulateTokenAuth(tokens, "realuser", tok, now));          // not the sentinel
+
+        // GET / (root) also serves the wallet on loopback.
+        d = SimulateDispatch(hv, true, tokens, true,
+            MakeRequest("GET", "/", "localhost:8332"), now, tok);
+        CHECK(d == Dispatched::WalletHtmlServed);
+        CHECK(!tok.empty());
+
+        // No-auth node: wallet HTML still served on loopback but NO token minted.
+        d = SimulateDispatch(hv, true, tokens, /*authConfigured=*/false,
+            MakeRequest("GET", "/wallet", "127.0.0.1"), now, tok);
+        CHECK(d == Dispatched::WalletHtmlServed);
+        CHECK(tok.empty());
+    }
+
+    // ---- C-01 REGRESSION: --public-api seed, external IP allowlisted for ----
+    // ---- RPC/REST, must NOT serve the token-bearing wallet page to it.   ----
+    {
+        HostValidator hv;
+        // Operator explicitly allowlisted the seed's public IP + a DNS name.
+        hv.Configure(8332, {"203.0.113.7", "seed.dilithion.org"});
+        SessionTokenStore tokens(/*ttl=*/3600);
+        std::string tok;
+
+        // The allowlisted external IP DOES pass the first gate for RPC/REST...
+        Dispatched d = SimulateDispatch(hv, true, tokens, true,
+            MakeRequest("POST", "/api/v1/broadcast", "203.0.113.7:8332"), now, tok);
+        CHECK(d == Dispatched::RestHandled);
+
+        // ...and the JSON-RPC path is reachable on it...
+        d = SimulateDispatch(hv, true, tokens, true,
+            MakeRequest("POST", "/", "203.0.113.7:8332"), now, tok);
+        CHECK(d == Dispatched::RpcAuthPath);
+
+        // ...BUT GET /wallet on that SAME allowlisted external IP is REJECTED
+        // (C-01): the token-minting page is loopback-only. No token is minted.
+        d = SimulateDispatch(hv, true, tokens, true,
+            MakeRequest("GET", "/wallet", "203.0.113.7:8332"), now, tok);
+        CHECK(d == Dispatched::WalletHtmlRejected);
+        CHECK(tok.empty());
+
+        d = SimulateDispatch(hv, true, tokens, true,
+            MakeRequest("GET", "/", "203.0.113.7:8332"), now, tok);
+        CHECK(d == Dispatched::WalletHtmlRejected);
+        CHECK(tok.empty());
+
+        // Same for an allowlisted DNS name.
+        d = SimulateDispatch(hv, true, tokens, true,
+            MakeRequest("GET", "/wallet", "seed.dilithion.org:8332"), now, tok);
+        CHECK(d == Dispatched::WalletHtmlRejected);
+        CHECK(tok.empty());
+
+        // Loopback on the SAME seed still gets the wallet + a token (operator
+        // local/SSH-tunnel use keeps working).
+        d = SimulateDispatch(hv, true, tokens, true,
+            MakeRequest("GET", "/wallet", "127.0.0.1:8332"), now, tok);
+        CHECK(d == Dispatched::WalletHtmlServed);
+        CHECK(!tok.empty());
+
+        // The store must never have minted a token for any non-loopback request:
+        // only the single loopback serve above minted -> exactly 1 live token.
+        CHECK(tokens.Size() == 1);
+    }
+
+    // ---- H-01 REGRESSION: validator-not-ready => FAIL-CLOSED (reject all). ----
+    {
+        HostValidator hv;
+        hv.Configure(8332, {});
+        SessionTokenStore tokens(/*ttl=*/3600);
+        std::string tok;
+
+        // Even a perfectly-good loopback request is rejected when the validator
+        // is not ready — the gate must never be skipped.
+        Dispatched d = SimulateDispatch(hv, /*hostValidatorReady=*/false, tokens, true,
+            MakeRequest("GET", "/wallet", "127.0.0.1:8332"), now, tok);
+        CHECK(d == Dispatched::HostRejected);
+        CHECK(tok.empty());
+
+        d = SimulateDispatch(hv, /*hostValidatorReady=*/false, tokens, true,
+            MakeRequest("POST", "/", "127.0.0.1:8332"), now, tok);
+        CHECK(d == Dispatched::HostRejected);
+    }
+
+    // ---- IsRequestLoopbackHost direct coverage: independent of allowlist. ----
+    {
+        HostValidator hv;
+        // Allowlist a non-loopback host; it must NOT be treated as loopback.
+        hv.Configure(8332, {"203.0.113.7"});
+        CHECK(hv.IsRequestLoopbackHost(MakeRequest("GET", "/wallet", "127.0.0.1:8332")));
+        CHECK(hv.IsRequestLoopbackHost(MakeRequest("GET", "/wallet", "localhost")));
+        CHECK(hv.IsRequestLoopbackHost(MakeRequest("GET", "/wallet", "[::1]:8332")));
+        CHECK(hv.IsRequestLoopbackHost(MakeRequest("GET", "/wallet", "[::ffff:127.0.0.1]")));
+        CHECK(!hv.IsRequestLoopbackHost(MakeRequest("GET", "/wallet", "203.0.113.7:8332")));
+        CHECK(!hv.IsRequestLoopbackHost(MakeRequest("GET", "/wallet", "evil.com")));
+        CHECK(!hv.IsRequestLoopbackHost(MakeRequest("GET", "/wallet", "127.0.0.1:9999"))); // wrong port
+        CHECK(!hv.IsRequestLoopbackHost(MakeRequest("GET", "/wallet", "", false)));         // no Host
+        // Static predicate.
+        CHECK(HostValidator::IsLoopbackHost("127.0.0.1"));
+        CHECK(HostValidator::IsLoopbackHost("::1"));
+        CHECK(HostValidator::IsLoopbackHost("localhost"));
+        CHECK(!HostValidator::IsLoopbackHost("203.0.113.7"));
+        CHECK(!HostValidator::IsLoopbackHost("seed.dilithion.org"));
+    }
+
+    std::cout << "  ok" << std::endl;
+}
+
 int main() {
     std::cout << "=== rpc_host_header_tests ===" << std::endl;
     TestHostBypassMatrix();
@@ -260,6 +492,7 @@ int main() {
     TestAddAllowedHostNormalization();
     TestSessionToken();
     TestSessionTokenCapacity();
+    TestHandleClientIntegration();
     std::cout << "ALL PASSED (" << g_checks << " checks)" << std::endl;
     return 0;
 }

--- a/src/test/rpc_host_header_tests.cpp
+++ b/src/test/rpc_host_header_tests.cpp
@@ -283,25 +283,47 @@ enum class Dispatched {
 // Faithful model of the server.cpp HandleClient ordering. Returns what the
 // dispatch did and, for WalletHtmlServed, the token that would be embedded in
 // the served HTML (so the test can round-trip it through the auth path).
+//
+// C-01b (F-003): the model now carries TWO socket-level dimensions the previous
+// version lacked — `peerIP` (the KERNEL-reported socket peer, i.e. GetClientIP)
+// and `publicAPI` (the --public-api flag). The wallet-HTML branch ordering
+// mirrors server.cpp exactly: (1) --public-api => reject outright; (2) the
+// socket-peer loopback gate (IsLoopbackIP on the REAL peer, NOT the Host header)
+// => reject if non-loopback; (3) the secondary Host-header anti-rebinding gate.
+// Modelling the socket peer is what lets the test express the C-01b attack (a
+// non-loopback peer sending `Host: localhost`).
 static Dispatched SimulateDispatch(const HostValidator& hv,
                                    bool hostValidatorReady,
                                    SessionTokenStore& tokens,
                                    bool authConfigured,
                                    const std::string& request,
                                    int64_t now,
-                                   std::string& servedTokenOut) {
+                                   std::string& servedTokenOut,
+                                   const std::string& peerIP = "127.0.0.1",
+                                   bool publicAPI = false) {
     servedTokenOut.clear();
 
-    // --- GATE 1 (server.cpp:1094): FAIL-CLOSED Host allowlist, FIRST. ---
+    // --- GATE 1 (server.cpp:1109): FAIL-CLOSED Host allowlist, FIRST. ---
     if (!hostValidatorReady || !hv.IsRequestHostAllowed(request)) {
         return Dispatched::HostRejected;
     }
 
     // --- GET /miner (skipped: irrelevant to token surface) ---
 
-    // --- GET / or GET /wallet (server.cpp:1134): token-minting wallet HTML. ---
+    // --- GET / or GET /wallet (server.cpp:1150): token-minting wallet HTML. ---
     if (request.find("GET /wallet") == 0 || request.find("GET / HTTP") == 0) {
-        // C-01: loopback-Host ONLY, regardless of the RPC/REST allowlist.
+        // C-01b safety net (server.cpp): wallet UI disabled entirely under
+        // --public-api, regardless of socket peer.
+        if (publicAPI) {
+            return Dispatched::WalletHtmlRejected;
+        }
+        // C-01b ORIGIN decision (server.cpp): require a LOOPBACK SOCKET PEER.
+        // This is the load-bearing gate — it consults the kernel-reported peer,
+        // NOT the Host header. A remote peer sending `Host: localhost` fails here.
+        if (!HostValidator::IsLoopbackIP(peerIP)) {
+            return Dispatched::WalletHtmlRejected;
+        }
+        // C-01 (secondary): Host-header anti-rebinding gate, loopback-Host only.
         if (!hostValidatorReady || !hv.IsRequestLoopbackHost(request)) {
             return Dispatched::WalletHtmlRejected;
         }
@@ -439,6 +461,95 @@ static void TestHandleClientIntegration() {
         // The store must never have minted a token for any non-loopback request:
         // only the single loopback serve above minted -> exactly 1 live token.
         CHECK(tokens.Size() == 1);
+    }
+
+    // ---- C-01b REGRESSION (F-003): the loopback ORIGIN decision rests on the ----
+    // ---- SOCKET PEER, never the Host header. A remote peer spoofing          ----
+    // ---- `Host: localhost` must NOT get the wallet page or a token; and the  ----
+    // ---- --public-api safety net rejects even a loopback peer.               ----
+    {
+        HostValidator hv;
+        // Default desktop allowlist (loopback names always allowed) — the
+        // attacker's spoofed `Host: localhost` PASSES both the general Host gate
+        // and the secondary loopback-Host gate, exactly as on a real node. The
+        // ONLY thing that stops the attack is the socket-peer check.
+        hv.Configure(8332, {});
+        SessionTokenStore tokens(/*ttl=*/3600);
+        std::string tok;
+
+        // (a) THE C-01b ATTACK: a NON-LOOPBACK socket peer (a remote attacker)
+        //     sends `Host: localhost`. Host gates pass; socket-peer gate REJECTS.
+        //     No wallet page, no token minted.
+        Dispatched d = SimulateDispatch(hv, true, tokens, true,
+            MakeRequest("GET", "/wallet", "localhost:8332"), now, tok,
+            /*peerIP=*/"203.0.113.7", /*publicAPI=*/false);
+        CHECK(d == Dispatched::WalletHtmlRejected);
+        CHECK(tok.empty());
+
+        // Same attack with `Host: 127.0.0.1` from the same remote peer.
+        d = SimulateDispatch(hv, true, tokens, true,
+            MakeRequest("GET", "/", "127.0.0.1:8332"), now, tok,
+            /*peerIP=*/"203.0.113.7", /*publicAPI=*/false);
+        CHECK(d == Dispatched::WalletHtmlRejected);
+        CHECK(tok.empty());
+
+        // (b) THE --public-api SAFETY NET: even a LEGIT LOOPBACK peer is rejected
+        //     when publicAPI is true (wallet UI disabled outright). No token.
+        d = SimulateDispatch(hv, true, tokens, true,
+            MakeRequest("GET", "/wallet", "localhost:8332"), now, tok,
+            /*peerIP=*/"127.0.0.1", /*publicAPI=*/true);
+        CHECK(d == Dispatched::WalletHtmlRejected);
+        CHECK(tok.empty());
+
+        // (c) THE LEGIT CASE: loopback socket peer, NON-public-api, loopback Host
+        //     -> served + token round-trips through the auth path.
+        d = SimulateDispatch(hv, true, tokens, true,
+            MakeRequest("GET", "/wallet", "localhost:8332"), now, tok,
+            /*peerIP=*/"127.0.0.1", /*publicAPI=*/false);
+        CHECK(d == Dispatched::WalletHtmlServed);
+        CHECK(!tok.empty());
+        CHECK(SimulateTokenAuth(tokens, "__token__", tok, now));
+
+        // No token was minted for either attack or the safety-net rejection:
+        // only the single legit serve in (c) minted -> exactly 1 live token.
+        CHECK(tokens.Size() == 1);
+    }
+
+    // ---- C-01b: IsLoopbackIP direct coverage (IP-LITERAL classifier, NOT a ----
+    // ---- Host-header parser; accepts no names; default-deny).              ----
+    {
+        // IPv4 loopback /8 — the WHOLE block, not just .1.
+        CHECK(HostValidator::IsLoopbackIP("127.0.0.1"));
+        CHECK(HostValidator::IsLoopbackIP("127.1.2.3"));
+        CHECK(HostValidator::IsLoopbackIP("127.255.255.254"));
+        CHECK(HostValidator::IsLoopbackIP("127.0.0.0"));
+        // IPv6 loopback (canonical + fully-expanded + bracketed + zone id).
+        CHECK(HostValidator::IsLoopbackIP("::1"));
+        CHECK(HostValidator::IsLoopbackIP("0:0:0:0:0:0:0:1"));
+        CHECK(HostValidator::IsLoopbackIP("[::1]"));
+        CHECK(HostValidator::IsLoopbackIP("::1%lo0"));
+        // IPv4-mapped loopback textual forms (defense in depth).
+        CHECK(HostValidator::IsLoopbackIP("::ffff:127.0.0.1"));
+        CHECK(HostValidator::IsLoopbackIP("::ffff:127.1.2.3"));
+        // NON-loopback — must all be rejected (default-deny).
+        CHECK(!HostValidator::IsLoopbackIP("203.0.113.7"));
+        CHECK(!HostValidator::IsLoopbackIP("128.0.0.1"));   // adjacent to 127/8
+        CHECK(!HostValidator::IsLoopbackIP("126.255.255.255"));
+        CHECK(!HostValidator::IsLoopbackIP("10.0.0.1"));
+        CHECK(!HostValidator::IsLoopbackIP("::ffff:203.0.113.7"));
+        CHECK(!HostValidator::IsLoopbackIP("2001:db8::1"));
+        // CRITICAL: the NAME "localhost" is a Host token, NOT an IP literal —
+        // IsLoopbackIP must NOT accept it (that is IsLoopbackHost's job, and the
+        // Host header must never be the origin basis).
+        CHECK(!HostValidator::IsLoopbackIP("localhost"));
+        // Malformed / empty / sentinel -> default-deny.
+        CHECK(!HostValidator::IsLoopbackIP(""));
+        CHECK(!HostValidator::IsLoopbackIP("unknown"));     // failed getpeername
+        CHECK(!HostValidator::IsLoopbackIP("127.0.0"));     // too few octets
+        CHECK(!HostValidator::IsLoopbackIP("127.0.0.1.5")); // too many octets
+        CHECK(!HostValidator::IsLoopbackIP("127.0.0.256")); // octet out of range
+        CHECK(!HostValidator::IsLoopbackIP("127.0.0.1:8332")); // a peer IP carries no port here
+        CHECK(!HostValidator::IsLoopbackIP("127.0.0.x"));   // non-numeric
     }
 
     // ---- H-01 REGRESSION: validator-not-ready => FAIL-CLOSED (reject all). ----

--- a/website/wallet.html
+++ b/website/wallet.html
@@ -3,6 +3,14 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <!-- wallet-rpc-login-restore: same-origin RPC session token.
+         When this page is served BY a Dilithion node, the node replaces the
+         placeholder below with a freshly-minted, server-validated session token.
+         The wallet uses it as its RPC credential (replacing the old rpc:rpc).
+         If the file is opened directly (not served by a node), the placeholder
+         stays as the literal sentinel and the wallet falls back to the
+         user-supplied rpcuser/rpcpassword fields. -->
+    <meta name="dilithion-rpc-token" content="__DILITHION_RPC_SESSION_TOKEN__">
     <title>Dilithion Web Wallet</title>
     <link rel="icon" type="image/x-icon" href="favicon.ico">
     <!-- PWA -->
@@ -1876,12 +1884,12 @@
                     <small style="color: var(--text-muted); font-size: 0.75rem;">DIL: 8332, DilV: 9332, Testnet: 18332</small>
                 </div>
                 <div class="form-group">
-                    <label class="form-label">RPC Username</label>
-                    <input type="text" class="form-input" id="rpcUser" value="rpc" placeholder="Default: rpc">
+                    <label class="form-label">RPC Username <small style="color: var(--text-muted); font-weight: normal;">(only if not served by your node)</small></label>
+                    <input type="text" class="form-input" id="rpcUser" value="" placeholder="from dilithion.conf / .cookie" autocomplete="off">
                 </div>
                 <div class="form-group">
                     <label class="form-label">RPC Password</label>
-                    <input type="password" class="form-input" id="rpcPass" value="rpc" placeholder="Default: rpc">
+                    <input type="password" class="form-input" id="rpcPass" value="" placeholder="from dilithion.conf / .cookie" autocomplete="off">
                 </div>
                 <button class="btn btn-primary" onclick="saveSettings()">Save & Connect</button>
             </div>
@@ -2175,9 +2183,27 @@
         let rpcConfig = {
             host: '127.0.0.1',
             port: 8332,  // Mainnet RPC port (testnet: 18332)
-            user: 'rpc',
-            pass: 'rpc'
+            user: '',    // wallet-rpc-login-restore: no guessable default (was 'rpc')
+            pass: ''     // populated only via manual override when not served by a node
         };
+
+        // wallet-rpc-login-restore: same-origin RPC session token.
+        // When this page is served BY a Dilithion node, the node injects a fresh
+        // server-validated token into the <meta name="dilithion-rpc-token"> tag.
+        // We use it as the RPC credential (Authorization: Basic __token__:<tok>)
+        // INSTEAD of a username/password. This is the supported same-origin login
+        // path on a default node — no credential paste required. The token is
+        // held in memory only (never localStorage) and re-read on each call so a
+        // freshly-served page always uses the latest minted token.
+        function getSessionToken() {
+            const m = document.querySelector('meta[name="dilithion-rpc-token"]');
+            if (!m) return '';
+            const v = (m.getAttribute('content') || '').trim();
+            // The literal sentinel means the page was NOT served by a node
+            // (opened from disk) — no token available, fall back to manual creds.
+            if (!v || v === '__DILITHION_RPC_SESSION_TOKEN__') return '';
+            return v;
+        }
 
         // Active chain: 'dil' or 'dilv'
         let activeChain = 'dil';  // Always start on DIL
@@ -2223,7 +2249,10 @@
             // Switch RPC port and reconnect
             rpcConfig.port = chainPorts[chain];
             document.getElementById('rpcPort').value = rpcConfig.port;
-            localStorage.setItem('dilithionWalletConfig', JSON.stringify(rpcConfig));
+            // wallet-rpc-login-restore: persist host/port ONLY — never credentials.
+            localStorage.setItem('dilithionWalletConfig', JSON.stringify({
+                host: rpcConfig.host, port: rpcConfig.port
+            }));
             // Update chain ID for transaction signing (DIL=1, DilV=2)
             if (txBuilder) txBuilder.chainId = chain === 'dilv' ? 2 : 1;
             // Update connection manager chain for API routing
@@ -2347,20 +2376,22 @@
         }
 
         // Load saved settings
+        // wallet-rpc-login-restore: only host/port are persisted. RPC credentials
+        // are NEVER written to localStorage (MED-1): on a node-served page the
+        // session token supplies auth; for a from-disk page the user re-enters
+        // manual creds each session (in-memory only).
         function loadSettings() {
             const saved = localStorage.getItem('dilithionWalletConfig');
             if (saved) {
                 try {
-                    rpcConfig = JSON.parse(saved);
+                    const savedCfg = JSON.parse(saved);
+                    rpcConfig.host = savedCfg.host || rpcConfig.host;
+                    rpcConfig.port = savedCfg.port || rpcConfig.port;
                     // Prefer per-chain port for current activeChain over the last-saved port
                     if (chainPorts[activeChain]) rpcConfig.port = chainPorts[activeChain];
                     document.getElementById('rpcHost').value = rpcConfig.host;
                     document.getElementById('rpcPort').value = rpcConfig.port;
-                    document.getElementById('rpcUser').value = rpcConfig.user || 'rpc';
-                    document.getElementById('rpcPass').value = rpcConfig.pass || 'rpc';
-                    // Ensure defaults are set even for old saved configs
-                    if (!rpcConfig.user) rpcConfig.user = 'rpc';
-                    if (!rpcConfig.pass) rpcConfig.pass = 'rpc';
+                    // Do NOT restore user/pass from storage — no guessable defaults.
                 } catch(e) {}
             }
         }
@@ -2369,11 +2400,15 @@
         function saveSettings() {
             rpcConfig.host = document.getElementById('rpcHost').value;
             rpcConfig.port = parseInt(document.getElementById('rpcPort').value);
+            // Manual-override credentials are kept in memory only (not persisted).
             rpcConfig.user = document.getElementById('rpcUser').value;
             rpcConfig.pass = document.getElementById('rpcPass').value;
             chainPorts[activeChain] = rpcConfig.port;
             localStorage.setItem('dilithionChainPorts', JSON.stringify(chainPorts));
-            localStorage.setItem('dilithionWalletConfig', JSON.stringify(rpcConfig));
+            // wallet-rpc-login-restore: persist host/port ONLY — never credentials.
+            localStorage.setItem('dilithionWalletConfig', JSON.stringify({
+                host: rpcConfig.host, port: rpcConfig.port
+            }));
             showNotification('Settings saved. Connecting...', 'info');
             connect();
         }
@@ -2417,10 +2452,18 @@
             const url = `http://${rpcConfig.host}:${rpcConfig.port}/`;
             const headers = {
                 'Content-Type': 'application/json',
-                'X-Dilithion-RPC': '1'  // Required for CSRF protection
+                'X-Dilithion-RPC': '1'  // Required for CSRF protection (presence-only)
             };
 
-            if (rpcConfig.user && rpcConfig.pass) {
+            // wallet-rpc-login-restore: prefer the node-injected same-origin
+            // session token. It is a REAL server-validated credential — the node
+            // maps "__token__:<token>" to the configured cookie/rpcuser creds and
+            // runs the existing auth + permissions path. Falls back to manual
+            // rpcuser/rpcpassword only when the page was not served by a node.
+            const sessionToken = getSessionToken();
+            if (sessionToken) {
+                headers['Authorization'] = 'Basic ' + btoa('__token__:' + sessionToken);
+            } else if (rpcConfig.user && rpcConfig.pass) {
                 headers['Authorization'] = 'Basic ' + btoa(rpcConfig.user + ':' + rpcConfig.pass);
             }
 


### PR DESCRIPTION
## What
Restores the bundled browser-wallet login to the node (broke when the v4.4.2 CVE fix began enforcing `.cookie` auth while the wallet still sent `rpc:rpc`) **and** closes the resulting DNS-rebinding / remote-admin-token surface. This is **Option A** from ADR-001 — the hardened status quo on the current single-port design (the explicit transitional bridge; the two-tier process split is the separate Option-E follow-on).

## Security model
- **Anti-DNS-rebinding Host-header allowlist** (geth `--http.vhosts` model): first gate in `HandleClient`, fail-closed, default-deny.
- **Wallet HTML (`GET /`, `/wallet`) served loopback-only by the KERNEL SOCKET PEER** (`IsLoopbackIP` via `getpeername`, never the Host header), AND disabled entirely under `--public-api` (hard safety net). Gate order: `--public-api` 403 → socket-peer → Host.
- **Same-origin session token** (CSPRNG, constant-time validate, 1h TTL, 512-bound) injected into the served HTML, used as a `__token__:<tok>` credential **alias** that resolves to the real cookie creds and flows through the existing RPCAuth+permissions (a credential alias, **not** a skip-auth). `__token__`/`__cookie__` reserved at config time.
- Security headers (CSP `frame-ancestors 'none'`, X-Frame-Options DENY, no-store) on the token page. No guessable static creds.

## Review chain (all green)
- **F-001** design red-team (folded) · **F-002** impl red-team → caught **C-01 CRITICAL** (remote admin-token via `--externalip` auto-allowlist) — fixed · **F-003** → caught **C-01b CRITICAL** (loopback decided on Host header not socket peer) — fixed · **F-004** red-team → **GO** · **F-005** behavioral → **PASS** (live sockets: loopback login works; `--public-api` page blocked; DNS-rebound `Host: evil` → 403) · **F-006** extreview → **GO**
- **Cursor close-readiness → READY-AFTER-FOLDS** — the one LOW fold (`--rpcallowhost --help` text contradicted the C-01 decision) is **applied** in this PR's final commit.
- Self-contained host-validator suite: **ALL PASSED (143 checks)**, post-merge + post-fold. Full `dilithion-node` + `dilv-node` builds OK.

## Deferred follow-ups (Cursor-confirmed acceptable to defer)
1. CSP `'unsafe-inline'` on the loopback-only wallet page (non-exploitable remotely; follow-up = externalize inline JS).
2. Test is model-level (faithful dispatch model) not the literal `HandleClient` socket loop; F-005 closed it on real sockets; a regtest socket test is blocked by a pre-existing `--testnet` genesis bug (separately tracked).
3. Session-token TTL 1h (a reviewer suggested 15m — LOW).

## Benign note (not a fold)
`GET /wallet` prefix-matches `/walletXYZ` (serves wallet HTML for any `/wallet*`) — loopback-gated, no security impact; flagged for awareness only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)