### PR TITLE
fix(consensus): LP-5 batch-verifier concurrency race — per-batch session (CCheckQueueControl)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -952,6 +952,30 @@ batch_verifier_race_tests: $(OBJ_DIR)/consensus/signature_batch_verifier.o $(OBJ
 	@$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LIBS)
 	@echo "$(COLOR_GREEN)✓ batch_verifier_race_tests built$(COLOR_RESET)"
 
+# ----------------------------------------------------------------------------
+# A-010 CONTROL target: SAME harness source, -DPREFIX_API, linked against the
+# FROZEN pre-fix verifier (src/test/lp5_control/, a verbatim copy of bb933d53).
+# This deterministically HANGS — proving the harness is a real discriminator,
+# not a no-op. The control-red and the fix-green therefore come from one source.
+#   make batch_verifier_race_control   # then run with a timeout; expect a HANG.
+# Distinct object dir so the -DPREFIX_API harness object never collides with the
+# default (no-PREFIX_API) batch_verifier_race_tests.o.
+$(OBJ_DIR)/test/lp5_control:
+	@mkdir -p $@
+
+$(OBJ_DIR)/test/lp5_control/signature_batch_verifier_prefix.o: src/test/lp5_control/signature_batch_verifier_prefix.cpp | $(OBJ_DIR)/test/lp5_control
+	@echo "$(COLOR_BLUE)[CXX]$(COLOR_RESET)  $< (LP-5 control, frozen pre-fix)"
+	@$(CXX) $(CXXFLAGS) $(INCLUDES) -I src/test/lp5_control -c $< -o $@
+
+$(OBJ_DIR)/test/lp5_control/batch_verifier_race_tests.o: src/test/batch_verifier_race_tests.cpp | $(OBJ_DIR)/test/lp5_control
+	@echo "$(COLOR_BLUE)[CXX]$(COLOR_RESET)  $< (-DPREFIX_API control variant)"
+	@$(CXX) $(CXXFLAGS) $(INCLUDES) -I src/test/lp5_control -DPREFIX_API -c $< -o $@
+
+batch_verifier_race_control: $(OBJ_DIR)/test/lp5_control/signature_batch_verifier_prefix.o $(OBJ_DIR)/test/lp5_control/batch_verifier_race_tests.o $(DILITHIUM_OBJECTS)
+	@echo "$(COLOR_BLUE)[LINK]$(COLOR_RESET) $@"
+	@$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LIBS)
+	@echo "$(COLOR_GREEN)✓ batch_verifier_race_control built (A-010 control — expect HANG when run)$(COLOR_RESET)"
+
 # ============================================================================
 # Run Tests
 # ============================================================================

--- a/Makefile
+++ b/Makefile
@@ -942,6 +942,17 @@ asert_test:
 	@echo "$(COLOR_GREEN)✓ ASERT test built successfully$(COLOR_RESET)"
 
 # ============================================================================
+# LP-5 batch-verifier concurrency race + differential harness (CRITICAL-1/MED-2)
+# Links only the verifier object + Dilithium primitives (no full CORE_OBJECTS):
+# the race lives entirely in CSignatureBatchVerifier's per-batch state.
+# Build under ThreadSanitizer on Linux:  make TSAN=1 batch_verifier_race_tests
+# ============================================================================
+batch_verifier_race_tests: $(OBJ_DIR)/consensus/signature_batch_verifier.o $(OBJ_DIR)/test/batch_verifier_race_tests.o $(DILITHIUM_OBJECTS)
+	@echo "$(COLOR_BLUE)[LINK]$(COLOR_RESET) $@"
+	@$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LIBS)
+	@echo "$(COLOR_GREEN)✓ batch_verifier_race_tests built$(COLOR_RESET)"
+
+# ============================================================================
 # Run Tests
 # ============================================================================
 

--- a/src/consensus/signature_batch_verifier.cpp
+++ b/src/consensus/signature_batch_verifier.cpp
@@ -71,32 +71,31 @@ void CSignatureBatchVerifier::Stop() {
     std::cout << "[SignatureVerifier] Stopped" << std::endl;
 }
 
