### PR TITLE
docs(agent-overlays): Dilithion overlays for decontaminated generic agents/skills (Slice 2)

### DIFF
--- a/docs/agent-overlays/close-session.overlay.md
+++ b/docs/agent-overlays/close-session.overlay.md
@@ -1,0 +1,83 @@
+# close-session — Dilithion project overlay
+
+Loaded by the generic close-session skill when present. Holds Dilithion's concrete repo paths, the disposition-tag hard-check, and OPERATIONS_BOARD/SESSIONS reconciliation specifics. Absent in non-Dilithion repos → generic inventory only.
+
+---
+
+## Concrete repo paths (the canonical clone-root triplet)
+
+The three canonical clone roots (always include these, even if "I didn't touch them" — verify-before-assert):
+- `c:/Users/will/dilithion`
+- `c:/Users/will/dilithion-private`
+- `c:/Users/will/dilithion-strategy`
+
+Plus a fourth repo (worktree under `c:/tmp/`, a separate `agent-comms` clone, anything else) if it is in the worktree-list output but not in the canonical three — INCLUDE it.
+
+Generic-skill placeholder mapping for this project:
+- `<working-repo>` → `c:/Users/will/dilithion`
+- `<agent-comms-hub>` → `c:/Users/will/dilithion-private`
+- `<strategy/state-repo>` → `c:/Users/will/dilithion-strategy`
+
+### Strategy-repo pull (Step 1.3)
+
+```
+cd c:/Users/will/dilithion-strategy && git pull --ff-only
+```
+
+### Session ledger + board paths (Steps 1.4, 5.3, 6.3)
+
+- Session ledger: `c:/Users/will/dilithion-strategy/00-context/SESSIONS.md` (grep `<this-session's-slug>` for paths declared at start)
+- `00-context/OPERATIONS_BOARD.md`
+- `00-context/SESSIONS.md`
+- `00-context/CURRENT_STATE.md`
+
+Strategy repo commit + push (Step 6.3):
+
+```
+cd c:/Users/will/dilithion-strategy
+git add 00-context/OPERATIONS_BOARD.md 00-context/SESSIONS.md
+# also CURRENT_STATE.md if updated, and any missions/<active>/ files
+git commit -m "session: <slug> <closed|parked> — <one-line outcome>"   # word matches the §5.3 disposition
+git push origin main
+git log @{u}..HEAD   # must be empty
+```
+
+`migrate-to-strategy` target (Step 3 categorization): `dilithion-strategy/missions/...`
+
+---
+
+## Principles + autonomy-contract references
+
+This skill enforces principles **#1 (single source of truth)**, **#8 (no silent skips)**,
+and **#37 (show your work)** from `dilithion-strategy/00-context/yoda_principles.md`.
+
+Mission audit trail — per [yoda_autonomy_contract.md §8](../../../../dilithion-strategy/00-context/yoda_autonomy_contract.md), every mission produces a fixed set of artifacts (`contract.md`, `decisions.md`, `cost.md`, `reviews/`, `amendments.md` if scope changed, `MISSION_CLOSE.md` on close). A close-pass that skips the §8 set silently violates principle #8 (no silent skips) and #34 (mission scope amendment audit trail).
+
+Other numbered-principle citations used by the generic skill map to this same ledger:
+- principle #7 (surface to Will, never silently halt under autonomy)
+- principle #34 (mission scope amendment audit trail)
+- principle #35 (session-boundary note)
+
+---
+
+## Disposition-tag hard-check (Step 7.1)
+
+- [ ] **Disposition-tag hard-check** (fires on every CLOSE-disposition `/close-session` run. **N/A on a PARK** — a parked session writes no `MISSION_CLOSE.md` and closes no mission, so skip this entire check; the mission dir legitimately has no `MISSION_CLOSE.md` while parked. See Canonical parsing rules in the mission contract that introduced this rule):
+  - If a mission dir exists under `dilithion-strategy/missions/<active>/<slug>/` AND `MISSION_CLOSE.md` exists in it: MUST execute
+    ```
+    bash c:/Users/will/dilithion-strategy/scripts/disposition_check.sh \
+      dilithion-strategy/missions/<active>/<slug>/MISSION_CLOSE.md \
+      dilithion-strategy/00-context/OPERATIONS_BOARD.md
+    ```
+    Exit `0` = pass. Exit `1` (parse violation: untagged item / missing heading / empty rationale / invalid slug) or exit `2` (orphan QUEUED: slug not at OPERATIONS_BOARD HEAD) = ❌ fail closed, surface the script's diagnostic + offending lines, do NOT push.
+  - If mission dir exists but `MISSION_CLOSE.md` is missing: ❌ fail closed with "MISSION_CLOSE.md missing for active mission".
+  - If no mission dir exists under `missions/<active>/`: no-op silent skip (session-close runs without mission state).
+  - **Prose-only inspection ("I read the file and it looks tagged") does NOT satisfy this check.** The script must actually run and its exit code must be observed. This is the specific failure mode `feedback_session_discipline_collapse.md` names.
+
+---
+
+## OPERATIONS_BOARD / SESSIONS reconciliation specifics
+
+- Mission directory archive move on close (done-branch, Step 8): `git mv dilithion-strategy/missions/<active>/<slug>/ dilithion-strategy/missions/_closed/<slug>_<date>/`
+- OPERATIONS_BOARD sections to reconcile against (Step 4): In-flight missions / Time-bound follow-ups / Production hot-list / Loss-risk inbox / Stale-state / Open PR decisions / CI tail / Backlog / Memory files / Recent closures.
+- SESSIONS.md tables: "Active sessions" → "Recently closed sessions" (CLOSE) or "Parked sessions" (PARK). Parked table schema: `| slug | worktree | branch | mission | parked-at | resume-when | notes |`.

