### PR TITLE
fix(wallet): DilV node-wallet connects — derive chain/port from serving origin (CSP)

### DIFF
--- a/src/api/wallet_html.h
+++ b/src/api/wallet_html.h
@@ -2275,7 +2275,12 @@ inline const std::string& GetWalletHTML() {
             // would block. Requires that sibling node to be running.
             if (servedOrigin) {
                 const targetPort = chainPorts[chain] || (chain === 'dilv' ? 9332 : 8332);
-                if (targetPort !== servedOrigin.port) {
+                // Defence-in-depth: targetPort derives from chainPorts (localStorage-
+                // sourced), so range-check it before using it as a navigation sink.
+                // Host is always this page's own loopback hostname, so navigation
+                // can only ever target another loopback port — never a remote origin.
+                if (Number.isInteger(targetPort) && targetPort > 0 && targetPort <= 65535 &&
+                    targetPort !== servedOrigin.port) {
                     window.location.href = window.location.protocol + '//' +
                         window.location.hostname + ':' + targetPort + '/';
                     return;

--- a/src/api/wallet_html.h
+++ b/src/api/wallet_html.h
@@ -23,6 +23,13 @@ inline const std::string& GetWalletHTML() {
          stays as the literal sentinel and the wallet falls back to the
          user-supplied rpcuser/rpcpassword fields. -->
     <meta name="dilithion-rpc-token" content="__DILITHION_RPC_SESSION_TOKEN__">
+    <!-- dilv-node-wallet-csp-origin: when served BY a node, the node replaces
+         this placeholder with its chain ("dil" or "dilv") so the wallet's chain
+         identity (units, and chainId for tx signing) is AUTHORITATIVE rather
+         than guessed from the RPC port — correct even on a custom --rpcport. If
+         opened from disk / not served by a node, the sentinel stays and the
+         wallet falls back to deriving the chain from the origin port. -->
+    <meta name="dilithion-chain" content="__DILITHION_CHAIN__">
     <title>Dilithion Web Wallet</title>
     <link rel="icon" type="image/x-icon" href="favicon.ico">
     <!-- PWA -->
@@ -2239,20 +2246,34 @@ inline const std::string& GetWalletHTML() {
         // ("Connection failed"). Returns null for opened-from-disk (file:) and
         // for the remotely-hosted wallet (https, no port) so those paths keep
         // their existing cross-origin / light-mode behaviour untouched.
+        // dilv-node-wallet-csp-origin: the node injects its chain ("dil"/"dilv")
+        // into the dilithion-chain meta when it serves the page; '' if opened
+        // from disk or the sentinel survived (not node-served). This is the node's
+        // authoritative answer and is preferred over guessing from the RPC port.
+        function getServedChainHint() {
+            const m = document.querySelector('meta[name="dilithion-chain"]');
+            if (!m) return '';
+            const v = (m.getAttribute('content') || '').trim();
+            return (v === 'dil' || v === 'dilv') ? v : '';
+        }
         function detectServedOrigin() {
             const loc = window.location;
             const isLoopback = loc.hostname === '127.0.0.1' || loc.hostname === 'localhost';
             if (loc.protocol !== 'http:' || !isLoopback || !loc.port) return null;
             const port = parseInt(loc.port, 10);
+            const chainHint = getServedChainHint();
             const knownNodePort = (port === chainPorts.dil || port === chainPorts.dilv ||
                 port === 8332 || port === 9332 || port === 18332 || port === 19332);
-            // Only treat as node-served when it's a recognised node RPC port OR
-            // the page carries a node-injected session token — avoids hijacking
-            // an unrelated local dev server that happens to run on loopback.
-            if (!knownNodePort && !getSessionToken()) return null;
-            // Map the origin port to a chain: DilV = 9332 / 19332 (or a custom
-            // chainPorts.dilv); everything else (8332/18332/custom) is DIL.
-            const chain = (port === chainPorts.dilv || port === 9332 || port === 19332) ? 'dilv' : 'dil';
+            // Treat as node-served when it's a recognised node RPC port, or the
+            // page carries a node-injected session token / chain hint — avoids
+            // hijacking an unrelated local dev server on loopback while still
+            // covering a node running on a custom --rpcport.
+            if (!knownNodePort && !getSessionToken() && !chainHint) return null;
+            // Chain identity: trust the node's authoritative hint when present;
+            // otherwise map the origin port (DilV = 9332 / 19332 / a custom
+            // chainPorts.dilv; everything else is DIL).
+            const chain = chainHint ||
+                ((port === chainPorts.dilv || port === 9332 || port === 19332) ? 'dilv' : 'dil');
             return { host: loc.hostname, port: port, chain: chain };
         }
         const servedOrigin = detectServedOrigin();

--- a/src/api/wallet_html.h
+++ b/src/api/wallet_html.h
@@ -2229,8 +2229,58 @@ inline const std::string& GetWalletHTML() {
         } catch(e) {}
         const chainUnits = { dil: 'DIL', dilv: 'DilV' };
 
+        // dilv-node-wallet-csp-origin: When this page is served BY a node, its
+        // own origin (host:port) IS that node's RPC endpoint, and the served
+        // page's CSP `connect-src 'self'` means it can ONLY fetch its own
+        // origin. The DIL node serves on :8332, the DilV node on :9332 — two
+        // different origins. So the chain/port MUST be derived from the serving
+        // origin, not the hardcoded DIL default; otherwise the DilV node's
+        // wallet (:9332) boots pointed at :8332 and every request is CSP-blocked
+        // ("Connection failed"). Returns null for opened-from-disk (file:) and
+        // for the remotely-hosted wallet (https, no port) so those paths keep
+        // their existing cross-origin / light-mode behaviour untouched.
+        function detectServedOrigin() {
+            const loc = window.location;
+            const isLoopback = loc.hostname === '127.0.0.1' || loc.hostname === 'localhost';
+            if (loc.protocol !== 'http:' || !isLoopback || !loc.port) return null;
+            const port = parseInt(loc.port, 10);
+            const knownNodePort = (port === chainPorts.dil || port === chainPorts.dilv ||
+                port === 8332 || port === 9332 || port === 18332 || port === 19332);
+            // Only treat as node-served when it's a recognised node RPC port OR
+            // the page carries a node-injected session token — avoids hijacking
+            // an unrelated local dev server that happens to run on loopback.
+            if (!knownNodePort && !getSessionToken()) return null;
+            // Map the origin port to a chain: DilV = 9332 / 19332 (or a custom
+            // chainPorts.dilv); everything else (8332/18332/custom) is DIL.
+            const chain = (port === chainPorts.dilv || port === 9332 || port === 19332) ? 'dilv' : 'dil';
+            return { host: loc.hostname, port: port, chain: chain };
+        }
+        const servedOrigin = detectServedOrigin();
+        if (servedOrigin) {
+            // The serving origin is authoritative for a node-served page.
+            activeChain = servedOrigin.chain;
+            rpcConfig.host = servedOrigin.host;
+            rpcConfig.port = servedOrigin.port;
+            chainPorts[servedOrigin.chain] = servedOrigin.port;
+        }
+
         function switchChain(chain) {
             if (chain === activeChain) return;
+            // dilv-node-wallet-csp-origin: on a node-served page each chain lives
+            // at a different origin (DIL :8332 / DilV :9332) and CSP
+            // `connect-src 'self'` forbids reaching the other port from this
+            // page. So switching chains here means NAVIGATING to the sibling
+            // node's own wallet page (which boots on its chain via
+            // detectServedOrigin), not an in-page cross-origin fetch the browser
+            // would block. Requires that sibling node to be running.
+            if (servedOrigin) {
+                const targetPort = chainPorts[chain] || (chain === 'dilv' ? 9332 : 8332);
+                if (targetPort !== servedOrigin.port) {
+                    window.location.href = window.location.protocol + '//' +
+                        window.location.hostname + ':' + targetPort + '/';
+                    return;
+                }
+            }
             activeChain = chain;
             const myGen = ++chainSwitchGen;  // Capture generation for stale detection
             localStorage.setItem('dilithionActiveChain', chain);
@@ -2379,7 +2429,10 @@ inline const std::string& GetWalletHTML() {
                     el.textContent = 'DilV';
                 });
                 document.title = 'DilV Web Wallet';
-                rpcConfig.port = 9332;
+                // dilv-node-wallet-csp-origin: use the resolved DilV port (a
+                // node-served page already set this from its origin; a custom
+                // chainPorts.dilv is honoured) instead of hardcoding 9332.
+                rpcConfig.port = chainPorts.dilv || 9332;
 
                 // Update connection manager chain
                 if (connectionManager) connectionManager.setChain('dilv');
@@ -2393,6 +2446,20 @@ inline const std::string& GetWalletHTML() {
         // session token supplies auth; for a from-disk page the user re-enters
         // manual creds each session (in-memory only).
         function loadSettings() {
+            // dilv-node-wallet-csp-origin: a node-served page MUST talk to its
+            // own origin (CSP connect-src 'self'); never let a stale saved
+            // host/port pull it cross-origin. The origin was already applied
+            // above — here we just sync the Settings inputs and skip the
+            // localStorage host/port override entirely.
+            if (servedOrigin) {
+                rpcConfig.host = servedOrigin.host;
+                rpcConfig.port = servedOrigin.port;
+                const hostEl = document.getElementById('rpcHost');
+                const portEl = document.getElementById('rpcPort');
+                if (hostEl) hostEl.value = rpcConfig.host;
+                if (portEl) portEl.value = rpcConfig.port;
+                return;
+            }
             const saved = localStorage.getItem('dilithionWalletConfig');
             if (saved) {
                 try {

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -1289,6 +1289,22 @@ void CRPCServer::HandleClient(int clientSocket) {
             if (ph != std::string::npos) wallet_html.replace(ph, placeholder.size(), "");
         }
 
+        // dilv-node-wallet-csp-origin: tell the page which chain this node serves
+        // ("dil"/"dilv") so the wallet's chain identity — units and the chainId
+        // used for tx signing (DIL=1/DilV=2) — is authoritative rather than
+        // guessed from the RPC port. Correct even on a custom --rpcport. Served
+        // from this node's own ChainParams; same DILV discriminator used by the
+        // swap RPCs. If the page is opened from disk the sentinel survives and
+        // the client falls back to deriving the chain from its origin port.
+        {
+            const std::string chain_ph = "__DILITHION_CHAIN__";
+            size_t cp = wallet_html.find(chain_ph);
+            if (cp != std::string::npos) {
+                wallet_html.replace(cp, chain_ph.size(),
+                    Dilithion::g_chainParams->IsDilV() ? "dilv" : "dil");
+            }
+        }
+
         std::ostringstream response;
         response << "HTTP/1.1 200 OK\r\n"
                  << "Content-Type: text/html; charset=utf-8\r\n"

--- a/website/wallet.html
+++ b/website/wallet.html
@@ -2217,8 +2217,58 @@
         } catch(e) {}
         const chainUnits = { dil: 'DIL', dilv: 'DilV' };
 
+        // dilv-node-wallet-csp-origin: When this page is served BY a node, its
+        // own origin (host:port) IS that node's RPC endpoint, and the served
+        // page's CSP `connect-src 'self'` means it can ONLY fetch its own
+        // origin. The DIL node serves on :8332, the DilV node on :9332 — two
+        // different origins. So the chain/port MUST be derived from the serving
+        // origin, not the hardcoded DIL default; otherwise the DilV node's
+        // wallet (:9332) boots pointed at :8332 and every request is CSP-blocked
+        // ("Connection failed"). Returns null for opened-from-disk (file:) and
+        // for the remotely-hosted wallet (https, no port) so those paths keep
+        // their existing cross-origin / light-mode behaviour untouched.
+        function detectServedOrigin() {
+            const loc = window.location;
+            const isLoopback = loc.hostname === '127.0.0.1' || loc.hostname === 'localhost';
+            if (loc.protocol !== 'http:' || !isLoopback || !loc.port) return null;
+            const port = parseInt(loc.port, 10);
+            const knownNodePort = (port === chainPorts.dil || port === chainPorts.dilv ||
+                port === 8332 || port === 9332 || port === 18332 || port === 19332);
+            // Only treat as node-served when it's a recognised node RPC port OR
+            // the page carries a node-injected session token — avoids hijacking
+            // an unrelated local dev server that happens to run on loopback.
+            if (!knownNodePort && !getSessionToken()) return null;
+            // Map the origin port to a chain: DilV = 9332 / 19332 (or a custom
+            // chainPorts.dilv); everything else (8332/18332/custom) is DIL.
+            const chain = (port === chainPorts.dilv || port === 9332 || port === 19332) ? 'dilv' : 'dil';
+            return { host: loc.hostname, port: port, chain: chain };
+        }
+        const servedOrigin = detectServedOrigin();
+        if (servedOrigin) {
+            // The serving origin is authoritative for a node-served page.
+            activeChain = servedOrigin.chain;
+            rpcConfig.host = servedOrigin.host;
+            rpcConfig.port = servedOrigin.port;
+            chainPorts[servedOrigin.chain] = servedOrigin.port;
+        }
+
         function switchChain(chain) {
             if (chain === activeChain) return;
+            // dilv-node-wallet-csp-origin: on a node-served page each chain lives
+            // at a different origin (DIL :8332 / DilV :9332) and CSP
+            // `connect-src 'self'` forbids reaching the other port from this
+            // page. So switching chains here means NAVIGATING to the sibling
+            // node's own wallet page (which boots on its chain via
+            // detectServedOrigin), not an in-page cross-origin fetch the browser
+            // would block. Requires that sibling node to be running.
+            if (servedOrigin) {
+                const targetPort = chainPorts[chain] || (chain === 'dilv' ? 9332 : 8332);
+                if (targetPort !== servedOrigin.port) {
+                    window.location.href = window.location.protocol + '//' +
+                        window.location.hostname + ':' + targetPort + '/';
+                    return;
+                }
+            }
             activeChain = chain;
             const myGen = ++chainSwitchGen;  // Capture generation for stale detection
             localStorage.setItem('dilithionActiveChain', chain);
@@ -2367,7 +2417,10 @@
                     el.textContent = 'DilV';
                 });
                 document.title = 'DilV Web Wallet';
-                rpcConfig.port = 9332;
+                // dilv-node-wallet-csp-origin: use the resolved DilV port (a
+                // node-served page already set this from its origin; a custom
+                // chainPorts.dilv is honoured) instead of hardcoding 9332.
+                rpcConfig.port = chainPorts.dilv || 9332;
 
                 // Update connection manager chain
                 if (connectionManager) connectionManager.setChain('dilv');
@@ -2381,6 +2434,20 @@
         // session token supplies auth; for a from-disk page the user re-enters
         // manual creds each session (in-memory only).
         function loadSettings() {
+            // dilv-node-wallet-csp-origin: a node-served page MUST talk to its
+            // own origin (CSP connect-src 'self'); never let a stale saved
+            // host/port pull it cross-origin. The origin was already applied
+            // above — here we just sync the Settings inputs and skip the
+            // localStorage host/port override entirely.
+            if (servedOrigin) {
+                rpcConfig.host = servedOrigin.host;
+                rpcConfig.port = servedOrigin.port;
+                const hostEl = document.getElementById('rpcHost');
+                const portEl = document.getElementById('rpcPort');
+                if (hostEl) hostEl.value = rpcConfig.host;
+                if (portEl) portEl.value = rpcConfig.port;
+                return;
+            }
             const saved = localStorage.getItem('dilithionWalletConfig');
             if (saved) {
                 try {

--- a/website/wallet.html
+++ b/website/wallet.html
@@ -2263,7 +2263,12 @@
             // would block. Requires that sibling node to be running.
             if (servedOrigin) {
                 const targetPort = chainPorts[chain] || (chain === 'dilv' ? 9332 : 8332);
-                if (targetPort !== servedOrigin.port) {
+                // Defence-in-depth: targetPort derives from chainPorts (localStorage-
+                // sourced), so range-check it before using it as a navigation sink.
+                // Host is always this page's own loopback hostname, so navigation
+                // can only ever target another loopback port — never a remote origin.
+                if (Number.isInteger(targetPort) && targetPort > 0 && targetPort <= 65535 &&
+                    targetPort !== servedOrigin.port) {
                     window.location.href = window.location.protocol + '//' +
                         window.location.hostname + ':' + targetPort + '/';
                     return;

--- a/website/wallet.html
+++ b/website/wallet.html
@@ -11,6 +11,13 @@
          stays as the literal sentinel and the wallet falls back to the
          user-supplied rpcuser/rpcpassword fields. -->
     <meta name="dilithion-rpc-token" content="__DILITHION_RPC_SESSION_TOKEN__">
+    <!-- dilv-node-wallet-csp-origin: when served BY a node, the node replaces
+         this placeholder with its chain ("dil" or "dilv") so the wallet's chain
+         identity (units, and chainId for tx signing) is AUTHORITATIVE rather
+         than guessed from the RPC port — correct even on a custom --rpcport. If
+         opened from disk / not served by a node, the sentinel stays and the
+         wallet falls back to deriving the chain from the origin port. -->
+    <meta name="dilithion-chain" content="__DILITHION_CHAIN__">
     <title>Dilithion Web Wallet</title>
     <link rel="icon" type="image/x-icon" href="favicon.ico">
     <!-- PWA -->
@@ -2227,20 +2234,34 @@
         // ("Connection failed"). Returns null for opened-from-disk (file:) and
         // for the remotely-hosted wallet (https, no port) so those paths keep
         // their existing cross-origin / light-mode behaviour untouched.
+        // dilv-node-wallet-csp-origin: the node injects its chain ("dil"/"dilv")
+        // into the dilithion-chain meta when it serves the page; '' if opened
+        // from disk or the sentinel survived (not node-served). This is the node's
+        // authoritative answer and is preferred over guessing from the RPC port.
+        function getServedChainHint() {
+            const m = document.querySelector('meta[name="dilithion-chain"]');
+            if (!m) return '';
+            const v = (m.getAttribute('content') || '').trim();
+            return (v === 'dil' || v === 'dilv') ? v : '';
+        }
         function detectServedOrigin() {
             const loc = window.location;
             const isLoopback = loc.hostname === '127.0.0.1' || loc.hostname === 'localhost';
             if (loc.protocol !== 'http:' || !isLoopback || !loc.port) return null;
             const port = parseInt(loc.port, 10);
+            const chainHint = getServedChainHint();
             const knownNodePort = (port === chainPorts.dil || port === chainPorts.dilv ||
                 port === 8332 || port === 9332 || port === 18332 || port === 19332);
-            // Only treat as node-served when it's a recognised node RPC port OR
-            // the page carries a node-injected session token — avoids hijacking
-            // an unrelated local dev server that happens to run on loopback.
-            if (!knownNodePort && !getSessionToken()) return null;
-            // Map the origin port to a chain: DilV = 9332 / 19332 (or a custom
-            // chainPorts.dilv); everything else (8332/18332/custom) is DIL.
-            const chain = (port === chainPorts.dilv || port === 9332 || port === 19332) ? 'dilv' : 'dil';
+            // Treat as node-served when it's a recognised node RPC port, or the
+            // page carries a node-injected session token / chain hint — avoids
+            // hijacking an unrelated local dev server on loopback while still
+            // covering a node running on a custom --rpcport.
+            if (!knownNodePort && !getSessionToken() && !chainHint) return null;
+            // Chain identity: trust the node's authoritative hint when present;
+            // otherwise map the origin port (DilV = 9332 / 19332 / a custom
+            // chainPorts.dilv; everything else is DIL).
+            const chain = chainHint ||
+                ((port === chainPorts.dilv || port === 9332 || port === 19332) ? 'dilv' : 'dil');
             return { host: loc.hostname, port: port, chain: chain };
         }
         const servedOrigin = detectServedOrigin();


### PR DESCRIPTION
## Problem (shipped in v4.4.5)

The DilV node wallet at `http://127.0.0.1:9332/` failed to connect ("Connection failed"), while the DIL node wallet at `:8332` worked. Reported by Will; reproduced live against both v4.4.5 nodes.

**Root cause:** v4.4.5 (PR #100) added `Content-Security-Policy: ... connect-src 'self'` to the node-served wallet page ([server.cpp ~L1306](../blob/main/src/rpc/server.cpp#L1306)). The DIL/DilV chain toggle switches the RPC **port** (8332↔9332) = a different browser **origin**. Under `connect-src 'self'` a node-served page can only `fetch()` its own origin, so:

- The served page hardcoded its default to **DIL/:8332** and never read `window.location.port` — so the DilV node's page (`:9332`) booted pointed at `:8332` and every request was CSP-blocked.
- The chain toggle did an **in-page cross-origin fetch** to the other port, which CSP also blocks.

DIL "worked" only because its port coincided with the hardcoded default. The DilV backend was always healthy (authed RPC on `:9332` returns `chain:dilv`). Pure client-side defect; the shared RPC server was never the problem — which is why the "covers both chains (shared RPC server)" assumption missed it.

## Fix (CSP header unchanged — no security loosening)

`website/wallet.html` (source; `src/api/wallet_html.h` regenerated via `scripts/gen-embedded-html.sh`), plus a small `src/rpc/server.cpp` addition:

- **`detectServedOrigin()`** — a node-served page derives chain + RPC host/port from its own origin. `:9332` boots as DilV and auto-connects; `:8332` as DIL. Returns `null` for the remotely-hosted (https, no port) and opened-from-disk (`file:`) paths, leaving their cross-origin / light-mode behaviour **untouched**.
- **`switchChain()`** — on a node-served page, switching chains **navigates** to the sibling node's wallet URL (range-checked loopback port) instead of an in-page cross-origin fetch the CSP forbids.
- **Server-injected `<meta name="dilithion-chain">`** — the node stamps its chain (`dil`/`dilv`) into the page (mirroring the session-token injection, from `g_chainParams->IsDilV()`), so the wallet's chain identity + tx-signing `chainId` are **authoritative**, correct even on a custom `--rpcport` (the client prefers the hint over port-guessing, falls back to the port for disk-opened pages).
- **`loadSettings()` / `initChainSelector()`** — never let a stale saved host/port pull a node-served page cross-origin; honour a custom `chainPorts.dilv`.

## Verification (live, real browser, both v4.4.5 nodes)

| Test | Before | After |
|---|---|---|
| Open `:9332` directly | ❌ defaults DIL → CSP-blocked | ✅ defaults DilV, auto-connects |
| DIL page → click DilV | ❌ CSP-blocked | ✅ navigates to `:9332`, connects |
| DilV page → click DIL | ❌ CSP-blocked | ✅ navigates to `:8332`, connects |
| Injected chain meta | n/a | ✅ `:9332`→`dilv`, `:8332`→`dil` |

Zero CSP `connect-src` violations after the fix; tx-signing `chainId` correct per origin (DIL=1 / DilV=2). The ~19 remaining console errors are pre-existing noise (external fonts/CDN/`/js/` 403s), identical on both chains, unrelated.

## Review

Two fresh-context `red-team-validator` passes (core fix + chain-hint delta): **no CRITICAL/HIGH/load-bearing**; signing/chainId safe on every path; navigation cannot reach a non-loopback origin or inject; chain-hint injection is a compile-time literal (no input path) and can't reach hosted/`file:` pages. **Folded:** LOW-1 (range-check nav port), LOW-3 (server chain hint — now the authoritative path). **Deferred** (pre-existing, separate non-served surface): MEDIUM-1/2 — hosted/`file:` wallet doesn't restore last-selected chain (boots DIL).

⚠️ v4.4.5 is already released with this bug, so reaching users needs a follow-up release (Will's call — `/evaluate` gate + forbidden surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)