-void CSignatureBatchVerifier::BeginBatch() {
-    // Reset batch state
-    m_pending_count.store(0);
-    m_batch_failed.store(false);
-
-    std::lock_guard<std::mutex> lock(m_error_mutex);
-    m_first_error.clear();
+std::shared_ptr<CBatchSession> CSignatureBatchVerifier::BeginBatch() {
+    // Each batch gets a fresh, independently-owned session. No shared global
+    // batch state is touched here (CRITICAL-1 fix), so concurrent BeginBatch()
+    // calls cannot clobber one another.
+    return std::make_shared<CBatchSession>();
 }
 
-void CSignatureBatchVerifier::Add(const std::vector<uint8_t>& signature,
+void CSignatureBatchVerifier::Add(const std::shared_ptr<CBatchSession>& session,
+                                   const std::vector<uint8_t>& signature,
                                    const std::vector<uint8_t>& message,
                                    const std::vector<uint8_t>& pubkey,
                                    size_t input_index) {
-    // Increment pending count BEFORE adding to queue
-    // This ensures Wait() won't return prematurely
-    m_pending_count.fetch_add(1);
+    // Increment THIS session's pending count BEFORE adding to queue so its
+    // Wait() won't return prematurely.
+    session->pending_count.fetch_add(1);
 
-    // Create task
+    // Create task, binding it to its owning session.
     CSignatureTask task;
     task.signature = signature;
     task.message = message;
     task.pubkey = pubkey;
+    task.session = session;   // keeps the session alive while queued (S-005)
     task.input_index = input_index;
-    task.error_out = nullptr;
 
-    // Add to queue
+    // Add to the shared worker queue
     {
         std::lock_guard<std::mutex> lock(m_queue_mutex);
         m_queue.push(std::move(task));
@@ -106,17 +105,24 @@ void CSignatureBatchVerifier::Add(const std::vector<uint8_t>& signature,
     m_queue_cv.notify_one();
 }
 
-bool CSignatureBatchVerifier::Wait(std::string& error) {
-    // Wait for all pending tasks to complete
-    std::unique_lock<std::mutex> lock(m_complete_mutex);
-    m_complete_cv.wait(lock, [this] {
-        return m_pending_count.load() == 0;
-    });
+bool CSignatureBatchVerifier::Wait(const std::shared_ptr<CBatchSession>& session,
+                                   std::string& error) {
+    // Wait for all pending tasks in THIS session to complete.
+    // The predicate (pending_count==0) is checked under complete_mutex, and the
+    // worker that drives the count to zero notifies under the SAME mutex
+    // (MED-2 lost-wakeup fix), so a Wait() entered just before the final
+    // decrement still wakes.
+    {
+        std::unique_lock<std::mutex> lock(session->complete_mutex);
+        session->complete_cv.wait(lock, [&session] {
+            return session->pending_count.load() == 0;
+        });
+    }
 
-    // Check if batch failed
-    if (m_batch_failed.load()) {
-        std::lock_guard<std::mutex> err_lock(m_error_mutex);
-        error = m_first_error;
+    // Check if THIS batch failed
+    if (session->batch_failed.load()) {
+        std::lock_guard<std::mutex> err_lock(session->error_mutex);
+        error = session->first_error;
         return false;
     }
 
@@ -150,27 +156,38 @@ void CSignatureBatchVerifier::WorkerThread() {
             continue;
         }
 
+        // Resolve the owning session for this task (always set by Add()).
+        std::shared_ptr<CBatchSession> session = task.session;
+
         // Verify signature
         bool valid = VerifySingle(task);
 
-        if (!valid) {
-            // Mark batch as failed
+        if (!valid && session) {
+            // Mark THIS batch as failed
             bool expected = false;
-            if (m_batch_failed.compare_exchange_strong(expected, true)) {
-                // First failure - store error
+            if (session->batch_failed.compare_exchange_strong(expected, true)) {
+                // First failure in this batch - store error
                 char buf[256];
                 snprintf(buf, sizeof(buf), "Signature verification failed for input %zu",
                          task.input_index);
 
-                std::lock_guard<std::mutex> lock(m_error_mutex);
-                m_first_error = buf;
+                std::lock_guard<std::mutex> lock(session->error_mutex);
+                session->first_error = buf;
             }
         }
 
-        // Decrement pending count and notify if batch complete
-        size_t remaining = m_pending_count.fetch_sub(1) - 1;
-        if (remaining == 0) {
-            m_complete_cv.notify_all();
+        // Decrement THIS session's pending count and notify its waiter if the
+        // batch is complete. The notify is done under complete_mutex so the
+        // waiter cannot miss it (MED-2). We capture the session in a local
+        // shared_ptr above and release the task (which may hold the last other
+        // reference) only after notifying, so the session stays alive across
+        // the notify even if Wait() has already returned and dropped its handle.
+        if (session) {
+            std::unique_lock<std::mutex> lock(session->complete_mutex);
+            size_t remaining = session->pending_count.fetch_sub(1) - 1;
+            if (remaining == 0) {
+                session->complete_cv.notify_all();
+            }
         }
     }
 }

--- a/src/consensus/signature_batch_verifier.cpp
+++ b/src/consensus/signature_batch_verifier.cpp
@@ -189,14 +189,20 @@ void CSignatureBatchVerifier::WorkerThread() {
             // worker dequeues each task exactly once, and Add() incremented before
             // enqueue. A zero here would mean a double-dequeue / double-decrement
             // regression, which would otherwise wrap size_t and hang Wait()
-            // forever (silent validator-thread DoS). Catch it loudly under test
-            // instead. The load is under complete_mutex so it is consistent with
-            // the fetch_sub that follows.
-            assert(session->pending_count.load() > 0 &&
-                   "CBatchSession pending_count underflow (double-decrement?)");
-            size_t remaining = session->pending_count.fetch_sub(1) - 1;
-            if (remaining == 0) {
-                session->complete_cv.notify_all();
+            // forever (silent validator-thread DoS). Guard the decrement so the
+            // underflow protection holds in release builds (NDEBUG) too, not just
+            // debug: if the count is already zero, log loudly and skip the
+            // fetch_sub rather than wrapping size_t. The load is under
+            // complete_mutex so it is consistent with the fetch_sub that follows.
+            if (session->pending_count.load() == 0) {
+                assert(false && "CBatchSession pending_count underflow (double-decrement?)");
+                std::cerr << "[SignatureVerifier] ERROR: pending_count underflow "
+                             "(double-decrement?) - skipping decrement" << std::endl;
+            } else {
+                size_t remaining = session->pending_count.fetch_sub(1) - 1;
+                if (remaining == 0) {
+                    session->complete_cv.notify_all();
+                }
             }
         }
     }

--- a/src/consensus/signature_batch_verifier.h
+++ b/src/consensus/signature_batch_verifier.h
@@ -16,7 +16,14 @@
  * Solution: Verify signatures in parallel using a thread pool.
  * With 4 workers, a block with 1000 signatures takes ~500-750ms instead.
  *
- * Architecture (based on Bitcoin Core's CCheckQueue):
+ * Architecture (based on Bitcoin Core's CCheckQueue / CCheckQueueControl):
+ *   Upstream reference: bitcoin/bitcoin src/checkqueue.h
+ *   (CCheckQueue<T> = the shared worker pool + CV batch driver;
+ *    CCheckQueueControl<T> = the RAII control object that owns ONE batch for its
+ *    scope and calls Wait() in its destructor so no batch is ever abandoned
+ *    un-waited). The CBatchSession + CBatchSessionGuard pair below mirrors that
+ *    split; pin the exact upstream commit here if a byte-level equivalence audit
+ *    is ever required.
  * - Main thread collects signature verification tasks
  * - Worker threads verify signatures in parallel
  * - Results aggregated - any failure fails the batch
@@ -206,6 +213,58 @@ private:
     // been moved into CBatchSession so that each in-flight batch owns its own
     // state. The verifier object now holds ONLY the shared worker pool +
     // queue, which is concurrency-safe to share across batches.
+};
+
+/**
+ * CBatchSessionGuard - RAII guard restoring upstream CCheckQueueControl's
+ * structural guarantee that a batch is never abandoned un-Wait()-ed.
+ *
+ * The port's ownership model (shared_ptr<CBatchSession>) is UAF-safe even if a
+ * caller drops its handle while tasks drain (every queued task keeps the session
+ * alive), so a missed Wait() is a correctness-clean *waste* (work runs, verdict
+ * discarded), not a crash. But upstream's RAII control object made an abandoned
+ * batch impossible by construction. This guard restores that: declare it once
+ * after BeginBatch(); its destructor drains the session via Wait() on EVERY exit
+ * path (early return, exception) unless the caller already consumed the result
+ * with WaitResult()/release(). This bounds latency and prevents a future edit
+ * from leaking queued work between BeginBatch() and the final Wait().
+ *
+ * Upstream reference: bitcoin/bitcoin src/checkqueue.h (CCheckQueueControl dtor).
+ */
+class CBatchSessionGuard {
+public:
+    CBatchSessionGuard(CSignatureBatchVerifier* verifier,
+                       std::shared_ptr<CBatchSession> session)
+        : m_verifier(verifier), m_session(std::move(session)) {}
+
+    // Non-copyable, non-movable (scoped to one BatchVerifyScripts call).
+    CBatchSessionGuard(const CBatchSessionGuard&) = delete;
+    CBatchSessionGuard& operator=(const CBatchSessionGuard&) = delete;
+
+    /**
+     * Wait for the session and consume the verdict. After this returns the guard
+     * will NOT drain again in its destructor (the batch is already complete).
+     */
+    bool WaitResult(std::string& error) {
+        m_waited = true;
+        return m_verifier->Wait(m_session, error);
+    }
+
+    const std::shared_ptr<CBatchSession>& session() const { return m_session; }
+
+    ~CBatchSessionGuard() {
+        // If the caller never consumed the result (early return / exception),
+        // drain the queued tasks so they don't run against an abandoned session.
+        if (!m_waited && m_verifier && m_session) {
+            std::string drain_error;
+            m_verifier->Wait(m_session, drain_error);
+        }
+    }
+
+private:
+    CSignatureBatchVerifier* m_verifier;
+    std::shared_ptr<CBatchSession> m_session;
+    bool m_waited{false};
 };
 
 /**

--- a/src/consensus/signature_batch_verifier.h
+++ b/src/consensus/signature_batch_verifier.h
@@ -41,6 +41,46 @@
 #include <functional>
 #include <cstdint>
 #include <string>
+#include <memory>
+
+/**
+ * CBatchSession - Per-batch verification state (CCheckQueueControl pattern)
+ *
+ * CRITICAL-1 fix (LP-5): the mutable per-batch state used to live as instance
+ * members of the process-wide CSignatureBatchVerifier global, so two concurrent
+ * callers (the RPC worker pool races itself and the P2P thread) would clobber
+ * each other's pending-count / failure flag / first-error and one caller's
+ * Wait() could read another caller's verdict — accepting an invalid signature,
+ * underflowing the shared counter (DoS hang), or diverging batch-vs-sequential.
+ *
+ * The fix mirrors Bitcoin Core's CCheckQueue/CCheckQueueControl split: the
+ * worker POOL stays shared (preserving parallelism), but each batch owns its
+ * own session. Every task carries a pointer to the session it belongs to;
+ * a worker decrements THAT session's counter, records errors into THAT
+ * session, and notifies THAT session's completion CV. Two concurrent batches
+ * therefore cannot see or mutate each other's state.
+ *
+ * Lifetime: a session is created by BeginBatch(), kept alive (shared_ptr) by
+ * both the caller's session handle AND every queued task referencing it, and
+ * destroyed only after Wait() returns and all tasks have run. This makes
+ * use-after-free of session state at teardown structurally impossible even if
+ * the caller's handle is released while tasks are still draining.
+ */
+struct CBatchSession {
+    std::atomic<size_t> pending_count{0};   // Tasks pending in THIS batch
+    std::atomic<bool>   batch_failed{false}; // Any task in THIS batch failed?
+
+    std::mutex          error_mutex;        // Guards first_error
+    std::string         first_error;        // First error encountered in THIS batch
+
+    // Completion notification for THIS batch. The mutex guards the wait
+    // predicate (pending_count==0) AND the notify, so no wakeup is lost
+    // (MED-2 fix): a worker driving pending_count to zero takes complete_mutex
+    // before notifying, so a Wait() that has read a non-zero count but not yet
+    // blocked cannot miss the notification.
+    std::mutex              complete_mutex;
+    std::condition_variable complete_cv;
+};
 
 /**
  * CSignatureTask - A single signature verification task
@@ -49,7 +89,7 @@ struct CSignatureTask {
     std::vector<uint8_t> signature;      // Dilithium3 signature (3309 bytes)
     std::vector<uint8_t> message;        // Message that was signed (32 bytes hash)
     std::vector<uint8_t> pubkey;         // Dilithium3 public key (1952 bytes)
-    std::string* error_out;              // Where to store error message if failed
+    std::shared_ptr<CBatchSession> session; // Batch this task belongs to (CRITICAL-1)
     size_t input_index;                  // Input index for error reporting
 };
 
@@ -86,31 +126,38 @@ public:
     void Stop();
 
     /**
-     * Begin a new batch of verifications
-     * Must be called before adding tasks for a new transaction/block
+     * Begin a new batch of verifications.
+     * Returns a fresh per-batch session that the caller owns for the whole
+     * BeginBatch -> Add... -> Wait lifetime. Concurrent callers each get their
+     * own session, so their batch state cannot cross-contaminate (CRITICAL-1).
+     *
+     * @return a shared_ptr to the new session; pass it to Add()/Wait().
      */
-    void BeginBatch();
+    std::shared_ptr<CBatchSession> BeginBatch();
 
     /**
-     * Add a signature verification task to the batch
-     * Thread-safe, can be called from any thread
+     * Add a signature verification task to the given batch session.
+     * Thread-safe, can be called from any thread.
      *
+     * @param session The session returned by BeginBatch() for this batch
      * @param signature Dilithium3 signature bytes
      * @param message Message hash (32 bytes)
      * @param pubkey Dilithium3 public key bytes
      * @param input_index Input index for error reporting
      */
-    void Add(const std::vector<uint8_t>& signature,
+    void Add(const std::shared_ptr<CBatchSession>& session,
+             const std::vector<uint8_t>& signature,
              const std::vector<uint8_t>& message,
              const std::vector<uint8_t>& pubkey,
              size_t input_index);
 
     /**
-     * Wait for all tasks in current batch to complete
+     * Wait for all tasks in the given batch session to complete.
+     * @param session The session returned by BeginBatch() for this batch
      * @param error Output parameter - set to first error if any verification fails
      * @return true if ALL signatures verified successfully
      */
-    bool Wait(std::string& error);
+    bool Wait(const std::shared_ptr<CBatchSession>& session, std::string& error);
 
     /**
      * Check if verifier is running
@@ -148,20 +195,17 @@ private:
     std::vector<std::thread> m_workers;
     std::atomic<bool> m_running{false};
 
-    // Task queue
+    // Task queue (the shared worker pool — CCheckQueue). Each queued task
+    // carries its own CBatchSession pointer, so no per-batch state lives here.
     std::queue<CSignatureTask> m_queue;
     std::mutex m_queue_mutex;
     std::condition_variable m_queue_cv;
 
-    // Batch state
-    std::atomic<size_t> m_pending_count{0};    // Tasks pending in current batch
-    std::atomic<bool> m_batch_failed{false};   // Any task in batch failed?
-    std::string m_first_error;                 // First error encountered
-    std::mutex m_error_mutex;
-
-    // Completion notification
-    std::mutex m_complete_mutex;
-    std::condition_variable m_complete_cv;
+    // NOTE (CRITICAL-1 / LP-5): the former shared per-batch members
+    // (m_pending_count / m_batch_failed / m_first_error / m_complete_*) have
+    // been moved into CBatchSession so that each in-flight batch owns its own
+    // state. The verifier object now holds ONLY the shared worker pool +
+    // queue, which is concurrency-safe to share across batches.
 };
 
 /**

--- a/src/consensus/tx_validation.cpp
+++ b/src/consensus/tx_validation.cpp
@@ -796,8 +796,10 @@ bool CTransactionValidator::BatchVerifyScripts(const CTransaction& tx, CUTXOSet&
         return false;
     }
 
-    // Begin new batch
-    g_signature_verifier->BeginBatch();
+    // Begin a new batch. The session is owned for the lifetime of this call
+    // (CRITICAL-1 / LP-5): concurrent BatchVerifyScripts callers each get their
+    // own session, so their batch state cannot cross-contaminate.
+    std::shared_ptr<CBatchSession> session = g_signature_verifier->BeginBatch();
 
     // Prepare and add all signature verification tasks
     for (size_t i = 0; i < tx.vin.size(); ++i) {
@@ -806,6 +808,10 @@ bool CTransactionValidator::BatchVerifyScripts(const CTransaction& tx, CUTXOSet&
         // Get UTXO for scriptPubKey
         CUTXOEntry entry;
         if (!utxoSet.GetUTXO(txin.prevout, entry)) {
+            error = "Failed to retrieve UTXO for batch verification";
+            // Drain any tasks already queued for this session before returning,
+            // so workers don't touch a session whose handle we've dropped.
+            g_signature_verifier->Wait(session, error);
             error = "Failed to retrieve UTXO for batch verification";
             return false;
         }
@@ -818,14 +824,17 @@ bool CTransactionValidator::BatchVerifyScripts(const CTransaction& tx, CUTXOSet&
             char buf[256];
             snprintf(buf, sizeof(buf), "Failed to prepare signature data for input %zu: %s",
                      i, prep_error.c_str());
+            // Drain queued tasks for this session before returning (see above).
+            std::string drain_error;
+            g_signature_verifier->Wait(session, drain_error);
             error = buf;
             return false;
         }
 
-        // Add to batch
-        g_signature_verifier->Add(signature, message, pubkey, i);
+        // Add to this batch's session
+        g_signature_verifier->Add(session, signature, message, pubkey, i);
     }
 
-    // Wait for all verifications to complete
-    return g_signature_verifier->Wait(error);
+    // Wait for all verifications in this session to complete
+    return g_signature_verifier->Wait(session, error);
 }

--- a/src/consensus/tx_validation.cpp
+++ b/src/consensus/tx_validation.cpp
@@ -799,7 +799,19 @@ bool CTransactionValidator::BatchVerifyScripts(const CTransaction& tx, CUTXOSet&
     // Begin a new batch. The session is owned for the lifetime of this call
     // (CRITICAL-1 / LP-5): concurrent BatchVerifyScripts callers each get their
     // own session, so their batch state cannot cross-contaminate.
+    //
+    // The RAII guard (CCheckQueueControl pattern, see checkqueue.h) drains the
+    // session via Wait() on EVERY exit path that does not consume the result —
+    // both early-return branches below and any future exception. Draining is a
+    // latency bound, not a safety requirement: every queued task shared_ptr-
+    // owns the session (signature_batch_verifier.h S-005), so an abandoned
+    // session is UAF-safe — the guard only avoids spending CPU on signatures
+    // we're about to discard and a leaked-task-on-an-abandoned-session waste.
+    // The guard's drain uses a throwaway error internally, so a bad signature
+    // in an already-queued task can never clobber the real operator-facing
+    // `error` we set on the early-return branches.
     std::shared_ptr<CBatchSession> session = g_signature_verifier->BeginBatch();
+    CBatchSessionGuard guard(g_signature_verifier, session);
 
     // Prepare and add all signature verification tasks
     for (size_t i = 0; i < tx.vin.size(); ++i) {
@@ -809,11 +821,7 @@ bool CTransactionValidator::BatchVerifyScripts(const CTransaction& tx, CUTXOSet&
         CUTXOEntry entry;
         if (!utxoSet.GetUTXO(txin.prevout, entry)) {
             error = "Failed to retrieve UTXO for batch verification";
-            // Drain any tasks already queued for this session before returning,
-            // so workers don't touch a session whose handle we've dropped.
-            g_signature_verifier->Wait(session, error);
-            error = "Failed to retrieve UTXO for batch verification";
-            return false;
+            return false;  // guard drains queued tasks; `error` preserved
         }
 
         // Prepare signature data
@@ -824,17 +832,15 @@ bool CTransactionValidator::BatchVerifyScripts(const CTransaction& tx, CUTXOSet&
             char buf[256];
             snprintf(buf, sizeof(buf), "Failed to prepare signature data for input %zu: %s",
                      i, prep_error.c_str());
-            // Drain queued tasks for this session before returning (see above).
-            std::string drain_error;
-            g_signature_verifier->Wait(session, drain_error);
             error = buf;
-            return false;
+            return false;  // guard drains queued tasks; `error` preserved
         }
 
         // Add to this batch's session
         g_signature_verifier->Add(session, signature, message, pubkey, i);
     }
 
-    // Wait for all verifications in this session to complete
-    return g_signature_verifier->Wait(session, error);
+    // Wait for all verifications in this session to complete. WaitResult()
+    // consumes the verdict so the guard does NOT drain again on destruction.
+    return guard.WaitResult(error);
 }

--- a/src/test/batch_verifier_race_tests.cpp
+++ b/src/test/batch_verifier_race_tests.cpp
@@ -28,12 +28,31 @@
 // (make TSAN=1 batch_verifier_race_tests) to additionally flag the data race
 // on the control and confirm clean on the fix.
 //
+// ONE SOURCE, BOTH VARIANTS (A-010 evidence is auditable, not a separate file):
+// this file compiles against EITHER verifier from the same source via a
+// compile-time switch, so the control-red and fix-green come from identical
+// harness logic:
+//   - default build  → fixed verifier (src/consensus/signature_batch_verifier.*),
+//                       session API: `make batch_verifier_race_tests`  → PASS.
+//   - -DPREFIX_API    → frozen pre-fix verifier
+//                       (src/test/lp5_control/signature_batch_verifier_prefix.*,
+//                       a verbatim copy of commit bb933d53), sessionless API:
+//                       `make batch_verifier_race_control`            → HANG.
+// The only thing PREFIX_API changes below is which header is included and the
+// BeginBatch/Add/Wait call shape; the load pattern, oracle, and assertions are
+// byte-identical across both variants. The HANG on the control is the proof that
+// a PASS on the fix is discriminating (the harness is not a no-op).
+//
 // The harness drives CSignatureBatchVerifier directly (not the full RPC stack)
 // because the race lives entirely in the verifier's per-batch state; this keeps
 // the proof minimal and deterministic while reproducing the exact concurrent
 // BeginBatch/Add/Wait load shape the RPC worker pool produces.
 
-#include <consensus/signature_batch_verifier.h>
+#ifdef PREFIX_API
+#include "lp5_control/signature_batch_verifier_prefix.h"  // frozen pre-fix control
+#else
+#include <consensus/signature_batch_verifier.h>           // the fixed verifier
+#endif
 
 #include <atomic>
 #include <cstdint>
@@ -167,14 +186,27 @@ int main() {
                 if (!OracleVerify(t)) { oracle_ok = false; break; }
             }
 
-            // Batch verifier verdict — the path under test.
+            // Batch verifier verdict — the path under test. The call shape is
+            // the ONLY thing that differs between control and fix (A-010): the
+            // pre-fix verifier has a sessionless BeginBatch/Add/Wait, the fixed
+            // verifier threads a per-batch session through all three.
+            std::string err;
+            bool batch_ok;
+#ifdef PREFIX_API
+            g_signature_verifier->BeginBatch();
+            for (size_t i = 0; i < batch.size(); ++i) {
+                g_signature_verifier->Add(batch[i].sig, batch[i].msg,
+                                          batch[i].pub, i);
+            }
+            batch_ok = g_signature_verifier->Wait(err);
+#else
             auto session = g_signature_verifier->BeginBatch();
             for (size_t i = 0; i < batch.size(); ++i) {
                 g_signature_verifier->Add(session, batch[i].sig, batch[i].msg,
                                           batch[i].pub, i);
             }
-            std::string err;
-            bool batch_ok = g_signature_verifier->Wait(session, err);
+            batch_ok = g_signature_verifier->Wait(session, err);
+#endif
 
             total_batches.fetch_add(1);
             if (batch_ok != oracle_ok) {

--- a/src/test/batch_verifier_race_tests.cpp
+++ b/src/test/batch_verifier_race_tests.cpp
@@ -1,0 +1,212 @@
+// Copyright (c) 2025 The Dilithion Core developers
+// Distributed under the MIT software license
+//
+// LP-5 / CRITICAL-1 + MED-2 concurrency stress + differential harness.
+//
+// Purpose (contract §3.2): prove the per-batch session refactor removes the
+// cross-batch race in CSignatureBatchVerifier.
+//
+//   - N concurrent caller threads each run BeginBatch -> Add(>=2 P2PKH-shaped
+//     Dilithium3 signature tasks) -> Wait, in a tight loop.
+//   - Batches are a mix of all-valid and "exactly-one-bad-signature" batches,
+//     interleaved at random so valid and invalid batches are in flight
+//     simultaneously under worker-pool contention.
+//   - DIFFERENTIAL INVARIANT (A-004): for every batch, the verifier's Wait()
+//     verdict MUST equal the sequential oracle (per-signature
+//     pqcrystals_dilithium3_ref_verify run directly, single-threaded). Any
+//     divergence is a fail.
+//   - A-002: a one-bad-sig batch must NEVER return true (no invalid-sig accept).
+//   - A-001 / A-003: a valid batch must NEVER return false (no cross-contam
+//     from a concurrent bad batch; no counter underflow / hang).
+//   - A-005: each iteration enters Wait() right after Add(), exercising the
+//     narrow window before the final worker decrement (lost-wakeup / MED-2).
+//
+// CONTROL vs FIX (A-010): on the pre-fix code (shared global batch state) this
+// harness reliably reports a differential mismatch and/or hangs on a size_t
+// underflow. On the fixed code (per-batch session) every iteration matches the
+// oracle and the run completes. Build under ThreadSanitizer on Linux
+// (make TSAN=1 batch_verifier_race_tests) to additionally flag the data race
+// on the control and confirm clean on the fix.
+//
+// The harness drives CSignatureBatchVerifier directly (not the full RPC stack)
+// because the race lives entirely in the verifier's per-batch state; this keeps
+// the proof minimal and deterministic while reproducing the exact concurrent
+// BeginBatch/Add/Wait load shape the RPC worker pool produces.
+
+#include <consensus/signature_batch_verifier.h>
+
+#include <atomic>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <random>
+#include <thread>
+#include <vector>
+
+extern "C" {
+int pqcrystals_dilithium3_ref_keypair(uint8_t* pk, uint8_t* sk);
+int pqcrystals_dilithium3_ref_signature(uint8_t* sig, size_t* siglen,
+                                        const uint8_t* m, size_t mlen,
+                                        const uint8_t* ctx, size_t ctxlen,
+                                        const uint8_t* sk);
+int pqcrystals_dilithium3_ref_verify(const uint8_t* sig, size_t siglen,
+                                     const uint8_t* m, size_t mlen,
+                                     const uint8_t* ctx, size_t ctxlen,
+                                     const uint8_t* pk);
+}
+
+static constexpr size_t PK_SIZE = 1952;   // Dilithium3 public key
+static constexpr size_t SIG_SIZE = 3309;  // Dilithium3 signature
+static constexpr size_t MSG_SIZE = 32;    // SHA3-256 preimage hash the node feeds
+
+// A single signature triple, in the exact (signature, message, pubkey) shape
+// that BatchVerifyScripts hands to verifier.Add().
+struct Triple {
+    std::vector<uint8_t> sig;
+    std::vector<uint8_t> msg;
+    std::vector<uint8_t> pub;
+};
+
+// Sequential oracle: verify one triple exactly as VerifySingle does (same sizes,
+// same ctx=nullptr,0), but on the calling thread with no shared state.
+static bool OracleVerify(const Triple& t) {
+    if (t.sig.size() != SIG_SIZE) return false;
+    if (t.pub.size() != PK_SIZE) return false;
+    if (t.msg.size() != MSG_SIZE) return false;
+    return pqcrystals_dilithium3_ref_verify(t.sig.data(), t.sig.size(),
+                                            t.msg.data(), t.msg.size(),
+                                            nullptr, 0, t.pub.data()) == 0;
+}
+
+// Build one valid triple from a fresh keypair over a random message.
+static Triple MakeValid(std::mt19937_64& rng) {
+    std::vector<uint8_t> pk(PK_SIZE), sk(4032 /*Dilithium3 SECRETKEYBYTES*/);
+    // keypair uses its own RNG internally; deterministic per call isn't required.
+    pqcrystals_dilithium3_ref_keypair(pk.data(), sk.data());
+
+    Triple t;
+    t.pub = pk;
+    t.msg.resize(MSG_SIZE);
+    for (auto& b : t.msg) b = static_cast<uint8_t>(rng());
+
+    t.sig.resize(SIG_SIZE);
+    size_t siglen = 0;
+    pqcrystals_dilithium3_ref_signature(t.sig.data(), &siglen, t.msg.data(),
+                                        t.msg.size(), nullptr, 0, sk.data());
+    t.sig.resize(siglen);
+    // Dilithium3 signature is fixed-length SIG_SIZE; pad/trim defensively.
+    t.sig.resize(SIG_SIZE);
+    return t;
+}
+
+// Corrupt a valid triple into an invalid one by flipping a message byte. The
+// signature no longer matches the message => verify must fail. This models the
+// "one bad signature in the batch" case without changing sizes.
+static Triple MakeBadFrom(const Triple& good) {
+    Triple t = good;
+    t.msg[0] ^= 0xFF;
+    return t;
+}
+
+int main() {
+    std::printf("[LP-5 harness] building key/signature pool...\n");
+
+    // Pre-generate a pool of valid triples (keypair+sign is ~ms; do it once).
+    std::mt19937_64 seed_rng(0xC0FFEEull);
+    constexpr size_t POOL = 24;
+    std::vector<Triple> pool;
+    pool.reserve(POOL);
+    for (size_t i = 0; i < POOL; ++i) pool.push_back(MakeValid(seed_rng));
+
+    // Sanity: every pooled triple verifies, and a corrupted one does not.
+    for (const auto& t : pool) {
+        if (!OracleVerify(t)) {
+            std::printf("[LP-5 harness] FAIL: pool triple did not self-verify\n");
+            return 1;
+        }
+    }
+    if (OracleVerify(MakeBadFrom(pool[0]))) {
+        std::printf("[LP-5 harness] FAIL: corrupted triple unexpectedly verified\n");
+        return 1;
+    }
+    std::printf("[LP-5 harness] pool ok (%zu triples)\n", POOL);
+
+    // Start the shared verifier (same shape as node startup: 4 workers).
+    InitSignatureVerifier(4);
+
+    constexpr int kThreads = 8;       // more concurrent callers than 4 workers
+    constexpr int kItersPerThread = 400;
+    constexpr size_t kMinInputs = 2;  // batch path requires >=2 inputs
+    constexpr size_t kMaxInputs = 6;
+
+    std::atomic<long> mismatches{0};
+    std::atomic<long> bad_accepted{0};
+    std::atomic<long> good_rejected{0};
+    std::atomic<long> total_batches{0};
+
+    auto worker = [&](int tid) {
+        std::mt19937_64 rng(0x9E3779B97F4A7C15ull ^ (uint64_t)(tid + 1));
+        for (int it = 0; it < kItersPerThread; ++it) {
+            // Compose a batch of [kMinInputs..kMaxInputs] triples drawn from pool.
+            size_t n = kMinInputs + (rng() % (kMaxInputs - kMinInputs + 1));
+            std::vector<Triple> batch;
+            batch.reserve(n);
+            for (size_t i = 0; i < n; ++i) {
+                batch.push_back(pool[rng() % pool.size()]);
+            }
+            // ~40% of batches carry exactly one bad signature.
+            bool inject_bad = (rng() % 5) < 2;
+            if (inject_bad) {
+                size_t k = rng() % n;
+                batch[k] = MakeBadFrom(batch[k]);
+            }
+
+            // Sequential oracle verdict for this exact batch.
+            bool oracle_ok = true;
+            for (const auto& t : batch) {
+                if (!OracleVerify(t)) { oracle_ok = false; break; }
+            }
+
+            // Batch verifier verdict — the path under test.
+            auto session = g_signature_verifier->BeginBatch();
+            for (size_t i = 0; i < batch.size(); ++i) {
+                g_signature_verifier->Add(session, batch[i].sig, batch[i].msg,
+                                          batch[i].pub, i);
+            }
+            std::string err;
+            bool batch_ok = g_signature_verifier->Wait(session, err);
+
+            total_batches.fetch_add(1);
+            if (batch_ok != oracle_ok) {
+                mismatches.fetch_add(1);
+                if (batch_ok && !oracle_ok) bad_accepted.fetch_add(1);
+                if (!batch_ok && oracle_ok) good_rejected.fetch_add(1);
+            }
+        }
+    };
+
+    std::printf("[LP-5 harness] running %d threads x %d iters (workers=4)...\n",
+                kThreads, kItersPerThread);
+    std::vector<std::thread> threads;
+    for (int t = 0; t < kThreads; ++t) threads.emplace_back(worker, t);
+    for (auto& th : threads) th.join();
+
+    ShutdownSignatureVerifier();
+
+    long mm = mismatches.load();
+    long ba = bad_accepted.load();
+    long gr = good_rejected.load();
+    long tot = total_batches.load();
+
+    std::printf("[LP-5 harness] batches=%ld  mismatches=%ld  bad-accepted=%ld  good-rejected=%ld\n",
+                tot, mm, ba, gr);
+
+    if (mm != 0) {
+        std::printf("[LP-5 harness] RESULT: FAIL — batch verdict diverged from sequential oracle.\n");
+        std::printf("                (bad-accepted=%ld is an invalid-signature acceptance; good-rejected=%ld is cross-batch contamination.)\n",
+                    ba, gr);
+        return 1;
+    }
+    std::printf("[LP-5 harness] RESULT: PASS — every batch matched the sequential oracle under concurrent load.\n");
+    return 0;
+}

--- a/src/test/lp5_control/signature_batch_verifier_prefix.cpp
+++ b/src/test/lp5_control/signature_batch_verifier_prefix.cpp
@@ -1,10 +1,20 @@
 // Copyright (c) 2025 The Dilithion Core developers
 // Distributed under the MIT software license
+//
+// ============================================================================
+// LP-5 / CRITICAL-1 CONTROL ARTIFACT — FROZEN PRE-FIX VERIFIER. DO NOT "FIX".
+// ============================================================================
+//
+// VERBATIM copy of the pre-fix CSignatureBatchVerifier implementation at commit
+// bb933d53 (`src/consensus/signature_batch_verifier.cpp`). Provenance:
+// `git show bb933d53:src/consensus/signature_batch_verifier.cpp`. The ONLY edit
+// is the #include pointing at the renamed control header. See the header banner
+// for why this exists (A-010 control: this code HANGS under the race harness).
+// ============================================================================
 
-#include <consensus/signature_batch_verifier.h>
+#include "signature_batch_verifier_prefix.h"
 #include <iostream>
 #include <cstdio>
-#include <cassert>
 
 // Dilithium3 external API
 extern "C" {
@@ -72,31 +82,32 @@ void CSignatureBatchVerifier::Stop() {
     std::cout << "[SignatureVerifier] Stopped" << std::endl;
 }
 
-std::shared_ptr<CBatchSession> CSignatureBatchVerifier::BeginBatch() {
-    // Each batch gets a fresh, independently-owned session. No shared global
-    // batch state is touched here (CRITICAL-1 fix), so concurrent BeginBatch()
-    // calls cannot clobber one another.
-    return std::make_shared<CBatchSession>();
+void CSignatureBatchVerifier::BeginBatch() {
+    // Reset batch state
+    m_pending_count.store(0);
+    m_batch_failed.store(false);
+
+    std::lock_guard<std::mutex> lock(m_error_mutex);
+    m_first_error.clear();
 }
 
-void CSignatureBatchVerifier::Add(const std::shared_ptr<CBatchSession>& session,
-                                   const std::vector<uint8_t>& signature,
+void CSignatureBatchVerifier::Add(const std::vector<uint8_t>& signature,
                                    const std::vector<uint8_t>& message,
                                    const std::vector<uint8_t>& pubkey,
                                    size_t input_index) {
-    // Increment THIS session's pending count BEFORE adding to queue so its
-    // Wait() won't return prematurely.
-    session->pending_count.fetch_add(1);
+    // Increment pending count BEFORE adding to queue
+    // This ensures Wait() won't return prematurely
+    m_pending_count.fetch_add(1);
 
-    // Create task, binding it to its owning session.
+    // Create task
     CSignatureTask task;
     task.signature = signature;
     task.message = message;
     task.pubkey = pubkey;
-    task.session = session;   // keeps the session alive while queued (S-005)
     task.input_index = input_index;
+    task.error_out = nullptr;
 
-    // Add to the shared worker queue
+    // Add to queue
     {
         std::lock_guard<std::mutex> lock(m_queue_mutex);
         m_queue.push(std::move(task));
@@ -106,24 +117,17 @@ void CSignatureBatchVerifier::Add(const std::shared_ptr<CBatchSession>& session,
     m_queue_cv.notify_one();
 }
 
-bool CSignatureBatchVerifier::Wait(const std::shared_ptr<CBatchSession>& session,
-                                   std::string& error) {
-    // Wait for all pending tasks in THIS session to complete.
-    // The predicate (pending_count==0) is checked under complete_mutex, and the
-    // worker that drives the count to zero notifies under the SAME mutex
-    // (MED-2 lost-wakeup fix), so a Wait() entered just before the final
-    // decrement still wakes.
-    {
-        std::unique_lock<std::mutex> lock(session->complete_mutex);
-        session->complete_cv.wait(lock, [&session] {
-            return session->pending_count.load() == 0;
-        });
-    }
+bool CSignatureBatchVerifier::Wait(std::string& error) {
+    // Wait for all pending tasks to complete
+    std::unique_lock<std::mutex> lock(m_complete_mutex);
+    m_complete_cv.wait(lock, [this] {
+        return m_pending_count.load() == 0;
+    });
 
-    // Check if THIS batch failed
-    if (session->batch_failed.load()) {
-        std::lock_guard<std::mutex> err_lock(session->error_mutex);
-        error = session->first_error;
+    // Check if batch failed
+    if (m_batch_failed.load()) {
+        std::lock_guard<std::mutex> err_lock(m_error_mutex);
+        error = m_first_error;
         return false;
     }
 
@@ -157,47 +161,27 @@ void CSignatureBatchVerifier::WorkerThread() {
             continue;
         }
 
-        // Resolve the owning session for this task (always set by Add()).
-        std::shared_ptr<CBatchSession> session = task.session;
-
         // Verify signature
         bool valid = VerifySingle(task);
 
-        if (!valid && session) {
-            // Mark THIS batch as failed
+        if (!valid) {
+            // Mark batch as failed
             bool expected = false;
-            if (session->batch_failed.compare_exchange_strong(expected, true)) {
-                // First failure in this batch - store error
+            if (m_batch_failed.compare_exchange_strong(expected, true)) {
+                // First failure - store error
                 char buf[256];
                 snprintf(buf, sizeof(buf), "Signature verification failed for input %zu",
                          task.input_index);
 
-                std::lock_guard<std::mutex> lock(session->error_mutex);
-                session->first_error = buf;
+                std::lock_guard<std::mutex> lock(m_error_mutex);
+                m_first_error = buf;
             }
         }
 
-        // Decrement THIS session's pending count and notify its waiter if the
-        // batch is complete. The notify is done under complete_mutex so the
-        // waiter cannot miss it (MED-2). We capture the session in a local
-        // shared_ptr above and release the task (which may hold the last other
-        // reference) only after notifying, so the session stays alive across
-        // the notify even if Wait() has already returned and dropped its handle.
-        if (session) {
-            std::unique_lock<std::mutex> lock(session->complete_mutex);
-            // Tripwire (A-003 defense-in-depth): the count must be > 0 here — one
-            // worker dequeues each task exactly once, and Add() incremented before
-            // enqueue. A zero here would mean a double-dequeue / double-decrement
-            // regression, which would otherwise wrap size_t and hang Wait()
-            // forever (silent validator-thread DoS). Catch it loudly under test
-            // instead. The load is under complete_mutex so it is consistent with
-            // the fetch_sub that follows.
-            assert(session->pending_count.load() > 0 &&
-                   "CBatchSession pending_count underflow (double-decrement?)");
-            size_t remaining = session->pending_count.fetch_sub(1) - 1;
-            if (remaining == 0) {
-                session->complete_cv.notify_all();
-            }
+        // Decrement pending count and notify if batch complete
+        size_t remaining = m_pending_count.fetch_sub(1) - 1;
+        if (remaining == 0) {
+            m_complete_cv.notify_all();
         }
     }
 }

--- a/src/test/lp5_control/signature_batch_verifier_prefix.h
+++ b/src/test/lp5_control/signature_batch_verifier_prefix.h
@@ -1,0 +1,114 @@
+// Copyright (c) 2025 The Dilithion Core developers
+// Distributed under the MIT software license
+//
+// ============================================================================
+// LP-5 / CRITICAL-1 CONTROL ARTIFACT — FROZEN PRE-FIX VERIFIER. DO NOT "FIX".
+// ============================================================================
+//
+// This is a VERBATIM copy of the pre-fix CSignatureBatchVerifier as it existed
+// at commit bb933d53 (`src/consensus/signature_batch_verifier.h`), BEFORE the
+// LP-5 per-batch-session refactor. It exists ONLY to build the A-010 "control"
+// variant of the race harness (`batch_verifier_race_tests.cpp` compiled with
+// -DPREFIX_API), which deterministically HANGS on this code — proving the
+// harness is a real discriminator, not a no-op that would pass on anything.
+//
+// Provenance: `git show bb933d53:src/consensus/signature_batch_verifier.h`.
+// The ONLY edits relative to that source are:
+//   - the include guard renamed (…_PREFIX_H) so it can coexist in-tree with the
+//     fixed header without a redefinition clash;
+//   - this provenance banner.
+// The class shape, the shared per-batch members (m_pending_count /
+// m_batch_failed / m_first_error / m_complete_*), and the sessionless
+// BeginBatch()/Add()/Wait() signatures are EXACTLY the pre-fix code — that
+// shared mutable batch state IS the bug the control reproduces.
+//
+// If you are tempted to make this compile "more cleanly" or share state with
+// the fixed verifier: don't. The whole point is that it is the broken code.
+// ============================================================================
+
+#ifndef DILITHION_TEST_LP5_CONTROL_SIGNATURE_BATCH_VERIFIER_PREFIX_H
+#define DILITHION_TEST_LP5_CONTROL_SIGNATURE_BATCH_VERIFIER_PREFIX_H
+
+#include <vector>
+#include <thread>
+#include <mutex>
+#include <condition_variable>
+#include <atomic>
+#include <queue>
+#include <functional>
+#include <cstdint>
+#include <string>
+
+/**
+ * CSignatureTask - A single signature verification task (PRE-FIX shape)
+ */
+struct CSignatureTask {
+    std::vector<uint8_t> signature;      // Dilithium3 signature (3309 bytes)
+    std::vector<uint8_t> message;        // Message that was signed (32 bytes hash)
+    std::vector<uint8_t> pubkey;         // Dilithium3 public key (1952 bytes)
+    std::string* error_out;              // Where to store error message if failed
+    size_t input_index;                  // Input index for error reporting
+};
+
+/**
+ * CSignatureBatchVerifier - Parallel Dilithium3 signature verifier (PRE-FIX)
+ *
+ * NOTE: shared per-batch state lives as instance members here — this is the
+ * CRITICAL-1 race. Two concurrent BeginBatch/Add/Wait callers clobber each
+ * other's m_pending_count, which the control harness drives into a size_t
+ * underflow and a permanent Wait() hang.
+ */
+class CSignatureBatchVerifier {
+public:
+    explicit CSignatureBatchVerifier(size_t num_workers = DEFAULT_WORKERS);
+    ~CSignatureBatchVerifier();
+
+    CSignatureBatchVerifier(const CSignatureBatchVerifier&) = delete;
+    CSignatureBatchVerifier& operator=(const CSignatureBatchVerifier&) = delete;
+
+    void Start();
+    void Stop();
+
+    // PRE-FIX sessionless API (the shape the LP-5 fix replaced).
+    void BeginBatch();
+    void Add(const std::vector<uint8_t>& signature,
+             const std::vector<uint8_t>& message,
+             const std::vector<uint8_t>& pubkey,
+             size_t input_index);
+    bool Wait(std::string& error);
+
+    bool IsRunning() const { return m_running.load(); }
+    size_t NumWorkers() const { return m_num_workers; }
+
+    static constexpr size_t DEFAULT_WORKERS = 4;
+    static constexpr size_t MAX_WORKERS = 16;
+
+private:
+    void WorkerThread();
+    bool VerifySingle(CSignatureTask& task);
+
+    size_t m_num_workers;
+
+    std::vector<std::thread> m_workers;
+    std::atomic<bool> m_running{false};
+
+    std::queue<CSignatureTask> m_queue;
+    std::mutex m_queue_mutex;
+    std::condition_variable m_queue_cv;
+
+    // SHARED batch state — the bug.
+    std::atomic<size_t> m_pending_count{0};
+    std::atomic<bool> m_batch_failed{false};
+    std::string m_first_error;
+    std::mutex m_error_mutex;
+
+    std::mutex m_complete_mutex;
+    std::condition_variable m_complete_cv;
+};
+
+extern CSignatureBatchVerifier* g_signature_verifier;
+
+void InitSignatureVerifier(size_t num_workers = CSignatureBatchVerifier::DEFAULT_WORKERS);
+void ShutdownSignatureVerifier();
+
+#endif // DILITHION_TEST_LP5_CONTROL_SIGNATURE_BATCH_VERIFIER_PREFIX_H


### PR DESCRIPTION
**LP-5 — batch-verifier concurrency race (DIL + DilV). CRITICAL. Consensus-neutral fix.**

Removes shared mutable per-batch state from the process-wide `g_signature_verifier`; each call now owns a `CBatchSession` (Bitcoin Core `CCheckQueueControl` port), so concurrent RPC/REST + P2P validations can't clobber each other. Fixes: non-deterministic invalid-signature acceptance, `size_t`-underflow validator-thread hang (DoS), batch-vs-sequential divergence, and the MED-2 lost-wakeup. Worker-pool parallelism preserved.

**Reviews done (all clean):**
- red-team-validator (impl): SOUND — no consensus/UAF/wrong-verdict/lost-wakeup defect.
- port-reviewer: PASS — preserves Bitcoin Core CCheckQueueControl invariants (stronger per-session isolation than upstream).
- round-2 convergence re-review: CLEAN — folds introduce no defect.
- Harness: 3200/3200 batches pass; pre-fix control **hangs** (differential proof the test is real, A-010).

**Remaining gates before merge/tag (NOT ready — DRAFT):**
- [ ] external_consensus-4-seat
- [ ] ThreadSanitizer run on NYC Linux seed (TSan unsupported on MSYS2)
- [ ] Cursor close-readiness (Will)
- [ ] Zach consensus co-sign
- [ ] /evaluate before tag; deploy = expedited v4.4.6 rolling restart (Will consent)

Contract: \`.claude/missions/batch-verifier-race/contract.md\`. Grill + reviews in the mission dir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)