--- a/docs/agent-overlays/evaluate.overlay.md
+++ b/docs/agent-overlays/evaluate.overlay.md
@@ -1,0 +1,53 @@
+# evaluate — Dilithion project overlay
+
+Loaded by the generic evaluate skill when present. Holds Dilithion-specific known-bug patterns and vulnerability classes to hunt during pre-commit review. Absent in non-Dilithion repos → generic criteria only.
+
+## Per-category known failure patterns
+
+These attach to the generic evaluation categories (B–G) and are drawn from Dilithion's actual bug history. When evaluating each category, ALSO apply the Dilithion-specific failure pattern and bullets below.
+
+### B. Memory & Resource Safety
+Known failure pattern: BUG #275 killed all 4 DilV seed nodes via OOM.
+- DilV runs 5x faster than DIL - will this amplify any memory issue?
+
+### C. P2P & DoS Resistance
+Known failure pattern: INV flooding caused cascading bans across the entire network.
+- Is there any code that calls `AnnounceTransactionToPeers()` in a loop? (ban factory)
+
+### D. Race Conditions & Thread Safety
+Known failure pattern: std::cout format state corruption crashed nodes during IBD.
+- Is std::cout/std::cerr used with format modifiers (std::fixed, std::setprecision) from threads?
+
+### E. UTXO & State Integrity
+Known failure pattern: BUG #276/#277 - UTXO corruption cascaded into false block rejections.
+- Does the code assume UTXO lookups always succeed? (They don't after OOM crashes)
+- Are there any new paths that mark blocks as BLOCK_FAILED_VALID? (Dangerous - permanent rejection)
+- Could a temporary state error cause permanent chain damage?
+- Is there proper error propagation vs. silent failure?
+
+### F. Build & Deployment Safety
+Known failure pattern: Header changes without `make clean` caused struct layout crashes on all seed nodes.
+- Are there new fields in CBlockIndex, ChainParams, NodeContext, or CNode?
+- If headers changed, will a partial build (`make -j4` without `make clean`) produce correct binaries?
+
+## Pattern hunt — Dilithion-specific vulnerability patterns
+
+These are patterns from Dilithion's actual bug history. Check EVERY ONE:
+
+1. **Unbounded queue/vector from peer data** - grep for `push_back`, `emplace_back`, `insert` on containers filled by peer messages. Each MUST have a size check.
+2. **Missing DilV handling** - grep for `IsTestnet()` / `isTestnet` switches. If there's no `IsDilV()` branch, DilV falls into mainnet path silently.
+3. **GMP long truncation on Windows** - any `mpz_mul_si`, `mpz_addmul_ui`, `mpz_submul_ui` with values that could exceed 32 bits.
+4. **Coinbase validation before ConnectTip** - fee-based rejection in ProcessNewBlock is unreliable if UTXO state is incomplete.
+5. **Cooldown/DFMP bypass** - any path that skips MIK validation or cooldown checks.
+
+## "What I Tested" — Dilithion-specific checklist additions
+
+- [ ] Checked for missing DilV branches
+
+## Modality-coverage repo set (preserves prior behavior)
+
+`modality_coverage_check.sh` now defaults to the current repo only (repo-agnostic). To restore Dilithion's prior cross-repo coverage, set this in `.claude/settings.json` `env`:
+
+```
+EVALUATE_COVERAGE_REPOS=".,c:/Users/will/dilithion-private,c:/Users/will/dilithion-strategy,c:/Users/will/dilithion"
+```

--- a/docs/agent-overlays/red-team-validator.overlay.md
+++ b/docs/agent-overlays/red-team-validator.overlay.md
@@ -1,0 +1,36 @@
+# red-team-validator — Dilithion project overlay
+
+Loaded by the generic red-team-validator agent when present (`docs/agent-overlays/red-team-validator.overlay.md`). Holds Dilithion-specific adversarial lenses (7–9) and the Matrix-1 change-class routing table. Absent in non-Dilithion repos → generic lenses only.
+
+## Dilithion concretes for the generic lenses (restored grep targets)
+
+The generic lenses 1–6 were de-Dilithion-ized; these are the concrete Dilithion targets that make them bite harder in this repo. Apply them in addition to the generic wording:
+
+- **Lens 3 (interface evolution) — build coverage:** the real build target is `make dilithion-node`; confirm the changed interface still compiles the node binary, not just the tests.
+- **Lens 5 (storage-of-record) — canonical stores:** Dilithion's authoritative stores are `CCoinsView` (UTXO), `BlockManager` (block index), and `LevelDB` (on-disk). Hunt new read paths that consult an in-memory map/cache/index instead of one of these.
+
+## Additional dangerous-surface lenses (Dilithion-specific)
+
+7. **Disclosure-attacker-view** → fires only when the embargo flag is set (Family G security-release within ~2-week coordinated-disclosure window per `memory/feedback_security_release_disclosure_pattern.md`). Hunt: does the diff itself, read by an attacker, reveal which input pattern triggers the bug? Is the unpatched surface still exploitable on miners/nodes that haven't upgraded yet — for how long? Does the commit message / PR title leak the exploit signature (e.g., "fix RPC auth bypass via X" tells an attacker exactly what to try on unpatched nodes)? Does the fix add a log line that, if seen in production, identifies an attacker mid-exploit (tripwire) — and is it actually wired to alerting? Could the fix itself be exploited via a different angle (a sanitizer too strict, DoS'ing legitimate traffic)? Are the seed nodes you control on the patched version BEFORE the patch ships publicly (roll-your-own-canary first)? Flag any commit message / PR title that *names* the vulnerability class without obfuscation. Fire this lens on the **public post-mortem PR** too, so unrelated leaked primitives are caught.
+8. **Principle-citation completeness** → activates on any heavy-tier change (Matrix 1 Families A-G). Source: `memory/feedback_check_project_principles_before_recommending.md`. Hunt: contract / PR description that proposes touching a safety surface without naming which principles were checked; changes that land on a principle's direct surface (KISS, stacked-defense, verify-before-assert, port-first / activation-after, storage-of-record, right-size methodology, design-review-before-spec) without acknowledging the principle; "reduce complexity" framing without arguing WHY removing the complexity is safe given the principle the complexity served; optimization PRs (latency / memory / disk) that touch safety-adjacent code without an argument for why the optimization preserves the safety invariant. **Output for each missed citation:** name the principle that should have been consulted and one sentence on what its application would have changed in this diff.
+9. **Sybil / mining-concentration adversarial** → fires on Matrix 1 Family A rows "DFMP / mining-distribution" or "DNA / attestation". Sources: `memory/sybil_defense_strategy.md`, `memory/dfmp_cooldown_reference.md`, `memory/feedback_no_sybil_advice.md`. Hunt: could a miner with N identities exploit this change to amplify their share beyond their compute? Does the change shorten a cooldown window or relax an attestation check in a way that helps Sybil setups disproportionately? Race conditions between attestation expiry and DFMP cooldown that a coordinated multi-MIK miner could exploit? New "trusted" signals that can be spoofed at the network edge (carrier-NAT /24 collisions, ASN re-assignment, etc.)? Does it weaken the entity-clustering analysis we rely on for monitoring concentration? Flag phrases: "this makes registration easier" / "loosens the attestation requirement" / "speeds up cooldown decay" — all need an adversarial-miner-view check before merge.
+
+## Lens-to-family map
+
+The orchestrator names the Matrix 1 family row in the dispatch prompt. Apply all lenses listed for that family (lenses 1-4 from the existing four-lens set; lenses 5-9 from the additions above):
+
+| Matrix 1 Family | Existing lenses | New lenses (additive) |
+|---|---|---|
+| **A** — Consensus surface | 1, 2, 3, 4 | 6, 8, 9 (if DFMP/DNA) |
+| **B** — Chain plumbing | 1, 2, 3, 4 | **5**, 8 |
+| **C** — P2P / network protocol | 1, 2, 3, 4 | 6, 8 |
+| **D** — Wallet & Bridge | 1, 2, 3, 4 | 6, 8 |
+| **E** — Port-of-upstream | 1, 2, 3, 4 | 8 |
+| **F** — Major-rewrite / large-surface-flip | 1, 2, 3, 4 | 5, 6, 8 |
+| **G** — Security release (embargo flagged) | 1, 2, 3, 4 | 6, **7**, 8 |
+| **H** — RPC / build / ops | 1, 2, 3, 4 (if non-trivial) | — |
+| **I** — Agent infra / synced surfaces | 1, 2, 3, 4 | — |
+| **J** — Docs | (red-team typically not dispatched) | — |
+| **K** — Tests / fuzz / behavioral | 1, 2, 3, **4** (especially) | — |
+
+If the dispatch prompt does not name a family row, **🛑 STOP — the dispatch is malformed.** Write a single finding `BLOCKER: dispatch missing Matrix 1 family row` and exit. Do not fall back to trigger-text matching: that path silently degrades the more-conservative routing source (deterministic family map) to a less-conservative one (text match) and violates principle #25 (production-grade asymmetry — weakening must be explicit, not implicit). Red-team M-6 fold, 2026-05-23.


### PR DESCRIPTION
## Dilithion overlays for the decontaminated generic agents/skills (Slice 2)

Companion to **agent-comms#111** (generic decontamination). Holds the Dilithion-specific content extracted from the now-generic shared agents/skills, loaded by them when present at `docs/agent-overlays/<name>.overlay.md`, absent in non-Dilithion repos.

These live in `docs/` (tracked) rather than `.claude/` because this repo intentionally gitignores all of `.claude/` — keeping the Dilithion review specifics version-controlled + shared, exactly as they were when inline in agent-comms.

### Overlays
- **red-team-validator.overlay.md** — adversarial lenses 7–9 + the Matrix-1 change-class routing table (verbatim), plus the restored lens-3/lens-5 concrete grep targets (`make dilithion-node`, `CCoinsView/BlockManager/LevelDB`).
- **evaluate.overlay.md** — Dilithion known-bug pattern catalog (BUG #275/#276/#277, DFMP/DilV/GMP-truncation patterns) + the `EVALUATE_COVERAGE_REPOS` value to restore cross-repo coverage.
- **close-session.overlay.md** — concrete repo paths, the disposition-tag hard-check, and OPERATIONS_BOARD/SESSIONS reconciliation specifics.

All content moved **verbatim** from the generic files (nothing-lost); Dilithion's review behavior is preserved. Reviewed alongside agent-comms#111 (red-team-validator + extreview consensus, GO-WITH-REVISIONS, revisions applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
