### PR TITLE
fix(wallet): LP-7 HD seed plaintext at rest — encrypt seed/mnemonic, authenticated v7 format + atomic migration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -541,6 +541,12 @@ wallet_persistence_tests: $(CORE_OBJECTS) $(OBJ_DIR)/test/wallet_persistence_tes
 	@echo "$(COLOR_BLUE)[LINK]$(COLOR_RESET) $@"
 	@$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LIBS)
 
+# LP-7: wallet encryption-at-rest fix tests (secrecy regression + negative control,
+# migration round-trip + interrupted migration, auth-tamper rejection).
+wallet_encryption_at_rest_tests: $(CORE_OBJECTS) $(OBJ_DIR)/test/wallet_encryption_at_rest_tests.o $(DILITHIUM_OBJECTS) $(CHIAVDF_OBJECTS)
+	@echo "$(COLOR_BLUE)[LINK]$(COLOR_RESET) $@"
+	@$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LIBS)
+
 test_iv_reuse_detection: $(CORE_OBJECTS) $(OBJ_DIR)/test/test_iv_reuse_detection.o $(DILITHIUM_OBJECTS) $(CHIAVDF_OBJECTS)
 	@echo "$(COLOR_BLUE)[LINK]$(COLOR_RESET) $@"
 	@$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LIBS)

--- a/src/api/wallet_html.h
+++ b/src/api/wallet_html.h
@@ -1787,7 +1787,16 @@ inline const std::string& GetWalletHTML() {
 
                 <!-- Encrypted -->
                 <div id="nodeWalletEncrypted" style="display: none;">
-                    <div style="display: flex; align-items: center; gap: 8px; margin-bottom: 16px; padding: 12px; background: rgba(34, 197, 94, 0.1); border-radius: 8px;">
+                    <!-- LP-7 (Cursor M2): armed state — seed still plaintext-at-rest despite "encrypted".
+                         Mirrors the dashboard migration banner so this card cannot falsely reassure. -->
+                    <div id="nodeWalletNeedsMigration" style="display: none; align-items: center; gap: 8px; margin-bottom: 16px; padding: 12px; background: rgba(239, 68, 68, 0.1); border-radius: 8px;">
+                        <span style="font-size: 1.2rem;">⚠️</span>
+                        <div>
+                            <div style="font-weight: 600; color: var(--error);">Security Upgrade Required</div>
+                            <div style="font-size: 0.8rem; color: var(--text-muted);">Your wallet is encrypted, but the seed is still stored unencrypted at rest (fixed bug LP-7). Unlock once to complete a one-time security upgrade.</div>
+                        </div>
+                    </div>
+                    <div id="nodeWalletEncryptedOk" style="display: flex; align-items: center; gap: 8px; margin-bottom: 16px; padding: 12px; background: rgba(34, 197, 94, 0.1); border-radius: 8px;">
                         <span style="font-size: 1.2rem;">✅</span>
                         <div>
                             <div style="font-weight: 600; color: var(--success);">Wallet Encrypted</div>
@@ -5532,12 +5541,23 @@ inline const std::string& GetWalletHTML() {
 
                 // Handle both boolean and string responses
                 const isEncrypted = walletInfo.encrypted === true || walletInfo.encrypted === 'true';
-                console.log('[Wallet] isEncrypted:', isEncrypted);
+                // LP-7 (Cursor M2): "encrypted" alone is not "safe" — the seed can still
+                // be plaintext-at-rest (armed for migration). Mirror the dashboard banner
+                // so this card reflects the armed state instead of falsely reassuring.
+                const needsMigration = walletInfo.needs_seed_migration === true || walletInfo.needs_seed_migration === 'true';
+                console.log('[Wallet] isEncrypted:', isEncrypted, 'needsMigration:', needsMigration);
 
                 document.getElementById('nodeWalletNotEncrypted').style.display = isEncrypted ? 'none' : 'block';
                 document.getElementById('nodeWalletEncrypted').style.display = isEncrypted ? 'block' : 'none';
 
                 if (isEncrypted) {
+                    // Gate the green "Wallet Encrypted" confirmation on !needsMigration;
+                    // show the armed-state warning instead while migration is pending.
+                    const okRow = document.getElementById('nodeWalletEncryptedOk');
+                    const migrationRow = document.getElementById('nodeWalletNeedsMigration');
+                    if (okRow) okRow.style.display = needsMigration ? 'none' : 'flex';
+                    if (migrationRow) migrationRow.style.display = needsMigration ? 'flex' : 'none';
+
                     const lockStatus = document.getElementById('nodeWalletLockStatus');
                     const isUnlocked = walletInfo.unlocked_until > 0 || walletInfo.locked === false;
                     lockStatus.textContent = isUnlocked ? 'Unlocked' : 'Locked';

--- a/src/api/wallet_html.h
+++ b/src/api/wallet_html.h
@@ -1217,6 +1217,35 @@ inline const std::string& GetWalletHTML() {
                 </div>
             </div>
 
+            <!-- LP-7 (force-migrate): persistent banner shown when the wallet is
+                 encrypted but its HD seed is still stored UNENCRYPTED at rest
+                 (pre-fix bug). Drives the one-time unlock that re-encrypts the seed.
+                 Reuses the standard walletpassphrase unlock flow. -->
+            <div id="seedMigrationBanner" style="display: none; background: rgba(255,68,68,0.10); border: 1px solid rgba(255,68,68,0.55); border-radius: 10px; padding: 20px; margin-bottom: 16px;">
+                <div style="display: flex; align-items: flex-start; gap: 12px;">
+                    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#ff4444" stroke-width="2" style="flex-shrink: 0; margin-top: 2px;">
+                        <path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"></path>
+                        <line x1="12" y1="9" x2="12" y2="13"></line>
+                        <line x1="12" y1="17" x2="12.01" y2="17"></line>
+                    </svg>
+                    <div style="flex: 1;">
+                        <div style="font-weight: 700; color: #ff4444; margin-bottom: 6px;">Security upgrade required</div>
+                        <div style="font-size: 0.88rem; color: var(--text-muted); margin-bottom: 12px;">
+                            This wallet is encrypted, but your recovery seed is still stored <strong>unencrypted on disk</strong>
+                            because it was created by an older version (bug LP-7). Unlock once to complete a one-time security
+                            upgrade that encrypts the seed at rest. Your funds are safe to keep using in the meantime.
+                        </div>
+                        <div style="display: flex; gap: 12px; align-items: flex-end;">
+                            <div style="flex: 1; max-width: 320px;">
+                                <label class="form-label" style="font-size: 0.85rem;">Wallet password</label>
+                                <input type="password" id="seedMigrationPassword" class="form-input" placeholder="Enter wallet password">
+                            </div>
+                            <button class="btn btn-primary" onclick="migrateSeedFromBanner()">Unlock &amp; upgrade</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
             <!-- Node Wallet Security Card (Dashboard) -->
             <div class="card" id="dashboardWalletSecurity" style="margin-bottom: 16px; display: none;">
                 <div class="card-title">
@@ -5597,23 +5626,31 @@ inline const std::string& GetWalletHTML() {
             const mode = connectionManager ? connectionManager.getMode() : 'full';
             const warningBanner = document.getElementById('encryptionWarningBanner');
             const okBanner = document.getElementById('encryptionOkBanner');
+            const migrationBanner = document.getElementById('seedMigrationBanner');
 
             // Only show in full node mode when connected
             if (mode !== 'full' || !connected) {
                 warningBanner.style.display = 'none';
                 okBanner.style.display = 'none';
+                if (migrationBanner) migrationBanner.style.display = 'none';
                 return;
             }
 
             try {
                 const walletInfo = await rpcCall('getwalletinfo');
                 const isEncrypted = walletInfo.encrypted === true || walletInfo.encrypted === 'true';
+                // LP-7 (force-migrate): seed plaintext-at-rest despite "encrypted".
+                const needsMigration = walletInfo.needs_seed_migration === true || walletInfo.needs_seed_migration === 'true';
+
+                // The migration banner takes priority: while it is up, do NOT present
+                // the wallet as safely-encrypted (suppress the green OK banner).
+                if (migrationBanner) migrationBanner.style.display = needsMigration ? 'block' : 'none';
 
                 warningBanner.style.display = isEncrypted ? 'none' : 'block';
-                okBanner.style.display = isEncrypted ? 'block' : 'none';
+                okBanner.style.display = (isEncrypted && !needsMigration) ? 'block' : 'none';
 
                 // Auto-hide the "encrypted OK" banner after 10 seconds (not a permanent fixture)
-                if (isEncrypted) {
+                if (isEncrypted && !needsMigration) {
                     setTimeout(() => {
                         okBanner.style.display = 'none';
                     }, 10000);
@@ -5622,6 +5659,40 @@ inline const std::string& GetWalletHTML() {
                 // If we can't check, hide both banners
                 warningBanner.style.display = 'none';
                 okBanner.style.display = 'none';
+                if (migrationBanner) migrationBanner.style.display = 'none';
+            }
+        }
+
+        // LP-7 (force-migrate): unlock from the seed-migration banner. The unlock
+        // triggers the one-time v7 seed re-encryption on the node side; we then
+        // re-poll so the banner clears once needs_seed_migration flips false.
+        async function migrateSeedFromBanner() {
+            const pwEl = document.getElementById('seedMigrationPassword');
+            const password = pwEl ? pwEl.value : '';
+
+            if (!password) {
+                showNotification('Please enter your wallet password', 'error');
+                return;
+            }
+
+            try {
+                showNotification('Unlocking and upgrading wallet security...', 'info');
+                // Standard unlock flow — the node re-encrypts the seed at rest on unlock.
+                await rpcCall('walletpassphrase', {passphrase: password, timeout: 60});
+                if (pwEl) pwEl.value = '';
+
+                // Re-poll: the node clears needs_seed_migration after the upgrade.
+                const walletInfo = await rpcCall('getwalletinfo');
+                const stillNeeds = walletInfo.needs_seed_migration === true || walletInfo.needs_seed_migration === 'true';
+                if (stillNeeds) {
+                    showNotification('Unlocked, but the security upgrade did not complete. It will retry on the next unlock.', 'error');
+                } else {
+                    showNotification('Security upgrade complete. Your seed is now encrypted at rest.', 'success');
+                }
+                await updateDashboardEncryptionBanner();
+                await checkNodeWalletEncryption();
+            } catch (e) {
+                showNotification('Failed to unlock: ' + e.message, 'error');
             }
         }
 

--- a/src/node/dilithion-node.cpp
+++ b/src/node/dilithion-node.cpp
@@ -565,6 +565,10 @@ struct NodeConfig {
     bool upnp_prompted = false;     // True if user was already prompted or used explicit flag
     std::string external_ip = "";   // --externalip: Manual external IP (for manual port forwarding)
     bool public_api = false;        // --public-api: Enable public REST API for light wallets (seed nodes only)
+    bool require_seed_migration = false;  // LP-7 L1 (opt-in): when set, refuse mining/spending while the
+                                          // wallet's HD seed is still plaintext-at-rest (NeedsSeedMigration()).
+                                          // DEFAULT OFF preserves warn-only behavior (operator is surfaced but
+                                          // not blocked); SET requires unlocking once to migrate before mining.
     int max_connections = 0;         // --maxconnections: Maximum peer connections (0 = default 125)
     int max_connections_per_ip = 2;  // --max-connections-per-ip: Max inbound per IP (default 2, range 1-64)
     int attestation_rate_limit = 1;  // --attestation-rate-limit: Max attestations per /24 subnet per day
@@ -759,6 +763,11 @@ struct NodeConfig {
                 // Public REST API: bind to 0.0.0.0 for light wallet access (seed nodes only)
                 public_api = true;
             }
+            else if (arg == "--require-seed-migration") {
+                // LP-7 L1 (opt-in, default OFF): refuse mining/spending while the HD
+                // seed is still plaintext-at-rest. Default behavior is warn-only.
+                require_seed_migration = true;
+            }
             else if (arg.find("--rpcallowhost=") == 0) {
                 // wallet-rpc-login-restore: add an allowed Host header to the
                 // anti-DNS-rebinding allowlist. Repeatable. Loopback
@@ -885,6 +894,10 @@ struct NodeConfig {
         std::cout << "                          Add --yes to skip the confirmation prompt." << std::endl;
         std::cout << "  --relay-only          Relay-only mode: skip wallet (for seed nodes)" << std::endl;
         std::cout << "  --public-api          Enable public REST API for light wallets (seed nodes)" << std::endl;
+        std::cout << "  --require-seed-migration  Refuse to mine/spend while the wallet's HD seed is" << std::endl;
+        std::cout << "                          still stored UNENCRYPTED at rest (fixed bug LP-7)." << std::endl;
+        std::cout << "                          Default is warn-only; this opt-in flag hard-gates the" << std::endl;
+        std::cout << "                          node until you unlock once to complete the upgrade." << std::endl;
         std::cout << "  --rpcallowhost=<host> Allow this Host header on the RPC/HTTP server" << std::endl;
         std::cout << "                          (anti-DNS-rebinding allowlist; repeatable)." << std::endl;
         std::cout << "                          Loopback (127.0.0.1/::1/localhost) is always" << std::endl;
@@ -5077,6 +5090,9 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
         // BUG #56 FIX: Full wallet persistence with Bitcoin Core pattern
         CWallet wallet;
         g_node_state.wallet = &wallet;
+        // LP-7 L1 (opt-in, default OFF): when --require-seed-migration is set, the
+        // wallet refuses to sign spends while the HD seed is still plaintext-at-rest.
+        wallet.SetRequireSeedMigration(config.require_seed_migration);
         // Phase 1.5: also wire the wallet into NodeContext so BroadcastDNASample
         // can find the MIK private key for signing. Without this, signed-DNA
         // broadcasts are silently skipped and Phase 1.5 has no effect on the wire.
@@ -5684,6 +5700,25 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                 config.start_mining = false;
                 g_node_state.mining_enabled = false;
             }
+        }
+
+        // LP-7 L1 (opt-in --require-seed-migration, default OFF): when the operator
+        // has opted in, REFUSE to mine while the HD seed is still plaintext-at-rest.
+        // (Unlocking above normally drives the one-time v7 migration and clears this;
+        // we still gate here for the case it did not complete — e.g. unlock failed, or
+        // migration could not persist.) Default OFF preserves the warn-only behavior:
+        // the operator is surfaced the state but not blocked.
+        if (config.require_seed_migration && config.start_mining && wallet.NeedsSeedMigration()) {
+            std::cerr << std::endl;
+            std::cerr << "  ERROR (--require-seed-migration): wallet HD seed is still stored" << std::endl;
+            std::cerr << "  UNENCRYPTED at rest (fixed bug LP-7). Refusing to mine." << std::endl;
+            std::cerr << "  Unlock the wallet ONCE to complete the one-time security upgrade:" << std::endl;
+            std::cerr << "    walletpassphrase <password> <timeout>" << std::endl;
+            std::cerr << "  Then restart with --mine. (Omit --require-seed-migration to run" << std::endl;
+            std::cerr << "  in warn-only mode.)" << std::endl;
+            std::cerr << std::endl;
+            config.start_mining = false;
+            g_node_state.mining_enabled = false;
         }
 
         }  // end else (!relay_only)

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -4333,12 +4333,20 @@ std::string CRPCServer::RPC_GetWalletInfo(const std::string& params) {
 
     bool isEncrypted = m_wallet->IsCrypted();
     bool isLocked = isEncrypted && m_wallet->IsLocked();
+    // LP-7 (force-migrate / round-3 SURVIVING-LEAK): surface the plaintext-seed-at-
+    // rest state so UI + operators + tests can drive the one-time unlock-and-migrate.
+    // True exactly when the wallet is encrypted but the HD seed is still stored in
+    // plaintext on disk (pre-fix bug) and has not yet been migrated. While true the
+    // wallet must NOT be presented as safely-encrypted.
+    bool needsSeedMigration = m_wallet->NeedsSeedMigration();
 
     std::ostringstream oss;
     oss << "{"
         << "\"encrypted\":" << (isEncrypted ? "true" : "false") << ","
         << "\"locked\":" << (isLocked ? "true" : "false") << ","
-        << "\"unlocked_until\":" << (isLocked ? 0 : 1)  // 0 if locked, 1 if unlocked
+        << "\"unlocked_until\":" << (isLocked ? 0 : 1) << ","  // 0 if locked, 1 if unlocked
+        << "\"needs_seed_migration\":" << (needsSeedMigration ? "true" : "false") << ","
+        << "\"seed_unencrypted_at_rest\":" << (needsSeedMigration ? "true" : "false")
         << "}";
 
     return oss.str();

--- a/src/test/wallet_encryption_at_rest_tests.cpp
+++ b/src/test/wallet_encryption_at_rest_tests.cpp
@@ -1818,6 +1818,166 @@ static void Test_ChangePassphraseLegacyV6WithMIK() {
     std::remove(path.c_str());
 }
 
+// ---------------------------------------------------------------------------
+// Test 9 — Cursor HIGH-2: EncryptWallet is transactional + the v7 plaintext-seed
+//          SaveUnlocked branch is fail-closed for an encrypted wallet.
+//
+// THE BUG (Cursor NO-GO): EncryptWallet clears mapKeys + sets the master key, then
+// on any HD-step failure (mnemonic recover / re-encrypt / EncryptHDMasterKey)
+// returned false WITHOUT rollback — leaving the wallet encrypted-in-memory
+// (masterKey valid) with fHDMasterKeyEncrypted==false and a PLAINTEXT seed. A new
+// HD wallet (m_loadedFileVersion==0 ⇒ writes v7) in that state, on the next
+// autosave, persisted a v7 file with encrypted spending keys + PLAINTEXT seed =
+// the LP-7 plaintext-at-rest bug reintroduced, with no migration arm on reload.
+//
+// This test pins BOTH halves of the fold:
+//   PART A (rollback): force an EncryptWallet mid-HD-step failure by corrupting
+//     vchEncryptedMnemonic so the mnemonic-recover Decrypt fails, then assert
+//     (a) EncryptWallet returns false, (b) the wallet rolled back to UNENCRYPTED
+//     (IsCrypted()==false, fHDMasterKeyEncrypted==false), and (c) the in-memory
+//     plaintext seed is intact (not scrubbed) — i.e. the wallet is exactly as it
+//     was before the failed attempt and can be retried.
+//   PART B (fail-closed guard): force the otherwise-unreachable encrypted-in-memory
+//     + plaintext-seed window directly, then drive SaveUnlocked and assert it
+//     REFUSES (no v7 plaintext-seed file for an encrypted wallet ever reaches disk).
+//
+// On the UNFIXED branch (b5a71676): PART A's rollback asserts FAIL (the wallet is
+// left encrypted with a plaintext seed) and PART B's Save SUCCEEDS writing a v7
+// file that contains the plaintext seed. On the fixed branch both PARTs pass.
+// ---------------------------------------------------------------------------
+struct LP7EncryptRollbackTester {
+    // Corrupt the encrypted-mnemonic ciphertext so EncryptWallet's mnemonic-recover
+    // Decrypt fails deterministically: appending one byte makes the length not a
+    // multiple of the AES block size, which DecryptAES256 rejects up front.
+    static bool CorruptMnemonicCiphertext(CWallet& w) {
+        if (w.vchEncryptedMnemonic.empty()) return false;
+        w.vchEncryptedMnemonic.push_back(0x00);  // length now %16 != 0 → Decrypt fails
+        return true;
+    }
+
+    // Force the encrypted-in-memory + plaintext-seed window that EncryptWallet used
+    // to leave behind on a failed HD step. Mirrors that exact partial state: a valid
+    // master key (so IsCrypted()==true) but fHDMasterKeyEncrypted==false with the
+    // plaintext seed still in the fixed slots, at v7 (a freshly generated HD wallet).
+    static bool ForceEncryptedPlaintextSeedWindow(CWallet& w) {
+        if (!w.fIsHDWallet) return false;
+        // Fabricate a structurally-valid master key so masterKey.IsValid() is true
+        // WITHOUT going through EncryptWallet (which we are deliberately bypassing).
+        w.masterKey.vchCryptedKey.assign(48, 0x11);
+        w.masterKey.vchSalt.assign(WALLET_CRYPTO_SALT_SIZE, 0x22);
+        w.masterKey.vchIV.assign(WALLET_CRYPTO_IV_SIZE, 0x33);
+        w.masterKey.vchMAC.assign(64, 0x44);
+        if (!w.masterKey.IsValid()) return false;
+        // The HD seed is STILL plaintext (not encrypted) — the bug state.
+        w.fHDMasterKeyEncrypted = false;
+        // A freshly generated wallet writes v7 (m_loadedFileVersion == 0). Pin it.
+        w.m_loadedFileVersion = WALLET_FILE_VERSION_7;
+        return true;
+    }
+
+    static bool ForceSave(CWallet& w, const std::string& path) { return w.SaveUnlocked(path); }
+    static bool IsHDEncrypted(const CWallet& w) { return w.fHDMasterKeyEncrypted; }
+    static bool SeedMatches(const CWallet& w, const std::vector<uint8_t>& seed) {
+        return seed.size() == 32 && std::memcmp(w.hdMasterKey.seed, seed.data(), 32) == 0;
+    }
+};
+
+static void Test_EncryptWalletRollback() {
+    std::cout << COLOR_BLUE "\n[Test 9] EncryptWallet transactional rollback + v7 plaintext-seed Save fail-closed (Cursor HIGH-1/HIGH-2)\n" COLOR_RESET;
+
+    const std::string pass = "R0llb@ck!Test#2026";
+
+    // === PART A: forced mid-HD-step failure rolls back to UNENCRYPTED ===
+    {
+        const std::string path = "lp7_rollback_wallet.dat";
+        std::remove(path.c_str());
+
+        std::string mnemonic;
+        CWallet w;
+        w.SetWalletFile(path);            // autosave on → a fresh v7 unencrypted wallet
+        CHECK(w.GenerateHDWallet(mnemonic), "Generated HD wallet (unencrypted v7)");
+
+        std::vector<uint8_t> seed, chaincode;
+        CHECK(DeriveSeedChaincode(mnemonic, seed, chaincode), "Derived expected seed from mnemonic");
+
+        // Corrupt the encrypted mnemonic so the mnemonic-recover step inside
+        // EncryptWallet fails AFTER the master key + key maps have been set up.
+        CHECK(LP7EncryptRollbackTester::CorruptMnemonicCiphertext(w),
+              "Corrupted vchEncryptedMnemonic (forces mnemonic-recover Decrypt to fail mid-encrypt)");
+
+        bool encrypted = w.EncryptWallet(pass);
+        CHECK(!encrypted, "LOAD-BEARING (a): EncryptWallet RETURNS FALSE on the mid-HD-step failure");
+
+        // Rollback invariants: the wallet must be back to its original UNENCRYPTED state.
+        CHECK(!w.IsCrypted(),
+              "LOAD-BEARING (b): wallet rolled back to UNENCRYPTED (IsCrypted()==false, master key cleared)");
+        CHECK(!LP7EncryptRollbackTester::IsHDEncrypted(w),
+              "LOAD-BEARING (b): fHDMasterKeyEncrypted==false after rollback");
+        CHECK(LP7EncryptRollbackTester::SeedMatches(w, seed),
+              "LOAD-BEARING (b): in-memory plaintext seed intact after rollback (not scrubbed)");
+
+        // A subsequent Save now writes a LEGITIMATE unencrypted wallet (the rollback
+        // returned it to unencrypted), so a plaintext seed on disk here is correct —
+        // and crucially the file must NOT be an encrypted wallet carrying a plaintext
+        // seed. Assert the file is unencrypted (flags bit 0 clear).
+        CHECK(w.Save(path), "Saved the rolled-back wallet");
+        {
+            std::vector<uint8_t> bytes = ReadFileBytes(path);
+            CHECK(bytes.size() >= 16, "Read the saved wallet file");
+            uint32_t flags = GetU32(bytes, 12);
+            CHECK((flags & 0x01) == 0,
+                  "LOAD-BEARING (c): saved file is UNENCRYPTED (no encrypted-wallet+plaintext-seed file produced)");
+            // The seed IS present, which is correct for an unencrypted wallet (matches
+            // Test 1's negative control). This is NOT the bug: the bug is an ENCRYPTED
+            // file with a plaintext seed, excluded by the flag assertion above.
+            CHECK(Contains(bytes, seed.data(), seed.size()),
+                  "Unencrypted rolled-back wallet legitimately stores the seed (negative-control consistency)");
+        }
+        std::remove(path.c_str());
+    }
+
+    // === PART B: SaveUnlocked is fail-closed for an encrypted wallet with a
+    //             plaintext seed (the v7 plaintext-branch guard) ===
+    {
+        const std::string path    = "lp7_rollback_src.dat";
+        const std::string savePath = "lp7_rollback_guard.dat";
+        std::remove(path.c_str());
+        std::remove(savePath.c_str());
+
+        std::string mnemonic;
+        CWallet w;                         // no SetWalletFile → autosave off
+        CHECK(w.GenerateHDWallet(mnemonic), "Generated HD wallet for guard test");
+        std::vector<uint8_t> seed, chaincode;
+        CHECK(DeriveSeedChaincode(mnemonic, seed, chaincode), "Derived expected seed");
+
+        // Force the exact bug window: encrypted-in-memory (master key valid) + the HD
+        // seed still PLAINTEXT, at v7. This is what a pre-fix failed EncryptWallet (or
+        // a future refactor) could leave behind.
+        CHECK(LP7EncryptRollbackTester::ForceEncryptedPlaintextSeedWindow(w),
+              "Entered encrypted-in-memory + plaintext-seed v7 window (IsCrypted && !fHDMasterKeyEncrypted)");
+        CHECK(w.IsCrypted() && !LP7EncryptRollbackTester::IsHDEncrypted(w),
+              "Window invariant holds: master key valid AND HD seed not encrypted");
+
+        // Drive the writer the public Save() reaches. With the v7 plaintext-branch
+        // guard this MUST refuse. Without it, a v7 file with the plaintext seed is
+        // written for an encrypted wallet (the LP-7 exposure).
+        bool saved = LP7EncryptRollbackTester::ForceSave(w, savePath);
+        CHECK(!saved,
+              "LOAD-BEARING: SaveUnlocked REFUSES to write a v7 plaintext seed for an encrypted wallet");
+
+        std::vector<uint8_t> savedBytes = ReadFileBytes(savePath);
+        CHECK(savedBytes.empty(),
+              "FAIL-CLOSED: no file written at the destination (no v7 encrypted+plaintext-seed artifact)");
+        if (!savedBytes.empty()) {
+            CHECK(!Contains(savedBytes, seed.data(), seed.size()),
+                  "FAIL-CLOSED: no plaintext seed persisted for the encrypted wallet");
+        }
+
+        std::remove(path.c_str());
+        std::remove(savePath.c_str());
+    }
+}
+
 int main() {
     std::cout << COLOR_BLUE "==== LP-7 wallet encryption-at-rest tests ====" COLOR_RESET "\n";
 
@@ -1830,6 +1990,7 @@ int main() {
     Test_LegacyPerAddressKey();
     Test_ChangePassphraseLegacyNonHD();
     Test_ChangePassphraseLegacyV6WithMIK();
+    Test_EncryptWalletRollback();
 
     std::cout << "\n=============================================\n";
     std::cout << "PASSED: " << g_pass << "   FAILED: " << g_fail << "\n";

--- a/src/test/wallet_encryption_at_rest_tests.cpp
+++ b/src/test/wallet_encryption_at_rest_tests.cpp
@@ -1280,6 +1280,104 @@ static void Test_LegacyPerAddressKey() {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Test 7 — MEDIUM-1 (round 3): ChangePassphrase on a LOADED legacy v3-v6 (non-HD)
+// encrypted wallet must SUCCEED with the correct old passphrase.
+//
+// A non-HD legacy v6 wallet never sets the seed-migration flag, so its master MAC
+// stays legacy-AES-keyed and m_loadedFileVersion stays 6. Before the fix,
+// ChangePassphrase open-coded crypter.VerifyMAC with the default (separated, v7)
+// keying → the legacy-keyed master MAC mismatched → ChangePassphrase returned false
+// for the CORRECT passphrase, permanently bricking passphrase rotation for this
+// population. After routing the verify through VerifyRecordMAC, the keying matches
+// the loaded file version and the change succeeds; the rewrite is always v7 with
+// correct (separated-keyed) MACs, so the wallet re-loads and remains spendable under
+// the NEW passphrase.
+// ---------------------------------------------------------------------------
+static void Test_ChangePassphraseLegacyNonHD() {
+    std::cout << COLOR_BLUE "\n[Test 7] ChangePassphrase on loaded legacy v6 non-HD wallet (MEDIUM-1)\n" COLOR_RESET;
+
+    const std::string path = "lp7_legacy_changepass_nonhd.dat";
+    const std::string oldPass = "Leg@cyOldP@ss!2026#";
+    const std::string newPass = "N3w$tr0ngP@ss!2026#";
+    std::remove(path.c_str());
+
+    LegacyV6NonHDResult nh;
+    bool built = BuildLegacyV6NonHDWalletWithKey(path, oldPass, nh);
+    CHECK(built, "Built legacy v6 NON-HD wallet (legacy-keyed master MAC, never migrates)");
+    if (!built) { std::remove(path.c_str()); return; }
+    CHECK(FileVersion(path) == WALLET_FILE_VERSION_6, "Legacy file is v6 before change");
+
+    // Change passphrase on the freshly-loaded legacy wallet. walletpassphrasechange
+    // does NOT require a prior unlock, so call ChangePassphrase directly on a loaded
+    // (but not unlocked) wallet — exactly the RPC's reachable path. Autosave ON so the
+    // successful change persists the v7 rewrite to disk.
+    {
+        CWallet w;
+        w.SetWalletFile(path);  // autosave on → the change rewrites the file
+        CHECK(w.Load(path), "Loaded legacy v6 non-HD wallet");
+        CHECK(FileVersion(path) == WALLET_FILE_VERSION_6,
+              "Still v6 immediately after load (no migration on non-HD load)");
+
+        bool changed = w.ChangePassphrase(oldPass, newPass);
+        CHECK(changed,
+              "LOAD-BEARING (MEDIUM-1): ChangePassphrase SUCCEEDS with the CORRECT old "
+              "passphrase on a legacy v6 wallet (was permanently false before the fix)");
+
+        // Negative control: a WRONG old passphrase must still be rejected (the verify
+        // must reject, not blindly accept) — guards against a fix that over-permits.
+        // Reload fresh so the wallet is back to a known (now-v7, newPass) state first.
+    }
+
+    // The successful change must have re-saved the wallet at v7 with correct MACs.
+    CHECK(FileVersion(path) == WALLET_FILE_VERSION_7,
+          "LOAD-BEARING: wallet re-saved at v7 after passphrase change");
+
+    // Reload the re-saved v7 wallet and confirm it unlocks with the NEW passphrase and
+    // the per-address key is still spendable → proves the v7 rewrite carries correct
+    // (separated-keyed) record MACs end-to-end.
+    {
+        CWallet w;
+        w.SetWalletFile(path);
+        CHECK(w.Load(path), "Reloaded the re-saved v7 wallet");
+        CHECK(FileVersion(path) == WALLET_FILE_VERSION_7, "Reloaded file is v7");
+        // NOTE: do NOT probe Unlock(oldPass) here — a failed unlock arms the wallet's
+        // unlock rate-limiter and would throttle the NEW-passphrase unlock below. The
+        // old-passphrase-no-longer-works property is implied by the successful v7
+        // re-save under the new passphrase; wrong-passphrase rejection is covered by
+        // the dedicated negative-control block at the end of this test.
+        CHECK(w.Unlock(newPass), "NEW passphrase unlocks the re-saved v7 wallet");
+
+        CKey recovered;
+        bool got = w.GetKey(nh.perAddr, recovered);
+        CHECK(got, "Per-address key readable from the re-saved v7 wallet");
+        CHECK(got && std::vector<uint8_t>(recovered.vchPrivKey.begin(), recovered.vchPrivKey.end())
+                  == nh.perAddrPriv,
+              "LOAD-BEARING: per-address key SPENDABLE after passphrase change (correct v7 MACs)");
+    }
+
+    // Negative control on a fresh load: a WRONG old passphrase must be rejected.
+    {
+        const std::string npath = "lp7_legacy_changepass_nonhd_neg.dat";
+        std::remove(npath.c_str());
+        LegacyV6NonHDResult nh2;
+        bool b2 = BuildLegacyV6NonHDWalletWithKey(npath, oldPass, nh2);
+        CHECK(b2, "Built second legacy v6 non-HD wallet (negative control)");
+        if (b2) {
+            CWallet w;
+            w.SetWalletFile(npath);
+            CHECK(w.Load(npath), "Loaded negative-control legacy wallet");
+            CHECK(!w.ChangePassphrase("Wr0ngOldP@ss!2026#", newPass),
+                  "NEGATIVE CONTROL: ChangePassphrase REJECTS a wrong old passphrase");
+            CHECK(FileVersion(npath) == WALLET_FILE_VERSION_6,
+                  "NEGATIVE CONTROL: file left untouched at v6 after a rejected change");
+        }
+        std::remove(npath.c_str());
+    }
+
+    std::remove(path.c_str());
+}
+
 int main() {
     std::cout << COLOR_BLUE "==== LP-7 wallet encryption-at-rest tests ====" COLOR_RESET "\n";
 
@@ -1289,6 +1387,7 @@ int main() {
     Test_PerRecordMACIsolation();
     Test_AtomicRenameCrashWindow();
     Test_LegacyPerAddressKey();
+    Test_ChangePassphraseLegacyNonHD();
 
     std::cout << "\n=============================================\n";
     std::cout << "PASSED: " << g_pass << "   FAILED: " << g_fail << "\n";

--- a/src/test/wallet_encryption_at_rest_tests.cpp
+++ b/src/test/wallet_encryption_at_rest_tests.cpp
@@ -136,6 +136,113 @@ static std::vector<uint8_t> out_default_or(const std::vector<uint8_t>& a) {
     return r;
 }
 
+// Read a little-endian uint32 at an absolute byte offset.
+static uint32_t GetU32(const std::vector<uint8_t>& b, size_t off) {
+    uint32_t x = 0;
+    if (off + 4 <= b.size()) std::memcpy(&x, b.data() + off, 4);
+    return x;
+}
+static void SetU32(std::vector<uint8_t>& b, size_t off, uint32_t x) {
+    if (off + 4 <= b.size()) std::memcpy(b.data() + off, &x, 4);
+}
+
+// ---------------------------------------------------------------------------
+// MEDIUM-1 helper: recompute the OUTER file-integrity HMAC over a (possibly
+// mutated) v7 wallet image so that Load() passes its file-HMAC check and the
+// per-RECORD MAC verification becomes the only remaining authenticity gate.
+//
+// Mirrors CWallet::SaveUnlocked exactly for the encrypted case: the HMAC key is
+// the first 32 bytes of the master-key salt (16 bytes here, zero-padded to 32),
+// and the HMAC covers [file-HMAC salt 32][body...] = everything from offset
+// HEADER_LEN onward. The master-key salt is in-file plaintext, so an attacker
+// who strips a per-record MAC can trivially repair this outer HMAC — which is
+// exactly why the per-record MAC is the real defense and must be enforced.
+//
+// v7 file layout (encrypted):
+//   [0]  magic            8
+//   [8]  version u32      4
+//   [12] flags u32        4
+//   [16] file-HMAC       32   (HEADER_LEN = 48)
+//   [48] file-HMAC salt  32
+//   [80] master-key block: cryptedLen u32 | ct | mkSalt 16 | mkIV 16 |
+//                          derivMethod u32 | iters u32 | macLen u32 | mac
+//   ... (mnemonic, HD-master, keys, ...)
+// ---------------------------------------------------------------------------
+static const size_t LP7_HEADER_LEN  = 48;   // magic+version+flags+HMAC
+static const size_t LP7_MKSALT_OFF  = 80 + 4;  // after [file-salt 32][cryptedLen u32]; +cryptedLen
+
+static bool RecomputeFileHMAC(std::vector<uint8_t>& file) {
+    if (file.size() < LP7_HEADER_LEN + WALLET_FILE_SALT_SIZE) return false;
+    // master-key salt sits at offset 80 + 4 + cryptedKeyLen
+    uint32_t cryptedKeyLen = GetU32(file, 80);
+    size_t mkSaltOff = 80 + 4 + cryptedKeyLen;
+    if (mkSaltOff + WALLET_CRYPTO_SALT_SIZE > file.size()) return false;
+
+    std::vector<uint8_t> hmac_key(32, 0);
+    std::memcpy(hmac_key.data(), file.data() + mkSaltOff,
+                std::min<size_t>(32, WALLET_CRYPTO_SALT_SIZE));
+
+    const uint8_t* body = file.data() + LP7_HEADER_LEN;
+    size_t body_len = file.size() - LP7_HEADER_LEN;
+    std::vector<uint8_t> hmac(WALLET_FILE_HMAC_SIZE);
+    HMAC_SHA3_256(hmac_key.data(), hmac_key.size(), body, body_len, hmac.data());
+    std::memcpy(file.data() + 16, hmac.data(), WALLET_FILE_HMAC_SIZE);
+    return true;
+}
+
+// Strip the MASTER-KEY MAC from a v7 image: locate the macLen field, set it to
+// 0, and drop the trailing MAC bytes. Returns false if the layout doesn't match.
+static bool StripMasterKeyMAC(std::vector<uint8_t>& file) {
+    if (file.size() < 80 + 4) return false;
+    uint32_t cryptedKeyLen = GetU32(file, 80);
+    // macLen field offset: 80 + 4(cryptedLen) + cryptedKeyLen + 16(mkSalt)
+    //                      + 16(mkIV) + 4(derivMethod) + 4(iters)
+    size_t macLenOff = 80 + 4 + cryptedKeyLen + 16 + 16 + 4 + 4;
+    if (macLenOff + 4 > file.size()) return false;
+    uint32_t macLen = GetU32(file, macLenOff);
+    if (macLen == 0 || macLen > 64) return false;            // expect a present MAC
+    if (macLenOff + 4 + macLen > file.size()) return false;
+    // Drop the MAC bytes and zero the length.
+    file.erase(file.begin() + macLenOff + 4,
+               file.begin() + macLenOff + 4 + macLen);
+    SetU32(file, macLenOff, 0);
+    return true;
+}
+
+// Strip a PER-ADDRESS key MAC from a v7 image. The on-disk per-address key
+// record (SaveUnlocked) is:
+//   [addr 21][pubKey 1952][cryptedLen u32][ct][iv 16][macLen u32][mac]
+// We locate the record by its 21-byte address, then walk to the macLen field and
+// drop the 64 MAC bytes. Unlike stripping the master-key MAC, this leaves
+// masterKey.IsValid() TRUE, so Load()'s outer-HMAC key selection (which keys on
+// the master-key salt only for valid master keys) is unchanged — isolating the
+// PER-RECORD MAC verify as the sole remaining gate.
+static bool StripPerAddressKeyMAC(std::vector<uint8_t>& file,
+                                  const std::vector<uint8_t>& addr21) {
+    if (addr21.size() < 21) return false;
+    // Find the address bytes (search past the header/master/HD region).
+    for (size_t i = 0; i + 21 <= file.size(); ++i) {
+        if (std::memcmp(file.data() + i, addr21.data(), 21) != 0) continue;
+        // Candidate record start at i. Layout: [addr 21][pubKey 1952]
+        //   [cryptedLen u32][ct][iv 16][macLen u32][mac]
+        size_t off = i + 21 + DILITHIUM_PUBLICKEY_SIZE;
+        if (off + 4 > file.size()) continue;
+        uint32_t cryptedLen = GetU32(file, off);
+        if (cryptedLen == 0 || cryptedLen > 8192) continue;  // sanity / wrong match
+        size_t macLenOff = off + 4 + cryptedLen + 16;        // after ct + iv16
+        if (macLenOff + 4 > file.size()) continue;
+        uint32_t macLen = GetU32(file, macLenOff);
+        if (macLen != 64) continue;                          // a v7 per-address MAC is 64B
+        if (macLenOff + 4 + macLen > file.size()) continue;
+        // Found it — drop the MAC bytes and zero the length.
+        file.erase(file.begin() + macLenOff + 4,
+                   file.begin() + macLenOff + 4 + macLen);
+        SetU32(file, macLenOff, 0);
+        return true;
+    }
+    return false;
+}
+
 // ---------------------------------------------------------------------------
 // Legacy v6 plaintext-seed encrypted-wallet builder.
 //
@@ -539,12 +646,215 @@ static void Test_AuthTamper() {
     std::remove(path.c_str());
 }
 
+// ---------------------------------------------------------------------------
+// Test 4 — MEDIUM-1: ISOLATING per-record MAC test (HIGH-1 regression guard)
+//
+// The TAMPER A/B tests are satisfied by the OUTER file-HMAC alone — they would
+// pass even if every per-record MAC check were deleted. This test isolates the
+// per-record MAC path: it strips the master-key MAC AND repairs the outer
+// file-HMAC (keyed with the in-file plaintext master-key salt), so Load()'s
+// integrity check passes and the only remaining authenticity gate is the
+// per-record MAC verify. Asserting the wallet refuses to unlock proves the v7
+// empty-MAC rejection on the MASTER KEY is live.
+//
+// This test FAILS without the HIGH-1 fix (a stripped master-key MAC makes
+// IsLegacy() true → MAC verify skipped → root secret decrypts unauthenticated →
+// Unlock succeeds) and PASSES with it (load/verify reject the empty MAC).
+// ---------------------------------------------------------------------------
+static void Test_PerRecordMACIsolation() {
+    std::cout << COLOR_BLUE "\n[Test 4] Per-record MAC isolation (MEDIUM-1 / HIGH-1 guard)\n" COLOR_RESET;
+
+    const std::string path = "lp7_macstrip_wallet.dat";
+    const std::string pass = "M@cStr1p!Test#88";
+    std::remove(path.c_str());
+
+    // Clean v7 encrypted wallet WITH a per-address (non-HD) spending key. We add
+    // the key BEFORE encryption so EncryptWallet migrates it into mapCryptedKeys
+    // with a per-record MAC and writes it to disk — giving us a per-address key
+    // record to isolate. Capture its 21-byte address by diffing GetAddresses.
+    std::string mnemonic;
+    std::vector<uint8_t> importedAddr21;
+    {
+        CWallet w;
+        w.SetWalletFile(path);
+        CHECK(w.GenerateHDWallet(mnemonic), "Generated HD wallet");
+        std::vector<CDilithiumAddress> before = w.GetAddresses();
+        CHECK(w.GenerateNewKey(), "Added a non-HD spending key (pre-encryption)");
+        std::vector<CDilithiumAddress> after = w.GetAddresses();
+        // The new address is the one in `after` not in `before`.
+        for (const auto& a : after) {
+            bool seen = false;
+            for (const auto& b : before) {
+                if (a.GetData() == b.GetData()) { seen = true; break; }
+            }
+            if (!seen) { importedAddr21 = a.GetData(); importedAddr21.resize(21, 0); break; }
+        }
+        CHECK(importedAddr21.size() == 21, "Captured the new spending key's 21-byte address");
+        CHECK(w.EncryptWallet(pass), "Encrypted → v7 (per-address key → mapCryptedKeys + MAC)");
+        CHECK(w.Lock(), "Locked");
+        CHECK(w.Save(path), "Saved v7 wallet");
+    }
+    CHECK(FileVersion(path) == WALLET_FILE_VERSION_7, "Wallet is v7");
+
+    std::vector<uint8_t> clean = ReadFileBytes(path);
+    CHECK(!clean.empty(), "Read v7 wallet bytes");
+
+    // POSITIVE CONTROL: recompute the outer file-HMAC over the UNMODIFIED image.
+    // This proves RecomputeFileHMAC is faithful — so any rejection in the strip
+    // cases below comes from the per-record MAC gate, not a broken outer HMAC.
+    {
+        std::vector<uint8_t> repaired = clean;
+        CHECK(RecomputeFileHMAC(repaired), "POSITIVE CONTROL: recomputed outer file-HMAC");
+        CHECK(repaired == clean,
+              "POSITIVE CONTROL: recomputed HMAC matches the writer's HMAC (helper is faithful)");
+        CHECK(WriteFileBytes(path, repaired), "Wrote HMAC-recomputed (unmodified) wallet");
+        CWallet w;
+        w.SetWalletFile(path);
+        bool loaded = w.Load(path);
+        bool unlocked = loaded && w.Unlock(pass);
+        CHECK(unlocked, "POSITIVE CONTROL: unmodified+rehmac'd wallet still unlocks (no false reject)");
+    }
+
+    // ISOLATING CASE 1 (the load-bearing HIGH-1 guard) — PER-ADDRESS KEY.
+    // Strip the per-address key's MAC, then REPAIR the outer file-HMAC so Load()
+    // passes. Stripping a per-address MAC keeps masterKey.IsValid() TRUE, so
+    // Load's outer-HMAC key is unchanged and the per-record MAC verify is the ONLY
+    // remaining gate. Without the HIGH-1 fix, IsLegacy() becomes true → verify
+    // skipped → the spending key decrypts unauthenticated and unlock SUCCEEDS.
+    // With the fix, load/verify reject the empty MAC. This assertion is the one
+    // that flips between fixed/unfixed.
+    {
+        std::vector<uint8_t> bad = clean;
+        bool stripped = StripPerAddressKeyMAC(bad, importedAddr21);
+        CHECK(stripped, "Stripped PER-ADDRESS key MAC (macLen→0, 64 bytes dropped)");
+        CHECK(RecomputeFileHMAC(bad),
+              "Repaired outer file-HMAC over the stripped image (forgeable: salt is in-file)");
+        CHECK(WriteFileBytes(path, bad), "Wrote per-address stripped-MAC, valid-outer-HMAC wallet");
+
+        CWallet w;
+        w.SetWalletFile(path);
+        bool loaded = w.Load(path);
+        bool unlocked = loaded && w.Unlock(pass);
+        CHECK(!unlocked,
+              "ISOLATING (per-address): v7 spending key with stripped MAC is REJECTED (HIGH-1 closed)");
+    }
+
+    // ISOLATING CASE 2 — MASTER KEY. Strip the master-key MAC and repair the outer
+    // HMAC. The fix rejects a v7 master key with an empty MAC at the load gate
+    // (and at the unlock verify-gate as defense-in-depth). Must not unlock.
+    {
+        std::vector<uint8_t> bad = clean;
+        bool stripped = StripMasterKeyMAC(bad);
+        CHECK(stripped, "Stripped MASTER-KEY MAC (macLen→0, 64 bytes dropped)");
+        CHECK(RecomputeFileHMAC(bad),
+              "Repaired outer file-HMAC over the master-stripped image");
+        CHECK(WriteFileBytes(path, bad), "Wrote master stripped-MAC, valid-outer-HMAC wallet");
+
+        CWallet w;
+        w.SetWalletFile(path);
+        bool loaded = w.Load(path);
+        bool unlocked = loaded && w.Unlock(pass);
+        CHECK(!unlocked,
+              "ISOLATING (master): v7 master key with stripped MAC is REJECTED (HIGH-1 closed)");
+    }
+
+    std::remove(path.c_str());
+}
+
+// ---------------------------------------------------------------------------
+// Test 5 — MEDIUM-2: atomic-rename crash-window invariant (S-002, real windows)
+//
+// The interrupted-migration test in Test 2 disables autosave, so it models
+// "SaveUnlocked was never called" — NOT "SaveUnlocked was interrupted
+// mid-rewrite". SaveUnlocked is temp-write+fsync → atomic rename over the
+// original (the original is never truncated), so the only crash windows are:
+//   (A) crash AFTER temp-write+fsync but BEFORE rename → on disk: original
+//       intact + an orphan ".tmp"; recovery opens the intact OLD wallet.
+//   (B) crash AFTER rename → on disk: the complete NEW wallet, no temp.
+// This test reconstructs each on-disk state from REAL saved images and asserts
+// the wallet is never corrupt/lost (old-or-new, always intact).
+// ---------------------------------------------------------------------------
+static void Test_AtomicRenameCrashWindow() {
+    std::cout << COLOR_BLUE "\n[Test 5] Atomic-rename crash window (MEDIUM-2 / S-002)\n" COLOR_RESET;
+
+    const std::string path = "lp7_atomic_wallet.dat";
+    const std::string pass = "At0mic!Rename#99";
+    std::remove(path.c_str());
+    std::remove((path + ".tmp").c_str());
+
+    // --- Produce a real OLD on-disk image (v7 encrypted wallet, version 1). ---
+    std::string mnemonic;
+    {
+        CWallet w;
+        w.SetWalletFile(path);
+        CHECK(w.GenerateHDWallet(mnemonic), "Generated HD wallet");
+        CHECK(w.EncryptWallet(pass), "Encrypted → v7");
+        CHECK(w.Lock(), "Locked");
+        CHECK(w.Save(path), "Saved OLD image");
+    }
+    std::vector<uint8_t> oldImage = ReadFileBytes(path);
+    CHECK(!oldImage.empty() && FileVersion(path) == WALLET_FILE_VERSION_7, "OLD image is a valid v7 wallet");
+
+    // --- Produce a real NEW on-disk image (re-save: a second valid v7 image). ---
+    // Re-saving the same wallet yields a byte-different but equally-valid image
+    // (fresh random IVs/salt), which stands in for "the rewrite the migration
+    // would have produced". This is the content the rename moves into place.
+    std::vector<uint8_t> newImage;
+    {
+        CWallet w;
+        w.SetWalletFile(path);
+        CHECK(w.Load(path), "Reloaded wallet to produce NEW image");
+        CHECK(w.Unlock(pass), "Unlocked");
+        CHECK(w.Save(path), "Saved NEW image (atomic rewrite)");
+        newImage = ReadFileBytes(path);
+    }
+    CHECK(!newImage.empty() && FileVersion(path) == WALLET_FILE_VERSION_7, "NEW image is a valid v7 wallet");
+    CHECK(oldImage != newImage, "OLD and NEW images differ (fresh IVs/salt — distinguishable)");
+
+    // --- WINDOW A: crash AFTER temp-write+fsync, BEFORE rename. ---
+    // On-disk state: original (OLD) intact + orphan ".tmp" (the unfinished NEW).
+    // The wallet path still holds the OLD image; the orphan temp must NOT prevent
+    // a clean open of the intact OLD wallet (no data loss, no corruption).
+    {
+        CHECK(WriteFileBytes(path, oldImage), "WINDOW A: restored OLD image at the wallet path");
+        CHECK(WriteFileBytes(path + ".tmp", newImage), "WINDOW A: left an orphan .tmp (unfinished rename)");
+        CWallet w;
+        w.SetWalletFile(path);
+        bool loaded = w.Load(path);
+        bool unlocked = loaded && w.Unlock(pass);
+        CHECK(unlocked, "WINDOW A: intact OLD wallet opens despite orphan temp (no loss)");
+        std::string m;
+        CHECK(loaded && w.ExportMnemonic(m) && m == mnemonic,
+              "WINDOW A: OLD wallet's mnemonic is fully recoverable");
+        std::remove((path + ".tmp").c_str());
+    }
+
+    // --- WINDOW B: crash AFTER rename completed. ---
+    // On-disk state: the wallet path holds the complete NEW image, no temp.
+    {
+        CHECK(WriteFileBytes(path, newImage), "WINDOW B: NEW image is in place (rename completed)");
+        CWallet w;
+        w.SetWalletFile(path);
+        bool loaded = w.Load(path);
+        bool unlocked = loaded && w.Unlock(pass);
+        CHECK(unlocked, "WINDOW B: complete NEW wallet opens cleanly");
+        std::string m;
+        CHECK(loaded && w.ExportMnemonic(m) && m == mnemonic,
+              "WINDOW B: NEW wallet's mnemonic is fully recoverable (same seed)");
+    }
+
+    std::remove(path.c_str());
+    std::remove((path + ".tmp").c_str());
+}
+
 int main() {
     std::cout << COLOR_BLUE "==== LP-7 wallet encryption-at-rest tests ====" COLOR_RESET "\n";
 
     Test_Secrecy();
     Test_Migration();
     Test_AuthTamper();
+    Test_PerRecordMACIsolation();
+    Test_AtomicRenameCrashWindow();
 
     std::cout << "\n=============================================\n";
     std::cout << "PASSED: " << g_pass << "   FAILED: " << g_fail << "\n";

--- a/src/test/wallet_encryption_at_rest_tests.cpp
+++ b/src/test/wallet_encryption_at_rest_tests.cpp
@@ -618,6 +618,182 @@ static bool BuildLegacyV6WalletWithPerAddressKey(const std::string& path,
 }
 
 // ---------------------------------------------------------------------------
+// v7-HEADER + PLAINTEXT-SEED builder (Cursor L2 regression scaffold).
+//
+// Reproduces the EXACT on-disk shape a *pre-fix binary that already wrote v7*
+// could have produced: a v7 file ("DILWLT07") whose WALLET is encrypted (master
+// key under a passphrase) but whose HD master SEED is still PLAINTEXT at rest in
+// the v7 plaintext-HD-block slots (encrypted_flag=0, hdEncLen=0). This is the LP-7
+// plaintext-seed-at-rest state with a v7 header — detection is handled at
+// wallet.cpp:2169 (arm migration when isEncrypted && plaintext-seed v7 branch),
+// but until now only the legacy-v6 shape was byte-tested (Test 2c). This builder
+// lets us byte-test the v7-labelled shape end-to-end (load → armed + plaintext at
+// rest → unlock → migrate → no plaintext at rest, flag clear), the same
+// ReadFileBytes/Contains approach as Test 2c.
+//
+// v7 layout differences vs v6 (see Load: wallet.cpp ~2055 mnemonic, ~2099 HD):
+//   - magic "DILWLT07", version 7
+//   - mnemonic block carries a trailing [mnMacLen][mnMAC] (v7 requires non-empty
+//     MAC on an encrypted wallet; Load only checks mnMacLen!=0, migration recovers
+//     the mnemonic via the obfuscation key, so a legacy-keyed MAC blob suffices)
+//   - HD block: [encrypted_flag=0][hdEncLen=0][seed32][chaincode32][depth][fp][ci]
+//     (NOTE the leading hdEncLen=0 u32 — absent in the v6 layout)
+// ---------------------------------------------------------------------------
+static bool BuildV7PlaintextSeedWallet(const std::string& path,
+                                       const std::string& passphrase,
+                                       LegacyV6Result& out) {
+    std::string scratch = path + ".scratch";
+    std::remove(scratch.c_str());
+
+    std::string mnemonic;
+    std::vector<uint8_t> defAddr;
+    {
+        CWallet w;
+        w.SetWalletFile(scratch);
+        if (!w.GenerateHDWallet(mnemonic)) return false;
+        std::vector<CDilithiumAddress> addrs = w.GetAddresses();
+        if (addrs.empty()) return false;
+        CDilithiumAddress def = w.GetNewHDAddress();
+        (void)def;
+        defAddr = w.GetAddresses().front().GetData();
+    }
+    std::remove(scratch.c_str());
+
+    std::vector<uint8_t> seed, chaincode;
+    if (!DeriveSeedChaincode(mnemonic, seed, chaincode)) return false;
+
+    CHDExtendedKey master;
+    {
+        uint8_t bip39seed[64];
+        if (!CMnemonic::ToSeed(mnemonic, "", bip39seed)) return false;
+        DeriveMaster(bip39seed, master);
+        memory_cleanse(bip39seed, 64);
+    }
+
+    // Encrypted master key block. v7 master MAC uses the SEPARATED (default) keying.
+    std::vector<uint8_t> vMasterKeyPlain(WALLET_CRYPTO_KEY_SIZE);
+    if (!GetStrongRandBytes(vMasterKeyPlain.data(), WALLET_CRYPTO_KEY_SIZE)) return false;
+    std::vector<uint8_t> mkSalt;
+    if (!GenerateSalt(mkSalt)) return false;
+    std::vector<uint8_t> derivedKey;
+    if (!DeriveKey(passphrase, mkSalt, WALLET_CRYPTO_PBKDF2_ROUNDS, derivedKey)) return false;
+    std::vector<uint8_t> mkIV;
+    if (!GenerateIV(mkIV)) return false;
+    CCrypter mkCrypter;
+    if (!mkCrypter.SetKey(derivedKey, mkIV)) return false;
+    std::vector<uint8_t> mkCipher;
+    if (!mkCrypter.Encrypt(vMasterKeyPlain, mkCipher)) return false;
+    std::vector<uint8_t> mkMAC;
+    // v7 master record: separated keying (useLegacyKeying=false) so the fixed
+    // binary's v7 Unlock MAC check passes.
+    if (!mkCrypter.ComputeMAC(mkCipher, mkMAC, /*useLegacyKeying=*/false)) return false;
+
+    // Legacy obfuscated mnemonic (key = HKDF(seed,"mnemonic")). The pre-fix binary
+    // never re-encrypted the mnemonic under the master key (the same as v6), so the
+    // obfuscation-keyed ciphertext is faithful. We attach a non-empty MAC because v7
+    // Load requires mnMacLen!=0 on an encrypted wallet (wallet.cpp:2089).
+    std::vector<uint8_t> obfKey(WALLET_CRYPTO_KEY_SIZE);
+    {
+        std::vector<uint8_t> hdSeed(master.seed, master.seed + 32);
+        DeriveEncryptionKey(hdSeed, "mnemonic", obfKey);
+        memory_cleanse(hdSeed.data(), hdSeed.size());
+    }
+    std::vector<uint8_t> mnIV;
+    if (!GenerateIV(mnIV)) return false;
+    CCrypter mnCrypter;
+    if (!mnCrypter.SetKey(obfKey, mnIV)) return false;
+    std::vector<uint8_t> mnemonicBytes(mnemonic.begin(), mnemonic.end());
+    std::vector<uint8_t> mnCipher;
+    if (!mnCrypter.Encrypt(mnemonicBytes, mnCipher)) return false;
+    std::vector<uint8_t> mnMAC;
+    if (!mnCrypter.ComputeMAC(mnCipher, mnMAC, /*useLegacyKeying=*/false)) return false;
+
+    // --- Assemble the body. ---
+    std::vector<uint8_t> hmacSalt(WALLET_FILE_SALT_SIZE);
+    if (!GetStrongRandBytes(hmacSalt.data(), hmacSalt.size())) return false;
+
+    std::vector<uint8_t> body;
+    PutBytes(body, hmacSalt);
+
+    // master key block
+    PutU32(body, static_cast<uint32_t>(mkCipher.size()));
+    PutBytes(body, mkCipher);
+    PutBytes(body, mkSalt);                // 16
+    PutBytes(body, mkIV);                  // 16
+    PutU32(body, 0u);                      // nDerivationMethod
+    PutU32(body, WALLET_CRYPTO_PBKDF2_ROUNDS);
+    PutU32(body, static_cast<uint32_t>(mkMAC.size()));
+    PutBytes(body, mkMAC);
+
+    // HD block (v7): mnemonic + trailing MAC
+    PutU32(body, static_cast<uint32_t>(mnCipher.size()));
+    PutBytes(body, mnCipher);
+    PutBytes(body, mnIV);                  // 16
+    PutU32(body, static_cast<uint32_t>(mnMAC.size()));   // v7-only mnemonic MAC len
+    PutBytes(body, mnMAC);                               // v7-only mnemonic MAC
+
+    // HD master key — v7 PLAINTEXT layout (the bug): [enc_flag=0][hdEncLen=0][seed][cc]...
+    body.push_back(0);                     // encrypted_flag = 0 (plaintext seed)
+    PutU32(body, 0u);                      // hdEncLen = 0 (plaintext branch)
+    PutBytes(body, master.seed, 32);
+    PutBytes(body, master.chaincode, 32);
+    PutU32(body, master.depth);
+    PutU32(body, master.fingerprint);
+    PutU32(body, master.child_index);
+
+    // HD chain state + 0 path mappings
+    PutU32(body, 0u);                      // account
+    PutU32(body, 0u);                      // external index
+    PutU32(body, 0u);                      // internal index
+    PutU32(body, 0u);                      // numPaths = 0
+
+    // keys (encrypted wallet) — 0 crypted keys
+    PutU32(body, 0u);
+
+    // default address
+    body.push_back(1);                     // hasDefault
+    PutBytes(body, out_default_or(defAddr));
+
+    // transactions — 0
+    PutU32(body, 0u);
+    // best block
+    std::vector<uint8_t> bestHash(32, 0);
+    PutBytes(body, bestHash);
+    int32_t bestHeight = -1;
+    PutBytes(body, reinterpret_cast<const uint8_t*>(&bestHeight), sizeof(bestHeight));
+    // MIK — none
+    body.push_back(0);
+    // sent tx — 0
+    PutU32(body, 0u);
+
+    // file integrity HMAC (key = first 32 bytes of mk salt)
+    std::vector<uint8_t> hmacKey(32, 0);
+    std::memcpy(hmacKey.data(), mkSalt.data(), std::min<size_t>(32, mkSalt.size()));
+    std::vector<uint8_t> fileHMAC(32);
+    HMAC_SHA3_256(hmacKey.data(), hmacKey.size(), body.data(), body.size(), fileHMAC.data());
+
+    // Full file: v7 magic + version 7
+    std::vector<uint8_t> file;
+    file.insert(file.end(), WALLET_FILE_MAGIC_V7, WALLET_FILE_MAGIC_V7 + 8);
+    PutU32(file, WALLET_FILE_VERSION_7);
+    uint32_t flags = 0x01 /*encrypted*/ | 0x02 /*HD*/;
+    PutU32(file, flags);
+    PutBytes(file, fileHMAC);
+    PutBytes(file, body);
+
+    memory_cleanse(vMasterKeyPlain.data(), vMasterKeyPlain.size());
+    memory_cleanse(derivedKey.data(), derivedKey.size());
+    memory_cleanse(obfKey.data(), obfKey.size());
+
+    out.seed = seed;
+    out.chaincode = chaincode;
+    out.mnemonic = mnemonic;
+    out.defaultAddr = defAddr;
+
+    return WriteFileBytes(path, file);
+}
+
+// ---------------------------------------------------------------------------
 // Legacy v6 NON-HD builder with ONE legacy-MAC'd per-address key.
 //
 // Isolates the RAW v6 GetKey path (manifestation 1 of HIGH-2): a NON-HD
@@ -1106,6 +1282,139 @@ static void Test_NeedsSeedMigrationSurfaced() {
         CHECK(w.IsCrypted(), "Migrated wallet still reports encrypted");
         CHECK(!w.NeedsSeedMigration(),
               "Migrated v7 wallet reports NeedsSeedMigration()==false at rest (no false alarm)");
+    }
+
+    std::remove(path.c_str());
+}
+
+// ---------------------------------------------------------------------------
+// Test 2d — v7-HEADER + plaintext-seed artifact (Cursor L2). Test 2c covered the
+// legacy-v6 byte shape; this covers the OTHER pre-fix shape detection handles
+// (wallet.cpp:2169): a v7-labelled file whose seed is still plaintext-at-rest.
+// Same ReadFileBytes/Contains byte-level approach: load → assert armed + plaintext
+// seed IS at rest (while LOCKED) → unlock/migrate → assert NO plaintext seed at
+// rest + flag false.
+// ---------------------------------------------------------------------------
+static void Test_V7PlaintextSeedArtifactMigrates() {
+    std::cout << COLOR_BLUE "\n[Test 2d] v7-header + plaintext-seed artifact: armed at rest, migrates clean\n" COLOR_RESET;
+
+    const std::string path = "lp7_v7_plaintext_seed_wallet.dat";
+    const std::string pass = "V7Header!Plain#2026";
+    std::remove(path.c_str());
+
+    LegacyV6Result art;
+    bool built = BuildV7PlaintextSeedWallet(path, pass, art);
+    CHECK(built, "Built v7-header + plaintext-seed encrypted wallet (pre-fix v7 artifact)");
+    if (!built) { std::remove(path.c_str()); return; }
+
+    CHECK(FileVersion(path) == WALLET_FILE_VERSION_7, "Artifact carries a v7 header");
+
+    // --- Surfaced at rest: encrypted, LOCKED, armed, plaintext seed on disk ---
+    {
+        CWallet w;
+        CHECK(w.Load(path), "Loaded v7-plaintext artifact (autosave off, never unlocked)");
+        CHECK(w.IsCrypted(), "Wallet reports encrypted (has master key)");
+        CHECK(w.IsLocked(), "Wallet is LOCKED at rest");
+        CHECK(w.NeedsSeedMigration(),
+              "SURFACED: NeedsSeedMigration()==true for a v7-header plaintext-seed wallet");
+        std::vector<uint8_t> bytes = ReadFileBytes(path);
+        CHECK(Contains(bytes, art.seed.data(), art.seed.size()),
+              "Plaintext seed IS at rest in the v7-header artifact (the leak being surfaced)");
+        CHECK(Contains(bytes, art.chaincode.data(), art.chaincode.size()),
+              "Plaintext chaincode IS at rest in the v7-header artifact");
+    }
+
+    // --- Migrate-on-unlock: flag flips false, no plaintext seed remains ---
+    {
+        CWallet w;
+        w.SetWalletFile(path);  // enables autosave → atomic v7 rewrite on unlock
+        CHECK(w.Load(path), "Reloaded v7-plaintext artifact (autosave on)");
+        CHECK(w.NeedsSeedMigration(), "Pre-unlock: still armed");
+        CHECK(w.Unlock(pass), "Unlock → drives the one-time re-encryption migration");
+        CHECK(!w.NeedsSeedMigration(),
+              "DRIVE-TO-SAFETY: NeedsSeedMigration() flips FALSE after migration");
+    }
+
+    CHECK(FileVersion(path) == WALLET_FILE_VERSION_7, "Post-migration file is (still) v7");
+    {
+        std::vector<uint8_t> bytes = ReadFileBytes(path);
+        CHECK(!Contains(bytes, art.seed.data(), art.seed.size()),
+              "Post-migration: NO plaintext seed at rest (v7-header artifact drive-to-safety verified)");
+        CHECK(!Contains(bytes, art.chaincode.data(), art.chaincode.size()),
+              "Post-migration: NO plaintext chaincode at rest");
+    }
+
+    // Reload: armed flag stays false (no false alarm on the now-clean v7 file).
+    {
+        CWallet w;
+        w.SetWalletFile(path);
+        CHECK(w.Load(path), "Reloaded migrated v7 wallet");
+        CHECK(w.IsCrypted(), "Migrated wallet still reports encrypted");
+        CHECK(!w.NeedsSeedMigration(),
+              "Migrated wallet reports NeedsSeedMigration()==false at rest (no false alarm)");
+    }
+
+    std::remove(path.c_str());
+}
+
+// ---------------------------------------------------------------------------
+// Test 2e — Cursor M1: the migration flag tracks ON-DISK state, NOT in-memory
+// re-encryption success. When a wallet is unlocked with autosave OFF (no wallet
+// file / persistence skipped), the migration MUST NOT clear the flag, because the
+// on-disk file STILL carries the plaintext seed. The invariant: NeedsSeedMigration()
+// is true exactly while a plaintext seed is still at rest on disk. Before the fix,
+// MigrateToEncryptedSeedV7Unlocked returned true on in-memory success and Unlock
+// cleared the flag + bumped to v7 → false-negative (surfacing turned off while the
+// disk file was still plaintext).
+// ---------------------------------------------------------------------------
+static void Test_M1_FlagTracksOnDiskNotInMemory() {
+    std::cout << COLOR_BLUE "\n[Test 2e] M1: migration flag tracks on-disk state (autosave-off stays armed)\n" COLOR_RESET;
+
+    const std::string path = "lp7_m1_autosave_off_wallet.dat";
+    const std::string pass = "AutoSaveOff!M1#2026";
+    std::remove(path.c_str());
+
+    LegacyV6Result legacy;
+    bool built = BuildLegacyV6Wallet(path, pass, legacy);
+    CHECK(built, "Built legacy v6 plaintext-seed encrypted wallet (pre-fix artifact)");
+    if (!built) { std::remove(path.c_str()); return; }
+
+    std::vector<uint8_t> before = ReadFileBytes(path);
+    CHECK(Contains(before, legacy.seed.data(), legacy.seed.size()),
+          "Plaintext seed IS at rest before any unlock");
+
+    // Load with autosave OFF (no SetWalletFile) → Unlock cannot persist a v7 rewrite.
+    {
+        CWallet w;
+        CHECK(w.Load(path), "Loaded pre-fix wallet (autosave OFF)");
+        CHECK(w.NeedsSeedMigration(), "Pre-unlock: armed (autosave off)");
+        CHECK(w.Unlock(pass), "Unlock succeeds (migration cannot persist, must not fail unlock)");
+        // THE M1 INVARIANT: flag STAYS armed because the on-disk file is still plaintext.
+        CHECK(w.NeedsSeedMigration(),
+              "M1: NeedsSeedMigration() STAYS true after autosave-off unlock (false-negative closed)");
+    }
+
+    // The on-disk file must be byte-identical (still legacy v6, still plaintext seed):
+    // nothing was persisted, so no in-memory-only half-migration reached disk.
+    std::vector<uint8_t> after = ReadFileBytes(path);
+    CHECK(after == before, "M1: on-disk file is byte-identical after autosave-off unlock");
+    CHECK(FileVersion(path) == WALLET_FILE_VERSION_6, "M1: on-disk file is still legacy v6");
+    CHECK(Contains(after, legacy.seed.data(), legacy.seed.size()),
+          "M1: plaintext seed STILL at rest (flag correctly stayed armed)");
+
+    // Sanity: with autosave ON, the same wallet DOES migrate and clears the flag.
+    {
+        CWallet w;
+        w.SetWalletFile(path);
+        CHECK(w.Load(path), "Reloaded (autosave ON)");
+        CHECK(w.Unlock(pass), "Unlock → migrates + persists");
+        CHECK(!w.NeedsSeedMigration(), "M1 sanity: flag clears once the v7 file is persisted");
+    }
+    CHECK(FileVersion(path) == WALLET_FILE_VERSION_7, "M1 sanity: file is v7 after persisted migration");
+    {
+        std::vector<uint8_t> bytes = ReadFileBytes(path);
+        CHECK(!Contains(bytes, legacy.seed.data(), legacy.seed.size()),
+              "M1 sanity: NO plaintext seed at rest after persisted migration");
     }
 
     std::remove(path.c_str());
@@ -2117,6 +2426,8 @@ int main() {
     Test_Secrecy();
     Test_Migration();
     Test_NeedsSeedMigrationSurfaced();
+    Test_V7PlaintextSeedArtifactMigrates();
+    Test_M1_FlagTracksOnDiskNotInMemory();
     Test_FailClosedScrubbedV6Window();
     Test_AuthTamper();
     Test_PerRecordMACIsolation();

--- a/src/test/wallet_encryption_at_rest_tests.cpp
+++ b/src/test/wallet_encryption_at_rest_tests.cpp
@@ -1042,6 +1042,107 @@ static void Test_Migration() {
 }
 
 // ---------------------------------------------------------------------------
+// Test 2b — fail-closed guard on the scrubbed-seed / legacy-v6 corruption window
+// (red-team LOW-1 hardening). A `friend struct` (declared in wallet.h) so the
+// test can construct the otherwise-unreachable window state and drive the
+// PRIVATE SaveUnlocked() writer directly.
+//
+// THE WINDOW: after a migration scrubs+encrypts the in-memory seed
+// (fHDMasterKeyEncrypted=true, memory_cleanse'd seed/chaincode slots) but BEFORE
+// m_loadedFileVersion is promoted to v7, the legacy-v6 writer path
+// (writeLegacyV6 == true) would write the now-ZEROED fixed seed/chaincode slots
+// → a structurally corrupt, unrecoverable wallet. In production Unlock promotes
+// the version atomically under cs_wallet the instant it scrubs, so this state is
+// never observable to any saver — but we harden the writer to fail-closed so the
+// corruption is structurally impossible even under a future refactor.
+// ---------------------------------------------------------------------------
+struct LP7FailClosedTester {
+    // Force the in-memory wallet into the window: encrypted-flag set + seed slots
+    // scrubbed (exactly what EncryptHDMasterKey leaves behind) while
+    // m_loadedFileVersion stays at v6. Returns true if the wallet looked like a
+    // loaded legacy-v6 HD wallet to begin with (precondition for the window).
+    static bool EnterScrubbedV6Window(CWallet& w) {
+        if (!w.fIsHDWallet) return false;
+        if (w.m_loadedFileVersion != WALLET_FILE_VERSION_6) return false;
+        // Model EncryptHDMasterKey's post-state: ciphertext present, slots scrubbed.
+        w.vchEncryptedHDMasterKey.assign(48, 0xAB);          // non-empty ciphertext
+        w.vchHDMasterKeyMAC.assign(32, 0xCD);                // non-empty MAC
+        w.vchHDMasterKeyIV.assign(WALLET_CRYPTO_IV_SIZE, 0xEF);
+        memory_cleanse(w.hdMasterKey.seed, 32);              // seed now ZEROED
+        memory_cleanse(w.hdMasterKey.chaincode, 32);         // chaincode now ZEROED
+        w.fHDMasterKeyEncrypted = true;
+        // m_loadedFileVersion deliberately LEFT at v6 → writeLegacyV6 == true.
+        return true;
+    }
+
+    // Drive the private writer the public Save() path reaches (Save() just locks
+    // cs_wallet then calls SaveUnlocked). Calling SaveUnlocked directly here is
+    // equivalent for this single-threaded test and avoids re-locking.
+    static bool ForceSave(CWallet& w, const std::string& path) {
+        return w.SaveUnlocked(path);
+    }
+
+    static uint32_t LoadedVersion(const CWallet& w) { return w.m_loadedFileVersion; }
+    static bool IsHDEncrypted(const CWallet& w) { return w.fHDMasterKeyEncrypted; }
+};
+
+static void Test_FailClosedScrubbedV6Window() {
+    std::cout << COLOR_BLUE "\n[Test 2b] Fail-closed guard: scrubbed-seed / legacy-v6 window (LOW-1)\n" COLOR_RESET;
+
+    const std::string path = "lp7_failclosed_wallet.dat";
+    const std::string savePath = "lp7_failclosed_save.dat";
+    const std::string pass = "FailClosed!Me#2026";
+    std::remove(path.c_str());
+    std::remove(savePath.c_str());
+
+    LegacyV6Result legacy;
+    bool built = BuildLegacyV6Wallet(path, pass, legacy);
+    CHECK(built, "Built legacy v6 plaintext-seed encrypted wallet");
+    if (!built) { std::remove(path.c_str()); return; }
+
+    // Load autosave-OFF so m_loadedFileVersion stays at v6 (no SetWalletFile()).
+    CWallet w;
+    CHECK(w.Load(path), "Loaded legacy v6 wallet (autosave off)");
+    CHECK(LP7FailClosedTester::LoadedVersion(w) == WALLET_FILE_VERSION_6,
+          "Loaded version is v6 (writeLegacyV6 would be true on save)");
+    CHECK(!LP7FailClosedTester::IsHDEncrypted(w),
+          "Post-load: HD master not yet flagged encrypted (plaintext-seed legacy)");
+
+    // Construct the corruption window: scrub the seed + set the encrypted flag,
+    // leaving the version at v6 (exactly the transient migration state).
+    CHECK(LP7FailClosedTester::EnterScrubbedV6Window(w),
+          "Entered scrubbed-seed / v6 window (fHDMasterKeyEncrypted=true, seed zeroed)");
+    CHECK(LP7FailClosedTester::IsHDEncrypted(w) &&
+          LP7FailClosedTester::LoadedVersion(w) == WALLET_FILE_VERSION_6,
+          "Window invariant holds: encrypted-in-memory AND m_loadedFileVersion still v6");
+
+    // Force a save to a SEPARATE path. With the fail-closed guard this must FAIL
+    // and write nothing. Without the guard, the legacy-v6 writer emits a v6 file
+    // whose fixed seed/chaincode slots are 64 zero bytes → corrupt wallet.
+    std::remove(savePath.c_str());
+    bool saved = LP7FailClosedTester::ForceSave(w, savePath);
+    CHECK(!saved, "FAIL-CLOSED: SaveUnlocked REFUSED to persist the scrubbed-seed v6 wallet");
+
+    // The atomic writer renames only on success; on a refusal the destination must
+    // not exist at all (no corrupt artifact, no zeroed-seed file left behind).
+    std::vector<uint8_t> savedBytes = ReadFileBytes(savePath);
+    CHECK(savedBytes.empty(),
+          "FAIL-CLOSED: no wallet file was written at the destination (no corrupt artifact)");
+
+    // Defensive cross-check: even if a future regression let a byte slip through,
+    // a v6 file with the seed scrubbed would carry 64 consecutive zero bytes in the
+    // HD-master slots. Assert no such all-zero seed block was persisted.
+    if (!savedBytes.empty()) {
+        std::vector<uint8_t> zero64(64, 0);
+        CHECK(!Contains(savedBytes, zero64.data(), zero64.size()),
+              "FAIL-CLOSED: no zeroed 64-byte seed/chaincode block persisted to disk");
+    }
+
+    std::remove(path.c_str());
+    std::remove(savePath.c_str());
+}
+
+// ---------------------------------------------------------------------------
 // Test 3 — auth-tamper rejection
 // ---------------------------------------------------------------------------
 static void Test_AuthTamper() {
@@ -1722,6 +1823,7 @@ int main() {
 
     Test_Secrecy();
     Test_Migration();
+    Test_FailClosedScrubbedV6Window();
     Test_AuthTamper();
     Test_PerRecordMACIsolation();
     Test_AtomicRenameCrashWindow();

--- a/src/test/wallet_encryption_at_rest_tests.cpp
+++ b/src/test/wallet_encryption_at_rest_tests.cpp
@@ -1042,6 +1042,76 @@ static void Test_Migration() {
 }
 
 // ---------------------------------------------------------------------------
+// Test 2c — surfaced state: NeedsSeedMigration() is the load-bearing hook for the
+// force-migrate fix (round-3 SURVIVING-LEAK). A pre-fix-encrypted wallet must
+// report needs_seed_migration==true at rest (while LOCKED, never unlocked), and
+// the flag must flip false exactly once the migration completes. This is what
+// drives the UI banner / operator remediation / RPC field and proves the
+// drive-to-safety path end to end (load → unlock → migrate → no plaintext seed).
+// ---------------------------------------------------------------------------
+static void Test_NeedsSeedMigrationSurfaced() {
+    std::cout << COLOR_BLUE "\n[Test 2c] Surfaced state: NeedsSeedMigration() flips false on migrate\n" COLOR_RESET;
+
+    const std::string path = "lp7_needs_migration_wallet.dat";
+    const std::string pass = "Surface!State#2026";
+    std::remove(path.c_str());
+
+    LegacyV6Result legacy;
+    bool built = BuildLegacyV6Wallet(path, pass, legacy);
+    CHECK(built, "Built legacy v6 plaintext-seed encrypted wallet (pre-fix artifact)");
+    if (!built) { std::remove(path.c_str()); return; }
+
+    // --- State surfaced at rest: armed, encrypted, LOCKED, NOT yet migrated ---
+    // Load with autosave OFF so nothing migrates; this models the receive/mine-only
+    // wallet that sits plaintext-at-rest forever. The surfaced flag must be true.
+    {
+        CWallet w;
+        CHECK(w.Load(path), "Loaded pre-fix wallet (autosave off, never unlocked)");
+        CHECK(w.IsCrypted(), "Wallet reports encrypted (has master key)");
+        CHECK(w.IsLocked(), "Wallet is LOCKED at rest (masterKey invalid until unlock)");
+        CHECK(w.NeedsSeedMigration(),
+              "SURFACED: NeedsSeedMigration()==true while encrypted+plaintext-seed-at-rest");
+        // Confirm the on-disk seed really is plaintext here (the thing we surface).
+        std::vector<uint8_t> bytes = ReadFileBytes(path);
+        CHECK(Contains(bytes, legacy.seed.data(), legacy.seed.size()),
+              "Seed plaintext IS at rest while NeedsSeedMigration()==true (the leak being surfaced)");
+    }
+
+    // --- Migrate-on-unlock: flag flips false, no plaintext seed remains ---
+    {
+        CWallet w;
+        w.SetWalletFile(path);  // enables autosave → atomic v7 rewrite on unlock
+        CHECK(w.Load(path), "Reloaded pre-fix wallet (autosave on)");
+        CHECK(w.NeedsSeedMigration(), "Pre-unlock: still armed (NeedsSeedMigration()==true)");
+        CHECK(w.Unlock(pass), "Unlock → drives the one-time migration");
+        CHECK(!w.NeedsSeedMigration(),
+              "DRIVE-TO-SAFETY: NeedsSeedMigration() flips FALSE after migration");
+    }
+
+    // After migration the wallet is genuinely safe at rest: v7, no plaintext seed.
+    CHECK(FileVersion(path) == WALLET_FILE_VERSION_7, "Post-migration file is v7");
+    {
+        std::vector<uint8_t> bytes = ReadFileBytes(path);
+        CHECK(!Contains(bytes, legacy.seed.data(), legacy.seed.size()),
+              "Post-migration: NO plaintext seed at rest (drive-to-safety verified)");
+        CHECK(!Contains(bytes, legacy.chaincode.data(), legacy.chaincode.size()),
+              "Post-migration: NO plaintext chaincode at rest");
+    }
+
+    // Reload the migrated wallet: the surfaced flag stays false (no false alarm).
+    {
+        CWallet w;
+        w.SetWalletFile(path);
+        CHECK(w.Load(path), "Reloaded migrated v7 wallet");
+        CHECK(w.IsCrypted(), "Migrated wallet still reports encrypted");
+        CHECK(!w.NeedsSeedMigration(),
+              "Migrated v7 wallet reports NeedsSeedMigration()==false at rest (no false alarm)");
+    }
+
+    std::remove(path.c_str());
+}
+
+// ---------------------------------------------------------------------------
 // Test 2b — fail-closed guard on the scrubbed-seed / legacy-v6 corruption window
 // (red-team LOW-1 hardening). A `friend struct` (declared in wallet.h) so the
 // test can construct the otherwise-unreachable window state and drive the
@@ -2046,6 +2116,7 @@ int main() {
 
     Test_Secrecy();
     Test_Migration();
+    Test_NeedsSeedMigrationSurfaced();
     Test_FailClosedScrubbedV6Window();
     Test_AuthTamper();
     Test_PerRecordMACIsolation();

--- a/src/test/wallet_encryption_at_rest_tests.cpp
+++ b/src/test/wallet_encryption_at_rest_tests.cpp
@@ -1,0 +1,553 @@
+// Copyright (c) 2025 The Dilithion Core developers
+// Distributed under the MIT software license
+
+/**
+ * LP-7 — Wallet encryption-at-rest tests
+ *
+ * Covers the three load-bearing scenarios from the LP-7 contract (§3.2):
+ *
+ *   1. SECRECY REGRESSION (S-001) + NEGATIVE CONTROL
+ *      - Create an HD wallet, save it UNENCRYPTED → the 32-byte seed and
+ *        32-byte chaincode are PRESENT in the on-disk file (negative control:
+ *        proves the byte-scan can find the seed when it is there).
+ *      - Encrypt the same wallet, lock it, save → the seed and chaincode
+ *        plaintext bytes are ABSENT from the on-disk file.
+ *
+ *   2. MIGRATION ROUND-TRIP (A-012 / S-002 / S-003) + INTERRUPTED MIGRATION
+ *      - Hand-build a LEGACY v6 plaintext-seed encrypted wallet on disk
+ *        (the pre-fix bug shape), open it with the fixed binary, unlock →
+ *        assert (a) seed now ABSENT from disk, (b) file version bumped to 7,
+ *        (c) mnemonic still exportable (Inv-4), (d) the default address is
+ *        unchanged across migration.
+ *      - INTERRUPTED migration: simulate a crash mid-rewrite by leaving a
+ *        stale ".tmp" file and making the rename target read-only is not
+ *        portable; instead we assert the atomicity *invariant directly*: after
+ *        a forced save failure the ORIGINAL legacy file is byte-for-byte
+ *        unchanged and still opens (old-or-new, never corrupt).
+ *
+ *   3. AUTH-TAMPER (S-004)
+ *      - Take a migrated v7 wallet, flip a byte in the encrypted-seed
+ *        ciphertext on disk → unlock/decrypt is REJECTED.
+ *      - Strip the HD-master MAC to empty on a v7 wallet → REJECTED.
+ *
+ * These tests drive the real CWallet against real on-disk files (no mocks).
+ */
+
+#include <wallet/wallet.h>
+#include <wallet/crypter.h>
+#include <wallet/hd_derivation.h>
+#include <wallet/mnemonic.h>
+
+#include <crypto/sha3.h>
+#include <crypto/hmac_sha3.h>
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#define COLOR_GREEN "\033[32m"
+#define COLOR_RED   "\033[31m"
+#define COLOR_BLUE  "\033[34m"
+#define COLOR_RESET "\033[0m"
+
+static int g_pass = 0;
+static int g_fail = 0;
+
+#define CHECK(cond, msg)                                                     \
+    do {                                                                     \
+        if (cond) {                                                          \
+            std::cout << COLOR_GREEN "  [PASS] " COLOR_RESET << msg << "\n"; \
+            ++g_pass;                                                        \
+        } else {                                                            \
+            std::cout << COLOR_RED   "  [FAIL] " COLOR_RESET << msg << "\n"; \
+            ++g_fail;                                                        \
+        }                                                                    \
+    } while (0)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+static std::vector<uint8_t> ReadFileBytes(const std::string& path) {
+    std::ifstream f(path, std::ios::binary);
+    if (!f.is_open()) return {};
+    return std::vector<uint8_t>((std::istreambuf_iterator<char>(f)),
+                                std::istreambuf_iterator<char>());
+}
+
+static bool WriteFileBytes(const std::string& path, const std::vector<uint8_t>& data) {
+    std::ofstream f(path, std::ios::binary | std::ios::trunc);
+    if (!f.is_open()) return false;
+    f.write(reinterpret_cast<const char*>(data.data()), data.size());
+    return f.good();
+}
+
+// Search for a needle byte-sequence inside a haystack.
+static bool Contains(const std::vector<uint8_t>& hay, const uint8_t* needle, size_t n) {
+    if (n == 0 || hay.size() < n) return false;
+    for (size_t i = 0; i + n <= hay.size(); ++i) {
+        if (std::memcmp(hay.data() + i, needle, n) == 0) return true;
+    }
+    return false;
+}
+
+// Read the file-format version from a Dilithion wallet file (offset 8, uint32).
+static uint32_t FileVersion(const std::string& path) {
+    std::vector<uint8_t> b = ReadFileBytes(path);
+    if (b.size() < 12) return 0;
+    uint32_t v = 0;
+    std::memcpy(&v, b.data() + 8, 4);
+    return v;
+}
+
+// Derive the master seed+chaincode the wallet stores from a mnemonic.
+static bool DeriveSeedChaincode(const std::string& mnemonic,
+                                std::vector<uint8_t>& seedOut,
+                                std::vector<uint8_t>& chaincodeOut) {
+    uint8_t bip39seed[64];
+    if (!CMnemonic::ToSeed(mnemonic, "", bip39seed)) return false;
+    CHDExtendedKey master;
+    DeriveMaster(bip39seed, master);
+    memory_cleanse(bip39seed, 64);
+    seedOut.assign(master.seed, master.seed + 32);
+    chaincodeOut.assign(master.chaincode, master.chaincode + 32);
+    return true;
+}
+
+// Buffered little-endian writers for the legacy v6 builder.
+static void PutU32(std::vector<uint8_t>& v, uint32_t x) {
+    for (int i = 0; i < 4; ++i) v.push_back(static_cast<uint8_t>((x >> (8 * i)) & 0xFF));
+}
+static void PutBytes(std::vector<uint8_t>& v, const uint8_t* p, size_t n) {
+    v.insert(v.end(), p, p + n);
+}
+static void PutBytes(std::vector<uint8_t>& v, const std::vector<uint8_t>& b) {
+    v.insert(v.end(), b.begin(), b.end());
+}
+
+// Pad/truncate an address blob to the fixed 21-byte on-disk width.
+static std::vector<uint8_t> out_default_or(const std::vector<uint8_t>& a) {
+    std::vector<uint8_t> r = a;
+    r.resize(21, 0);
+    return r;
+}
+
+// ---------------------------------------------------------------------------
+// Legacy v6 plaintext-seed encrypted-wallet builder.
+//
+// Reproduces the EXACT pre-LP-7 on-disk layout for a MINIMAL HD wallet that is
+// encrypted but has NO mapKeys/mapCryptedKeys, NO txs, NO MIK, NO sentTx — i.e.
+// the bug shape: master key encrypted, but the HD seed written PLAINTEXT in the
+// fixed 32+32 slots and the mnemonic stored under the seed-derived obfuscation
+// key. Layout (matches SaveUnlocked v6):
+//   [Magic 8][Version u32][Flags u32][HMAC 32][Salt 32]
+//   <master key block: cryptedLen u32, ct, salt16, iv16, derivMethod u32,
+//                      iters u32, macLen u32, mac64>
+//   <HD: mnemonicLen u32, ct, iv16 | seed32 | chaincode32 | depth u32 |
+//        fingerprint u32 | child_index u32 | encFlag u8 (0) >
+//   <HD chain state: account u32, ext u32, int u32>
+//   <numPaths u32 = 0>
+//   <numCryptedKeys u32 = 0>
+//   <hasDefault u8 (1), addr 21>
+//   <numTxs u32 = 0>
+//   <bestHash 32><bestHeight i32>
+//   <hasMIK u8 (0)>
+//   <numSentTx u32 = 0>
+//   [HMAC over Salt..end, keyed by first 32 bytes of master-key salt]
+// ---------------------------------------------------------------------------
+struct LegacyV6Result {
+    std::vector<uint8_t> seed;        // plaintext seed (for scan assertions)
+    std::vector<uint8_t> chaincode;   // plaintext chaincode
+    std::string mnemonic;             // for Inv-4 export assertion
+    std::vector<uint8_t> defaultAddr; // 21-byte default address
+};
+
+static bool BuildLegacyV6Wallet(const std::string& path,
+                                const std::string& passphrase,
+                                LegacyV6Result& out) {
+    // --- 1. Use a real CWallet to mint a consistent HD wallet, then read out the
+    //        pieces we need (mnemonic, seed, chaincode, default address). ---
+    std::string scratch = path + ".scratch";
+    std::remove(scratch.c_str());
+
+    std::string mnemonic;
+    std::vector<uint8_t> defAddr;
+    {
+        CWallet w;
+        w.SetWalletFile(scratch);
+        if (!w.GenerateHDWallet(mnemonic)) return false;
+        std::vector<CDilithiumAddress> addrs = w.GetAddresses();
+        if (addrs.empty()) return false;
+        CDilithiumAddress def = w.GetNewHDAddress();  // ensure a default exists
+        (void)def;
+        // The first sorted address is the v6 default for HD wallets.
+        defAddr = w.GetAddresses().front().GetData();
+    }
+    std::remove(scratch.c_str());
+
+    std::vector<uint8_t> seed, chaincode;
+    if (!DeriveSeedChaincode(mnemonic, seed, chaincode)) return false;
+
+    CHDExtendedKey master;
+    {
+        uint8_t bip39seed[64];
+        if (!CMnemonic::ToSeed(mnemonic, "", bip39seed)) return false;
+        DeriveMaster(bip39seed, master);
+        memory_cleanse(bip39seed, 64);
+    }
+
+    // --- 2. Build the encrypted master key block (PBKDF2 + AES-CBC + MAC, legacy
+    //        AES-keyed HMAC keying). ---
+    std::vector<uint8_t> vMasterKeyPlain(WALLET_CRYPTO_KEY_SIZE);
+    if (!GetStrongRandBytes(vMasterKeyPlain.data(), WALLET_CRYPTO_KEY_SIZE)) return false;
+
+    std::vector<uint8_t> mkSalt;
+    if (!GenerateSalt(mkSalt)) return false;
+    std::vector<uint8_t> derivedKey;
+    if (!DeriveKey(passphrase, mkSalt, WALLET_CRYPTO_PBKDF2_ROUNDS, derivedKey)) return false;
+    std::vector<uint8_t> mkIV;
+    if (!GenerateIV(mkIV)) return false;
+
+    CCrypter mkCrypter;
+    if (!mkCrypter.SetKey(derivedKey, mkIV)) return false;
+    std::vector<uint8_t> mkCipher;
+    if (!mkCrypter.Encrypt(vMasterKeyPlain, mkCipher)) return false;
+    std::vector<uint8_t> mkMAC;
+    // Legacy keying (AES key == HMAC key) so the fixed binary's Unlock MAC check
+    // (which uses legacy keying for v<7) passes.
+    if (!mkCrypter.ComputeMAC(mkCipher, mkMAC, /*useLegacyKeying=*/true)) return false;
+
+    // --- 3. Build the legacy obfuscated mnemonic (key = HKDF(seed,"mnemonic")). ---
+    std::vector<uint8_t> obfKey(WALLET_CRYPTO_KEY_SIZE);
+    {
+        std::vector<uint8_t> hdSeed(master.seed, master.seed + 32);
+        DeriveEncryptionKey(hdSeed, "mnemonic", obfKey);
+        memory_cleanse(hdSeed.data(), hdSeed.size());
+    }
+    std::vector<uint8_t> mnIV;
+    if (!GenerateIV(mnIV)) return false;
+    CCrypter mnCrypter;
+    if (!mnCrypter.SetKey(obfKey, mnIV)) return false;
+    std::vector<uint8_t> mnemonicBytes(mnemonic.begin(), mnemonic.end());
+    std::vector<uint8_t> mnCipher;
+    if (!mnCrypter.Encrypt(mnemonicBytes, mnCipher)) return false;
+
+    // --- 4. Assemble the body (everything after the [Salt]). ---
+    std::vector<uint8_t> hmacSalt(WALLET_FILE_SALT_SIZE);  // 32 bytes (NOT the 16-byte IV size)
+    if (!GetStrongRandBytes(hmacSalt.data(), hmacSalt.size())) return false;
+
+    std::vector<uint8_t> body;  // starts at the file-HMAC salt
+    PutBytes(body, hmacSalt);
+
+    // master key block
+    PutU32(body, static_cast<uint32_t>(mkCipher.size()));
+    PutBytes(body, mkCipher);
+    PutBytes(body, mkSalt);                // 16
+    PutBytes(body, mkIV);                  // 16
+    PutU32(body, 0u);                      // nDerivationMethod
+    PutU32(body, WALLET_CRYPTO_PBKDF2_ROUNDS);
+    PutU32(body, static_cast<uint32_t>(mkMAC.size()));
+    PutBytes(body, mkMAC);
+
+    // HD block (v6 layout): mnemonic
+    PutU32(body, static_cast<uint32_t>(mnCipher.size()));
+    PutBytes(body, mnCipher);
+    PutBytes(body, mnIV);                  // 16
+    // HD master key — PLAINTEXT seed + chaincode (the bug)
+    PutBytes(body, master.seed, 32);
+    PutBytes(body, master.chaincode, 32);
+    PutU32(body, master.depth);
+    PutU32(body, master.fingerprint);
+    PutU32(body, master.child_index);
+    body.push_back(0);                     // encrypted_flag = 0 (no IV follows)
+    // HD chain state
+    PutU32(body, 0u);                      // account
+    PutU32(body, 0u);                      // external index (0 ⇒ no derived paths,
+    PutU32(body, 0u);                      // internal index   consistent with 0 paths
+                                           //                  → passes the HD gap check)
+    // HD path mappings — 0 (keeps the builder minimal; load tolerates this)
+    PutU32(body, 0u);
+
+    // keys (encrypted wallet) — 0 crypted keys
+    PutU32(body, 0u);
+
+    // default address
+    body.push_back(1);                     // hasDefault
+    PutBytes(body, out_default_or(defAddr));// 21 bytes
+
+    // transactions — 0
+    PutU32(body, 0u);
+
+    // best block pointer
+    std::vector<uint8_t> bestHash(32, 0);
+    PutBytes(body, bestHash);
+    int32_t bestHeight = -1;
+    PutBytes(body, reinterpret_cast<const uint8_t*>(&bestHeight), sizeof(bestHeight));
+
+    // MIK — none
+    body.push_back(0);                     // hasMIK = 0
+
+    // sent tx — 0
+    PutU32(body, 0u);
+
+    // --- 5. Compute the file integrity HMAC (key = first 32 bytes of mk salt). ---
+    std::vector<uint8_t> hmacKey(32, 0);
+    std::memcpy(hmacKey.data(), mkSalt.data(), std::min<size_t>(32, mkSalt.size()));
+    std::vector<uint8_t> fileHMAC(32);
+    HMAC_SHA3_256(hmacKey.data(), hmacKey.size(), body.data(), body.size(), fileHMAC.data());
+
+    // --- 6. Assemble the full file: [Magic][Version][Flags][HMAC][body...] ---
+    std::vector<uint8_t> file;
+    file.insert(file.end(), WALLET_FILE_MAGIC_V6, WALLET_FILE_MAGIC_V6 + 8);
+    PutU32(file, WALLET_FILE_VERSION_6);
+    uint32_t flags = 0x01 /*encrypted*/ | 0x02 /*HD*/;
+    PutU32(file, flags);
+    PutBytes(file, fileHMAC);
+    PutBytes(file, body);
+
+    memory_cleanse(vMasterKeyPlain.data(), vMasterKeyPlain.size());
+    memory_cleanse(derivedKey.data(), derivedKey.size());
+    memory_cleanse(obfKey.data(), obfKey.size());
+
+    out.seed = seed;
+    out.chaincode = chaincode;
+    out.mnemonic = mnemonic;
+    out.defaultAddr = defAddr;
+
+    return WriteFileBytes(path, file);
+}
+
+// ---------------------------------------------------------------------------
+// Test 1 — secrecy regression + negative control
+// ---------------------------------------------------------------------------
+static void Test_Secrecy() {
+    std::cout << COLOR_BLUE "\n[Test 1] Secrecy at rest (S-001) + negative control\n" COLOR_RESET;
+
+    const std::string path = "lp7_secrecy_wallet.dat";
+    std::remove(path.c_str());
+
+    std::string mnemonic;
+    {
+        CWallet w;
+        w.SetWalletFile(path);
+        bool ok = w.GenerateHDWallet(mnemonic);
+        CHECK(ok, "Generated HD wallet");
+        if (!ok) return;
+        // GenerateHDWallet auto-saves an UNENCRYPTED wallet.
+    }
+
+    std::vector<uint8_t> seed, chaincode;
+    CHECK(DeriveSeedChaincode(mnemonic, seed, chaincode), "Derived seed+chaincode from mnemonic");
+
+    // NEGATIVE CONTROL: unencrypted wallet's seed IS on disk (scan can find it).
+    {
+        std::vector<uint8_t> bytes = ReadFileBytes(path);
+        CHECK(Contains(bytes, seed.data(), seed.size()),
+              "NEGATIVE CONTROL: unencrypted wallet file CONTAINS the seed (scan works)");
+        CHECK(Contains(bytes, chaincode.data(), chaincode.size()),
+              "NEGATIVE CONTROL: unencrypted wallet file CONTAINS the chaincode");
+    }
+
+    // Now encrypt + lock + save, then re-scan: seed/chaincode must be ABSENT.
+    {
+        CWallet w;
+        w.SetWalletFile(path);
+        CHECK(w.Load(path), "Reloaded unencrypted wallet");
+        CHECK(w.EncryptWallet("Str0ng!Passphrase#42"), "Encrypted wallet (re-encrypts seed+mnemonic)");
+        CHECK(w.Lock(), "Locked wallet");
+        // Encryption auto-saved; force a save to be sure the locked-state file is written.
+        CHECK(w.Save(path), "Saved encrypted wallet");
+    }
+
+    {
+        std::vector<uint8_t> bytes = ReadFileBytes(path);
+        CHECK(FileVersion(path) == WALLET_FILE_VERSION_7, "Encrypted wallet written at v7");
+        CHECK(!Contains(bytes, seed.data(), seed.size()),
+              "SECRECY: encrypted wallet file does NOT contain the seed plaintext");
+        CHECK(!Contains(bytes, chaincode.data(), chaincode.size()),
+              "SECRECY: encrypted wallet file does NOT contain the chaincode plaintext");
+    }
+
+    std::remove(path.c_str());
+}
+
+// ---------------------------------------------------------------------------
+// Test 2 — migration round-trip + interrupted-migration atomicity
+// ---------------------------------------------------------------------------
+static void Test_Migration() {
+    std::cout << COLOR_BLUE "\n[Test 2] Migration round-trip (A-012/S-002/S-003) + interrupted\n" COLOR_RESET;
+
+    const std::string path = "lp7_migrate_wallet.dat";
+    const std::string pass = "Migrate!Me#2026";
+    std::remove(path.c_str());
+
+    LegacyV6Result legacy;
+    bool built = BuildLegacyV6Wallet(path, pass, legacy);
+    CHECK(built, "Built legacy v6 plaintext-seed encrypted wallet");
+    if (!built) { std::remove(path.c_str()); return; }
+
+    // Sanity: the legacy file IS v6 and DOES contain the plaintext seed.
+    {
+        std::vector<uint8_t> bytes = ReadFileBytes(path);
+        CHECK(FileVersion(path) == WALLET_FILE_VERSION_6, "Legacy file is v6");
+        CHECK(Contains(bytes, legacy.seed.data(), legacy.seed.size()),
+              "Legacy v6 file CONTAINS plaintext seed (pre-migration bug confirmed)");
+    }
+
+    // --- Interrupted-migration atomicity invariant ---
+    // Capture the exact legacy bytes; load with autosave DISABLED so the unlock's
+    // migration attempt cannot rewrite the file. The original file must remain
+    // byte-for-byte identical and still open afterwards.
+    std::vector<uint8_t> legacyBytesBefore = ReadFileBytes(path);
+    {
+        CWallet w;
+        // Do NOT SetWalletFile() (which enables autosave). Load directly so
+        // m_walletFile is set but m_autoSave stays false → migration re-encrypts
+        // in memory but the SaveUnlocked step is skipped (no rewrite), modelling
+        // an interruption BEFORE the atomic rename.
+        CHECK(w.Load(path), "Loaded legacy wallet (autosave off)");
+        CHECK(w.Unlock(pass), "Unlocked legacy wallet (migration attempted, rewrite skipped)");
+    }
+    std::vector<uint8_t> legacyBytesAfter = ReadFileBytes(path);
+    CHECK(legacyBytesBefore == legacyBytesAfter,
+          "INTERRUPTED MIGRATION: original legacy file is byte-for-byte unchanged");
+    CHECK(FileVersion(path) == WALLET_FILE_VERSION_6,
+          "INTERRUPTED MIGRATION: file still opens as the intact v6 wallet (no corruption)");
+
+    // --- Full migration round-trip (autosave ON → atomic v7 rewrite) ---
+    std::string exportedMnemonic;
+    std::vector<uint8_t> defAddrAfter;
+    {
+        CWallet w;
+        w.SetWalletFile(path);  // enables autosave
+        CHECK(w.Load(path), "Loaded legacy wallet (autosave on)");
+        CHECK(w.Unlock(pass), "Unlocked → triggers atomic migration to v7");
+        CHECK(w.ExportMnemonic(exportedMnemonic), "ExportMnemonic works post-migration (Inv-4)");
+        std::vector<CDilithiumAddress> addrs = w.GetAddresses();
+        if (!addrs.empty()) defAddrAfter = addrs.front().GetData();
+    }
+
+    CHECK(exportedMnemonic == legacy.mnemonic, "Mnemonic round-trips identically after migration");
+    CHECK(FileVersion(path) == WALLET_FILE_VERSION_7, "File version bumped to v7 after migration");
+
+    {
+        std::vector<uint8_t> bytes = ReadFileBytes(path);
+        CHECK(!Contains(bytes, legacy.seed.data(), legacy.seed.size()),
+              "MIGRATED: seed plaintext ABSENT from the v7 file");
+        CHECK(!Contains(bytes, legacy.chaincode.data(), legacy.chaincode.size()),
+              "MIGRATED: chaincode plaintext ABSENT from the v7 file");
+    }
+
+    // Reopen the migrated v7 wallet and confirm it still unlocks + exports.
+    {
+        CWallet w;
+        w.SetWalletFile(path);
+        CHECK(w.Load(path), "Reloaded migrated v7 wallet");
+        CHECK(FileVersion(path) == WALLET_FILE_VERSION_7, "Reloaded file is v7");
+        CHECK(w.Unlock(pass), "Migrated v7 wallet unlocks");
+        std::string m2;
+        CHECK(w.ExportMnemonic(m2) && m2 == legacy.mnemonic,
+              "Migrated v7 wallet exports the original mnemonic");
+    }
+
+    std::remove(path.c_str());
+}
+
+// ---------------------------------------------------------------------------
+// Test 3 — auth-tamper rejection
+// ---------------------------------------------------------------------------
+static void Test_AuthTamper() {
+    std::cout << COLOR_BLUE "\n[Test 3] Authenticated-before-decrypt (S-004)\n" COLOR_RESET;
+
+    const std::string path = "lp7_tamper_wallet.dat";
+    const std::string pass = "T@mper!Test#77";
+    std::remove(path.c_str());
+
+    // Produce a clean v7 encrypted wallet.
+    std::string mnemonic;
+    {
+        CWallet w;
+        w.SetWalletFile(path);
+        CHECK(w.GenerateHDWallet(mnemonic), "Generated HD wallet");
+        CHECK(w.EncryptWallet(pass), "Encrypted → v7");
+        CHECK(w.Lock(), "Locked");
+        CHECK(w.Save(path), "Saved v7 wallet");
+    }
+    CHECK(FileVersion(path) == WALLET_FILE_VERSION_7, "Wallet is v7");
+
+    std::vector<uint8_t> clean = ReadFileBytes(path);
+    CHECK(!clean.empty(), "Read v7 wallet bytes");
+
+    // Baseline: the clean wallet unlocks.
+    {
+        CWallet w;
+        w.SetWalletFile(path);
+        CHECK(w.Load(path), "Loaded clean v7 wallet");
+        CHECK(w.Unlock(pass), "Clean v7 wallet unlocks (baseline)");
+    }
+
+    // TAMPER A: flip a byte in the second half of the file (HD-master ciphertext /
+    // MAC region lives well past the header). Flipping any authenticated byte must
+    // cause unlock/decrypt to fail (either the outer file-HMAC or a record MAC).
+    {
+        std::vector<uint8_t> bad = clean;
+        size_t idx = bad.size() * 3 / 4;   // deep in the HD/MAC region
+        bad[idx] ^= 0xFF;
+        CHECK(WriteFileBytes(path, bad), "Wrote byte-flipped wallet");
+
+        CWallet w;
+        w.SetWalletFile(path);
+        bool loaded = w.Load(path);
+        bool unlocked = loaded && w.Unlock(pass);
+        CHECK(!unlocked, "TAMPER A: byte-flipped ciphertext is REJECTED (no unlock)");
+    }
+
+    // Restore clean, then TAMPER B: corrupt the LAST 64 bytes region of the body,
+    // which on a freshly-saved v7 HD wallet sits inside MAC-protected content, and
+    // additionally verify that an empty-MAC HD record on a v7 wallet is refused by
+    // direct unit assertion below.
+    {
+        CHECK(WriteFileBytes(path, clean), "Restored clean wallet");
+        std::vector<uint8_t> bad = clean;
+        // Flip a byte near the front of the encrypted-seed region (right after the
+        // header+master block is variable, so flip mid-file too).
+        size_t idx = clean.size() / 2;
+        bad[idx] ^= 0x01;
+        CHECK(WriteFileBytes(path, bad), "Wrote second tampered wallet");
+
+        CWallet w;
+        w.SetWalletFile(path);
+        bool loaded = w.Load(path);
+        bool unlocked = loaded && w.Unlock(pass);
+        CHECK(!unlocked, "TAMPER B: mid-file corruption is REJECTED");
+    }
+
+    // EMPTY-MAC REJECTION (unit-level): a v7 CCrypter VerifyMAC of an empty MAC
+    // must fail (mac.size()!=64), which is what the v7 decrypt paths rely on to
+    // reject a stripped MAC.
+    {
+        std::vector<uint8_t> key(32, 0x11), iv(16, 0x22), ct(32, 0x33), emptyMac;
+        CCrypter c;
+        c.SetKey(key, iv);
+        CHECK(!c.VerifyMAC(ct, emptyMac), "EMPTY-MAC: VerifyMAC rejects an empty MAC (v7 stripping closed)");
+    }
+
+    std::remove(path.c_str());
+}
+
+int main() {
+    std::cout << COLOR_BLUE "==== LP-7 wallet encryption-at-rest tests ====" COLOR_RESET "\n";
+
+    Test_Secrecy();
+    Test_Migration();
+    Test_AuthTamper();
+
+    std::cout << "\n=============================================\n";
+    std::cout << "PASSED: " << g_pass << "   FAILED: " << g_fail << "\n";
+    std::cout << "=============================================\n";
+    return g_fail == 0 ? 0 : 1;
+}

--- a/src/test/wallet_encryption_at_rest_tests.cpp
+++ b/src/test/wallet_encryption_at_rest_tests.cpp
@@ -738,6 +738,174 @@ static bool BuildLegacyV6NonHDWalletWithKey(const std::string& path,
 }
 
 // ---------------------------------------------------------------------------
+// Legacy v6 NON-HD builder WITH an encrypted MIK present (round-5 BLOCKER-5).
+//
+// This is the missing builder: every existing legacy-v6 builder hard-codes
+// hasMIK=0, so they never exercised the MIK record on the v6 write path — which
+// is exactly where the BLOCKER-5 desync lived. A genuine pre-LP-7 v6 file with
+// an encrypted MIK carries the MIK block WITHOUT any per-record mikMacLen field
+// (the v7-only MAC field did not exist pre-LP-7). On the UNFIXED binary
+// (8e4d3abb), ChangePassphrase rewrites this wallet at v6 via SaveUnlocked, which
+// (pre-fix) emits the mikMacLen field UNCONDITIONALLY → the v6 reader (which gates
+// the read on version>=V7) never consumes it → the stream desyncs and the MIK /
+// sent-history / best-block fields are misparsed → reload fails or loads corrupt
+// MIK state. On the FIXED binary the mikMacLen field is !writeLegacyV6-gated, so
+// the v6 rewrite is byte-symmetric with the v6 reader and the MIK round-trips.
+//
+// NON-HD is deliberate: a non-HD encrypted wallet never sets the seed-migration
+// flag, so it STAYS v6 forever and EVERY SaveUnlocked runs in writeLegacyV6 mode
+// (the broadest, irreversible trigger surface). A mining wallet carrying a MIK is
+// the common case this protects.
+//
+// Non-HD encrypted v6 layout WITH MIK (matches SaveUnlocked for is_hd_wallet=false):
+//   [Magic 8][Version=6 u32][Flags=0x01][HMAC 32][salt 32]
+//   <master key block>
+//   <numCryptedKeys u32 = 1><addr 21><pubKey 1952><cryptedLen u32><ct><iv 16>
+//     <macLen u32 = 64><mac>
+//   <hasDefault u8><addr 21><numTxs u32 = 0><bestHash 32><bestHeight i32>
+//   <hasMIK u8 = 1>
+//     <pubkeyLen u32><MIK pubKey>
+//     <encPrivKeyLen u32><MIK priv ct>
+//     <ivLen u32><MIK iv>
+//     ( NO mikMacLen field — v6 never had it )
+//     <mikRegistered u8 = 0>
+//     <hasUnencryptedMIK u8 = 0>   (encrypted wallet → MIK priv stored encrypted)
+//   <numSentTx u32 = 0>
+// ---------------------------------------------------------------------------
+struct LegacyV6MIKResult {
+    CDilithiumAddress    perAddr;
+    std::vector<uint8_t> perAddrPriv;
+    std::string          mikIdentityHex;   // expected MIK identity after round-trip
+};
+
+static bool BuildLegacyV6NonHDWalletWithMIK(const std::string& path,
+                                            const std::string& passphrase,
+                                            LegacyV6MIKResult& out) {
+    // Encrypted master key block (legacy AES-keyed MAC so v<7 Unlock passes).
+    std::vector<uint8_t> vMasterKeyPlain(WALLET_CRYPTO_KEY_SIZE);
+    if (!GetStrongRandBytes(vMasterKeyPlain.data(), WALLET_CRYPTO_KEY_SIZE)) return false;
+    std::vector<uint8_t> mkSalt;
+    if (!GenerateSalt(mkSalt)) return false;
+    std::vector<uint8_t> derivedKey;
+    if (!DeriveKey(passphrase, mkSalt, WALLET_CRYPTO_PBKDF2_ROUNDS, derivedKey)) return false;
+    std::vector<uint8_t> mkIV;
+    if (!GenerateIV(mkIV)) return false;
+    CCrypter mkCrypter;
+    if (!mkCrypter.SetKey(derivedKey, mkIV)) return false;
+    std::vector<uint8_t> mkCipher;
+    if (!mkCrypter.Encrypt(vMasterKeyPlain, mkCipher)) return false;
+    std::vector<uint8_t> mkMAC;
+    if (!mkCrypter.ComputeMAC(mkCipher, mkMAC, /*useLegacyKeying=*/true)) return false;
+
+    // Per-address spending key: real keypair, encrypted under the master key,
+    // MAC'd with LEGACY keying (so it stays spendable across the v6 rewrite).
+    CKey perKey;
+    if (!WalletCrypto::GenerateKeyPair(perKey)) return false;
+    CDilithiumAddress perAddr(perKey.vchPubKey);
+    std::vector<uint8_t> keyIV;
+    if (!GenerateIV(keyIV)) return false;
+    CCrypter keyCrypter;
+    if (!keyCrypter.SetKey(vMasterKeyPlain, keyIV)) return false;
+    std::vector<uint8_t> keyCipher;
+    if (!keyCrypter.Encrypt(perKey.vchPrivKey, keyCipher)) return false;
+    std::vector<uint8_t> keyMAC;
+    if (!keyCrypter.ComputeMAC(keyCipher, keyMAC, /*useLegacyKeying=*/true)) return false;
+
+    // --- The MIK: a real Dilithium3 keypair, private key encrypted under the
+    //     master key with its own IV. NO MAC field is written (v6 shape). ---
+    DFMP::CMiningIdentityKey mik;
+    if (!mik.Generate()) return false;
+    if (!mik.IsValid() || !mik.HasPrivateKey()) return false;
+    std::string mikIdentityHex = mik.GetIdentityHex();
+
+    std::vector<uint8_t> mikIV;
+    if (!GenerateIV(mikIV)) return false;
+    CCrypter mikCrypter;
+    if (!mikCrypter.SetKey(vMasterKeyPlain, mikIV)) return false;
+    std::vector<uint8_t> mikPlain(mik.privkey.begin(), mik.privkey.end());
+    std::vector<uint8_t> mikCipher;
+    if (!mikCrypter.Encrypt(mikPlain, mikCipher)) {
+        memory_cleanse(mikPlain.data(), mikPlain.size());
+        return false;
+    }
+    memory_cleanse(mikPlain.data(), mikPlain.size());
+
+    std::vector<uint8_t> hmacSalt(WALLET_FILE_SALT_SIZE);
+    if (!GetStrongRandBytes(hmacSalt.data(), hmacSalt.size())) return false;
+
+    std::vector<uint8_t> body;
+    PutBytes(body, hmacSalt);
+
+    // master key block
+    PutU32(body, static_cast<uint32_t>(mkCipher.size()));
+    PutBytes(body, mkCipher);
+    PutBytes(body, mkSalt);
+    PutBytes(body, mkIV);
+    PutU32(body, 0u);
+    PutU32(body, WALLET_CRYPTO_PBKDF2_ROUNDS);
+    PutU32(body, static_cast<uint32_t>(mkMAC.size()));
+    PutBytes(body, mkMAC);
+
+    // keys — ONE encrypted per-address key (no HD block; flags has no 0x02)
+    PutU32(body, 1u);
+    PutBytes(body, out_default_or(perAddr.GetData()));
+    PutBytes(body, perKey.vchPubKey);
+    PutU32(body, static_cast<uint32_t>(keyCipher.size()));
+    PutBytes(body, keyCipher);
+    PutBytes(body, keyIV);
+    PutU32(body, static_cast<uint32_t>(keyMAC.size()));
+    PutBytes(body, keyMAC);
+
+    // default address = the per-address key
+    body.push_back(1);
+    PutBytes(body, out_default_or(perAddr.GetData()));
+    // transactions — 0
+    PutU32(body, 0u);
+    // best block
+    std::vector<uint8_t> bestHash(32, 0);
+    PutBytes(body, bestHash);
+    int32_t bestHeight = -1;
+    PutBytes(body, reinterpret_cast<const uint8_t*>(&bestHeight), sizeof(bestHeight));
+
+    // MIK — PRESENT (the whole point of this builder). v6 shape: NO mikMacLen.
+    body.push_back(1);                                          // hasMIK = 1
+    PutU32(body, static_cast<uint32_t>(mik.pubkey.size()));     // pubkeyLen
+    PutBytes(body, mik.pubkey);                                 // MIK pubkey
+    PutU32(body, static_cast<uint32_t>(mikCipher.size()));      // encPrivKeyLen
+    PutBytes(body, mikCipher);                                  // MIK priv ciphertext
+    PutU32(body, static_cast<uint32_t>(mikIV.size()));          // ivLen
+    PutBytes(body, mikIV);                                      // MIK iv
+    // NO mikMacLen field — a genuine v6 file never carried it.
+    body.push_back(0);                                          // mikRegistered = 0
+    body.push_back(0);                                          // hasUnencryptedMIK = 0
+
+    // sent tx — 0
+    PutU32(body, 0u);
+
+    std::vector<uint8_t> hmacKey(32, 0);
+    std::memcpy(hmacKey.data(), mkSalt.data(), std::min<size_t>(32, mkSalt.size()));
+    std::vector<uint8_t> fileHMAC(32);
+    HMAC_SHA3_256(hmacKey.data(), hmacKey.size(), body.data(), body.size(), fileHMAC.data());
+
+    std::vector<uint8_t> file;
+    file.insert(file.end(), WALLET_FILE_MAGIC_V6, WALLET_FILE_MAGIC_V6 + 8);
+    PutU32(file, WALLET_FILE_VERSION_6);
+    uint32_t flags = 0x01;   // encrypted, NOT HD
+    PutU32(file, flags);
+    PutBytes(file, fileHMAC);
+    PutBytes(file, body);
+
+    out.perAddr = perAddr;
+    out.perAddrPriv.assign(perKey.vchPrivKey.begin(), perKey.vchPrivKey.end());
+    out.mikIdentityHex = mikIdentityHex;
+
+    memory_cleanse(vMasterKeyPlain.data(), vMasterKeyPlain.size());
+    memory_cleanse(derivedKey.data(), derivedKey.size());
+
+    return WriteFileBytes(path, file);
+}
+
+// ---------------------------------------------------------------------------
 // Test 1 — secrecy regression + negative control
 // ---------------------------------------------------------------------------
 static void Test_Secrecy() {
@@ -1469,6 +1637,86 @@ static void Test_ChangePassphraseLegacyNonHD() {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Test 8 — ChangePassphrase on a legacy v6 wallet WITH an encrypted MIK
+//          (round-5 BLOCKER-5 regression).
+//
+// FAILS on 8e4d3abb (unfixed: SaveUnlocked emits the v7-only mikMacLen field into
+// the v6 layout → reader desyncs → reload fails / MIK corrupt). PASSES after the
+// !writeLegacyV6 gate on the MIK-MAC write. The decisive assertion is that the
+// wallet OPENS and the MIK round-trips after ChangePassphrase-in-place.
+// ---------------------------------------------------------------------------
+static void Test_ChangePassphraseLegacyV6WithMIK() {
+    std::cout << COLOR_BLUE "\n[Test 8] ChangePassphrase v6-in-place with an encrypted MIK present "
+                            "(BLOCKER-5: MIK-MAC field must NOT leak into v6)\n" COLOR_RESET;
+
+    const std::string oldPass = "M1n3rOldP@ss!2026#";
+    const std::string newPass = "M1n3rN3wP@ss!2026#";
+    const std::string path = "lp7_changepass_mik_v6.dat";
+    std::remove(path.c_str());
+
+    LegacyV6MIKResult mikw;
+    bool built = BuildLegacyV6NonHDWalletWithMIK(path, oldPass, mikw);
+    CHECK(built, "Built legacy v6 non-HD ENCRYPTED wallet WITH an encrypted MIK (hasMIK=1, no mikMacLen)");
+    if (!built) { std::remove(path.c_str()); return; }
+    CHECK(FileVersion(path) == WALLET_FILE_VERSION_6, "MIK wallet file is v6 before change");
+
+    // Sanity: the freshly-built v6 file loads and the MIK round-trips BEFORE any
+    // ChangePassphrase — isolates the regression to the v6 WRITE path, not the build.
+    {
+        CWallet w;
+        w.SetWalletFile(path);
+        CHECK(w.Load(path), "Pre-change: loaded the v6 MIK wallet");
+        CHECK(w.HasMIK(), "Pre-change: MIK present after load");
+        CHECK(w.Unlock(oldPass), "Pre-change: OLD passphrase unlocks the v6 MIK wallet");
+        CHECK(w.GetMIKIdentityHex() == mikw.mikIdentityHex,
+              "Pre-change: MIK identity matches (encrypted MIK decrypts on the legacy path)");
+    }
+    // Unlock with autosave on a NON-HD wallet does NOT migrate (no seed-migration
+    // flag), so the file must still be v6.
+    CHECK(FileVersion(path) == WALLET_FILE_VERSION_6,
+          "Pre-change: non-HD wallet stays v6 after unlock (no migration)");
+
+    // The load-bearing path: ChangePassphrase rewrites the v6 file in place via
+    // SaveUnlocked(writeLegacyV6). On the unfixed binary this emits the spurious
+    // mikMacLen field and desyncs the stream.
+    {
+        CWallet w;
+        w.SetWalletFile(path);   // autosave on → the change rewrites the file in place
+        CHECK(w.Load(path), "Loaded v6 MIK wallet (locked) for ChangePassphrase");
+        CHECK(w.ChangePassphrase(oldPass, newPass),
+              "ChangePassphrase SUCCEEDS on a legacy v6 wallet WITH a MIK");
+    }
+    CHECK(FileVersion(path) == WALLET_FILE_VERSION_6,
+          "File STAYS v6 after ChangePassphrase (no v7 promotion)");
+
+    // THE decisive assertion: the rewritten v6 file must OPEN and the MIK must
+    // still round-trip. On 8e4d3abb the spurious mikMacLen field desyncs the
+    // reader and either Load() fails outright or the MIK is misparsed.
+    {
+        CWallet w;
+        w.SetWalletFile(path);
+        CHECK(w.Load(path),
+              "LOAD-BEARING (BLOCKER-5): rewritten v6 MIK wallet OPENS (no stream desync)");
+        CHECK(w.HasMIK(),
+              "LOAD-BEARING (BLOCKER-5): MIK still present after the v6 rewrite");
+        CHECK(w.Unlock(newPass),
+              "NEW passphrase unlocks the rotated v6 MIK wallet");
+        CHECK(w.GetMIKIdentityHex() == mikw.mikIdentityHex,
+              "LOAD-BEARING (BLOCKER-5): MIK identity ROUND-TRIPS after ChangePassphrase "
+              "(encrypted MIK private key intact, no desync)");
+        // The per-address spending key must also survive (proves the stream stayed
+        // in sync through the MIK block: a desync would corrupt everything after it).
+        CKey recovered;
+        bool got = w.GetKey(mikw.perAddr, recovered);
+        CHECK(got && std::vector<uint8_t>(recovered.vchPrivKey.begin(), recovered.vchPrivKey.end())
+                  == mikw.perAddrPriv,
+              "Per-address key still SPENDABLE after the v6 MIK rewrite (stream stayed in sync)");
+    }
+
+    std::remove(path.c_str());
+}
+
 int main() {
     std::cout << COLOR_BLUE "==== LP-7 wallet encryption-at-rest tests ====" COLOR_RESET "\n";
 
@@ -1479,6 +1727,7 @@ int main() {
     Test_AtomicRenameCrashWindow();
     Test_LegacyPerAddressKey();
     Test_ChangePassphraseLegacyNonHD();
+    Test_ChangePassphraseLegacyV6WithMIK();
 
     std::cout << "\n=============================================\n";
     std::cout << "PASSED: " << g_pass << "   FAILED: " << g_fail << "\n";

--- a/src/test/wallet_encryption_at_rest_tests.cpp
+++ b/src/test/wallet_encryption_at_rest_tests.cpp
@@ -1281,88 +1281,114 @@ static void Test_LegacyPerAddressKey() {
 }
 
 // ---------------------------------------------------------------------------
-// Test 7 — MEDIUM-1 (round 3): ChangePassphrase on a LOADED legacy v3-v6 (non-HD)
-// encrypted wallet must SUCCEED with the correct old passphrase.
+// Test 7 — LP-7 ratified ChangePassphrase-in-place design.
 //
-// A non-HD legacy v6 wallet never sets the seed-migration flag, so its master MAC
-// stays legacy-AES-keyed and m_loadedFileVersion stays 6. Before the fix,
-// ChangePassphrase open-coded crypter.VerifyMAC with the default (separated, v7)
-// keying → the legacy-keyed master MAC mismatched → ChangePassphrase returned false
-// for the CORRECT passphrase, permanently bricking passphrase rotation for this
-// population. After routing the verify through VerifyRecordMAC, the keying matches
-// the loaded file version and the change succeeds; the rewrite is always v7 with
-// correct (separated-keyed) MACs, so the wallet re-loads and remains spendable under
-// the NEW passphrase.
+// ChangePassphrase rotates the passphrase on the wallet's EXISTING format ONLY. It
+// must NOT promote the file to v7, NOT migrate the HD seed, and NOT re-MAC the
+// non-master records. The one-time v6->v7 migration happens on the NEXT Unlock.
+// This test pins all three legs:
+//   (a) ChangePassphrase on a LOADED legacy v6 ENCRYPTED HD wallet (no prior unlock,
+//       the RPC-reachable path): correct old pass SUCCEEDS, the file STAYS v6, the
+//       wallet still unlocks + the mnemonic is still exportable under the NEW pass,
+//       and a WRONG old pass is rejected (negative control).
+//   (b) After (a)'s passphrase change, the NEXT Unlock migrates the (still-v6) file
+//       to v7 correctly: seed plaintext ABSENT from the v7 file, mnemonic still
+//       exportable.
+//   (c) ChangePassphrase on a NATIVE v7 wallet keeps it v7 and still works.
+//
+// Round-4 BLOCKER-1 (ChangePassphrase mints a v7-labelled plaintext-seed file that
+// permanently disarms migration) and BLOCKER-2 (empty-MAC mnemonic/MIK bricked on the
+// v7 re-save) are both structurally impossible under this design: leg (a) asserts the
+// file stays v6 (so no v7 promotion, no empty-MAC v7 rejection), and leg (b) asserts
+// migration still fires + succeeds on the next Unlock.
 // ---------------------------------------------------------------------------
 static void Test_ChangePassphraseLegacyNonHD() {
-    std::cout << COLOR_BLUE "\n[Test 7] ChangePassphrase on loaded legacy v6 non-HD wallet (MEDIUM-1)\n" COLOR_RESET;
+    std::cout << COLOR_BLUE "\n[Test 7] ChangePassphrase-in-place: v6 stays v6, next Unlock migrates (LP-7 ratified)\n" COLOR_RESET;
 
-    const std::string path = "lp7_legacy_changepass_nonhd.dat";
     const std::string oldPass = "Leg@cyOldP@ss!2026#";
     const std::string newPass = "N3w$tr0ngP@ss!2026#";
+
+    // === Leg (a): ChangePassphrase on a loaded legacy v6 ENCRYPTED HD wallet ===
+    const std::string path = "lp7_changepass_hd_v6.dat";
     std::remove(path.c_str());
 
-    LegacyV6NonHDResult nh;
-    bool built = BuildLegacyV6NonHDWalletWithKey(path, oldPass, nh);
-    CHECK(built, "Built legacy v6 NON-HD wallet (legacy-keyed master MAC, never migrates)");
+    LegacyV6Result legacy;
+    bool built = BuildLegacyV6Wallet(path, oldPass, legacy);
+    CHECK(built, "Built legacy v6 plaintext-seed encrypted HD wallet");
     if (!built) { std::remove(path.c_str()); return; }
-    CHECK(FileVersion(path) == WALLET_FILE_VERSION_6, "Legacy file is v6 before change");
+    CHECK(FileVersion(path) == WALLET_FILE_VERSION_6, "Legacy HD file is v6 before change");
 
-    // Change passphrase on the freshly-loaded legacy wallet. walletpassphrasechange
-    // does NOT require a prior unlock, so call ChangePassphrase directly on a loaded
-    // (but not unlocked) wallet — exactly the RPC's reachable path. Autosave ON so the
-    // successful change persists the v7 rewrite to disk.
+    // walletpassphrasechange does NOT require a prior unlock → call ChangePassphrase
+    // directly on a loaded-but-locked wallet (the RPC-reachable path). Autosave ON.
     {
         CWallet w;
-        w.SetWalletFile(path);  // autosave on → the change rewrites the file
-        CHECK(w.Load(path), "Loaded legacy v6 non-HD wallet");
-        CHECK(FileVersion(path) == WALLET_FILE_VERSION_6,
-              "Still v6 immediately after load (no migration on non-HD load)");
+        w.SetWalletFile(path);  // autosave on → the change rewrites the file in place
+        CHECK(w.Load(path), "Loaded legacy v6 HD wallet (locked)");
 
         bool changed = w.ChangePassphrase(oldPass, newPass);
         CHECK(changed,
-              "LOAD-BEARING (MEDIUM-1): ChangePassphrase SUCCEEDS with the CORRECT old "
-              "passphrase on a legacy v6 wallet (was permanently false before the fix)");
-
-        // Negative control: a WRONG old passphrase must still be rejected (the verify
-        // must reject, not blindly accept) — guards against a fix that over-permits.
-        // Reload fresh so the wallet is back to a known (now-v7, newPass) state first.
+              "LOAD-BEARING: ChangePassphrase SUCCEEDS with the CORRECT old passphrase "
+              "on a loaded legacy v6 HD wallet (no prior unlock)");
     }
 
-    // The successful change must have re-saved the wallet at v7 with correct MACs.
-    CHECK(FileVersion(path) == WALLET_FILE_VERSION_7,
-          "LOAD-BEARING: wallet re-saved at v7 after passphrase change");
+    // BLOCKER-1 structural guard: the file must STAY v6 (NOT promoted to v7). A v7
+    // promotion here without seed migration is exactly the round-4 plaintext-seed
+    // re-introduction that permanently disarmed migration.
+    CHECK(FileVersion(path) == WALLET_FILE_VERSION_6,
+          "LOAD-BEARING (BLOCKER-1 closed): file STAYS v6 after ChangePassphrase (no v7 promotion)");
 
-    // Reload the re-saved v7 wallet and confirm it unlocks with the NEW passphrase and
-    // the per-address key is still spendable → proves the v7 rewrite carries correct
-    // (separated-keyed) record MACs end-to-end.
+    // The legacy file still legitimately carries the plaintext seed (we did NOT migrate
+    // — migration is the NEXT Unlock's job). The seed-at-rest is the PRE-EXISTING v6
+    // state, re-armed for migration on reload, NOT a new v7 exposure.
+    {
+        std::vector<uint8_t> bytes = ReadFileBytes(path);
+        CHECK(Contains(bytes, legacy.seed.data(), legacy.seed.size()),
+              "v6 file still carries plaintext seed (migration deferred to next Unlock, as designed)");
+    }
+
+    // Reload + unlock under the NEW passphrase, and confirm the mnemonic is still
+    // exportable → proves the master-key rotation kept legacy keying that round-trips,
+    // and the non-master (mnemonic) record was untouched and stays readable.
     {
         CWallet w;
         w.SetWalletFile(path);
-        CHECK(w.Load(path), "Reloaded the re-saved v7 wallet");
-        CHECK(FileVersion(path) == WALLET_FILE_VERSION_7, "Reloaded file is v7");
-        // NOTE: do NOT probe Unlock(oldPass) here — a failed unlock arms the wallet's
-        // unlock rate-limiter and would throttle the NEW-passphrase unlock below. The
-        // old-passphrase-no-longer-works property is implied by the successful v7
-        // re-save under the new passphrase; wrong-passphrase rejection is covered by
-        // the dedicated negative-control block at the end of this test.
-        CHECK(w.Unlock(newPass), "NEW passphrase unlocks the re-saved v7 wallet");
-
-        CKey recovered;
-        bool got = w.GetKey(nh.perAddr, recovered);
-        CHECK(got, "Per-address key readable from the re-saved v7 wallet");
-        CHECK(got && std::vector<uint8_t>(recovered.vchPrivKey.begin(), recovered.vchPrivKey.end())
-                  == nh.perAddrPriv,
-              "LOAD-BEARING: per-address key SPENDABLE after passphrase change (correct v7 MACs)");
+        CHECK(w.Load(path), "Reloaded the rotated v6 wallet");
+        CHECK(FileVersion(path) == WALLET_FILE_VERSION_6, "Reloaded file is still v6");
+        CHECK(w.Unlock(newPass), "NEW passphrase unlocks the rotated v6 wallet");
+        std::string m;
+        CHECK(w.ExportMnemonic(m) && m == legacy.mnemonic,
+              "LOAD-BEARING (BLOCKER-2 closed): mnemonic still exportable after passphrase change");
     }
 
-    // Negative control on a fresh load: a WRONG old passphrase must be rejected.
+    // === Leg (b): the NEXT Unlock migrates the (rotated) v6 wallet to v7 ===
+    // The Unlock above (autosave ON) already triggered migration. Confirm the file is
+    // now v7 with the seed plaintext ABSENT, and the mnemonic still exports.
+    CHECK(FileVersion(path) == WALLET_FILE_VERSION_7,
+          "LOAD-BEARING: next Unlock migrated the rotated v6 wallet to v7");
     {
-        const std::string npath = "lp7_legacy_changepass_nonhd_neg.dat";
+        std::vector<uint8_t> bytes = ReadFileBytes(path);
+        CHECK(!Contains(bytes, legacy.seed.data(), legacy.seed.size()),
+              "MIGRATED: seed plaintext ABSENT from the v7 file after Unlock migration");
+        CHECK(!Contains(bytes, legacy.chaincode.data(), legacy.chaincode.size()),
+              "MIGRATED: chaincode plaintext ABSENT from the v7 file after Unlock migration");
+
+        CWallet w;
+        w.SetWalletFile(path);
+        CHECK(w.Load(path), "Reloaded the migrated v7 wallet");
+        CHECK(w.Unlock(newPass), "Migrated v7 wallet unlocks under the NEW passphrase");
+        std::string m;
+        CHECK(w.ExportMnemonic(m) && m == legacy.mnemonic,
+              "Migrated v7 wallet still exports the original mnemonic");
+    }
+    std::remove(path.c_str());
+
+    // === Leg (a) negative control: a WRONG old passphrase must be rejected ===
+    {
+        const std::string npath = "lp7_changepass_hd_v6_neg.dat";
         std::remove(npath.c_str());
-        LegacyV6NonHDResult nh2;
-        bool b2 = BuildLegacyV6NonHDWalletWithKey(npath, oldPass, nh2);
-        CHECK(b2, "Built second legacy v6 non-HD wallet (negative control)");
+        LegacyV6Result neg;
+        bool b2 = BuildLegacyV6Wallet(npath, oldPass, neg);
+        CHECK(b2, "Built second legacy v6 HD wallet (negative control)");
         if (b2) {
             CWallet w;
             w.SetWalletFile(npath);
@@ -1375,7 +1401,72 @@ static void Test_ChangePassphraseLegacyNonHD() {
         std::remove(npath.c_str());
     }
 
-    std::remove(path.c_str());
+    // === Also pin the legacy NON-HD path (never migrates; stays v6 forever) ===
+    {
+        const std::string nhpath = "lp7_changepass_nonhd_v6.dat";
+        std::remove(nhpath.c_str());
+        LegacyV6NonHDResult nh;
+        bool nbuilt = BuildLegacyV6NonHDWalletWithKey(nhpath, oldPass, nh);
+        CHECK(nbuilt, "Built legacy v6 NON-HD wallet (legacy-keyed master MAC, never migrates)");
+        if (nbuilt) {
+            {
+                CWallet w;
+                w.SetWalletFile(nhpath);
+                CHECK(w.Load(nhpath), "Loaded legacy v6 non-HD wallet");
+                CHECK(w.ChangePassphrase(oldPass, newPass),
+                      "ChangePassphrase SUCCEEDS on a legacy v6 non-HD wallet");
+            }
+            // Non-HD wallet never migrates → STAYS v6.
+            CHECK(FileVersion(nhpath) == WALLET_FILE_VERSION_6,
+                  "Non-HD wallet STAYS v6 after ChangePassphrase (never migrates)");
+            {
+                CWallet w;
+                w.SetWalletFile(nhpath);
+                CHECK(w.Load(nhpath), "Reloaded the rotated non-HD v6 wallet");
+                CHECK(w.Unlock(newPass), "NEW passphrase unlocks the rotated non-HD v6 wallet");
+                CKey recovered;
+                bool got = w.GetKey(nh.perAddr, recovered);
+                CHECK(got && std::vector<uint8_t>(recovered.vchPrivKey.begin(), recovered.vchPrivKey.end())
+                          == nh.perAddrPriv,
+                      "LOAD-BEARING: per-address key SPENDABLE after non-HD passphrase change (legacy MACs intact)");
+            }
+        }
+        std::remove(nhpath.c_str());
+    }
+
+    // === Leg (c): ChangePassphrase on a NATIVE v7 wallet keeps v7 + works ===
+    {
+        const std::string vpath = "lp7_changepass_native_v7.dat";
+        std::remove(vpath.c_str());
+        std::string mnemonic;
+        {
+            CWallet w;
+            w.SetWalletFile(vpath);
+            CHECK(w.GenerateHDWallet(mnemonic), "Generated native HD wallet");
+            CHECK(w.EncryptWallet(oldPass), "Encrypted → native v7");
+            CHECK(w.Save(vpath), "Saved native v7 wallet");
+        }
+        CHECK(FileVersion(vpath) == WALLET_FILE_VERSION_7, "Native wallet is v7");
+        {
+            CWallet w;
+            w.SetWalletFile(vpath);
+            CHECK(w.Load(vpath), "Loaded native v7 wallet");
+            CHECK(w.ChangePassphrase(oldPass, newPass),
+                  "ChangePassphrase SUCCEEDS on a native v7 wallet");
+        }
+        CHECK(FileVersion(vpath) == WALLET_FILE_VERSION_7,
+              "LOAD-BEARING (leg c): native v7 wallet STAYS v7 after ChangePassphrase");
+        {
+            CWallet w;
+            w.SetWalletFile(vpath);
+            CHECK(w.Load(vpath), "Reloaded the rotated native v7 wallet");
+            CHECK(w.Unlock(newPass), "NEW passphrase unlocks the rotated native v7 wallet");
+            std::string m;
+            CHECK(w.ExportMnemonic(m) && m == mnemonic,
+                  "Native v7 wallet still exports its mnemonic after passphrase change");
+        }
+        std::remove(vpath.c_str());
+    }
 }
 
 int main() {

--- a/src/test/wallet_encryption_at_rest_tests.cpp
+++ b/src/test/wallet_encryption_at_rest_tests.cpp
@@ -1875,6 +1875,21 @@ struct LP7EncryptRollbackTester {
         return true;
     }
 
+    // red-team HIGH-1 variant: the SAME encrypted-in-memory + plaintext-seed window
+    // but pinned to the LEGACY-v6 writer (m_loadedFileVersion == 6 ⇒ writeLegacyV6
+    // == true). This exercises the legacy-v6 plaintext-seed write path (wallet.cpp
+    // ~3000), which the v7 guard did NOT cover. The dangerous state is the same:
+    // masterKey.IsValid()==true && fHDMasterKeyEncrypted==false flowing to a 32-byte
+    // plaintext seed write. On the pre-fix-#1 binary the legacy-v6 branch's only
+    // guard checks the INVERSE (fHDMasterKeyEncrypted), so this Save SUCCEEDS and
+    // leaks the plaintext seed; with the masterKey.IsValid() guard it must REFUSE.
+    static bool ForceEncryptedPlaintextSeedWindowV6(CWallet& w) {
+        if (!ForceEncryptedPlaintextSeedWindow(w)) return false;
+        // Override the version: legacy-v6 writer path instead of v7.
+        w.m_loadedFileVersion = WALLET_FILE_VERSION_6;
+        return true;
+    }
+
     static bool ForceSave(CWallet& w, const std::string& path) { return w.SaveUnlocked(path); }
     static bool IsHDEncrypted(const CWallet& w) { return w.fHDMasterKeyEncrypted; }
     static bool SeedMatches(const CWallet& w, const std::vector<uint8_t>& seed) {
@@ -1971,6 +1986,54 @@ static void Test_EncryptWalletRollback() {
         if (!savedBytes.empty()) {
             CHECK(!Contains(savedBytes, seed.data(), seed.size()),
                   "FAIL-CLOSED: no plaintext seed persisted for the encrypted wallet");
+        }
+
+        std::remove(path.c_str());
+        std::remove(savePath.c_str());
+    }
+
+    // === PART C (red-team HIGH-1): the LEGACY-v6 writer path is ALSO fail-closed
+    //             for an encrypted wallet with a plaintext seed. The first fold
+    //             only guarded the v7 plaintext branch; the parallel legacy-v6
+    //             writer (writeLegacyV6 == true, wallet.cpp ~3000) wrote the 32-byte
+    //             plaintext seed with no masterKey.IsValid() guard, so the LP-7 leak
+    //             stayed live for v6-loaded encrypted wallets. This case FAILS on
+    //             head 6d6e0b3a (proving HIGH-1) and PASSES after fix #1. ===
+    {
+        const std::string path     = "lp7_rollback_v6_src.dat";
+        const std::string savePath = "lp7_rollback_v6_guard.dat";
+        std::remove(path.c_str());
+        std::remove(savePath.c_str());
+
+        std::string mnemonic;
+        CWallet w;                         // no SetWalletFile → autosave off
+        CHECK(w.GenerateHDWallet(mnemonic), "Generated HD wallet for v6 guard test");
+        std::vector<uint8_t> seed, chaincode;
+        CHECK(DeriveSeedChaincode(mnemonic, seed, chaincode), "Derived expected seed (v6 case)");
+
+        // Force the SAME bug window but pinned to the legacy-v6 writer: encrypted-
+        // in-memory (master key valid) + HD seed still PLAINTEXT, m_loadedFileVersion
+        // == 6 ⇒ writeLegacyV6 == true. The seed is intact (not scrubbed), so the
+        // pre-existing scrubbed-seed guard (fHDMasterKeyEncrypted) does NOT catch it —
+        // only the new masterKey.IsValid() guard refuses this write.
+        CHECK(LP7EncryptRollbackTester::ForceEncryptedPlaintextSeedWindowV6(w),
+              "Entered encrypted-in-memory + plaintext-seed LEGACY-V6 window");
+        CHECK(w.IsCrypted() && !LP7EncryptRollbackTester::IsHDEncrypted(w),
+              "Window invariant holds (v6): master key valid AND HD seed not encrypted");
+
+        // Drive the legacy-v6 writer. With fix #1 (masterKey.IsValid() guard on the
+        // v6 branch) this MUST refuse. Without it, a v6 file with the plaintext seed
+        // is written for an encrypted wallet — the LP-7 leak on the v6 path.
+        bool saved = LP7EncryptRollbackTester::ForceSave(w, savePath);
+        CHECK(!saved,
+              "LOAD-BEARING (HIGH-1): SaveUnlocked REFUSES to write a legacy-v6 plaintext seed for an encrypted wallet");
+
+        std::vector<uint8_t> savedBytes = ReadFileBytes(savePath);
+        CHECK(savedBytes.empty(),
+              "FAIL-CLOSED (v6): no file written at the destination (no v6 encrypted+plaintext-seed artifact)");
+        if (!savedBytes.empty()) {
+            CHECK(!Contains(savedBytes, seed.data(), seed.size()),
+                  "FAIL-CLOSED (v6): no plaintext seed persisted for the encrypted wallet");
         }
 
         std::remove(path.c_str());

--- a/src/test/wallet_encryption_at_rest_tests.cpp
+++ b/src/test/wallet_encryption_at_rest_tests.cpp
@@ -429,6 +429,315 @@ static bool BuildLegacyV6Wallet(const std::string& path,
 }
 
 // ---------------------------------------------------------------------------
+// Legacy v6 builder WITH a per-address spending key carrying a LEGACY-keyed MAC.
+//
+// HIGH-2 regression scaffold. Reproduces the exact pre-LP-7 v6 on-disk shape of
+// a wallet that holds ONE encrypted per-address spending key whose MAC was
+// computed with the LEGACY AES-keyed HMAC (AES key == HMAC key) — the keying
+// every pre-LP-7 build used before key separation was introduced. On the
+// unfixed binary, GetKey verifies this MAC with the SEPARATED keying (the :336
+// default), so it mismatches and the key is unspendable. On the fixed binary the
+// version-keyed gate selects legacy keying for v6 and the key is spendable; and
+// migration re-MACs it under v7 keying so it stays spendable post-migration.
+//
+// Builds on the v6 layout from BuildLegacyV6Wallet but sets numCryptedKeys=1 and
+// emits one per-address key record:
+//   [addr 21][pubKey 1952][cryptedLen u32][ct][iv 16][macLen u32][mac 64]
+// ---------------------------------------------------------------------------
+struct LegacyV6KeyResult {
+    std::vector<uint8_t> seed;
+    std::vector<uint8_t> chaincode;
+    std::string mnemonic;
+    std::vector<uint8_t> defaultAddr;   // 21-byte default (HD) address
+    CDilithiumAddress    perAddr;       // address of the imported per-address key
+    std::vector<uint8_t> perAddrPriv;   // its plaintext private key (for spend assertion)
+};
+
+static bool BuildLegacyV6WalletWithPerAddressKey(const std::string& path,
+                                                 const std::string& passphrase,
+                                                 LegacyV6KeyResult& out) {
+    std::string scratch = path + ".scratch";
+    std::remove(scratch.c_str());
+
+    std::string mnemonic;
+    std::vector<uint8_t> defAddr;
+    {
+        CWallet w;
+        w.SetWalletFile(scratch);
+        if (!w.GenerateHDWallet(mnemonic)) return false;
+        std::vector<CDilithiumAddress> addrs = w.GetAddresses();
+        if (addrs.empty()) return false;
+        defAddr = w.GetAddresses().front().GetData();
+    }
+    std::remove(scratch.c_str());
+
+    std::vector<uint8_t> seed, chaincode;
+    if (!DeriveSeedChaincode(mnemonic, seed, chaincode)) return false;
+
+    CHDExtendedKey master;
+    {
+        uint8_t bip39seed[64];
+        if (!CMnemonic::ToSeed(mnemonic, "", bip39seed)) return false;
+        DeriveMaster(bip39seed, master);
+        memory_cleanse(bip39seed, 64);
+    }
+
+    // Encrypted master key block (legacy AES-keyed MAC so v<7 Unlock passes).
+    std::vector<uint8_t> vMasterKeyPlain(WALLET_CRYPTO_KEY_SIZE);
+    if (!GetStrongRandBytes(vMasterKeyPlain.data(), WALLET_CRYPTO_KEY_SIZE)) return false;
+    std::vector<uint8_t> mkSalt;
+    if (!GenerateSalt(mkSalt)) return false;
+    std::vector<uint8_t> derivedKey;
+    if (!DeriveKey(passphrase, mkSalt, WALLET_CRYPTO_PBKDF2_ROUNDS, derivedKey)) return false;
+    std::vector<uint8_t> mkIV;
+    if (!GenerateIV(mkIV)) return false;
+    CCrypter mkCrypter;
+    if (!mkCrypter.SetKey(derivedKey, mkIV)) return false;
+    std::vector<uint8_t> mkCipher;
+    if (!mkCrypter.Encrypt(vMasterKeyPlain, mkCipher)) return false;
+    std::vector<uint8_t> mkMAC;
+    if (!mkCrypter.ComputeMAC(mkCipher, mkMAC, /*useLegacyKeying=*/true)) return false;
+
+    // Legacy obfuscated mnemonic (key = HKDF(seed,"mnemonic")).
+    std::vector<uint8_t> obfKey(WALLET_CRYPTO_KEY_SIZE);
+    {
+        std::vector<uint8_t> hdSeed(master.seed, master.seed + 32);
+        DeriveEncryptionKey(hdSeed, "mnemonic", obfKey);
+        memory_cleanse(hdSeed.data(), hdSeed.size());
+    }
+    std::vector<uint8_t> mnIV;
+    if (!GenerateIV(mnIV)) return false;
+    CCrypter mnCrypter;
+    if (!mnCrypter.SetKey(obfKey, mnIV)) return false;
+    std::vector<uint8_t> mnemonicBytes(mnemonic.begin(), mnemonic.end());
+    std::vector<uint8_t> mnCipher;
+    if (!mnCrypter.Encrypt(mnemonicBytes, mnCipher)) return false;
+
+    // --- The per-address spending key: real keypair, encrypted under the master
+    //     key with its own IV, MAC'd with LEGACY keying. ---
+    CKey perKey;
+    if (!WalletCrypto::GenerateKeyPair(perKey)) return false;
+    CDilithiumAddress perAddr(perKey.vchPubKey);  // same derivation Load uses
+    std::vector<uint8_t> keyIV;
+    if (!GenerateIV(keyIV)) return false;
+    CCrypter keyCrypter;
+    if (!keyCrypter.SetKey(vMasterKeyPlain, keyIV)) return false;
+    std::vector<uint8_t> keyCipher;
+    if (!keyCrypter.Encrypt(perKey.vchPrivKey, keyCipher)) return false;
+    std::vector<uint8_t> keyMAC;
+    // LEGACY keying — this is the crux: a pre-LP-7 build wrote per-address MACs
+    // keyed with the AES key, NOT the separated MAC key.
+    if (!keyCrypter.ComputeMAC(keyCipher, keyMAC, /*useLegacyKeying=*/true)) return false;
+
+    // --- Assemble the body. ---
+    std::vector<uint8_t> hmacSalt(WALLET_FILE_SALT_SIZE);
+    if (!GetStrongRandBytes(hmacSalt.data(), hmacSalt.size())) return false;
+
+    std::vector<uint8_t> body;
+    PutBytes(body, hmacSalt);
+
+    // master key block
+    PutU32(body, static_cast<uint32_t>(mkCipher.size()));
+    PutBytes(body, mkCipher);
+    PutBytes(body, mkSalt);
+    PutBytes(body, mkIV);
+    PutU32(body, 0u);
+    PutU32(body, WALLET_CRYPTO_PBKDF2_ROUNDS);
+    PutU32(body, static_cast<uint32_t>(mkMAC.size()));
+    PutBytes(body, mkMAC);
+
+    // HD block (v6): mnemonic + PLAINTEXT seed (the bug shape)
+    PutU32(body, static_cast<uint32_t>(mnCipher.size()));
+    PutBytes(body, mnCipher);
+    PutBytes(body, mnIV);
+    PutBytes(body, master.seed, 32);
+    PutBytes(body, master.chaincode, 32);
+    PutU32(body, master.depth);
+    PutU32(body, master.fingerprint);
+    PutU32(body, master.child_index);
+    body.push_back(0);                     // encrypted_flag = 0
+
+    // HD chain state + 0 path mappings
+    PutU32(body, 0u);
+    PutU32(body, 0u);
+    PutU32(body, 0u);
+    PutU32(body, 0u);                      // numPaths = 0
+
+    // keys — ONE encrypted per-address key
+    PutU32(body, 1u);                      // numCryptedKeys = 1
+    PutBytes(body, out_default_or(perAddr.GetData()));     // [addr 21]
+    PutBytes(body, perKey.vchPubKey);                      // [pubKey 1952]
+    PutU32(body, static_cast<uint32_t>(keyCipher.size())); // [cryptedLen]
+    PutBytes(body, keyCipher);                             // [ct]
+    PutBytes(body, keyIV);                                 // [iv 16]
+    PutU32(body, static_cast<uint32_t>(keyMAC.size()));    // [macLen = 64]
+    PutBytes(body, keyMAC);                                // [mac]
+
+    // default address (HD default)
+    body.push_back(1);
+    PutBytes(body, out_default_or(defAddr));
+
+    // transactions — 0
+    PutU32(body, 0u);
+    // best block
+    std::vector<uint8_t> bestHash(32, 0);
+    PutBytes(body, bestHash);
+    int32_t bestHeight = -1;
+    PutBytes(body, reinterpret_cast<const uint8_t*>(&bestHeight), sizeof(bestHeight));
+    // MIK — none
+    body.push_back(0);
+    // sent tx — 0
+    PutU32(body, 0u);
+
+    // file integrity HMAC (key = first 32 bytes of mk salt)
+    std::vector<uint8_t> hmacKey(32, 0);
+    std::memcpy(hmacKey.data(), mkSalt.data(), std::min<size_t>(32, mkSalt.size()));
+    std::vector<uint8_t> fileHMAC(32);
+    HMAC_SHA3_256(hmacKey.data(), hmacKey.size(), body.data(), body.size(), fileHMAC.data());
+
+    std::vector<uint8_t> file;
+    file.insert(file.end(), WALLET_FILE_MAGIC_V6, WALLET_FILE_MAGIC_V6 + 8);
+    PutU32(file, WALLET_FILE_VERSION_6);
+    uint32_t flags = 0x01 | 0x02;
+    PutU32(file, flags);
+    PutBytes(file, fileHMAC);
+    PutBytes(file, body);
+
+    out.seed = seed;
+    out.chaincode = chaincode;
+    out.mnemonic = mnemonic;
+    out.defaultAddr = defAddr;
+    out.perAddr = perAddr;
+    out.perAddrPriv.assign(perKey.vchPrivKey.begin(), perKey.vchPrivKey.end());
+
+    memory_cleanse(vMasterKeyPlain.data(), vMasterKeyPlain.size());
+    memory_cleanse(derivedKey.data(), derivedKey.size());
+    memory_cleanse(obfKey.data(), obfKey.size());
+
+    return WriteFileBytes(path, file);
+}
+
+// ---------------------------------------------------------------------------
+// Legacy v6 NON-HD builder with ONE legacy-MAC'd per-address key.
+//
+// Isolates the RAW v6 GetKey path (manifestation 1 of HIGH-2): a NON-HD
+// encrypted wallet has no plaintext HD seed, so loading it does NOT set the
+// seed-migration flag and Unlock does NOT migrate — m_loadedFileVersion stays 6
+// when GetKey runs. This exercises the version-keyed selection in isolation
+// (legacyKeying==true for v6) without any in-memory migration masking it. On the
+// unfixed binary GetKey verifies the legacy-keyed MAC with separated keying →
+// fails → the key is unspendable on a wallet that never migrates.
+//
+// Non-HD encrypted v6 layout (matches SaveUnlocked for is_hd_wallet=false):
+//   [Magic 8][Version u32][Flags=0x01][HMAC 32][salt 32]
+//   <master key block>
+//   <numCryptedKeys u32 = 1><addr 21><pubKey 1952><cryptedLen u32><ct><iv 16>
+//     <macLen u32 = 64><mac>
+//   <hasDefault u8><addr 21><numTxs u32 = 0><bestHash 32><bestHeight i32>
+//   <hasMIK u8 = 0><numSentTx u32 = 0>
+// ---------------------------------------------------------------------------
+struct LegacyV6NonHDResult {
+    CDilithiumAddress    perAddr;
+    std::vector<uint8_t> perAddrPriv;
+};
+
+static bool BuildLegacyV6NonHDWalletWithKey(const std::string& path,
+                                            const std::string& passphrase,
+                                            LegacyV6NonHDResult& out) {
+    // Encrypted master key block (legacy AES-keyed MAC).
+    std::vector<uint8_t> vMasterKeyPlain(WALLET_CRYPTO_KEY_SIZE);
+    if (!GetStrongRandBytes(vMasterKeyPlain.data(), WALLET_CRYPTO_KEY_SIZE)) return false;
+    std::vector<uint8_t> mkSalt;
+    if (!GenerateSalt(mkSalt)) return false;
+    std::vector<uint8_t> derivedKey;
+    if (!DeriveKey(passphrase, mkSalt, WALLET_CRYPTO_PBKDF2_ROUNDS, derivedKey)) return false;
+    std::vector<uint8_t> mkIV;
+    if (!GenerateIV(mkIV)) return false;
+    CCrypter mkCrypter;
+    if (!mkCrypter.SetKey(derivedKey, mkIV)) return false;
+    std::vector<uint8_t> mkCipher;
+    if (!mkCrypter.Encrypt(vMasterKeyPlain, mkCipher)) return false;
+    std::vector<uint8_t> mkMAC;
+    if (!mkCrypter.ComputeMAC(mkCipher, mkMAC, /*useLegacyKeying=*/true)) return false;
+
+    // Per-address spending key: real keypair, encrypted under the master key,
+    // MAC'd with LEGACY keying.
+    CKey perKey;
+    if (!WalletCrypto::GenerateKeyPair(perKey)) return false;
+    CDilithiumAddress perAddr(perKey.vchPubKey);
+    std::vector<uint8_t> keyIV;
+    if (!GenerateIV(keyIV)) return false;
+    CCrypter keyCrypter;
+    if (!keyCrypter.SetKey(vMasterKeyPlain, keyIV)) return false;
+    std::vector<uint8_t> keyCipher;
+    if (!keyCrypter.Encrypt(perKey.vchPrivKey, keyCipher)) return false;
+    std::vector<uint8_t> keyMAC;
+    if (!keyCrypter.ComputeMAC(keyCipher, keyMAC, /*useLegacyKeying=*/true)) return false;
+
+    std::vector<uint8_t> hmacSalt(WALLET_FILE_SALT_SIZE);
+    if (!GetStrongRandBytes(hmacSalt.data(), hmacSalt.size())) return false;
+
+    std::vector<uint8_t> body;
+    PutBytes(body, hmacSalt);
+
+    // master key block
+    PutU32(body, static_cast<uint32_t>(mkCipher.size()));
+    PutBytes(body, mkCipher);
+    PutBytes(body, mkSalt);
+    PutBytes(body, mkIV);
+    PutU32(body, 0u);
+    PutU32(body, WALLET_CRYPTO_PBKDF2_ROUNDS);
+    PutU32(body, static_cast<uint32_t>(mkMAC.size()));
+    PutBytes(body, mkMAC);
+
+    // keys — ONE encrypted per-address key (no HD block; flags has no 0x02)
+    PutU32(body, 1u);
+    PutBytes(body, out_default_or(perAddr.GetData()));
+    PutBytes(body, perKey.vchPubKey);
+    PutU32(body, static_cast<uint32_t>(keyCipher.size()));
+    PutBytes(body, keyCipher);
+    PutBytes(body, keyIV);
+    PutU32(body, static_cast<uint32_t>(keyMAC.size()));
+    PutBytes(body, keyMAC);
+
+    // default address = the per-address key
+    body.push_back(1);
+    PutBytes(body, out_default_or(perAddr.GetData()));
+    // transactions — 0
+    PutU32(body, 0u);
+    // best block
+    std::vector<uint8_t> bestHash(32, 0);
+    PutBytes(body, bestHash);
+    int32_t bestHeight = -1;
+    PutBytes(body, reinterpret_cast<const uint8_t*>(&bestHeight), sizeof(bestHeight));
+    // MIK — none
+    body.push_back(0);
+    // sent tx — 0
+    PutU32(body, 0u);
+
+    std::vector<uint8_t> hmacKey(32, 0);
+    std::memcpy(hmacKey.data(), mkSalt.data(), std::min<size_t>(32, mkSalt.size()));
+    std::vector<uint8_t> fileHMAC(32);
+    HMAC_SHA3_256(hmacKey.data(), hmacKey.size(), body.data(), body.size(), fileHMAC.data());
+
+    std::vector<uint8_t> file;
+    file.insert(file.end(), WALLET_FILE_MAGIC_V6, WALLET_FILE_MAGIC_V6 + 8);
+    PutU32(file, WALLET_FILE_VERSION_6);
+    uint32_t flags = 0x01;   // encrypted, NOT HD
+    PutU32(file, flags);
+    PutBytes(file, fileHMAC);
+    PutBytes(file, body);
+
+    out.perAddr = perAddr;
+    out.perAddrPriv.assign(perKey.vchPrivKey.begin(), perKey.vchPrivKey.end());
+
+    memory_cleanse(vMasterKeyPlain.data(), vMasterKeyPlain.size());
+    memory_cleanse(derivedKey.data(), derivedKey.size());
+
+    return WriteFileBytes(path, file);
+}
+
+// ---------------------------------------------------------------------------
 // Test 1 — secrecy regression + negative control
 // ---------------------------------------------------------------------------
 static void Test_Secrecy() {
@@ -847,6 +1156,130 @@ static void Test_AtomicRenameCrashWindow() {
     std::remove((path + ".tmp").c_str());
 }
 
+// ---------------------------------------------------------------------------
+// Test 6 — HIGH-2: legacy per-address spending key is SPENDABLE (direct read
+// AND after migration).
+//
+// Builds a genuine legacy v6 encrypted wallet that carries ONE per-address
+// spending key whose MAC was written with the LEGACY AES-keyed HMAC. The round-2
+// finding: the per-address GetKey verify (wallet.cpp:336) used the SEPARATED
+// keying unconditionally while the other four decrypt paths were version-keyed,
+// so this legacy key's MAC mismatches → GetKey fails → funds unspendable, both on
+// direct read and baked into the migrated v7 file (no per-address re-MAC loop).
+//
+// This test MUST FAIL on commit b7534b1c (key unspendable) and PASS after the
+// fold (centralized version-keyed VerifyRecordMAC + per-address re-MAC in
+// migration). The load-bearing assertions are the two "spendable" checks.
+// ---------------------------------------------------------------------------
+static void Test_LegacyPerAddressKey() {
+    std::cout << COLOR_BLUE "\n[Test 6] Legacy per-address spending key spendable (HIGH-2)\n" COLOR_RESET;
+
+    const std::string path = "lp7_legacy_peraddr_wallet.dat";
+    const std::string pass = "Leg@cyKey!Spend#2026";
+    std::remove(path.c_str());
+
+    LegacyV6KeyResult legacy;
+    bool built = BuildLegacyV6WalletWithPerAddressKey(path, pass, legacy);
+    CHECK(built, "Built legacy v6 wallet WITH a legacy-MAC'd per-address key");
+    if (!built) { std::remove(path.c_str()); return; }
+
+    CHECK(FileVersion(path) == WALLET_FILE_VERSION_6, "Legacy file is v6");
+    CHECK(legacy.perAddrPriv.size() == DILITHIUM_SECRETKEY_SIZE,
+          "Captured the per-address plaintext private key");
+
+    // --- (A) DIRECT LEGACY READ: the per-address key must be SPENDABLE without
+    //         any migration. Load with autosave OFF so we exercise the raw v6
+    //         read path (m_loadedFileVersion == 6) before any rewrite. ---
+    {
+        CWallet w;
+        bool loaded = w.Load(path);   // no SetWalletFile → autosave off → no rewrite
+        CHECK(loaded, "Loaded legacy v6 wallet (autosave off, no migration)");
+        CHECK(loaded && w.Unlock(pass), "Unlocked legacy v6 wallet");
+
+        CKey recovered;
+        bool got = loaded && w.GetKey(legacy.perAddr, recovered);
+        CHECK(got, "DIRECT READ: GetKey succeeds on the legacy-MAC'd per-address key");
+        CHECK(got && recovered.vchPrivKey.size() == DILITHIUM_SECRETKEY_SIZE &&
+              std::vector<uint8_t>(recovered.vchPrivKey.begin(), recovered.vchPrivKey.end())
+                  == legacy.perAddrPriv,
+              "DIRECT READ (LOAD-BEARING): decrypted private key matches — key is SPENDABLE");
+        // Confirm still v6 on disk (no rewrite happened).
+        CHECK(FileVersion(path) == WALLET_FILE_VERSION_6,
+              "DIRECT READ: file untouched (still v6, autosave off)");
+    }
+
+    // --- (B) AFTER MIGRATION: load with autosave ON → unlock triggers the atomic
+    //         v7 rewrite (incl. the per-address re-MAC loop). The same key must
+    //         remain spendable, and the re-MAC must persist to disk. ---
+    {
+        CWallet w;
+        w.SetWalletFile(path);  // autosave on
+        CHECK(w.Load(path), "Loaded legacy v6 wallet (autosave on)");
+        CHECK(w.Unlock(pass), "Unlocked → triggers atomic migration to v7");
+        CHECK(FileVersion(path) == WALLET_FILE_VERSION_7, "File migrated to v7");
+
+        CKey recovered;
+        bool got = w.GetKey(legacy.perAddr, recovered);
+        CHECK(got, "POST-MIGRATION (in memory): GetKey still succeeds");
+        CHECK(got && std::vector<uint8_t>(recovered.vchPrivKey.begin(), recovered.vchPrivKey.end())
+                  == legacy.perAddrPriv,
+              "POST-MIGRATION (LOAD-BEARING): key still SPENDABLE in the migrating instance");
+    }
+
+    // --- (C) RELOAD the migrated v7 file fresh: the per-address key must be
+    //         spendable from the on-disk v7 record (proves the re-MAC was
+    //         written, not just held in memory). ---
+    {
+        CWallet w;
+        w.SetWalletFile(path);
+        CHECK(w.Load(path), "Reloaded migrated v7 wallet from disk");
+        CHECK(FileVersion(path) == WALLET_FILE_VERSION_7, "Reloaded file is v7");
+        CHECK(w.Unlock(pass), "Migrated v7 wallet unlocks");
+
+        CKey recovered;
+        bool got = w.GetKey(legacy.perAddr, recovered);
+        CHECK(got, "RELOADED v7: GetKey succeeds on the re-MAC'd per-address key");
+        CHECK(got && std::vector<uint8_t>(recovered.vchPrivKey.begin(), recovered.vchPrivKey.end())
+                  == legacy.perAddrPriv,
+              "RELOADED v7 (LOAD-BEARING): on-disk v7 per-address key is SPENDABLE (re-MAC persisted)");
+    }
+
+    std::remove(path.c_str());
+
+    // --- (D) RAW v6 READ, NO MIGRATION (manifestation 1, isolated). A NON-HD
+    //         encrypted v6 wallet never sets the seed-migration flag, so Unlock
+    //         does NOT migrate and m_loadedFileVersion stays 6 when GetKey runs.
+    //         This drives the per-address VerifyRecordMAC with legacyKeying==true
+    //         in isolation (no in-memory migration to mask it). On the unfixed
+    //         binary the legacy-keyed MAC is verified with separated keying →
+    //         GetKey fails → the key is unspendable on a wallet that never
+    //         migrates. ---
+    {
+        const std::string nhpath = "lp7_legacy_peraddr_nonhd.dat";
+        std::remove(nhpath.c_str());
+        LegacyV6NonHDResult nh;
+        bool nbuilt = BuildLegacyV6NonHDWalletWithKey(nhpath, pass, nh);
+        CHECK(nbuilt, "Built legacy v6 NON-HD wallet with a legacy-MAC'd per-address key");
+        if (nbuilt) {
+            CWallet w;
+            bool loaded = w.Load(nhpath);   // autosave off
+            CHECK(loaded, "Loaded non-HD legacy v6 wallet");
+            CHECK(loaded && w.Unlock(pass), "Unlocked non-HD legacy v6 wallet (NO migration)");
+            // File must still be v6 — proves migration did not run.
+            CHECK(FileVersion(nhpath) == WALLET_FILE_VERSION_6,
+                  "RAW v6: file still v6 after unlock (no migration ran)");
+
+            CKey recovered;
+            bool got = loaded && w.GetKey(nh.perAddr, recovered);
+            CHECK(got, "RAW v6: GetKey succeeds while m_loadedFileVersion==6");
+            CHECK(got && std::vector<uint8_t>(recovered.vchPrivKey.begin(), recovered.vchPrivKey.end())
+                      == nh.perAddrPriv,
+                  "RAW v6 (LOAD-BEARING): legacy-keyed per-address key SPENDABLE on un-migrated v6 wallet");
+        }
+        std::remove(nhpath.c_str());
+    }
+}
+
 int main() {
     std::cout << COLOR_BLUE "==== LP-7 wallet encryption-at-rest tests ====" COLOR_RESET "\n";
 
@@ -855,6 +1288,7 @@ int main() {
     Test_AuthTamper();
     Test_PerRecordMACIsolation();
     Test_AtomicRenameCrashWindow();
+    Test_LegacyPerAddressKey();
 
     std::cout << "\n=============================================\n";
     std::cout << "PASSED: " << g_pass << "   FAILED: " << g_fail << "\n";

--- a/src/wallet/crypter.cpp
+++ b/src/wallet/crypter.cpp
@@ -166,7 +166,8 @@ bool CCrypter::Decrypt(const std::vector<uint8_t>& ciphertext,
 // ============================================================================
 
 bool CCrypter::ComputeMAC(const std::vector<uint8_t>& ciphertext,
-                          std::vector<uint8_t>& mac) {
+                          std::vector<uint8_t>& mac,
+                          bool useLegacyKeying) {
     if (!fKeySet) return false;
     if (ciphertext.empty()) return false;
 
@@ -179,24 +180,48 @@ bool CCrypter::ComputeMAC(const std::vector<uint8_t>& ciphertext,
     data.insert(data.end(), vchIV.begin(), vchIV.end());
     data.insert(data.end(), ciphertext.begin(), ciphertext.end());
 
-    // Compute HMAC-SHA3-512
     mac.resize(64);
-    HMAC_SHA3_512(vchKey.data_ptr(), vchKey.size(),
+
+    if (useLegacyKeying) {
+        // LEGACY (v3-v6 wallets): HMAC was keyed with the AES key itself.
+        // This branch exists ONLY to verify MACs on records that were written
+        // before the LP-7 key-separation fix, so that pre-fix encrypted wallets
+        // still unlock and can be migrated. Never used when WRITING new records.
+        HMAC_SHA3_512(vchKey.data_ptr(), vchKey.size(),
+                      data.data(), data.size(),
+                      mac.data());
+        return true;
+    }
+
+    // LP-7 (wallet-Inv-2): KEY-SEPARATION FIX (v7+).
+    // The same key must not be used for two different primitives (AES-CBC and
+    // HMAC). Derive a distinct MAC key from the AES key via HKDF-SHA3-256 with a
+    // dedicated context so the HMAC key is independent of the cipher key.
+    std::vector<uint8_t> aesKey(vchKey.data_ptr(), vchKey.data_ptr() + vchKey.size());
+    std::vector<uint8_t> macKey;
+    DeriveEncryptionKey(aesKey, "wallet-record-mac", macKey);
+    memory_cleanse(aesKey.data(), aesKey.size());
+
+    // Compute HMAC-SHA3-512 keyed with the SEPARATE MAC key (not the AES key)
+    HMAC_SHA3_512(macKey.data(), macKey.size(),
                   data.data(), data.size(),
                   mac.data());
+
+    memory_cleanse(macKey.data(), macKey.size());
 
     return true;
 }
 
 bool CCrypter::VerifyMAC(const std::vector<uint8_t>& ciphertext,
-                         const std::vector<uint8_t>& mac) {
+                         const std::vector<uint8_t>& mac,
+                         bool useLegacyKeying) {
     if (!fKeySet) return false;
     if (ciphertext.empty()) return false;
     if (mac.size() != 64) return false;  // HMAC-SHA3-512 is 64 bytes
 
     // Compute expected MAC
     std::vector<uint8_t> expected_mac;
-    if (!ComputeMAC(ciphertext, expected_mac)) {
+    if (!ComputeMAC(ciphertext, expected_mac, useLegacyKeying)) {
         return false;
     }
 

--- a/src/wallet/crypter.h
+++ b/src/wallet/crypter.h
@@ -264,21 +264,27 @@ public:
      *
      * @param ciphertext Encrypted data
      * @param mac Output buffer for 64-byte HMAC
+     * @param useLegacyKeying LP-7: if true, key HMAC with the AES key (legacy
+     *        v3-v6 behaviour, used ONLY to verify pre-fix records for migration);
+     *        if false (default), key HMAC with a separately-derived MAC key
+     *        (v7+ key-separation). New records MUST use the default (false).
      * @return true on success, false if key not set
      */
     bool ComputeMAC(const std::vector<uint8_t>& ciphertext,
-                    std::vector<uint8_t>& mac);
+                    std::vector<uint8_t>& mac,
+                    bool useLegacyKeying = false);
 
     /**
      * FIX-009: Template overload for ComputeMAC() to support SecureAllocator
      */
     template<typename Alloc1, typename Alloc2>
     bool ComputeMAC(const std::vector<uint8_t, Alloc1>& ciphertext,
-                    std::vector<uint8_t, Alloc2>& mac) {
+                    std::vector<uint8_t, Alloc2>& mac,
+                    bool useLegacyKeying = false) {
         std::vector<uint8_t> cipher_std(ciphertext.begin(), ciphertext.end());
         std::vector<uint8_t> mac_std;
 
-        bool result = ComputeMAC(cipher_std, mac_std);
+        bool result = ComputeMAC(cipher_std, mac_std, useLegacyKeying);
 
         if (result) {
             mac.assign(mac_std.begin(), mac_std.end());
@@ -295,21 +301,26 @@ public:
      *
      * @param ciphertext Encrypted data
      * @param mac MAC to verify (must be 64 bytes)
+     * @param useLegacyKeying LP-7: verify against the legacy AES-keyed HMAC
+     *        (v3-v6 records) when true; against the separately-derived MAC key
+     *        (v7+) when false (default).
      * @return true if MAC is valid, false otherwise
      */
     bool VerifyMAC(const std::vector<uint8_t>& ciphertext,
-                   const std::vector<uint8_t>& mac);
+                   const std::vector<uint8_t>& mac,
+                   bool useLegacyKeying = false);
 
     /**
      * FIX-009: Template overload for VerifyMAC() to support SecureAllocator
      */
     template<typename Alloc1, typename Alloc2>
     bool VerifyMAC(const std::vector<uint8_t, Alloc1>& ciphertext,
-                   const std::vector<uint8_t, Alloc2>& mac) {
+                   const std::vector<uint8_t, Alloc2>& mac,
+                   bool useLegacyKeying = false) {
         std::vector<uint8_t> cipher_std(ciphertext.begin(), ciphertext.end());
         std::vector<uint8_t> mac_std(mac.begin(), mac.end());
 
-        return VerifyMAC(cipher_std, mac_std);
+        return VerifyMAC(cipher_std, mac_std, useLegacyKeying);
     }
 
     /**

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2874,6 +2874,25 @@ bool CWallet::SaveUnlocked(const std::string& filename) const {
             // at v7. Writing v7 here instead (with fHDMasterKeyEncrypted==false) is
             // exactly round-4 BLOCKER-1: it would mint a v7-labelled plaintext-seed
             // file that permanently disarms migration. (Mirrors the pre-LP-7 writer.)
+            //
+            // FAIL-CLOSED GUARD (red-team LOW-1 hardening): the legacy-v6 layout
+            // carries the seed in the FIXED plaintext slots written just below. If
+            // fHDMasterKeyEncrypted is true at this point, the in-memory seed/chaincode
+            // have already been scrubbed (memory_cleanse) by EncryptHDMasterKey — so
+            // these slots would persist 32+32 ZERO bytes, corrupting the wallet
+            // irrecoverably. By construction this combination is impossible (Unlock
+            // promotes m_loadedFileVersion to v7 atomically under cs_wallet the instant
+            // it scrubs, so writeLegacyV6 is never true while encrypted), but we refuse
+            // here as belt-and-suspenders so the corruption is structurally impossible
+            // even if a future refactor introduces a scrub-without-promote caller. This
+            // mirrors the refuse-on-empty-ciphertext guard in the encrypted branch below.
+            if (fHDMasterKeyEncrypted) {
+                std::cerr << "[Wallet] CRITICAL: refusing legacy-v6 save of an encrypted "
+                             "HD wallet — the plaintext seed slots have been scrubbed and "
+                             "writing them would corrupt the wallet (version promotion to "
+                             "v7 must precede any save of an encrypted seed)" << std::endl;
+                return false;
+            }
             file.write(reinterpret_cast<const char*>(hdMasterKey.seed), 32);
             if (!file.good()) return false;
             file.write(reinterpret_cast<const char*>(hdMasterKey.chaincode), 32);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -283,6 +283,39 @@ bool CWallet::HasKey(const CDilithiumAddress& address) const {
     return mapCryptedKeys.find(address) != mapCryptedKeys.end();
 }
 
+// LP-7 (HIGH-2): the ONE authenticated-decrypt gate shared by all five at-rest
+// record types. See the declaration in wallet.h for the full policy contract.
+// Returns true iff the caller may proceed to decrypt `ciphertext`.
+bool CWallet::VerifyRecordMAC(CCrypter& crypter,
+                             const std::vector<uint8_t>& ciphertext,
+                             const std::vector<uint8_t>& mac) const {
+    const bool isV7 = (m_loadedFileVersion >= WALLET_FILE_VERSION_7);
+
+    if (mac.empty()) {
+        // v7: an empty MAC is a corrupt/stripped record — refuse to decrypt the
+        // secret unauthenticated. pre-v7: this is the genuine legacy record that
+        // never carried a MAC — allow the (unauthenticated) legacy decrypt so the
+        // wallet loads and can be migrated to v7.
+        return !isV7;
+    }
+
+    // MAC present — verify it BEFORE the caller decrypts, with the keying that
+    // matches the on-disk version: legacy AES-keyed HMAC for v3-v6, separated
+    // MAC key for v7. (m_loadedFileVersion == 0 means a freshly-created in-memory
+    // wallet whose records this build wrote with the default separated keying.)
+    const bool legacyKeying =
+        (m_loadedFileVersion != 0 && m_loadedFileVersion < WALLET_FILE_VERSION_7);
+    return crypter.VerifyMAC(ciphertext, mac, legacyKeying);
+}
+
+// LP-7 (HIGH-2): the ONE MAC-compute helper for writes / re-MAC. Always v7
+// separated keying — new and migrated records are written ONLY at v7.
+bool CWallet::ComputeRecordMAC(CCrypter& crypter,
+                              const std::vector<uint8_t>& ciphertext,
+                              std::vector<uint8_t>& macOut) const {
+    return crypter.ComputeMAC(ciphertext, macOut /*default = separated v7 keying*/);
+}
+
 // Public GetKey - acquires lock
 bool CWallet::GetKey(const CDilithiumAddress& address, CKey& keyOut) const {
     std::lock_guard<std::mutex> lock(cs_wallet);
@@ -320,23 +353,16 @@ bool CWallet::GetKeyUnlocked(const CDilithiumAddress& address, CKey& keyOut) con
         return false;
     }
 
-    // FIX-008 (CRYPT-007): Verify MAC before decryption (prevents padding oracle)
-    // For legacy keys without MAC, skip verification
-    // LP-7 (HIGH-1 / S-004 / A-007): on a v7 wallet a per-address spending key
-    // MUST carry a non-empty MAC. An empty MAC would make IsLegacy() true and
-    // skip the verify below — re-opening the MAC downgrade on a spending key. The
-    // v7 load path already rejects an empty per-address MAC; this is a
-    // zero-false-positive defense-in-depth gate at the verify boundary. v3-v6
-    // keys keep the legacy unauthenticated path for migration.
-    if (m_loadedFileVersion >= WALLET_FILE_VERSION_7 && encKey.vchMAC.empty()) {
+    // LP-7 (HIGH-2): authenticate-before-decrypt via the ONE centralized gate.
+    // This is the per-address spending-key consumer that round-2 found left on
+    // the default (separated) keying while the other four paths were version-
+    // keyed — making legacy v3-v6 per-address keys (which carry a non-empty
+    // legacy-AES-keyed MAC) fail verification and become unspendable. Routing
+    // through VerifyRecordMAC fixes the keying selection AND the empty-MAC policy
+    // in one place so this can never drift from the other four record types.
+    if (!VerifyRecordMAC(crypter, encKey.vchCryptedKey, encKey.vchMAC)) {
         memory_cleanse(masterKeyVec.data(), masterKeyVec.size());
-        return false;  // v7 spending key with no MAC — refuse to decrypt unauthenticated
-    }
-    if (!encKey.IsLegacy()) {
-        if (!crypter.VerifyMAC(encKey.vchCryptedKey, encKey.vchMAC)) {
-            memory_cleanse(masterKeyVec.data(), masterKeyVec.size());
-            return false;  // MAC verification failed - corrupted or tampered key
-        }
+        return false;  // empty MAC on v7, or MAC verification failed — refuse
     }
 
     std::vector<uint8_t> decryptedPrivKey;
@@ -1156,30 +1182,15 @@ bool CWallet::Unlock(const std::string& passphrase, int64_t timeout) {
         return false;
     }
 
-    // FIX-008 (CRYPT-007): Verify MAC before decryption (prevents padding oracle)
-    // For legacy keys without MAC, skip verification.
-    // LP-7: the master-key MAC keying depends on the on-disk format version —
-    // v3-v6 used the legacy AES-keyed HMAC; v7 uses the separately-derived MAC
-    // key. Select the keying by the loaded version so pre-v7 wallets still unlock
-    // (and can then migrate).
-    // LP-7 (HIGH-1 / S-004 / A-007): on a v7 wallet the master-key MAC is
-    // mandatory. An empty MAC here would make IsLegacy() true and skip the
-    // verify below — re-opening the encrypt-then-MAC downgrade on the root
-    // secret. The v7 load path already rejects an empty master MAC, so this is a
-    // zero-false-positive defense-in-depth gate at the verify boundary.
-    if (m_loadedFileVersion >= WALLET_FILE_VERSION_7 && masterKey.vchMAC.empty()) {
+    // LP-7 (HIGH-2): authenticate-before-decrypt via the ONE centralized gate.
+    // Master-key consumer. The gate handles both the v7-empty-MAC rejection and
+    // the version-keyed verify; on any failure we still record a failed-unlock
+    // attempt (WL-011) since a tampered/empty MAC is indistinguishable from a
+    // wrong passphrase from the user's perspective.
+    if (!VerifyRecordMAC(crypter, masterKey.vchCryptedKey, masterKey.vchMAC)) {
         nUnlockFailedAttempts++;
         nLastFailedUnlock = std::chrono::steady_clock::now();
-        return false;  // v7 master key with no MAC — refuse to decrypt unauthenticated
-    }
-    if (!masterKey.IsLegacy()) {
-        bool legacyKeying = (m_loadedFileVersion != 0 && m_loadedFileVersion < WALLET_FILE_VERSION_7);
-        if (!crypter.VerifyMAC(masterKey.vchCryptedKey, masterKey.vchMAC, legacyKeying)) {
-            // WL-011 FIX: Track failed unlock attempt
-            nUnlockFailedAttempts++;
-            nLastFailedUnlock = std::chrono::steady_clock::now();
-            return false;  // MAC verification failed - wrong passphrase or tampered data
-        }
+        return false;  // empty MAC on v7, or MAC verification failed
     }
 
     std::vector<uint8_t> decryptedKey;
@@ -1238,7 +1249,7 @@ bool CWallet::Unlock(const std::string& passphrase, int64_t timeout) {
         // the new (default) separated keying. Snapshot for rollback symmetry.
         std::vector<uint8_t> snap_masterMAC = masterKey.vchMAC;
         std::vector<uint8_t> newMasterMAC;
-        bool macOk = crypter.ComputeMAC(masterKey.vchCryptedKey, newMasterMAC /*default=separated*/);
+        bool macOk = ComputeRecordMAC(crypter, masterKey.vchCryptedKey, newMasterMAC);
         if (macOk) {
             masterKey.vchMAC = newMasterMAC;
         }
@@ -1835,6 +1846,14 @@ bool CWallet::Load(const std::string& filename) {
                 file.read(reinterpret_cast<char*>(&mnMacLen), sizeof(mnMacLen));
                 if (!file.good()) return false;
                 if (mnMacLen > 64) return false;  // HMAC-SHA3-512 is 64 bytes
+                // LP-7 (HIGH-2 item 3, load-symmetry): on a v7 ENCRYPTED wallet a
+                // present mnemonic ciphertext MUST carry a non-empty MAC (it was
+                // master-key-encrypted-then-MAC'd). An empty MAC here is corrupt —
+                // reject at load to match master/per-address/HD-master. (An
+                // UNencrypted v7 wallet legitimately writes mnMacLen==0 because the
+                // mnemonic is under the obfuscation key, so only enforce when the
+                // master key is valid.)
+                if (mnMacLen == 0 && temp_masterKey.IsValid()) return false;
                 if (mnMacLen > 0) {
                     temp_vchMnemonicMAC.resize(mnMacLen);
                     file.read(reinterpret_cast<char*>(temp_vchMnemonicMAC.data()), mnMacLen);
@@ -2251,6 +2270,17 @@ bool CWallet::Load(const std::string& filename) {
             if (file.good() && version >= WALLET_FILE_VERSION_7) {
                 uint32_t mikMacLen = 0;
                 file.read(reinterpret_cast<char*>(&mikMacLen), sizeof(mikMacLen));
+                if (mikMacLen > 64) return false;  // HMAC-SHA3-512 is 64 bytes
+                // LP-7 (HIGH-2 item 3, load-symmetry): a v7 ENCRYPTED wallet that
+                // carries an encrypted MIK private key MUST carry its MAC — an
+                // empty MAC on that record is corrupt; reject at load to match the
+                // other records. (Unencrypted wallets / no-MIK files write
+                // mikMacLen==0 legitimately, so only enforce when both an encrypted
+                // MIK privkey is present AND the wallet master key is valid.)
+                if (mikMacLen == 0 && temp_masterKey.IsValid() &&
+                    !temp_vchEncryptedMIKPrivKey.empty()) {
+                    return false;
+                }
                 if (file.good() && mikMacLen > 0 && mikMacLen <= 64) {
                     temp_vchMIKPrivKeyMAC.resize(mikMacLen);
                     file.read(reinterpret_cast<char*>(temp_vchMIKPrivKeyMAC.data()), mikMacLen);
@@ -5153,6 +5183,10 @@ bool CWallet::MigrateToEncryptedSeedV7Unlocked() {
     std::vector<uint8_t> snap_vchMIKPrivKeyMAC_all = vchMIKPrivKeyMAC;
     std::vector<uint8_t> snap_vchMIKPrivKeyIV_all(vchMIKPrivKeyIV.begin(), vchMIKPrivKeyIV.end());
     std::vector<uint8_t> snap_vchMIKPubKey = vchMIKPubKey;
+    // LP-7 (HIGH-2): per-address spending keys are re-MAC'd in Step 2c so the
+    // migrated v7 file carries v7-keyed (not legacy-AES-keyed) per-address MACs.
+    // Snapshot the whole map so a later failure restores the legacy MACs.
+    std::map<CDilithiumAddress, CEncryptedKey> snap_mapCryptedKeys = mapCryptedKeys;
 
     auto rollback = [&]() {
         hdMasterKey = snap_hdMasterKey;
@@ -5170,6 +5204,7 @@ bool CWallet::MigrateToEncryptedSeedV7Unlocked() {
         vchMIKPrivKeyMAC = snap_vchMIKPrivKeyMAC_all;
         vchMIKPrivKeyIV.assign(snap_vchMIKPrivKeyIV_all.begin(), snap_vchMIKPrivKeyIV_all.end());
         vchMIKPubKey = snap_vchMIKPubKey;
+        mapCryptedKeys = snap_mapCryptedKeys;
     };
 
     // --- Step 1: recover + re-encrypt the mnemonic under the master key ---
@@ -5267,6 +5302,45 @@ bool CWallet::MigrateToEncryptedSeedV7Unlocked() {
             m_mikIdentity = DFMP::Identity();
             m_mik.reset();
         }
+    }
+
+    // --- Step 2c: re-MAC every per-address spending key under v7 keying ---
+    // LP-7 (HIGH-2): a pre-LP-7 build computed per-address MACs with the legacy
+    // AES-keyed HMAC (or, for a v3-v6 key that predates the MAC, with no MAC at
+    // all). Once this file is marked v7, GetKey verifies per-address MACs with the
+    // SEPARATED keying — so the legacy-keyed / empty MACs would mismatch and the
+    // keys would become unspendable in a file that claims to be v7. Recompute each
+    // MAC with v7 separated keying now (the encrypt-then-MAC tag is over the
+    // ciphertext, which migration does NOT change, so no decrypt is needed — we
+    // re-key the crypter with each key's own IV and recompute). The master key in
+    // vMasterKey is the same key these were encrypted under.
+    {
+        std::vector<uint8_t> mkVec(vMasterKey.data_ptr(),
+                                   vMasterKey.data_ptr() + vMasterKey.size());
+        for (auto& kv : mapCryptedKeys) {
+            CEncryptedKey& ek = kv.second;
+            if (ek.vchCryptedKey.empty() || ek.vchIV.size() != WALLET_CRYPTO_IV_SIZE) {
+                // Malformed entry — cannot re-MAC safely. Abort rather than write a
+                // v7 file with a per-address key that can't be authenticated.
+                memory_cleanse(mkVec.data(), mkVec.size());
+                rollback();
+                return false;
+            }
+            CCrypter keyCrypter;
+            if (!keyCrypter.SetKey(mkVec, ek.vchIV)) {
+                memory_cleanse(mkVec.data(), mkVec.size());
+                rollback();
+                return false;
+            }
+            std::vector<uint8_t> newMAC;
+            if (!ComputeRecordMAC(keyCrypter, ek.vchCryptedKey, newMAC)) {
+                memory_cleanse(mkVec.data(), mkVec.size());
+                rollback();
+                return false;
+            }
+            ek.vchMAC = newMAC;
+        }
+        memory_cleanse(mkVec.data(), mkVec.size());
     }
 
     // --- Step 3: atomic v7 rewrite. SaveUnlocked never truncates the original. ---
@@ -5409,20 +5483,13 @@ bool CWallet::DecryptHDMasterKey(CHDExtendedKey& decrypted) const {
         return false;
     }
 
-    // LP-7 (S-004): verify the MAC BEFORE decrypting (authenticated-before-decrypt).
-    // v7 records carry a non-empty MAC; an empty MAC on a v7 wallet is rejected.
-    // Legacy v3-v6 records never had an HD-master MAC, so we only enforce the MAC
-    // when one is present (it always is for v7), selecting the keying by version.
-    if (!vchHDMasterKeyMAC.empty()) {
-        bool legacyKeying = (m_loadedFileVersion != 0 && m_loadedFileVersion < WALLET_FILE_VERSION_7);
-        if (!crypter.VerifyMAC(vchEncryptedHDMasterKey, vchHDMasterKeyMAC, legacyKeying)) {
-            memory_cleanse(vMasterKeyVec.data(), vMasterKeyVec.size());
-            return false;  // Tampered or wrong key
-        }
-    } else if (m_loadedFileVersion >= WALLET_FILE_VERSION_7) {
-        // A v7 wallet MUST carry a MAC on the HD-master record.
+    // LP-7 (HIGH-2): authenticate-before-decrypt via the ONE centralized gate.
+    // HD-master-seed consumer. Empty MAC on a v7 wallet is rejected; legacy v3-v6
+    // records (no HD-master MAC) take the unauthenticated legacy path; a present
+    // MAC is verified with the version-correct keying.
+    if (!VerifyRecordMAC(crypter, vchEncryptedHDMasterKey, vchHDMasterKeyMAC)) {
         memory_cleanse(vMasterKeyVec.data(), vMasterKeyVec.size());
-        return false;
+        return false;  // empty MAC on v7, or MAC verification failed
     }
 
     std::vector<uint8_t> decrypted_data;
@@ -5562,20 +5629,13 @@ bool CWallet::DecryptMnemonic(std::string& mnemonic) const {
             return false;
         }
 
-        // LP-7 (wallet-Inv-2 / S-004): authenticate BEFORE decrypt.
-        // - v7 wallet: a non-empty, valid MAC is REQUIRED (empty MAC rejected).
-        // - legacy v3-v6 encrypted mnemonic had no MAC: verify only if present,
-        //   selecting the legacy AES-keyed HMAC.
-        if (!vchMnemonicMAC.empty()) {
-            bool legacyKeying = (m_loadedFileVersion != 0 && m_loadedFileVersion < WALLET_FILE_VERSION_7);
-            if (!crypter.VerifyMAC(vchEncryptedMnemonic, vchMnemonicMAC, legacyKeying)) {
-                memory_cleanse(vMasterKeyVec.data(), vMasterKeyVec.size());
-                return false;  // Tampered or wrong key
-            }
-        } else if (m_loadedFileVersion >= WALLET_FILE_VERSION_7) {
-            // v7 wallet with a master-key-encrypted mnemonic MUST carry a MAC.
+        // LP-7 (HIGH-2): authenticate-before-decrypt via the ONE centralized gate.
+        // Mnemonic consumer. Empty MAC on a v7 wallet is rejected; legacy v3-v6
+        // (no mnemonic MAC) takes the unauthenticated legacy path; a present MAC
+        // is verified with the version-correct keying.
+        if (!VerifyRecordMAC(crypter, vchEncryptedMnemonic, vchMnemonicMAC)) {
             memory_cleanse(vMasterKeyVec.data(), vMasterKeyVec.size());
-            return false;
+            return false;  // empty MAC on v7, or MAC verification failed
         }
 
         if (!crypter.Decrypt(vchEncryptedMnemonic, decrypted)) {
@@ -5742,18 +5802,12 @@ bool CWallet::DecryptMIKPrivKey(std::vector<uint8_t, SecureAllocator<uint8_t>>& 
         return false;
     }
 
-    // LP-7 (wallet-Inv-2 / S-004): authenticate BEFORE decrypt.
-    // v7 requires a non-empty valid MAC; legacy v3-v6 MIK records had none, so
-    // verify only when present (legacy keying for pre-v7 files).
-    if (!vchMIKPrivKeyMAC.empty()) {
-        bool legacyKeying = (m_loadedFileVersion != 0 && m_loadedFileVersion < WALLET_FILE_VERSION_7);
-        if (!crypter.VerifyMAC(vchEncryptedMIKPrivKey, vchMIKPrivKeyMAC, legacyKeying)) {
-            std::cerr << "[WALLET] DecryptMIKPrivKey: MAC verification failed" << std::endl;
-            memory_cleanse(vMasterKeyVec.data(), vMasterKeyVec.size());
-            return false;
-        }
-    } else if (m_loadedFileVersion >= WALLET_FILE_VERSION_7) {
-        std::cerr << "[WALLET] DecryptMIKPrivKey: missing MAC on v7 wallet" << std::endl;
+    // LP-7 (HIGH-2): authenticate-before-decrypt via the ONE centralized gate.
+    // MIK-private-key consumer. Empty MAC on a v7 wallet is rejected; legacy v3-v6
+    // (no MIK MAC) takes the unauthenticated legacy path; a present MAC is
+    // verified with the version-correct keying.
+    if (!VerifyRecordMAC(crypter, vchEncryptedMIKPrivKey, vchMIKPrivKeyMAC)) {
+        std::cerr << "[WALLET] DecryptMIKPrivKey: MAC verification failed or missing on v7 wallet" << std::endl;
         memory_cleanse(vMasterKeyVec.data(), vMasterKeyVec.size());
         return false;
     }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -308,19 +308,23 @@ bool CWallet::HasKey(const CDilithiumAddress& address) const {
 //         now routed.)
 //
 //   COMPUTE (write / re-MAC) — all route through ComputeRecordMAC:
-//     a. master key (EncryptWallet)          -> ComputeRecordMAC
-//     b. per-address key (EncryptWallet)     -> ComputeRecordMAC
-//     c. master key re-MAC (Unlock migration)-> ComputeRecordMAC
-//     d. per-address re-MAC (migration Step 2c) -> ComputeRecordMAC
-//     e. master key (ChangePassphrase write) -> ComputeRecordMAC
-//     f. HD-master seed (EncryptHDMasterKey) -> ComputeRecordMAC
-//     g. mnemonic (EncryptMnemonic, encrypted branch) -> ComputeRecordMAC
-//     h. MIK private key (EncryptMIKPrivKey) -> ComputeRecordMAC
-//     i. ChangePassphrase legacy->v7 record re-MAC (per-address, HD-master,
-//        mnemonic, MIK) -> ReMACAllRecordsToV7Unlocked -> ComputeRecordMAC
-//        (MEDIUM-1 fix: ChangePassphrase re-saves at v7, so every NON-master record
-//         on a loaded legacy wallet must be re-MAC'd to separated keying too — not
-//         just the master key — or it fails VerifyRecordMAC on the next load.)
+//     a. master key (EncryptWallet)          -> ComputeRecordMAC (separated v7 keying)
+//     b. per-address key (EncryptWallet)     -> ComputeRecordMAC (separated v7 keying)
+//     c. master key re-MAC (Unlock migration)-> ComputeRecordMAC (separated v7 keying)
+//     d. per-address re-MAC (migration Step 2c) -> ComputeRecordMAC (separated v7 keying)
+//     e. master key (ChangePassphrase write) -> ComputeRecordMAC with VERSION-MATCHED
+//        keying: legacy AES-keyed HMAC when the loaded file is v3-v6 (the file STAYS
+//        at its version — LP-7 ratified design: ChangePassphrase rotates the
+//        passphrase in place and never promotes to v7), separated v7 keying when the
+//        loaded file is already v7. The whole `ReMACAllRecordsToV7Unlocked`
+//        re-MAC-everything surface that the round-1..4 recurrence lived in is DELETED:
+//        ChangePassphrase touches ONLY the master-key record now; v3-v6 non-master
+//        records keep their legacy MACs and stay valid because the file stays v6, and
+//        the v6->v7 migration (with full re-MAC) happens exactly once, on the next
+//        Unlock (MigrateToEncryptedSeedV7Unlocked — the single source of truth).
+//     f. HD-master seed (EncryptHDMasterKey) -> ComputeRecordMAC (separated v7 keying)
+//     g. mnemonic (EncryptMnemonic, encrypted branch) -> ComputeRecordMAC (separated v7 keying)
+//     h. MIK private key (EncryptMIKPrivKey) -> ComputeRecordMAC (separated v7 keying)
 //
 //   The ONLY direct crypter.VerifyMAC / crypter.ComputeMAC calls remaining are the two
 //   inside VerifyRecordMAC / ComputeRecordMAC themselves (the implementations).
@@ -360,66 +364,15 @@ bool CWallet::VerifyRecordMAC(CCrypter& crypter,
     return crypter.VerifyMAC(ciphertext, mac, legacyKeying);
 }
 
-// LP-7 (HIGH-2): the ONE MAC-compute helper for writes / re-MAC. Always v7
-// separated keying — new and migrated records are written ONLY at v7.
+// LP-7 (HIGH-2): the ONE MAC-compute helper for writes / re-MAC. Default = v7
+// separated keying (new + migrated records). `useLegacyKeying == true` emits the
+// pre-v7 AES-keyed HMAC, used ONLY when a record is persisted back into a file that
+// stays at its existing v3-v6 version (LP-7 ratified ChangePassphrase-in-place).
 bool CWallet::ComputeRecordMAC(CCrypter& crypter,
                               const std::vector<uint8_t>& ciphertext,
-                              std::vector<uint8_t>& macOut) const {
-    return crypter.ComputeMAC(ciphertext, macOut /*default = separated v7 keying*/);
-}
-
-// LP-7 (round 3, MEDIUM-1): re-MAC every present at-rest record with v7 separated
-// keying. See the declaration in wallet.h for the full rationale. Caller holds
-// cs_wallet. On false, the caller MUST treat in-memory state as inconsistent and
-// roll back (do not save). A pure re-MAC: the ciphertext is unchanged, so no decrypt
-// of the secret is performed.
-bool CWallet::ReMACAllRecordsToV7Unlocked(const std::vector<uint8_t>& vMasterKeyPlain) {
-    // Re-MAC each per-address spending key (same logic as migration Step 2c).
-    for (auto& kv : mapCryptedKeys) {
-        CEncryptedKey& ek = kv.second;
-        if (ek.vchCryptedKey.empty() || ek.vchIV.size() != WALLET_CRYPTO_IV_SIZE) {
-            return false;  // malformed — cannot authenticate; abort rather than mis-MAC
-        }
-        CCrypter c;
-        if (!c.SetKey(vMasterKeyPlain, ek.vchIV)) return false;
-        std::vector<uint8_t> newMAC;
-        if (!ComputeRecordMAC(c, ek.vchCryptedKey, newMAC)) return false;
-        ek.vchMAC = newMAC;
-    }
-
-    // Re-MAC the encrypted HD-master seed, if present.
-    if (fHDMasterKeyEncrypted && !vchEncryptedHDMasterKey.empty()) {
-        if (vchHDMasterKeyIV.size() != WALLET_CRYPTO_IV_SIZE) return false;
-        CCrypter c;
-        if (!c.SetKey(vMasterKeyPlain, vchHDMasterKeyIV)) return false;
-        std::vector<uint8_t> newMAC;
-        if (!ComputeRecordMAC(c, vchEncryptedHDMasterKey, newMAC)) return false;
-        vchHDMasterKeyMAC = newMAC;
-    }
-
-    // Re-MAC the encrypted mnemonic, if present (encrypted-wallet branch only —
-    // an obfuscation-keyed unencrypted mnemonic carries no MAC and never reaches here
-    // because masterKey.IsValid() gates ChangePassphrase).
-    if (!vchEncryptedMnemonic.empty() && !vchMnemonicMAC.empty()) {
-        if (vchMnemonicIV.size() != WALLET_CRYPTO_IV_SIZE) return false;
-        CCrypter c;
-        if (!c.SetKey(vMasterKeyPlain, vchMnemonicIV)) return false;
-        std::vector<uint8_t> newMAC;
-        if (!ComputeRecordMAC(c, vchEncryptedMnemonic, newMAC)) return false;
-        vchMnemonicMAC = newMAC;
-    }
-
-    // Re-MAC the encrypted MIK private key, if present.
-    if (!vchEncryptedMIKPrivKey.empty() && !vchMIKPrivKeyMAC.empty()) {
-        if (vchMIKPrivKeyIV.size() != WALLET_CRYPTO_IV_SIZE) return false;
-        CCrypter c;
-        if (!c.SetKey(vMasterKeyPlain, vchMIKPrivKeyIV)) return false;
-        std::vector<uint8_t> newMAC;
-        if (!ComputeRecordMAC(c, vchEncryptedMIKPrivKey, newMAC)) return false;
-        vchMIKPrivKeyMAC = newMAC;
-    }
-
-    return true;
+                              std::vector<uint8_t>& macOut,
+                              bool useLegacyKeying) const {
+    return crypter.ComputeMAC(ciphertext, macOut, useLegacyKeying);
 }
 
 // Public GetKey - acquires lock
@@ -1585,6 +1538,15 @@ bool CWallet::EncryptWallet(const std::string& passphrase) {
     memory_cleanse(vMasterKeyPlain.data(), vMasterKeyPlain.size());
     memory_cleanse(derivedKey.data(), derivedKey.size());
 
+    // LP-7 (version-aware writer): encrypting the wallet produces v7-shaped records
+    // (encrypted variable-length HD seed when HD; separated-keyed master + per-record
+    // MACs). Promote the loaded version to v7 so SaveUnlocked emits the v7 layout — a
+    // v6 write here would (a) re-emit the now-SCRUBBED plaintext seed slots as zeros
+    // and (b) write separated-keyed MACs under a v6 header. New wallets are
+    // m_loadedFileVersion==0 (already write v7); this matters for a wallet LOADED from
+    // a v6 file and then encrypted in place.
+    m_loadedFileVersion = WALLET_FILE_VERSION_7;
+
     // Save wallet to disk — encryption MUST be persisted
     if (m_autoSave && !m_walletFile.empty()) {
         if (!SaveUnlocked()) {
@@ -1705,12 +1667,20 @@ bool CWallet::ChangePassphrase(const std::string& passphraseOld,
     }
 
     // FIX-008 (CRYPT-007): Compute MAC for authenticated encryption.
-    // LP-7 (round 3): route through ComputeRecordMAC so every at-rest record MAC
-    // *compute* also flows through the central helper. The rewrite is always v7, so
-    // this is semantically identical to the prior open-coded call (separated keying)
-    // — but it keeps the "zero bypass" invariant true for compute as well as verify.
+    // LP-7 (ratified design): route through ComputeRecordMAC with the keying that
+    // MATCHES the file's current on-disk version. ChangePassphrase rotates the
+    // passphrase IN PLACE and does NOT promote the file to v7 (SaveUnlocked re-emits
+    // the loaded version), so the rewritten master-key MAC must use the SAME keying
+    // the rest of that file uses, or VerifyRecordMAC rejects the correct passphrase on
+    // the next load:
+    //   - loaded v3-v6  -> legacy AES-keyed HMAC (file stays v6)
+    //   - loaded v7 / 0 -> separated v7 keying (file is/stays v7)
+    // (The single v6->v7 migration — which DOES recompute every MAC to separated
+    // keying — still happens exactly once, on the next Unlock, never here.)
+    const bool legacyMasterKeying =
+        (m_loadedFileVersion != 0 && m_loadedFileVersion < WALLET_FILE_VERSION_7);
     std::vector<uint8_t> newMAC;
-    if (!ComputeRecordMAC(crypterNew, newCryptedKey, newMAC)) {
+    if (!ComputeRecordMAC(crypterNew, newCryptedKey, newMAC, legacyMasterKeying)) {
         memory_cleanse(derivedKeyOld.data(), derivedKeyOld.size());
         memory_cleanse(derivedKeyNew.data(), derivedKeyNew.size());
         memory_cleanse(vMasterKeyPlain.data(), vMasterKeyPlain.size());
@@ -1729,52 +1699,21 @@ bool CWallet::ChangePassphrase(const std::string& passphraseOld,
     masterKey.vchMAC = newMAC;  // FIX-008: Store MAC
     masterKey.vchIV = newIV;
 
-    // LP-7 (round 3, MEDIUM-1): a successful ChangePassphrase ALWAYS re-saves the
-    // file at v7 (SaveUnlocked writes DILWLT07). When the loaded file was a legacy
-    // v3-v6 wallet, its NON-master records (per-address keys, HD-master, mnemonic,
-    // MIK) still carry legacy-AES-keyed MACs in memory. If we re-saved as v7 without
-    // re-MACing them, they would fail VerifyRecordMAC (separated keying) on the next
-    // load — re-opening exactly the HIGH-2 / MEDIUM-1 keying-mismatch class (the
-    // master key alone was re-MAC'd above; the rest were missed). The Unlock path
-    // handles this via MigrateToEncryptedSeedV7Unlocked, but ChangePassphrase is
-    // reachable WITHOUT a prior unlock (the RPC calls it directly), and a non-HD
-    // legacy wallet never arms that migration. Re-MAC all records here, then advance
-    // m_loadedFileVersion so subsequent verifies in this instance also use v7 keying.
-    const uint32_t prevLoadedVersion = m_loadedFileVersion;
-    bool didReMAC = false;
-    // Snapshot non-master record MACs for rollback symmetry.
-    std::vector<std::pair<CDilithiumAddress, std::vector<uint8_t>>> snapPerAddrMAC;
-    std::vector<uint8_t> snapHDMAC = vchHDMasterKeyMAC;
-    std::vector<uint8_t> snapMnemonicMAC = vchMnemonicMAC;
-    std::vector<uint8_t> snapMIKMAC = vchMIKPrivKeyMAC;
-    if (m_loadedFileVersion != 0 && m_loadedFileVersion < WALLET_FILE_VERSION_7) {
-        for (const auto& kv : mapCryptedKeys) {
-            snapPerAddrMAC.emplace_back(kv.first, kv.second.vchMAC);
-        }
-        if (!ReMACAllRecordsToV7Unlocked(vMasterKeyPlain)) {
-            // Restore master key + any partially-rewritten record MACs; leave the
-            // on-disk legacy file untouched.
-            masterKey.vchCryptedKey = oldCryptedKey;
-            masterKey.vchSalt = oldSalt;
-            masterKey.vchMAC = oldMAC;
-            masterKey.vchIV = oldIV;
-            for (auto& s : snapPerAddrMAC) {
-                auto it = mapCryptedKeys.find(s.first);
-                if (it != mapCryptedKeys.end()) it->second.vchMAC = s.second;
-            }
-            vchHDMasterKeyMAC = snapHDMAC;
-            vchMnemonicMAC = snapMnemonicMAC;
-            vchMIKPrivKeyMAC = snapMIKMAC;
-            memory_cleanse(derivedKeyOld.data(), derivedKeyOld.size());
-            memory_cleanse(derivedKeyNew.data(), derivedKeyNew.size());
-            memory_cleanse(vMasterKeyPlain.data(), vMasterKeyPlain.size());
-            std::cerr << "[Wallet] LP-7: ChangePassphrase aborted — could not re-MAC a "
-                         "legacy record to v7; passphrase unchanged, file untouched" << std::endl;
-            return false;
-        }
-        m_loadedFileVersion = WALLET_FILE_VERSION_7;
-        didReMAC = true;
-    }
+    // LP-7 (ratified design): ChangePassphrase rotates the passphrase IN PLACE only.
+    // It touches ONLY the master-key record (re-encrypted above under the new
+    // passphrase-derived key + version-matched MAC). It deliberately does NOT:
+    //   - promote m_loadedFileVersion to v7,
+    //   - touch fHDMasterKeyEncrypted or migrate the HD seed,
+    //   - re-MAC the per-address / HD-master / mnemonic / MIK records.
+    // Those non-master records are encrypted under the (UNCHANGED) master key, so a
+    // passphrase rotation leaves their ciphertext + IV + MAC byte-identical — nothing
+    // to rewrite. SaveUnlocked re-emits the file at its existing version (legacy v6
+    // layout for a loaded v6 wallet), so the legacy-keyed non-master MACs stay valid
+    // on reload. The one-time v6->v7 migration (re-encrypt seed + re-MAC every record)
+    // happens on the next Unlock via MigrateToEncryptedSeedV7Unlocked — the single
+    // source of truth. This DELETES the round-1..4 ReMACAllRecordsToV7Unlocked seam
+    // that re-introduced plaintext-seed-at-rest (BLOCKER-1) and bricked empty-MAC
+    // mnemonic/MIK records (BLOCKER-2).
 
     // Wipe sensitive data
     memory_cleanse(derivedKeyOld.data(), derivedKeyOld.size());
@@ -1790,23 +1729,12 @@ bool CWallet::ChangePassphrase(const std::string& passphraseOld,
             std::this_thread::sleep_for(std::chrono::milliseconds(500));
             if (!SaveUnlocked()) {
                 std::cerr << "[Wallet] CRITICAL: Retry failed. Reverting passphrase change." << std::endl;
-                // Revert so in-memory state matches what's on disk (legacy file).
+                // Revert the master key so in-memory state matches what's on disk
+                // (the original, untouched file). Only the master-key record changed.
                 masterKey.vchCryptedKey = oldCryptedKey;
                 masterKey.vchSalt = oldSalt;
                 masterKey.vchMAC = oldMAC;
                 masterKey.vchIV = oldIV;
-                if (didReMAC) {
-                    // Restore the legacy-keyed record MACs and the loaded version so
-                    // in-memory state matches the untouched on-disk legacy file.
-                    for (auto& s : snapPerAddrMAC) {
-                        auto it = mapCryptedKeys.find(s.first);
-                        if (it != mapCryptedKeys.end()) it->second.vchMAC = s.second;
-                    }
-                    vchHDMasterKeyMAC = snapHDMAC;
-                    vchMnemonicMAC = snapMnemonicMAC;
-                    vchMIKPrivKeyMAC = snapMIKMAC;
-                    m_loadedFileVersion = prevLoadedVersion;
-                }
                 memory_cleanse(vMasterKeyPlain.data(), vMasterKeyPlain.size());
                 return false;
             }
@@ -2771,13 +2699,31 @@ bool CWallet::SaveUnlocked(const std::string& filename) const {
 
     // FIX-011 (PERSIST-001): Write header with file integrity HMAC (v3 format)
     // Format: [Magic][Version][Flags][HMAC-placeholder][Salt][Data...]
-    // LP-7: write v7 ("DILWLT07") — encryption-at-rest fix (variable-length
-    // encrypted HD seed + per-record MACs). One-way: we always emit v7; legacy
-    // formats are read-only (for migration).
-    file.write(WALLET_FILE_MAGIC_V7, 8);  // "DILWLT07"
+    //
+    // LP-7 (ratified design, version-aware write): SaveUnlocked normally emits v7
+    // ("DILWLT07") — variable-length encrypted HD seed + per-record MACs. The ONE
+    // exception is a wallet LOADED from a legacy v3-v6 file that has NOT yet been
+    // migrated (m_loadedFileVersion < v7): there we re-emit the SAME on-disk version
+    // (legacy plaintext-seed layout, no per-record mnemonic/MIK MAC). This is what
+    // lets ChangePassphrase rotate the passphrase IN PLACE without promoting the
+    // file to v7 — which previously (round 4) re-introduced plaintext-seed-at-rest
+    // (BLOCKER-1) and bricked empty-MAC mnemonic/MIK records (BLOCKER-2). The single
+    // v6->v7 migration (re-encrypt seed, re-MAC every record) still happens exactly
+    // once, on the next Unlock (MigrateToEncryptedSeedV7Unlocked) — which bumps
+    // m_loadedFileVersion to v7, so this writer then emits v7 from then on. A freshly
+    // created in-memory wallet (m_loadedFileVersion == 0) and an already-v7 wallet
+    // both write v7.
+    const bool writeLegacyV6 =
+        (m_loadedFileVersion != 0 && m_loadedFileVersion < WALLET_FILE_VERSION_7);
+
+    if (writeLegacyV6) {
+        file.write(WALLET_FILE_MAGIC_V6, 8);  // "DILWLT06" — keep the loaded version
+    } else {
+        file.write(WALLET_FILE_MAGIC_V7, 8);  // "DILWLT07"
+    }
     if (!file.good()) return false;
 
-    uint32_t version = WALLET_FILE_VERSION_7;
+    uint32_t version = writeLegacyV6 ? WALLET_FILE_VERSION_6 : WALLET_FILE_VERSION_7;
     file.write(reinterpret_cast<const char*>(&version), sizeof(version));
     if (!file.good()) return false;
 
@@ -2856,13 +2802,20 @@ bool CWallet::SaveUnlocked(const std::string& filename) const {
             if (!file.good()) return false;
 
             // LP-7 (v7): write the mnemonic MAC (variable-length; empty for the
-            // unencrypted-obfuscation case).
-            uint32_t mnMacLen = static_cast<uint32_t>(vchMnemonicMAC.size());
-            file.write(reinterpret_cast<const char*>(&mnMacLen), sizeof(mnMacLen));
-            if (!file.good()) return false;
-            if (mnMacLen > 0) {
-                file.write(reinterpret_cast<const char*>(vchMnemonicMAC.data()), mnMacLen);
+            // unencrypted-obfuscation case). LEGACY v3-v6 files never carried a
+            // per-record mnemonic MAC, so when re-emitting at the loaded v6 version
+            // we must NOT write the mnMacLen field — the v6 reader does not expect it
+            // and writing it would desync the stream. (The mnemonic stays readable on
+            // reload via the legacy unauthenticated path; it gains an authenticated
+            // MAC only at the v6->v7 Unlock migration.)
+            if (!writeLegacyV6) {
+                uint32_t mnMacLen = static_cast<uint32_t>(vchMnemonicMAC.size());
+                file.write(reinterpret_cast<const char*>(&mnMacLen), sizeof(mnMacLen));
                 if (!file.good()) return false;
+                if (mnMacLen > 0) {
+                    file.write(reinterpret_cast<const char*>(vchMnemonicMAC.data()), mnMacLen);
+                    if (!file.good()) return false;
+                }
             }
         }
 
@@ -2873,7 +2826,37 @@ bool CWallet::SaveUnlocked(const std::string& filename) const {
         // plaintext.
         uint8_t encrypted_flag = fHDMasterKeyEncrypted ? 1 : 0;
 
-        if (fHDMasterKeyEncrypted) {
+        if (writeLegacyV6) {
+            // LP-7 (ratified): re-emit the EXACT legacy v3-v6 HD-master layout when
+            // the file stays at its loaded version (ChangePassphrase-in-place). A
+            // legacy-loaded wallet keeps its seed in the fixed plaintext slots and is
+            // flagged for migration on next Unlock — we are NOT migrating here, so we
+            // preserve that on-disk shape byte-for-byte:
+            //   [seed32][chaincode32][depth][fp][ci][encrypted_flag][IV if flagged]
+            // This is NOT a NEW plaintext-at-rest exposure: the seed was already
+            // plaintext in this v6 file before ChangePassphrase, Load re-arms
+            // m_fNeedsSeedMigration for it, and the next Unlock encrypts it + rewrites
+            // at v7. Writing v7 here instead (with fHDMasterKeyEncrypted==false) is
+            // exactly round-4 BLOCKER-1: it would mint a v7-labelled plaintext-seed
+            // file that permanently disarms migration. (Mirrors the pre-LP-7 writer.)
+            file.write(reinterpret_cast<const char*>(hdMasterKey.seed), 32);
+            if (!file.good()) return false;
+            file.write(reinterpret_cast<const char*>(hdMasterKey.chaincode), 32);
+            if (!file.good()) return false;
+            file.write(reinterpret_cast<const char*>(&hdMasterKey.depth), sizeof(hdMasterKey.depth));
+            if (!file.good()) return false;
+            file.write(reinterpret_cast<const char*>(&hdMasterKey.fingerprint), sizeof(hdMasterKey.fingerprint));
+            if (!file.good()) return false;
+            file.write(reinterpret_cast<const char*>(&hdMasterKey.child_index), sizeof(hdMasterKey.child_index));
+            if (!file.good()) return false;
+
+            file.write(reinterpret_cast<const char*>(&encrypted_flag), 1);
+            if (!file.good()) return false;
+            if (fHDMasterKeyEncrypted) {
+                file.write(reinterpret_cast<const char*>(vchHDMasterKeyIV.data()), WALLET_CRYPTO_IV_SIZE);
+                if (!file.good()) return false;
+            }
+        } else if (fHDMasterKeyEncrypted) {
             if (vchEncryptedHDMasterKey.empty()) {
                 // Encrypted-but-no-ciphertext is a programming error; refuse to
                 // persist rather than risk writing/keeping plaintext.
@@ -5364,8 +5347,15 @@ bool CWallet::MigrateToEncryptedSeedV7Unlocked() {
     // migrated v7 file carries v7-keyed (not legacy-AES-keyed) per-address MACs.
     // Snapshot the whole map so a later failure restores the legacy MACs.
     std::map<CDilithiumAddress, CEncryptedKey> snap_mapCryptedKeys = mapCryptedKeys;
+    // LP-7 (version-aware writer): migration IS the v6->v7 promotion event. We bump
+    // m_loadedFileVersion to v7 BEFORE the Step-3 SaveUnlocked so the version-aware
+    // writer emits the v7 layout (encrypted seed, per-record MACs). Snapshot for
+    // rollback so a failed migration restores the loaded version → the version-aware
+    // writer would then (correctly) emit the intact legacy layout again.
+    uint32_t snap_loadedFileVersion = m_loadedFileVersion;
 
     auto rollback = [&]() {
+        m_loadedFileVersion = snap_loadedFileVersion;
         hdMasterKey = snap_hdMasterKey;
         fHDMasterKeyEncrypted = snap_fHDMasterKeyEncrypted;
         fHDMasterKeyCached = snap_fHDMasterKeyCached;
@@ -5521,10 +5511,17 @@ bool CWallet::MigrateToEncryptedSeedV7Unlocked() {
     }
 
     // --- Step 3: atomic v7 rewrite. SaveUnlocked never truncates the original. ---
+    // Promote to v7 FIRST so the version-aware SaveUnlocked emits the v7 layout (the
+    // seed is now encrypted; a v6 write here would be wrong). rollback() restores the
+    // loaded version if the save fails, keeping in-memory state consistent with the
+    // still-intact on-disk legacy file. (When autosave is off — an in-memory-only
+    // migration — we do NOT touch m_loadedFileVersion here; the caller's Unlock bumps
+    // it, and the on-disk file legitimately stays v6 until a real rewrite occurs.)
     if (m_autoSave && !m_walletFile.empty()) {
+        m_loadedFileVersion = WALLET_FILE_VERSION_7;
         if (!SaveUnlocked()) {
             // The on-disk legacy file is still intact (temp file was discarded).
-            // Roll back in-memory state to match it.
+            // Roll back in-memory state to match it (including the loaded version).
             rollback();
             return false;
         }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1399,6 +1399,19 @@ bool CWallet::EncryptWallet(const std::string& passphrase) {
     std::vector<uint8_t> snap_vchMIKPrivKeyIV(vchMIKPrivKeyIV.begin(), vchMIKPrivKeyIV.end());
     std::vector<uint8_t> snap_vchMIKPubKey = vchMIKPubKey;
     uint32_t snap_loadedFileVersion = m_loadedFileVersion;
+    // LP-7 (red-team MEDIUM-1): snapshot the in-memory MIK plaintext private key.
+    // EncryptMIKPrivKey() + m_mik->privkey.clear() below moves the MIK to a
+    // ciphertext-only in-memory state. The rollback restores the MIK CIPHERTEXT
+    // fields (vchEncryptedMIKPrivKey/...MAC/...IV) to their PRE-encryption snapshot
+    // (i.e. empty, since the wallet was unencrypted) AND restores masterKey to
+    // invalid — so without restoring the plaintext too, a save-failure rollback
+    // would leave the MIK with neither a usable plaintext nor a decryptable
+    // ciphertext (no master key to decrypt with), permanently losing the mining
+    // identity. Snapshot the plaintext so rollback can restore it verbatim.
+    bool snap_mikHadPriv = (m_mik && m_mik->HasPrivateKey());
+    std::vector<uint8_t, SecureAllocator<uint8_t>> snap_mikPrivKey =
+        snap_mikHadPriv ? m_mik->privkey
+                        : std::vector<uint8_t, SecureAllocator<uint8_t>>();
 
     auto rollback = [&]() {
         masterKey = snap_masterKey;
@@ -1429,6 +1442,13 @@ bool CWallet::EncryptWallet(const std::string& passphrase) {
         vchMIKPrivKeyIV.assign(snap_vchMIKPrivKeyIV.begin(), snap_vchMIKPrivKeyIV.end());
         vchMIKPubKey = snap_vchMIKPubKey;
         m_loadedFileVersion = snap_loadedFileVersion;
+        // LP-7 (red-team MEDIUM-1): restore the in-memory MIK plaintext private key
+        // that EncryptMIKPrivKey()+clear() may have scrubbed. Without this the MIK
+        // would be unrecoverable after a save-failure rollback (ciphertext snapshot
+        // is the pre-encryption empty state and masterKey is restored to invalid).
+        if (m_mik && snap_mikHadPriv) {
+            m_mik->privkey = snap_mikPrivKey;
+        }
     };
 
     // Generate random master key
@@ -2995,6 +3015,44 @@ bool CWallet::SaveUnlocked(const std::string& filename) const {
                              "HD wallet — the plaintext seed slots have been scrubbed and "
                              "writing them would corrupt the wallet (version promotion to "
                              "v7 must precede any save of an encrypted seed)" << std::endl;
+                return false;
+            }
+            // STRUCTURAL FAIL-CLOSED GUARD (red-team HIGH-1): close the LP-7
+            // plaintext-seed-at-rest leak on the legacy-v6 write path.
+            //
+            // The dangerous state is masterKey.IsValid()==true (encrypted in memory)
+            // && fHDMasterKeyEncrypted==false (HD seed still plaintext) flowing to the
+            // 32-byte plaintext-seed write below. There are TWO ways to reach that
+            // state on the v6 path, and they are NOT equivalent:
+            //
+            //   (1) LEGITIMATE (ratified BLOCKER-1, Test 7): a wallet LOADED from a
+            //       legacy v3-v6 file is always re-armed for migration on load
+            //       (m_fNeedsSeedMigration=true, see Load ~line 2191). ChangePassphrase
+            //       rewrites it IN PLACE at v6 — preserving the PRE-EXISTING plaintext
+            //       seed shape and deferring re-encryption to the next Unlock's
+            //       migration. This is NOT a new exposure: the seed was already
+            //       plaintext at rest, and migration is still armed to fix it.
+            //
+            //   (2) LEAK (red-team HIGH-1): a wallet that is encrypted-in-memory with a
+            //       plaintext seed but is NOT armed for migration (m_fNeedsSeedMigration
+            //       ==false) — e.g. an EncryptWallet that aborted mid-HD-step without
+            //       rolling back. Persisting the plaintext seed here is a genuine new
+            //       LP-7 exposure with no migration arm to ever fix it.
+            //
+            // Discriminator: refuse exactly the un-armed encrypted state. A migration-
+            // armed legacy wallet (case 1) is allowed to round-trip its pre-existing v6
+            // shape; an un-armed encrypted wallet (case 2) is refused. (The
+            // fHDMasterKeyEncrypted guard above independently catches the scrubbed-seed
+            // corruption window. This guard closes the plaintext-seed leak.)
+            if (masterKey.IsValid() && !m_fNeedsSeedMigration) {
+                std::cerr << "[Wallet] CRITICAL: refusing legacy-v6 plaintext-seed save of an "
+                             "encrypted HD wallet that is NOT armed for seed migration — the "
+                             "wallet has a master key but the HD seed is not encrypted "
+                             "(fHDMasterKeyEncrypted==false) and m_fNeedsSeedMigration==false; "
+                             "persisting a plaintext seed for an encrypted wallet with no "
+                             "migration arm is the LP-7 plaintext-at-rest exposure. The HD seed "
+                             "must be encrypted (EncryptHDMasterKey) before any save of such a "
+                             "wallet." << std::endl;
                 return false;
             }
             file.write(reinterpret_cast<const char*>(hdMasterKey.seed), 32);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -322,6 +322,16 @@ bool CWallet::GetKeyUnlocked(const CDilithiumAddress& address, CKey& keyOut) con
 
     // FIX-008 (CRYPT-007): Verify MAC before decryption (prevents padding oracle)
     // For legacy keys without MAC, skip verification
+    // LP-7 (HIGH-1 / S-004 / A-007): on a v7 wallet a per-address spending key
+    // MUST carry a non-empty MAC. An empty MAC would make IsLegacy() true and
+    // skip the verify below — re-opening the MAC downgrade on a spending key. The
+    // v7 load path already rejects an empty per-address MAC; this is a
+    // zero-false-positive defense-in-depth gate at the verify boundary. v3-v6
+    // keys keep the legacy unauthenticated path for migration.
+    if (m_loadedFileVersion >= WALLET_FILE_VERSION_7 && encKey.vchMAC.empty()) {
+        memory_cleanse(masterKeyVec.data(), masterKeyVec.size());
+        return false;  // v7 spending key with no MAC — refuse to decrypt unauthenticated
+    }
     if (!encKey.IsLegacy()) {
         if (!crypter.VerifyMAC(encKey.vchCryptedKey, encKey.vchMAC)) {
             memory_cleanse(masterKeyVec.data(), masterKeyVec.size());
@@ -1152,6 +1162,16 @@ bool CWallet::Unlock(const std::string& passphrase, int64_t timeout) {
     // v3-v6 used the legacy AES-keyed HMAC; v7 uses the separately-derived MAC
     // key. Select the keying by the loaded version so pre-v7 wallets still unlock
     // (and can then migrate).
+    // LP-7 (HIGH-1 / S-004 / A-007): on a v7 wallet the master-key MAC is
+    // mandatory. An empty MAC here would make IsLegacy() true and skip the
+    // verify below — re-opening the encrypt-then-MAC downgrade on the root
+    // secret. The v7 load path already rejects an empty master MAC, so this is a
+    // zero-false-positive defense-in-depth gate at the verify boundary.
+    if (m_loadedFileVersion >= WALLET_FILE_VERSION_7 && masterKey.vchMAC.empty()) {
+        nUnlockFailedAttempts++;
+        nLastFailedUnlock = std::chrono::steady_clock::now();
+        return false;  // v7 master key with no MAC — refuse to decrypt unauthenticated
+    }
     if (!masterKey.IsLegacy()) {
         bool legacyKeying = (m_loadedFileVersion != 0 && m_loadedFileVersion < WALLET_FILE_VERSION_7);
         if (!crypter.VerifyMAC(masterKey.vchCryptedKey, masterKey.vchMAC, legacyKeying)) {
@@ -1748,6 +1768,17 @@ bool CWallet::Load(const std::string& filename) {
             temp_masterKey.vchMAC.clear();
         }
 
+        // LP-7 (HIGH-1 / S-004 / A-007): a v7 wallet MUST carry a non-empty
+        // master-key MAC. The v7 writer always populates it (wallet.cpp), so an
+        // empty/absent MAC on a v7 file means the MAC was stripped — reject it as
+        // corrupt rather than silently falling back to the unauthenticated
+        // "legacy" path (which would re-open the encrypt-then-MAC downgrade on the
+        // root secret). The legacy unauthenticated path is preserved ONLY for
+        // genuine v3-v6 files being read for migration.
+        if (version >= WALLET_FILE_VERSION_7 && temp_masterKey.vchMAC.empty()) {
+            return false;  // v7 master key with stripped/absent MAC — reject as tampered
+        }
+
         // Wallet starts locked (encryption status determined by masterKey.IsValid())
         temp_fWalletUnlocked = false;
     }
@@ -2033,6 +2064,15 @@ bool CWallet::Load(const std::string& filename) {
                     encKey.vchMAC.resize(macLen);
                     file.read(reinterpret_cast<char*>(encKey.vchMAC.data()), macLen);
                     if (!file.good()) return false;  // SEC-001: Check I/O error
+                }
+                // LP-7 (HIGH-1 / S-004 / A-007): a v7 wallet MUST carry a
+                // non-empty MAC on every per-address spending key. The v7 writer
+                // always populates it, so macLen==0 on a v7 file means the MAC was
+                // stripped — reject as tampered rather than loading it as an
+                // unauthenticated "legacy" key (which would re-open the MAC
+                // downgrade on a spending key). v3-v6 keys keep the legacy path.
+                if (version >= WALLET_FILE_VERSION_7 && encKey.vchMAC.empty()) {
+                    return false;  // v7 per-address key with stripped/absent MAC — reject
                 }
             } else {
                 // Legacy v1/v2: try to read macLen, seek back if not present

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1045,6 +1045,16 @@ bool CWallet::IsLocked() const {
     return masterKey.IsValid() && !fWalletUnlocked;
 }
 
+bool CWallet::NeedsSeedMigration() const {
+    std::lock_guard<std::mutex> lock(cs_wallet);
+    // m_fNeedsSeedMigration is armed at load (CWallet::Load) only when the wallet
+    // is encrypted (masterKey valid) AND the on-disk format held the HD seed in
+    // plaintext (pre-fix bug shape); it is cleared the moment the v7 migration
+    // completes inside Unlock. We additionally require masterKey.IsValid() so a
+    // non-encrypted wallet can never report this state.
+    return masterKey.IsValid() && m_fNeedsSeedMigration;
+}
+
 // VULN-002 FIX: Helper to check if unlock is still valid (not expired)
 // Assumes caller holds cs_wallet lock
 // BUG #74 FIX: Internal version that assumes caller already holds cs_wallet
@@ -2772,6 +2782,18 @@ bool CWallet::Load(const std::string& filename) {
         m_fNeedsSeedMigration = temp_fNeedsSeedMigration;
 
         m_walletFile = filename;  // Set wallet file path only on successful load
+
+        // LP-7 (force-migrate / round-3 SURVIVING-LEAK): if this encrypted wallet
+        // was loaded with a plaintext HD seed at rest (pre-fix bug), emit a LOUD
+        // one-time-per-load CRITICAL so the operator/UI is driven to unlock-and-
+        // migrate. A receive/mine-only wallet would otherwise sit plaintext forever
+        // while reporting "encrypted". The per-autosave warning (SaveUnlocked) keeps
+        // surfacing it until the migration runs on the next Unlock.
+        if (m_fNeedsSeedMigration) {
+            std::cerr << "[Wallet] CRITICAL: wallet seed is stored UNENCRYPTED at rest "
+                         "despite the wallet being encrypted (fixed bug LP-7). Unlock once "
+                         "to complete a one-time security upgrade." << std::endl;
+        }
     }
 
     return true;
@@ -2824,6 +2846,19 @@ bool CWallet::SaveUnlocked(const std::string& filename) const {
     std::string saveFile = filename.empty() ? m_walletFile : filename;
     if (saveFile.empty()) {
         return false;  // No wallet file specified
+    }
+
+    // LP-7 (force-migrate / round-3 SURVIVING-LEAK): re-emit the CRITICAL on EVERY
+    // save while the seed is still plaintext-at-rest (not once). An armed wallet
+    // that is never unlocked is autosaved repeatedly (receive/mine); each save
+    // re-writes the plaintext seed to disk, so each save must re-surface the
+    // remediation. This fires for the legacy v6 path (which re-emits v6 plaintext)
+    // until the next Unlock runs MigrateToEncryptedSeedV7Unlocked() and clears the
+    // flag. Caller holds cs_wallet (SaveUnlocked precondition), so the read is safe.
+    if (masterKey.IsValid() && m_fNeedsSeedMigration) {
+        std::cerr << "[Wallet] CRITICAL: wallet seed is stored UNENCRYPTED at rest "
+                     "despite the wallet being encrypted (fixed bug LP-7). Unlock once "
+                     "to complete a one-time security upgrade." << std::endl;
     }
 
     // SEC-001 FIX: Atomic file write pattern

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2660,6 +2660,41 @@ bool CWallet::Save(const std::string& filename) const {
 }
 
 // Private SaveUnlocked() method - assumes caller already holds cs_wallet lock
+// ============================================================================
+// LP-7 READER/WRITER VERSION-GATE SYMMETRY TABLE (authoritative)
+// ----------------------------------------------------------------------------
+// This writer (SaveUnlocked) emits ONLY v6 ("DILWLT06", writeLegacyV6==true) or
+// v7 ("DILWLT07"). The matching reader is CWallet::Load. EVERY field whose
+// presence/layout depends on the file version is listed below; for each, the
+// writer's gate MUST exactly match the reader's gate. A field present in a v6
+// write MUST be read in v6; a v7-only field MUST be `!writeLegacyV6`-gated on
+// write AND `version >= WALLET_FILE_VERSION_7` on read. ZERO mismatches allowed.
+//
+//  field                | write-gate (SaveUnlocked)          | read-gate (Load)                 | status
+//  ---------------------+------------------------------------+----------------------------------+-------
+//  header magic+version | writeLegacyV6 ? v6 : v7            | reads+validates version 1..7     | MATCH
+//  HMAC + salt block    | unconditional (writer always >=v6) | version >= 3                     | MATCH (v6,v7 >=3)
+//  v1/v2 reserved[16]   | never written                      | version < 3 (else-branch)        | MATCH (writer never <v3)
+//  master-key MAC       | uncond. within masterKey.IsValid() | v3+: always present (uncond.)    | MATCH
+//  mnemonic MAC         | if (!writeLegacyV6)                | if (version >= V7)               | MATCH
+//  HD-master block      | writeLegacyV6 ? legacy-slots : v7  | version >= V7 ? v7 : legacy      | MATCH
+//  HD-master MAC        | v7 encrypted branch (!writeLegacyV6)| v7 encrypted branch (>= V7)     | MATCH
+//  wtx fCoinbase        | unconditional (writer always >=v6) | version >= 4                     | MATCH (v6,v7 >=4)
+//  MIK block (hasMIK..) | unconditional (writer always >=v6) | version >= 5                     | MATCH (v6,v7 >=5)
+//  MIK private-key MAC  | if (!writeLegacyV6)   [LP-7 fix]    | if (version >= V7)               | MATCH
+//  mapSentTx            | unconditional (writer always >=v6) | version >= 6                     | MATCH (v6,v7 >=6)
+//
+// Per-address spending-key MAC (macLen) is a v3+ field written unconditionally
+// and read unconditionally for v3+ (v1/v2 seek-back), so it is NOT version-
+// conditional within this writer's v6/v7 output — symmetric by construction.
+//
+// INVARIANT: every v7-only per-record MAC field (mnemonic, MIK) is
+// `!writeLegacyV6`-gated on write. The HD-master MAC lives inside the v7-only
+// encrypted HD-master branch, so it is structurally excluded from the v6 path.
+// If you add ANY new version-conditional field, add a row here and confirm the
+// write-gate equals the read-gate BEFORE merging — the MIK-MAC desync
+// (round-5 BLOCKER-5) was exactly a missing row in this table.
+// ============================================================================
 bool CWallet::SaveUnlocked(const std::string& filename) const {
     // Use current wallet file if no filename specified
     std::string saveFile = filename.empty() ? m_walletFile : filename;
@@ -3090,13 +3125,25 @@ bool CWallet::SaveUnlocked(const std::string& filename) const {
         }
 
         // LP-7 (v7): write the MIK private-key MAC (variable-length; empty when
-        // the wallet is unencrypted / no encrypted MIK present).
-        uint32_t mikMacLen = static_cast<uint32_t>(vchMIKPrivKeyMAC.size());
-        file.write(reinterpret_cast<const char*>(&mikMacLen), sizeof(mikMacLen));
-        if (!file.good()) return false;
-        if (mikMacLen > 0) {
-            file.write(reinterpret_cast<const char*>(vchMIKPrivKeyMAC.data()), mikMacLen);
+        // the wallet is unencrypted / no encrypted MIK present). LEGACY v3-v6 files
+        // never carried a per-record MIK MAC, so when re-emitting at the loaded v6
+        // version (ChangePassphrase-in-place / non-HD legacy autosave) we must NOT
+        // write the mikMacLen field — the v6 reader does not expect it (it gates the
+        // read on version >= WALLET_FILE_VERSION_7) and writing it would desync the
+        // stream and silently corrupt the MIK / sent-history / best-block fields that
+        // follow. This MUST mirror the mnemonic-MAC gating above exactly. (The MIK
+        // gains its authenticated MAC at the v6->v7 Unlock migration, same as the
+        // mnemonic — see MigrateToEncryptedSeedV7Unlocked.) See the reader/writer
+        // version-gate symmetry table above SaveUnlocked: EVERY v7-only per-record
+        // MAC field is !writeLegacyV6-gated.
+        if (!writeLegacyV6) {
+            uint32_t mikMacLen = static_cast<uint32_t>(vchMIKPrivKeyMAC.size());
+            file.write(reinterpret_cast<const char*>(&mikMacLen), sizeof(mikMacLen));
             if (!file.good()) return false;
+            if (mikMacLen > 0) {
+                file.write(reinterpret_cast<const char*>(vchMIKPrivKeyMAC.data()), mikMacLen);
+                if (!file.good()) return false;
+            }
         }
 
         // Write MIK registered flag

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1363,6 +1363,74 @@ bool CWallet::EncryptWallet(const std::string& passphrase) {
 
     // Allow encrypting empty wallet - keys will be encrypted as they're generated
 
+    // --- TRANSACTIONAL SNAPSHOT (Cursor HIGH-2) ---
+    // EncryptWallet mutates the master key, the key maps, the in-memory unlocked
+    // state, and (for HD wallets) the HD seed/mnemonic/MIK ciphertext fields, and
+    // it scrubs the plaintext seed in EncryptHDMasterKey(). If any later step fails
+    // (mnemonic recover/re-encrypt, EncryptHDMasterKey), the previous code returned
+    // false WITHOUT undoing those mutations — leaving the wallet encrypted-in-memory
+    // (masterKey valid) with fHDMasterKeyEncrypted==false and a plaintext seed. A new
+    // HD wallet (m_loadedFileVersion==0 ⇒ v7 writer) in that state would persist a v7
+    // file with encrypted spending keys + PLAINTEXT seed on the next autosave — the
+    // LP-7 bug reintroduced, with no migration arm on reload.
+    //
+    // Snapshot the full pre-encryption state here (BEFORE any mutation) and RESTORE it
+    // on every failure path so the wallet returns to its original UNENCRYPTED state.
+    // Mirrors the snapshot/rollback structure of MigrateToEncryptedSeedV7Unlocked().
+    CMasterKey snap_masterKey = masterKey;
+    std::map<CDilithiumAddress, CKey> snap_mapKeys = mapKeys;
+    std::map<CDilithiumAddress, CEncryptedKey> snap_mapCryptedKeys = mapCryptedKeys;
+    bool snap_fWalletUnlocked = fWalletUnlocked;
+    std::chrono::time_point<std::chrono::steady_clock> snap_nUnlockTime = nUnlockTime;
+    bool snap_vMasterKey_set = !vMasterKey.empty();
+    CHDExtendedKey snap_hdMasterKey = hdMasterKey;
+    bool snap_fHDMasterKeyEncrypted = fHDMasterKeyEncrypted;
+    bool snap_fHDMasterKeyCached = fHDMasterKeyCached;
+    CHDExtendedKey snap_hdMasterKeyDecrypted = hdMasterKeyDecrypted;
+    std::vector<uint8_t> snap_vchEncryptedMnemonic = vchEncryptedMnemonic;
+    std::vector<uint8_t> snap_vchMnemonicMAC = vchMnemonicMAC;
+    std::vector<uint8_t> snap_vchMnemonicIV(vchMnemonicIV.begin(), vchMnemonicIV.end());
+    std::vector<uint8_t> snap_vchEncryptedHDMasterKey = vchEncryptedHDMasterKey;
+    std::vector<uint8_t> snap_vchHDMasterKeyMAC = vchHDMasterKeyMAC;
+    std::vector<uint8_t> snap_vchHDMasterKeyIV(vchHDMasterKeyIV.begin(), vchHDMasterKeyIV.end());
+    bool snap_fHasMIK = fHasMIK;
+    std::vector<uint8_t> snap_vchEncryptedMIKPrivKey = vchEncryptedMIKPrivKey;
+    std::vector<uint8_t> snap_vchMIKPrivKeyMAC = vchMIKPrivKeyMAC;
+    std::vector<uint8_t> snap_vchMIKPrivKeyIV(vchMIKPrivKeyIV.begin(), vchMIKPrivKeyIV.end());
+    std::vector<uint8_t> snap_vchMIKPubKey = vchMIKPubKey;
+    uint32_t snap_loadedFileVersion = m_loadedFileVersion;
+
+    auto rollback = [&]() {
+        masterKey = snap_masterKey;
+        mapKeys = snap_mapKeys;
+        mapCryptedKeys = snap_mapCryptedKeys;
+        fWalletUnlocked = snap_fWalletUnlocked;
+        nUnlockTime = snap_nUnlockTime;
+        // The wallet was UNENCRYPTED before this call (guarded by masterKey.IsValid()
+        // at the top), so vMasterKey must not retain a usable master key after a
+        // failed encryption — scrub it. (snap_vMasterKey_set is false in the normal
+        // pre-encryption case; this is belt-and-suspenders.)
+        if (!snap_vMasterKey_set && !vMasterKey.empty()) {
+            memory_cleanse(vMasterKey.data_ptr(), vMasterKey.size());
+        }
+        hdMasterKey = snap_hdMasterKey;
+        fHDMasterKeyEncrypted = snap_fHDMasterKeyEncrypted;
+        fHDMasterKeyCached = snap_fHDMasterKeyCached;
+        hdMasterKeyDecrypted = snap_hdMasterKeyDecrypted;
+        vchEncryptedMnemonic = snap_vchEncryptedMnemonic;
+        vchMnemonicMAC = snap_vchMnemonicMAC;
+        vchMnemonicIV.assign(snap_vchMnemonicIV.begin(), snap_vchMnemonicIV.end());
+        vchEncryptedHDMasterKey = snap_vchEncryptedHDMasterKey;
+        vchHDMasterKeyMAC = snap_vchHDMasterKeyMAC;
+        vchHDMasterKeyIV.assign(snap_vchHDMasterKeyIV.begin(), snap_vchHDMasterKeyIV.end());
+        fHasMIK = snap_fHasMIK;
+        vchEncryptedMIKPrivKey = snap_vchEncryptedMIKPrivKey;
+        vchMIKPrivKeyMAC = snap_vchMIKPrivKeyMAC;
+        vchMIKPrivKeyIV.assign(snap_vchMIKPrivKeyIV.begin(), snap_vchMIKPrivKeyIV.end());
+        vchMIKPubKey = snap_vchMIKPubKey;
+        m_loadedFileVersion = snap_loadedFileVersion;
+    };
+
     // Generate random master key
     std::vector<uint8_t> vMasterKeyPlain(WALLET_CRYPTO_KEY_SIZE);
     if (!GetStrongRandBytes(vMasterKeyPlain.data(), WALLET_CRYPTO_KEY_SIZE)) {
@@ -1372,6 +1440,7 @@ bool CWallet::EncryptWallet(const std::string& passphrase) {
     // Generate salt for PBKDF2
     if (!GenerateSalt(masterKey.vchSalt)) {
         memory_cleanse(vMasterKeyPlain.data(), vMasterKeyPlain.size());
+        rollback();
         return false;
     }
 
@@ -1379,6 +1448,7 @@ bool CWallet::EncryptWallet(const std::string& passphrase) {
     std::vector<uint8_t> derivedKey;
     if (!DeriveKey(passphrase, masterKey.vchSalt, WALLET_CRYPTO_PBKDF2_ROUNDS, derivedKey)) {
         memory_cleanse(vMasterKeyPlain.data(), vMasterKeyPlain.size());
+        rollback();
         return false;
     }
 
@@ -1386,6 +1456,7 @@ bool CWallet::EncryptWallet(const std::string& passphrase) {
     if (!GenerateUniqueIV_Locked(masterKey.vchIV)) {
         memory_cleanse(vMasterKeyPlain.data(), vMasterKeyPlain.size());
         memory_cleanse(derivedKey.data(), derivedKey.size());
+        rollback();
         return false;
     }
 
@@ -1394,12 +1465,14 @@ bool CWallet::EncryptWallet(const std::string& passphrase) {
     if (!masterCrypter.SetKey(derivedKey, masterKey.vchIV)) {
         memory_cleanse(vMasterKeyPlain.data(), vMasterKeyPlain.size());
         memory_cleanse(derivedKey.data(), derivedKey.size());
+        rollback();
         return false;
     }
 
     if (!masterCrypter.Encrypt(vMasterKeyPlain, masterKey.vchCryptedKey)) {
         memory_cleanse(vMasterKeyPlain.data(), vMasterKeyPlain.size());
         memory_cleanse(derivedKey.data(), derivedKey.size());
+        rollback();
         return false;
     }
 
@@ -1408,6 +1481,7 @@ bool CWallet::EncryptWallet(const std::string& passphrase) {
     if (!ComputeRecordMAC(masterCrypter, masterKey.vchCryptedKey, masterKey.vchMAC)) {
         memory_cleanse(vMasterKeyPlain.data(), vMasterKeyPlain.size());
         memory_cleanse(derivedKey.data(), derivedKey.size());
+        rollback();
         return false;
     }
 
@@ -1426,6 +1500,7 @@ bool CWallet::EncryptWallet(const std::string& passphrase) {
         if (!GenerateUniqueIV_Locked(encKey.vchIV)) {
             memory_cleanse(vMasterKeyPlain.data(), vMasterKeyPlain.size());
             memory_cleanse(derivedKey.data(), derivedKey.size());
+            rollback();
             return false;
         }
 
@@ -1434,12 +1509,14 @@ bool CWallet::EncryptWallet(const std::string& passphrase) {
         if (!keyCrypter.SetKey(vMasterKeyPlain, encKey.vchIV)) {
             memory_cleanse(vMasterKeyPlain.data(), vMasterKeyPlain.size());
             memory_cleanse(derivedKey.data(), derivedKey.size());
+            rollback();
             return false;
         }
 
         if (!keyCrypter.Encrypt(key.vchPrivKey, encKey.vchCryptedKey)) {
             memory_cleanse(vMasterKeyPlain.data(), vMasterKeyPlain.size());
             memory_cleanse(derivedKey.data(), derivedKey.size());
+            rollback();
             return false;
         }
 
@@ -1448,6 +1525,7 @@ bool CWallet::EncryptWallet(const std::string& passphrase) {
         if (!ComputeRecordMAC(keyCrypter, encKey.vchCryptedKey, encKey.vchMAC)) {
             memory_cleanse(vMasterKeyPlain.data(), vMasterKeyPlain.size());
             memory_cleanse(derivedKey.data(), derivedKey.size());
+            rollback();
             return false;
         }
 
@@ -1493,6 +1571,7 @@ bool CWallet::EncryptWallet(const std::string& passphrase) {
                 memory_cleanse(vMasterKeyPlain.data(), vMasterKeyPlain.size());
                 memory_cleanse(derivedKey.data(), derivedKey.size());
                 std::cerr << "[Wallet] CRITICAL: failed to recover mnemonic for re-encryption" << std::endl;
+                rollback();
                 return false;
             }
             memory_cleanse(obfKey.data(), obfKey.size());
@@ -1508,6 +1587,7 @@ bool CWallet::EncryptWallet(const std::string& passphrase) {
                 memory_cleanse(vMasterKeyPlain.data(), vMasterKeyPlain.size());
                 memory_cleanse(derivedKey.data(), derivedKey.size());
                 std::cerr << "[Wallet] CRITICAL: failed to re-encrypt mnemonic" << std::endl;
+                rollback();
                 return false;
             }
         }
@@ -1518,6 +1598,7 @@ bool CWallet::EncryptWallet(const std::string& passphrase) {
             memory_cleanse(vMasterKeyPlain.data(), vMasterKeyPlain.size());
             memory_cleanse(derivedKey.data(), derivedKey.size());
             std::cerr << "[Wallet] CRITICAL: failed to encrypt HD master key" << std::endl;
+            rollback();
             return false;
         }
     }
@@ -1550,7 +1631,15 @@ bool CWallet::EncryptWallet(const std::string& passphrase) {
     // Save wallet to disk — encryption MUST be persisted
     if (m_autoSave && !m_walletFile.empty()) {
         if (!SaveUnlocked()) {
-            std::cerr << "[Wallet] CRITICAL: Wallet encrypted in memory but failed to save to disk!" << std::endl;
+            // Transactional (Cursor HIGH-2): the in-memory encryption is complete
+            // and correct (HD seed encrypted, fHDMasterKeyEncrypted==true) so this
+            // is NOT the plaintext-at-rest state — but the encryption did not reach
+            // disk. Roll the in-memory state back to UNENCRYPTED so the on-disk file
+            // and memory agree (both unencrypted) and the failure is total rather
+            // than leaving the wallet encrypted-in-memory-but-unsaved. EncryptWallet
+            // can then be retried cleanly.
+            std::cerr << "[Wallet] CRITICAL: Wallet encrypted in memory but failed to save to disk — rolling back to unencrypted state" << std::endl;
+            rollback();
             return false;
         }
     }
@@ -2026,6 +2115,21 @@ bool CWallet::Load(const std::string& filename) {
                 if (!file.good()) return false;
                 file.read(reinterpret_cast<char*>(&temp_hdMasterKey.child_index), sizeof(temp_hdMasterKey.child_index));
                 if (!file.good()) return false;
+
+                // LOAD-TIME DEFENSE-IN-DEPTH (Cursor HIGH-1/HIGH-2): a v7 file whose
+                // HD seed is PLAINTEXT (this branch) while the WALLET is encrypted
+                // (isEncrypted: spending keys under a passphrase master key) is the
+                // LP-7 plaintext-seed-at-rest state — it should never have been
+                // written (the SaveUnlocked guard now refuses it, and EncryptWallet
+                // is now transactional), but a wallet produced by a pre-fix binary
+                // could still exist on disk. Arm migration so the next Unlock
+                // re-encrypts the seed and rewrites the file at v7, exactly as the
+                // legacy-layout branch below does for legacy plaintext seeds. (An
+                // UNencrypted v7 wallet legitimately stores a plaintext seed here —
+                // only arm when the wallet has a master key.)
+                if (isEncrypted) {
+                    temp_fNeedsSeedMigration = true;
+                }
             }
         } else {
             // LEGACY v3-v6 layout: fixed [seed32][chaincode32][depth][fp][ci]
@@ -2952,6 +3056,31 @@ bool CWallet::SaveUnlocked(const std::string& filename) const {
             // Unencrypted HD wallet: seed is plaintext by design (no passphrase
             // set). Write the fixed 32+32 plaintext slots + metadata. An
             // unencrypted seed length of 0 (variable-length) marks "plaintext".
+            //
+            // STRUCTURAL FAIL-CLOSED GUARD (Cursor HIGH-1): refuse to persist a
+            // plaintext HD seed whenever the wallet is encrypted in memory. The
+            // only legitimate way to reach this branch is an UNencrypted wallet
+            // (no passphrase master key). If a master key exists
+            // (masterKey.IsValid()) but fHDMasterKeyEncrypted is still false, the
+            // wallet is encrypted-in-memory with a plaintext seed — exactly the
+            // LP-7 plaintext-seed-at-rest exposure (e.g. an EncryptWallet that
+            // aborted mid-HD-step without rolling back). Writing the v7 plaintext
+            // layout here would mint a v7-labelled file carrying encrypted
+            // spending keys alongside a 32-byte plaintext seed, with no migration
+            // arm on reload (the loader only arms migration for the LEGACY layout).
+            // Refuse the save so this combination is structurally impossible. This
+            // mirrors the refuse guards in the legacy-v6 branch above and the
+            // empty-ciphertext check in the encrypted branch.
+            if (masterKey.IsValid()) {
+                std::cerr << "[Wallet] CRITICAL: refusing v7 plaintext-seed save of an "
+                             "encrypted HD wallet — the wallet has a master key but the HD "
+                             "seed is not encrypted (fHDMasterKeyEncrypted==false); persisting "
+                             "a plaintext seed for an encrypted wallet is the LP-7 "
+                             "plaintext-at-rest exposure. The HD seed must be encrypted "
+                             "(EncryptHDMasterKey) before any save of an encrypted wallet."
+                          << std::endl;
+                return false;
+            }
             file.write(reinterpret_cast<const char*>(&encrypted_flag), 1);
             if (!file.good()) return false;
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1323,15 +1323,24 @@ bool CWallet::Unlock(const std::string& passphrase, int64_t timeout) {
             masterKey.vchMAC = newMasterMAC;
         }
 
-        if (macOk && MigrateToEncryptedSeedV7Unlocked()) {
+        // Cursor M1: clear the migration flag / promote to v7 ONLY when the migrated
+        // v7 (no-plaintext) file actually reached disk (persistedToDisk == true).
+        // MigrateToEncryptedSeedV7Unlocked returns false (no in-memory mutation) when
+        // it cannot persist (autosave off / no file), so the flag STAYS armed and the
+        // on-disk-plaintext state keeps surfacing. Invariant: NeedsSeedMigration() is
+        // true exactly while a plaintext seed is still at rest on disk.
+        bool migrationPersisted = false;
+        if (macOk && MigrateToEncryptedSeedV7Unlocked(&migrationPersisted) && migrationPersisted) {
             m_fNeedsSeedMigration = false;
             m_loadedFileVersion = WALLET_FILE_VERSION_7;
             std::cout << "[Wallet] LP-7: migrated wallet to encrypted-seed v7 format" << std::endl;
         } else {
             // Restore the legacy master MAC so the in-memory state stays consistent
-            // with the untouched on-disk legacy file.
+            // with the untouched on-disk legacy file. Reached when the MAC recompute
+            // failed, the migration could not persist (autosave off → flag stays
+            // armed, surfaced), or the save failed (retry next unlock).
             masterKey.vchMAC = snap_masterMAC;
-            std::cerr << "[Wallet] LP-7: WARNING — seed migration to v7 failed; "
+            std::cerr << "[Wallet] LP-7: seed migration to v7 not persisted; "
                          "original wallet file left unchanged, will retry on next unlock" << std::endl;
         }
     }
@@ -4890,6 +4899,19 @@ bool CWallet::SignTransaction(CTransaction& tx, CUTXOSet& utxo_set, std::string&
             return false;
         }
 
+        // LP-7 L1 (opt-in --require-seed-migration, default OFF): refuse to sign any
+        // spend while the HD seed is still plaintext-at-rest. This is the single spend
+        // signing funnel, so this one gate covers sendtoaddress, raw-tx signing, HTLC,
+        // and bridge spends. Default OFF leaves the warn-only behavior intact.
+        // (masterKey.IsValid() && m_fNeedsSeedMigration mirrors NeedsSeedMigration()
+        // without re-locking cs_wallet, which we already hold here.)
+        if (m_requireSeedMigration && masterKey.IsValid() && m_fNeedsSeedMigration) {
+            error = "Refusing to spend: wallet HD seed is still stored UNENCRYPTED at rest "
+                    "(fixed bug LP-7). Unlock once to complete the one-time security upgrade "
+                    "(walletpassphrase), then retry. (Started with --require-seed-migration.)";
+            return false;
+        }
+
         // Check chain params before loop
         if (Dilithion::g_chainParams == nullptr) {
             error = "Chain parameters not initialized";
@@ -5603,12 +5625,25 @@ bool CWallet::DeriveAndCacheHDAddress(const CHDKeyPath& path) {
 //     in-memory HD state to its pre-migration plaintext-seed form so the wallet
 //     stays consistent with the still-on-disk legacy file, and return false. The
 //     caller does not fail the unlock; migration retries next unlock.
-bool CWallet::MigrateToEncryptedSeedV7Unlocked() {
+bool CWallet::MigrateToEncryptedSeedV7Unlocked(bool* persistedToDisk) {
+    if (persistedToDisk) *persistedToDisk = false;
     if (!masterKey.IsValid() || !fWalletUnlocked || !fIsHDWallet) {
         return false;
     }
     // Defensive: only migrate when the seed is actually plaintext.
     if (fHDMasterKeyEncrypted) {
+        return false;
+    }
+    // Cursor M1: migration is only meaningful if we can PERSIST the migrated v7
+    // (no-plaintext) file. If autosave is off / no wallet file, an in-memory-only
+    // re-encryption would (a) scrub the plaintext seed in memory while the on-disk
+    // file STILL holds it, and (b) leave m_loadedFileVersion at the legacy version,
+    // so a later SaveUnlocked would emit the v6 layout from now-scrubbed seed slots
+    // (data corruption). Skip migration entirely here: keep the wallet in its
+    // consistent legacy-plaintext state (both in memory and on disk) and leave the
+    // caller's m_fNeedsSeedMigration armed so NeedsSeedMigration() stays true and the
+    // remediation keeps surfacing until a real, persistable rewrite can occur.
+    if (!m_autoSave || m_walletFile.empty()) {
         return false;
     }
 
@@ -5802,9 +5837,11 @@ bool CWallet::MigrateToEncryptedSeedV7Unlocked() {
     // Promote to v7 FIRST so the version-aware SaveUnlocked emits the v7 layout (the
     // seed is now encrypted; a v6 write here would be wrong). rollback() restores the
     // loaded version if the save fails, keeping in-memory state consistent with the
-    // still-intact on-disk legacy file. (When autosave is off — an in-memory-only
-    // migration — we do NOT touch m_loadedFileVersion here; the caller's Unlock bumps
-    // it, and the on-disk file legitimately stays v6 until a real rewrite occurs.)
+    // still-intact on-disk legacy file.
+    // Cursor M1: persist-capability (autosave on + wallet file set) was verified at
+    // entry — if it had not held we returned early WITHOUT any in-memory mutation, so
+    // we never reach here with a half-migrated state we cannot persist. The guard
+    // below is kept defensively (the else-arm fails closed).
     if (m_autoSave && !m_walletFile.empty()) {
         m_loadedFileVersion = WALLET_FILE_VERSION_7;
         if (!SaveUnlocked()) {
@@ -5813,6 +5850,15 @@ bool CWallet::MigrateToEncryptedSeedV7Unlocked() {
             rollback();
             return false;
         }
+        // The migrated v7 (no-plaintext) file is now on disk — only NOW is it safe
+        // for the caller to clear the migration flag / treat the file as v7.
+        if (persistedToDisk) *persistedToDisk = true;
+    } else {
+        // Unreachable given the entry guard, but fail closed rather than report a
+        // half-migrated success: roll back so in-memory state stays consistent with
+        // the unchanged on-disk legacy file.
+        rollback();
+        return false;
     }
 
     return true;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -286,6 +286,58 @@ bool CWallet::HasKey(const CDilithiumAddress& address) const {
 // LP-7 (HIGH-2): the ONE authenticated-decrypt gate shared by all five at-rest
 // record types. See the declaration in wallet.h for the full policy contract.
 // Returns true iff the caller may proceed to decrypt `ciphertext`.
+//
+// =====================================================================================
+// LP-7 (round 3, MEDIUM-1): EXHAUSTIVE AT-REST RECORD MAC-CONSUMER ENUMERATION
+// -------------------------------------------------------------------------------------
+// Every per-record at-rest MAC verify/compute in the wallet MUST route through
+// VerifyRecordMAC (reads) or ComputeRecordMAC (writes) so the keying selection is
+// version-correct in exactly ONE place. The complete census (grep the wallet for
+// `\.VerifyMAC(` / `\.ComputeMAC(`):
+//
+//   VERIFY (read-before-decrypt) — all 6 route through VerifyRecordMAC:
+//     1. per-address spending key   wallet.cpp  GetKeyUnlocked        -> VerifyRecordMAC
+//     2. master key                 wallet.cpp  Unlock                -> VerifyRecordMAC
+//     3. HD-master seed             wallet.cpp  DecryptHDMasterKey    -> VerifyRecordMAC
+//     4. mnemonic                   wallet.cpp  DecryptMnemonic       -> VerifyRecordMAC
+//     5. MIK private key            wallet.cpp  DecryptMIKPrivKey     -> VerifyRecordMAC
+//     6. master key (passphrase rotation)  wallet.cpp  ChangePassphrase
+//                                                                     -> VerifyRecordMAC
+//        (this was the MEDIUM-1 bypass: it open-coded crypter.VerifyMAC with default
+//         v7 keying and bricked passphrase change on loaded legacy v3-v6 wallets;
+//         now routed.)
+//
+//   COMPUTE (write / re-MAC) — all route through ComputeRecordMAC:
+//     a. master key (EncryptWallet)          -> ComputeRecordMAC
+//     b. per-address key (EncryptWallet)     -> ComputeRecordMAC
+//     c. master key re-MAC (Unlock migration)-> ComputeRecordMAC
+//     d. per-address re-MAC (migration Step 2c) -> ComputeRecordMAC
+//     e. master key (ChangePassphrase write) -> ComputeRecordMAC
+//     f. HD-master seed (EncryptHDMasterKey) -> ComputeRecordMAC
+//     g. mnemonic (EncryptMnemonic, encrypted branch) -> ComputeRecordMAC
+//     h. MIK private key (EncryptMIKPrivKey) -> ComputeRecordMAC
+//     i. ChangePassphrase legacy->v7 record re-MAC (per-address, HD-master,
+//        mnemonic, MIK) -> ReMACAllRecordsToV7Unlocked -> ComputeRecordMAC
+//        (MEDIUM-1 fix: ChangePassphrase re-saves at v7, so every NON-master record
+//         on a loaded legacy wallet must be re-MAC'd to separated keying too — not
+//         just the master key — or it fails VerifyRecordMAC on the next load.)
+//
+//   The ONLY direct crypter.VerifyMAC / crypter.ComputeMAC calls remaining are the two
+//   inside VerifyRecordMAC / ComputeRecordMAC themselves (the implementations).
+//
+//   LEGITIMATELY NOT routed (different mechanism, by design):
+//     - The whole-file integrity HMAC (wallet.cpp Load/SaveUnlocked, HMAC_SHA3_256 over
+//       [salt||data], keyed off the master-key salt). This is a file-level integrity
+//       seal, NOT a per-record authenticated-decrypt MAC — it has no version-keyed
+//       legacy/separated split and must not flow through the per-record helper.
+//     - Obfuscation-keyed crypter.Decrypt paths on UNencrypted wallets (mnemonic/MIK
+//       else-branches): by-design-unauthenticated obfuscation, no MAC is written or
+//       checked (the write side clears the MAC), so there is nothing to route.
+//
+//   INVARIANT: there are ZERO at-rest record MAC verify/compute sites that bypass the
+//   central helper. If you add a new at-rest encrypted record, its MAC verify/compute
+//   MUST go through VerifyRecordMAC/ComputeRecordMAC — extend this census.
+// =====================================================================================
 bool CWallet::VerifyRecordMAC(CCrypter& crypter,
                              const std::vector<uint8_t>& ciphertext,
                              const std::vector<uint8_t>& mac) const {
@@ -314,6 +366,60 @@ bool CWallet::ComputeRecordMAC(CCrypter& crypter,
                               const std::vector<uint8_t>& ciphertext,
                               std::vector<uint8_t>& macOut) const {
     return crypter.ComputeMAC(ciphertext, macOut /*default = separated v7 keying*/);
+}
+
+// LP-7 (round 3, MEDIUM-1): re-MAC every present at-rest record with v7 separated
+// keying. See the declaration in wallet.h for the full rationale. Caller holds
+// cs_wallet. On false, the caller MUST treat in-memory state as inconsistent and
+// roll back (do not save). A pure re-MAC: the ciphertext is unchanged, so no decrypt
+// of the secret is performed.
+bool CWallet::ReMACAllRecordsToV7Unlocked(const std::vector<uint8_t>& vMasterKeyPlain) {
+    // Re-MAC each per-address spending key (same logic as migration Step 2c).
+    for (auto& kv : mapCryptedKeys) {
+        CEncryptedKey& ek = kv.second;
+        if (ek.vchCryptedKey.empty() || ek.vchIV.size() != WALLET_CRYPTO_IV_SIZE) {
+            return false;  // malformed — cannot authenticate; abort rather than mis-MAC
+        }
+        CCrypter c;
+        if (!c.SetKey(vMasterKeyPlain, ek.vchIV)) return false;
+        std::vector<uint8_t> newMAC;
+        if (!ComputeRecordMAC(c, ek.vchCryptedKey, newMAC)) return false;
+        ek.vchMAC = newMAC;
+    }
+
+    // Re-MAC the encrypted HD-master seed, if present.
+    if (fHDMasterKeyEncrypted && !vchEncryptedHDMasterKey.empty()) {
+        if (vchHDMasterKeyIV.size() != WALLET_CRYPTO_IV_SIZE) return false;
+        CCrypter c;
+        if (!c.SetKey(vMasterKeyPlain, vchHDMasterKeyIV)) return false;
+        std::vector<uint8_t> newMAC;
+        if (!ComputeRecordMAC(c, vchEncryptedHDMasterKey, newMAC)) return false;
+        vchHDMasterKeyMAC = newMAC;
+    }
+
+    // Re-MAC the encrypted mnemonic, if present (encrypted-wallet branch only —
+    // an obfuscation-keyed unencrypted mnemonic carries no MAC and never reaches here
+    // because masterKey.IsValid() gates ChangePassphrase).
+    if (!vchEncryptedMnemonic.empty() && !vchMnemonicMAC.empty()) {
+        if (vchMnemonicIV.size() != WALLET_CRYPTO_IV_SIZE) return false;
+        CCrypter c;
+        if (!c.SetKey(vMasterKeyPlain, vchMnemonicIV)) return false;
+        std::vector<uint8_t> newMAC;
+        if (!ComputeRecordMAC(c, vchEncryptedMnemonic, newMAC)) return false;
+        vchMnemonicMAC = newMAC;
+    }
+
+    // Re-MAC the encrypted MIK private key, if present.
+    if (!vchEncryptedMIKPrivKey.empty() && !vchMIKPrivKeyMAC.empty()) {
+        if (vchMIKPrivKeyIV.size() != WALLET_CRYPTO_IV_SIZE) return false;
+        CCrypter c;
+        if (!c.SetKey(vMasterKeyPlain, vchMIKPrivKeyIV)) return false;
+        std::vector<uint8_t> newMAC;
+        if (!ComputeRecordMAC(c, vchEncryptedMIKPrivKey, newMAC)) return false;
+        vchMIKPrivKeyMAC = newMAC;
+    }
+
+    return true;
 }
 
 // Public GetKey - acquires lock
@@ -1344,8 +1450,9 @@ bool CWallet::EncryptWallet(const std::string& passphrase) {
         return false;
     }
 
-    // FIX-008 (CRYPT-007): Compute MAC for authenticated encryption
-    if (!masterCrypter.ComputeMAC(masterKey.vchCryptedKey, masterKey.vchMAC)) {
+    // FIX-008 (CRYPT-007): Compute MAC for authenticated encryption (master key).
+    // LP-7 (round 3): route through ComputeRecordMAC — at-rest record, always v7.
+    if (!ComputeRecordMAC(masterCrypter, masterKey.vchCryptedKey, masterKey.vchMAC)) {
         memory_cleanse(vMasterKeyPlain.data(), vMasterKeyPlain.size());
         memory_cleanse(derivedKey.data(), derivedKey.size());
         return false;
@@ -1383,8 +1490,9 @@ bool CWallet::EncryptWallet(const std::string& passphrase) {
             return false;
         }
 
-        // FIX-008 (CRYPT-007): Compute MAC for authenticated encryption
-        if (!keyCrypter.ComputeMAC(encKey.vchCryptedKey, encKey.vchMAC)) {
+        // FIX-008 (CRYPT-007): Compute MAC for authenticated encryption (per-address key).
+        // LP-7 (round 3): route through ComputeRecordMAC — at-rest record, always v7.
+        if (!ComputeRecordMAC(keyCrypter, encKey.vchCryptedKey, encKey.vchMAC)) {
             memory_cleanse(vMasterKeyPlain.data(), vMasterKeyPlain.size());
             memory_cleanse(derivedKey.data(), derivedKey.size());
             return false;
@@ -1533,13 +1641,19 @@ bool CWallet::ChangePassphrase(const std::string& passphraseOld,
         return false;
     }
 
-    // FIX-008 (CRYPT-007): Verify MAC before decryption (prevents padding oracle)
-    // For legacy keys without MAC, skip verification
-    if (!masterKey.IsLegacy()) {
-        if (!crypterOld.VerifyMAC(masterKey.vchCryptedKey, masterKey.vchMAC)) {
-            memory_cleanse(derivedKeyOld.data(), derivedKeyOld.size());
-            return false;  // MAC verification failed - wrong passphrase or tampered data
-        }
+    // FIX-008 (CRYPT-007): Verify MAC before decryption (prevents padding oracle).
+    // LP-7 (MEDIUM-1, round 3): route through the central VerifyRecordMAC gate so the
+    // keying selection matches the LOADED file version, exactly like the five read
+    // paths. The previous open-coded `crypterOld.VerifyMAC(...)` used the default
+    // separated (v7) keying unconditionally; on a loaded legacy v3-v6 wallet whose
+    // master MAC is legacy-AES-keyed (and non-empty, so IsLegacy()==false), that
+    // mismatched the on-disk MAC and made ChangePassphrase reject the CORRECT
+    // passphrase — permanently bricking passphrase rotation for non-HD legacy
+    // wallets (which never migrate). VerifyRecordMAC also subsumes the empty-MAC
+    // pre-v7 case, so the IsLegacy() special-case is no longer needed.
+    if (!VerifyRecordMAC(crypterOld, masterKey.vchCryptedKey, masterKey.vchMAC)) {
+        memory_cleanse(derivedKeyOld.data(), derivedKeyOld.size());
+        return false;  // MAC verification failed - wrong passphrase or tampered data
     }
 
     std::vector<uint8_t> vMasterKeyPlain;
@@ -1590,9 +1704,13 @@ bool CWallet::ChangePassphrase(const std::string& passphraseOld,
         return false;
     }
 
-    // FIX-008 (CRYPT-007): Compute MAC for authenticated encryption
+    // FIX-008 (CRYPT-007): Compute MAC for authenticated encryption.
+    // LP-7 (round 3): route through ComputeRecordMAC so every at-rest record MAC
+    // *compute* also flows through the central helper. The rewrite is always v7, so
+    // this is semantically identical to the prior open-coded call (separated keying)
+    // — but it keeps the "zero bypass" invariant true for compute as well as verify.
     std::vector<uint8_t> newMAC;
-    if (!crypterNew.ComputeMAC(newCryptedKey, newMAC)) {
+    if (!ComputeRecordMAC(crypterNew, newCryptedKey, newMAC)) {
         memory_cleanse(derivedKeyOld.data(), derivedKeyOld.size());
         memory_cleanse(derivedKeyNew.data(), derivedKeyNew.size());
         memory_cleanse(vMasterKeyPlain.data(), vMasterKeyPlain.size());
@@ -1611,6 +1729,53 @@ bool CWallet::ChangePassphrase(const std::string& passphraseOld,
     masterKey.vchMAC = newMAC;  // FIX-008: Store MAC
     masterKey.vchIV = newIV;
 
+    // LP-7 (round 3, MEDIUM-1): a successful ChangePassphrase ALWAYS re-saves the
+    // file at v7 (SaveUnlocked writes DILWLT07). When the loaded file was a legacy
+    // v3-v6 wallet, its NON-master records (per-address keys, HD-master, mnemonic,
+    // MIK) still carry legacy-AES-keyed MACs in memory. If we re-saved as v7 without
+    // re-MACing them, they would fail VerifyRecordMAC (separated keying) on the next
+    // load — re-opening exactly the HIGH-2 / MEDIUM-1 keying-mismatch class (the
+    // master key alone was re-MAC'd above; the rest were missed). The Unlock path
+    // handles this via MigrateToEncryptedSeedV7Unlocked, but ChangePassphrase is
+    // reachable WITHOUT a prior unlock (the RPC calls it directly), and a non-HD
+    // legacy wallet never arms that migration. Re-MAC all records here, then advance
+    // m_loadedFileVersion so subsequent verifies in this instance also use v7 keying.
+    const uint32_t prevLoadedVersion = m_loadedFileVersion;
+    bool didReMAC = false;
+    // Snapshot non-master record MACs for rollback symmetry.
+    std::vector<std::pair<CDilithiumAddress, std::vector<uint8_t>>> snapPerAddrMAC;
+    std::vector<uint8_t> snapHDMAC = vchHDMasterKeyMAC;
+    std::vector<uint8_t> snapMnemonicMAC = vchMnemonicMAC;
+    std::vector<uint8_t> snapMIKMAC = vchMIKPrivKeyMAC;
+    if (m_loadedFileVersion != 0 && m_loadedFileVersion < WALLET_FILE_VERSION_7) {
+        for (const auto& kv : mapCryptedKeys) {
+            snapPerAddrMAC.emplace_back(kv.first, kv.second.vchMAC);
+        }
+        if (!ReMACAllRecordsToV7Unlocked(vMasterKeyPlain)) {
+            // Restore master key + any partially-rewritten record MACs; leave the
+            // on-disk legacy file untouched.
+            masterKey.vchCryptedKey = oldCryptedKey;
+            masterKey.vchSalt = oldSalt;
+            masterKey.vchMAC = oldMAC;
+            masterKey.vchIV = oldIV;
+            for (auto& s : snapPerAddrMAC) {
+                auto it = mapCryptedKeys.find(s.first);
+                if (it != mapCryptedKeys.end()) it->second.vchMAC = s.second;
+            }
+            vchHDMasterKeyMAC = snapHDMAC;
+            vchMnemonicMAC = snapMnemonicMAC;
+            vchMIKPrivKeyMAC = snapMIKMAC;
+            memory_cleanse(derivedKeyOld.data(), derivedKeyOld.size());
+            memory_cleanse(derivedKeyNew.data(), derivedKeyNew.size());
+            memory_cleanse(vMasterKeyPlain.data(), vMasterKeyPlain.size());
+            std::cerr << "[Wallet] LP-7: ChangePassphrase aborted — could not re-MAC a "
+                         "legacy record to v7; passphrase unchanged, file untouched" << std::endl;
+            return false;
+        }
+        m_loadedFileVersion = WALLET_FILE_VERSION_7;
+        didReMAC = true;
+    }
+
     // Wipe sensitive data
     memory_cleanse(derivedKeyOld.data(), derivedKeyOld.size());
     memory_cleanse(derivedKeyNew.data(), derivedKeyNew.size());
@@ -1625,11 +1790,23 @@ bool CWallet::ChangePassphrase(const std::string& passphraseOld,
             std::this_thread::sleep_for(std::chrono::milliseconds(500));
             if (!SaveUnlocked()) {
                 std::cerr << "[Wallet] CRITICAL: Retry failed. Reverting passphrase change." << std::endl;
-                // Revert so in-memory state matches what's on disk
+                // Revert so in-memory state matches what's on disk (legacy file).
                 masterKey.vchCryptedKey = oldCryptedKey;
                 masterKey.vchSalt = oldSalt;
                 masterKey.vchMAC = oldMAC;
                 masterKey.vchIV = oldIV;
+                if (didReMAC) {
+                    // Restore the legacy-keyed record MACs and the loaded version so
+                    // in-memory state matches the untouched on-disk legacy file.
+                    for (auto& s : snapPerAddrMAC) {
+                        auto it = mapCryptedKeys.find(s.first);
+                        if (it != mapCryptedKeys.end()) it->second.vchMAC = s.second;
+                    }
+                    vchHDMasterKeyMAC = snapHDMAC;
+                    vchMnemonicMAC = snapMnemonicMAC;
+                    vchMIKPrivKeyMAC = snapMIKMAC;
+                    m_loadedFileVersion = prevLoadedVersion;
+                }
                 memory_cleanse(vMasterKeyPlain.data(), vMasterKeyPlain.size());
                 return false;
             }
@@ -5410,8 +5587,9 @@ bool CWallet::EncryptHDMasterKey() {
 
     // LP-7 (wallet-Inv-2): authenticate the ciphertext (encrypt-then-MAC) with a
     // separately-derived MAC key (key separation, default keying).
+    // LP-7 (round 3): route through ComputeRecordMAC — at-rest HD-master record, always v7.
     std::vector<uint8_t> mac;
-    if (!crypter.ComputeMAC(encrypted, mac)) {
+    if (!ComputeRecordMAC(crypter, encrypted, mac)) {
         memory_cleanse(vMasterKeyVec.data(), vMasterKeyVec.size());
         memory_cleanse(masterKeyData.data(), masterKeyData.size());
         memory_cleanse(encrypted.data(), encrypted.size());
@@ -5547,7 +5725,8 @@ bool CWallet::EncryptMnemonic(const std::string& mnemonic) {
         }
 
         // LP-7 (wallet-Inv-2): authenticate the mnemonic ciphertext (encrypt-then-MAC)
-        if (!crypter.ComputeMAC(vchEncryptedMnemonic, vchMnemonicMAC)) {
+        // LP-7 (round 3): route through ComputeRecordMAC — at-rest mnemonic record, always v7.
+        if (!ComputeRecordMAC(crypter, vchEncryptedMnemonic, vchMnemonicMAC)) {
             memory_cleanse(vMasterKeyVec.data(), vMasterKeyVec.size());
             memory_cleanse(mnemonicBytes.data(), mnemonicBytes.size());
             return false;
@@ -5763,7 +5942,8 @@ bool CWallet::EncryptMIKPrivKey() {
     }
 
     // LP-7 (wallet-Inv-2): authenticate the MIK ciphertext (encrypt-then-MAC)
-    if (!crypter.ComputeMAC(vchEncryptedMIKPrivKey, vchMIKPrivKeyMAC)) {
+    // LP-7 (round 3): route through ComputeRecordMAC — at-rest MIK record, always v7.
+    if (!ComputeRecordMAC(crypter, vchEncryptedMIKPrivKey, vchMIKPrivKeyMAC)) {
         memory_cleanse(vMasterKeyVec.data(), vMasterKeyVec.size());
         memory_cleanse(plaintext.data(), plaintext.size());
         return false;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1147,9 +1147,14 @@ bool CWallet::Unlock(const std::string& passphrase, int64_t timeout) {
     }
 
     // FIX-008 (CRYPT-007): Verify MAC before decryption (prevents padding oracle)
-    // For legacy keys without MAC, skip verification
+    // For legacy keys without MAC, skip verification.
+    // LP-7: the master-key MAC keying depends on the on-disk format version —
+    // v3-v6 used the legacy AES-keyed HMAC; v7 uses the separately-derived MAC
+    // key. Select the keying by the loaded version so pre-v7 wallets still unlock
+    // (and can then migrate).
     if (!masterKey.IsLegacy()) {
-        if (!crypter.VerifyMAC(masterKey.vchCryptedKey, masterKey.vchMAC)) {
+        bool legacyKeying = (m_loadedFileVersion != 0 && m_loadedFileVersion < WALLET_FILE_VERSION_7);
+        if (!crypter.VerifyMAC(masterKey.vchCryptedKey, masterKey.vchMAC, legacyKeying)) {
             // WL-011 FIX: Track failed unlock attempt
             nUnlockFailedAttempts++;
             nLastFailedUnlock = std::chrono::steady_clock::now();
@@ -1198,6 +1203,40 @@ bool CWallet::Unlock(const std::string& passphrase, int64_t timeout) {
     memory_cleanse(derivedKey.data(), derivedKey.size());
     memory_cleanse(decryptedKey.data(), decryptedKey.size());
 
+    // LP-7 (wallet-Inv-5 migration): if this encrypted wallet was loaded from a
+    // legacy plaintext-seed format, re-encrypt the seed+mnemonic now that we hold
+    // the master key, and atomically rewrite the file at v7. The rewrite is
+    // atomic + reversible-on-failure (SaveUnlocked: temp-write + fsync + rename;
+    // the original is never truncated). A migration failure does NOT fail the
+    // unlock — the wallet is fully usable in memory and migration retries on the
+    // next unlock; the on-disk file is left byte-identical.
+    if (m_fNeedsSeedMigration) {
+        // The master-key MAC on a v3-v6 file was computed with the legacy
+        // AES-keyed HMAC. Once we rewrite as v7, Unlock will verify it with the
+        // separated-key HMAC, so recompute it here with the SAME crypter that just
+        // decrypted the master key (keyed with the passphrase-derived key) using
+        // the new (default) separated keying. Snapshot for rollback symmetry.
+        std::vector<uint8_t> snap_masterMAC = masterKey.vchMAC;
+        std::vector<uint8_t> newMasterMAC;
+        bool macOk = crypter.ComputeMAC(masterKey.vchCryptedKey, newMasterMAC /*default=separated*/);
+        if (macOk) {
+            masterKey.vchMAC = newMasterMAC;
+        }
+
+        if (macOk && MigrateToEncryptedSeedV7Unlocked()) {
+            m_fNeedsSeedMigration = false;
+            m_loadedFileVersion = WALLET_FILE_VERSION_7;
+            std::cout << "[Wallet] LP-7: migrated wallet to encrypted-seed v7 format" << std::endl;
+        } else {
+            // Restore the legacy master MAC so the in-memory state stays consistent
+            // with the untouched on-disk legacy file.
+            masterKey.vchMAC = snap_masterMAC;
+            std::cerr << "[Wallet] LP-7: WARNING — seed migration to v7 failed; "
+                         "original wallet file left unchanged, will retry on next unlock" << std::endl;
+        }
+    }
+
+    // Wipe the unlock crypter's key material is handled by CCrypter's destructor.
     return true;
 }
 
@@ -1330,6 +1369,66 @@ bool CWallet::EncryptWallet(const std::string& passphrase) {
     memcpy(vMasterKey.data_ptr(), vMasterKeyPlain.data(), WALLET_CRYPTO_KEY_SIZE);
     fWalletUnlocked = true;
     nUnlockTime = std::chrono::steady_clock::time_point::max();
+
+    // LP-7 (wallet-Inv-5 + wallet-Inv-4): re-encrypt the HD seed + mnemonic under
+    // the wallet master key. The previous code never did this, so encrypted HD
+    // wallets shipped a PLAINTEXT seed at rest and ExportMnemonic broke (the
+    // mnemonic stayed under the unencrypted-obfuscation key while DecryptMnemonic
+    // switched to the master-key branch).
+    //
+    // ORDER MATTERS: decrypt the mnemonic FIRST (while the HD seed is still
+    // plaintext, since the obfuscation key is derived from it), re-encrypt the
+    // mnemonic under the master key, THEN encrypt the HD master key (which scrubs
+    // the plaintext seed). Both are encrypted under, and later decrypted with, the
+    // SAME master key — fixing the key mismatch.
+    if (fIsHDWallet) {
+        if (!vchEncryptedMnemonic.empty()) {
+            // Recover the plaintext mnemonic using the current (pre-encryption,
+            // obfuscation-key) representation. masterKey is now valid, so call the
+            // obfuscation-key derivation explicitly rather than via DecryptMnemonic
+            // (which would already take the master-key branch).
+            std::vector<uint8_t> obfKey(WALLET_CRYPTO_KEY_SIZE);
+            std::vector<uint8_t> hdSeed(hdMasterKey.seed, hdMasterKey.seed + 32);
+            DeriveEncryptionKey(hdSeed, "mnemonic", obfKey);
+            memory_cleanse(hdSeed.data(), hdSeed.size());
+
+            CCrypter obfCrypter;
+            std::vector<uint8_t> ivVec(vchMnemonicIV.begin(), vchMnemonicIV.end());
+            std::vector<uint8_t> mnemonicPlain;
+            if (!obfCrypter.SetKey(obfKey, ivVec) ||
+                !obfCrypter.Decrypt(vchEncryptedMnemonic, mnemonicPlain)) {
+                memory_cleanse(obfKey.data(), obfKey.size());
+                memory_cleanse(vMasterKeyPlain.data(), vMasterKeyPlain.size());
+                memory_cleanse(derivedKey.data(), derivedKey.size());
+                std::cerr << "[Wallet] CRITICAL: failed to recover mnemonic for re-encryption" << std::endl;
+                return false;
+            }
+            memory_cleanse(obfKey.data(), obfKey.size());
+
+            std::string mnemonicStr(mnemonicPlain.begin(), mnemonicPlain.end());
+            memory_cleanse(mnemonicPlain.data(), mnemonicPlain.size());
+
+            // Re-encrypt under master key (masterKey.IsValid() is now true → master
+            // branch → also computes the mnemonic MAC).
+            bool ok = EncryptMnemonic(mnemonicStr);
+            memory_cleanse(&mnemonicStr[0], mnemonicStr.size());
+            if (!ok) {
+                memory_cleanse(vMasterKeyPlain.data(), vMasterKeyPlain.size());
+                memory_cleanse(derivedKey.data(), derivedKey.size());
+                std::cerr << "[Wallet] CRITICAL: failed to re-encrypt mnemonic" << std::endl;
+                return false;
+            }
+        }
+
+        // Encrypt the HD master seed (scrubs the plaintext seed; stores the
+        // variable-length ciphertext + MAC; sets fHDMasterKeyEncrypted).
+        if (!EncryptHDMasterKey()) {
+            memory_cleanse(vMasterKeyPlain.data(), vMasterKeyPlain.size());
+            memory_cleanse(derivedKey.data(), derivedKey.size());
+            std::cerr << "[Wallet] CRITICAL: failed to encrypt HD master key" << std::endl;
+            return false;
+        }
+    }
 
     // Encrypt MIK private key if present (must happen after vMasterKey is set)
     if (fHasMIK && m_mik && m_mik->HasPrivateKey()) {
@@ -1547,14 +1646,16 @@ bool CWallet::Load(const std::string& filename) {
     std::string magic_str(magic, 8);
     // FIX-011 (PERSIST-001): Support DILWLT03 format with file integrity HMAC
     // v4: Added fCoinbase field to track mining rewards
-    if (magic_str != "DILWLT01" && magic_str != "DILWLT02" && magic_str != "DILWLT03" && magic_str != "DILWLT04" && magic_str != "DILWLT05" && magic_str != "DILWLT06") {
+    // LP-7: v7 (DILWLT07) — encryption-at-rest fix (variable-length encrypted seed
+    // + per-record MACs).
+    if (magic_str != "DILWLT01" && magic_str != "DILWLT02" && magic_str != "DILWLT03" && magic_str != "DILWLT04" && magic_str != "DILWLT05" && magic_str != "DILWLT06" && magic_str != "DILWLT07") {
         return false;  // Invalid file format
     }
 
     uint32_t version;
     file.read(reinterpret_cast<char*>(&version), sizeof(version));
     if (!file.good()) return false;  // SEC-001: Check I/O error
-    if (version != 1 && version != 2 && version != 3 && version != 4 && version != 5 && version != 6) {
+    if (version != 1 && version != 2 && version != 3 && version != 4 && version != 5 && version != 6 && version != 7) {
         return false;  // Unsupported version
     }
 
@@ -1654,10 +1755,16 @@ bool CWallet::Load(const std::string& filename) {
     // Read HD wallet data (v2 only)
     bool temp_fIsHDWallet = false;
     std::vector<uint8_t> temp_vchEncryptedMnemonic;
+    std::vector<uint8_t> temp_vchMnemonicMAC;          // LP-7 (v7)
     std::vector<uint8_t> temp_vchMnemonicIV;
     CHDExtendedKey temp_hdMasterKey;
     bool temp_fHDMasterKeyEncrypted = false;
+    std::vector<uint8_t> temp_vchEncryptedHDMasterKey;  // LP-7 (v7): variable-length seed ciphertext
+    std::vector<uint8_t> temp_vchHDMasterKeyMAC;        // LP-7 (v7)
     std::vector<uint8_t> temp_vchHDMasterKeyIV;
+    // LP-7: true if this is an encrypted wallet whose HD seed is plaintext at rest
+    // (the pre-v7 bug) and therefore needs migration on next unlock.
+    bool temp_fNeedsSeedMigration = false;
     uint32_t temp_nHDAccountIndex = 0;
     uint32_t temp_nHDExternalChainIndex = 0;
     uint32_t temp_nHDInternalChainIndex = 0;
@@ -1690,34 +1797,120 @@ bool CWallet::Load(const std::string& filename) {
             // FIX-010: Register mnemonic IV to prevent reuse
             // CID 1675317 FIX: Access to usedIVs is protected by lock acquired at line 1260
             usedIVs.insert(temp_vchMnemonicIV);
+
+            // LP-7 (v7): read the mnemonic MAC (variable-length). Absent in v3-v6.
+            if (version >= WALLET_FILE_VERSION_7) {
+                uint32_t mnMacLen = 0;
+                file.read(reinterpret_cast<char*>(&mnMacLen), sizeof(mnMacLen));
+                if (!file.good()) return false;
+                if (mnMacLen > 64) return false;  // HMAC-SHA3-512 is 64 bytes
+                if (mnMacLen > 0) {
+                    temp_vchMnemonicMAC.resize(mnMacLen);
+                    file.read(reinterpret_cast<char*>(temp_vchMnemonicMAC.data()), mnMacLen);
+                    if (!file.good()) return false;
+                }
+            }
         }
 
-        // Read HD master key
-        file.read(reinterpret_cast<char*>(temp_hdMasterKey.seed), 32);
-        if (!file.good()) return false;
-        file.read(reinterpret_cast<char*>(temp_hdMasterKey.chaincode), 32);
-        if (!file.good()) return false;
-        file.read(reinterpret_cast<char*>(&temp_hdMasterKey.depth), sizeof(temp_hdMasterKey.depth));
-        if (!file.good()) return false;
-        file.read(reinterpret_cast<char*>(&temp_hdMasterKey.fingerprint), sizeof(temp_hdMasterKey.fingerprint));
-        if (!file.good()) return false;
-        file.read(reinterpret_cast<char*>(&temp_hdMasterKey.child_index), sizeof(temp_hdMasterKey.child_index));
-        if (!file.good()) return false;
+        // LP-7: the HD-master block layout depends on the file version.
+        if (version >= WALLET_FILE_VERSION_7) {
+            // v7 layout: [encrypted_flag]
+            //   if encrypted: [hdEncLen][ciphertext][hdMacLen][mac][depth][fp][ci][IV]
+            //   if plaintext: [hdEncLen=0][seed32][chaincode32][depth][fp][ci]
+            uint8_t encrypted_flag;
+            file.read(reinterpret_cast<char*>(&encrypted_flag), 1);
+            if (!file.good()) return false;
+            temp_fHDMasterKeyEncrypted = (encrypted_flag != 0);
 
-        // Read HD master key encryption flag
-        uint8_t encrypted_flag;
-        file.read(reinterpret_cast<char*>(&encrypted_flag), 1);
-        if (!file.good()) return false;
-        temp_fHDMasterKeyEncrypted = (encrypted_flag != 0);
-
-        if (temp_fHDMasterKeyEncrypted) {
-            temp_vchHDMasterKeyIV.resize(WALLET_CRYPTO_IV_SIZE);
-            file.read(reinterpret_cast<char*>(temp_vchHDMasterKeyIV.data()), WALLET_CRYPTO_IV_SIZE);
+            uint32_t hdEncLen = 0;
+            file.read(reinterpret_cast<char*>(&hdEncLen), sizeof(hdEncLen));
             if (!file.good()) return false;
 
-            // FIX-010: Register HD master key IV to prevent reuse
-            // CID 1675317 FIX: Access to usedIVs is protected by lock acquired at line 1260
-            usedIVs.insert(temp_vchHDMasterKeyIV);
+            if (temp_fHDMasterKeyEncrypted) {
+                // Variable-length ciphertext (bounded: 64-byte plaintext → 80-byte
+                // ciphertext; allow generous slack but reject absurd sizes).
+                const uint32_t MAX_HD_ENC_SIZE = 4096;
+                if (hdEncLen == 0 || (hdEncLen % 16) != 0 || hdEncLen > MAX_HD_ENC_SIZE) {
+                    return false;
+                }
+                temp_vchEncryptedHDMasterKey.resize(hdEncLen);
+                file.read(reinterpret_cast<char*>(temp_vchEncryptedHDMasterKey.data()), hdEncLen);
+                if (!file.good()) return false;
+
+                uint32_t hdMacLen = 0;
+                file.read(reinterpret_cast<char*>(&hdMacLen), sizeof(hdMacLen));
+                if (!file.good()) return false;
+                if (hdMacLen == 0 || hdMacLen > 64) return false;  // v7 requires a MAC
+                temp_vchHDMasterKeyMAC.resize(hdMacLen);
+                file.read(reinterpret_cast<char*>(temp_vchHDMasterKeyMAC.data()), hdMacLen);
+                if (!file.good()) return false;
+
+                file.read(reinterpret_cast<char*>(&temp_hdMasterKey.depth), sizeof(temp_hdMasterKey.depth));
+                if (!file.good()) return false;
+                file.read(reinterpret_cast<char*>(&temp_hdMasterKey.fingerprint), sizeof(temp_hdMasterKey.fingerprint));
+                if (!file.good()) return false;
+                file.read(reinterpret_cast<char*>(&temp_hdMasterKey.child_index), sizeof(temp_hdMasterKey.child_index));
+                if (!file.good()) return false;
+
+                temp_vchHDMasterKeyIV.resize(WALLET_CRYPTO_IV_SIZE);
+                file.read(reinterpret_cast<char*>(temp_vchHDMasterKeyIV.data()), WALLET_CRYPTO_IV_SIZE);
+                if (!file.good()) return false;
+                usedIVs.insert(temp_vchHDMasterKeyIV);
+                // seed/chaincode slots remain zero in memory; ciphertext is the
+                // storage-of-record. No plaintext seed present in a v7 file.
+            } else {
+                // Plaintext (unencrypted wallet) — hdEncLen must be 0.
+                if (hdEncLen != 0) return false;
+                file.read(reinterpret_cast<char*>(temp_hdMasterKey.seed), 32);
+                if (!file.good()) return false;
+                file.read(reinterpret_cast<char*>(temp_hdMasterKey.chaincode), 32);
+                if (!file.good()) return false;
+                file.read(reinterpret_cast<char*>(&temp_hdMasterKey.depth), sizeof(temp_hdMasterKey.depth));
+                if (!file.good()) return false;
+                file.read(reinterpret_cast<char*>(&temp_hdMasterKey.fingerprint), sizeof(temp_hdMasterKey.fingerprint));
+                if (!file.good()) return false;
+                file.read(reinterpret_cast<char*>(&temp_hdMasterKey.child_index), sizeof(temp_hdMasterKey.child_index));
+                if (!file.good()) return false;
+            }
+        } else {
+            // LEGACY v3-v6 layout: fixed [seed32][chaincode32][depth][fp][ci]
+            //                      [encrypted_flag] [IV if encrypted]
+            // In this format the seed is ALWAYS stored in the fixed slots, in
+            // PLAINTEXT (the LP-7 bug) — the encrypted_flag only ever gated the IV.
+            file.read(reinterpret_cast<char*>(temp_hdMasterKey.seed), 32);
+            if (!file.good()) return false;
+            file.read(reinterpret_cast<char*>(temp_hdMasterKey.chaincode), 32);
+            if (!file.good()) return false;
+            file.read(reinterpret_cast<char*>(&temp_hdMasterKey.depth), sizeof(temp_hdMasterKey.depth));
+            if (!file.good()) return false;
+            file.read(reinterpret_cast<char*>(&temp_hdMasterKey.fingerprint), sizeof(temp_hdMasterKey.fingerprint));
+            if (!file.good()) return false;
+            file.read(reinterpret_cast<char*>(&temp_hdMasterKey.child_index), sizeof(temp_hdMasterKey.child_index));
+            if (!file.good()) return false;
+
+            uint8_t encrypted_flag;
+            file.read(reinterpret_cast<char*>(&encrypted_flag), 1);
+            if (!file.good()) return false;
+            bool legacyEncFlag = (encrypted_flag != 0);
+
+            if (legacyEncFlag) {
+                temp_vchHDMasterKeyIV.resize(WALLET_CRYPTO_IV_SIZE);
+                file.read(reinterpret_cast<char*>(temp_vchHDMasterKeyIV.data()), WALLET_CRYPTO_IV_SIZE);
+                if (!file.good()) return false;
+                usedIVs.insert(temp_vchHDMasterKeyIV);
+            }
+
+            // LP-7 (wallet-Inv-5): in legacy files the seed is plaintext at rest
+            // regardless of the flag. We deliberately treat the in-memory HD master
+            // as NOT encrypted (plaintext seed loaded into the slots) and, if the
+            // wallet is encrypted (has a passphrase master key), flag it for
+            // migration on next unlock so the seed gets re-encrypted and rewritten
+            // at v7. The stored legacyEncFlag is ignored on purpose: the old
+            // "encrypted" path never produced a recoverable ciphertext.
+            temp_fHDMasterKeyEncrypted = false;
+            if (isEncrypted) {
+                temp_fNeedsSeedMigration = true;
+            }
         }
 
         // Read HD chain state
@@ -1980,6 +2173,7 @@ bool CWallet::Load(const std::string& filename) {
     bool temp_fMIKRegistered = false;
     std::vector<uint8_t> temp_vchMIKPubKey;
     std::vector<uint8_t> temp_vchEncryptedMIKPrivKey;
+    std::vector<uint8_t> temp_vchMIKPrivKeyMAC;  // LP-7 (v7)
     std::vector<uint8_t, SecureAllocator<uint8_t>> temp_vchMIKPrivKeyIV;
     std::vector<uint8_t, SecureAllocator<uint8_t>> temp_vchMIKPrivKey;
 
@@ -2011,6 +2205,16 @@ bool CWallet::Load(const std::string& filename) {
             if (file.good() && ivLen > 0 && ivLen <= 32) {
                 temp_vchMIKPrivKeyIV.resize(ivLen);
                 file.read(reinterpret_cast<char*>(temp_vchMIKPrivKeyIV.data()), ivLen);
+            }
+
+            // LP-7 (v7): Read MIK private-key MAC (variable-length). Absent in v5-v6.
+            if (file.good() && version >= WALLET_FILE_VERSION_7) {
+                uint32_t mikMacLen = 0;
+                file.read(reinterpret_cast<char*>(&mikMacLen), sizeof(mikMacLen));
+                if (file.good() && mikMacLen > 0 && mikMacLen <= 64) {
+                    temp_vchMIKPrivKeyMAC.resize(mikMacLen);
+                    file.read(reinterpret_cast<char*>(temp_vchMIKPrivKeyMAC.data()), mikMacLen);
+                }
             }
 
             // Read MIK registered flag
@@ -2194,6 +2398,10 @@ bool CWallet::Load(const std::string& filename) {
         // temp_hdMasterKey is a local variable that's no longer used after assignment
         hdMasterKey = std::move(temp_hdMasterKey);
         fHDMasterKeyEncrypted = temp_fHDMasterKeyEncrypted;
+        // LP-7 (v7) variable-length encrypted-seed + per-record MACs
+        vchEncryptedHDMasterKey = std::move(temp_vchEncryptedHDMasterKey);
+        vchHDMasterKeyMAC = std::move(temp_vchHDMasterKeyMAC);
+        vchMnemonicMAC = std::move(temp_vchMnemonicMAC);
         // FIX-009: Use assign() for SecureAllocator vectors
         vchHDMasterKeyIV.assign(temp_vchHDMasterKeyIV.begin(), temp_vchHDMasterKeyIV.end());
         nHDAccountIndex = temp_nHDAccountIndex;
@@ -2224,6 +2432,7 @@ bool CWallet::Load(const std::string& filename) {
         fMIKRegistered = temp_fMIKRegistered;
         vchMIKPubKey = std::move(temp_vchMIKPubKey);
         vchEncryptedMIKPrivKey = std::move(temp_vchEncryptedMIKPrivKey);
+        vchMIKPrivKeyMAC = std::move(temp_vchMIKPrivKeyMAC);
         vchMIKPrivKeyIV = std::move(temp_vchMIKPrivKeyIV);
 
         if (temp_fHasMIK) {
@@ -2256,6 +2465,12 @@ bool CWallet::Load(const std::string& filename) {
 
         // v6: Restore sent transaction history
         mapSentTx = std::move(temp_mapSentTx);
+
+        // LP-7: record the on-disk format version + whether this encrypted wallet
+        // carries a plaintext HD seed (pre-v7 bug) and therefore needs migration
+        // on next unlock.
+        m_loadedFileVersion = version;
+        m_fNeedsSeedMigration = temp_fNeedsSeedMigration;
 
         m_walletFile = filename;  // Set wallet file path only on successful load
     }
@@ -2309,10 +2524,13 @@ bool CWallet::SaveUnlocked(const std::string& filename) const {
 
     // FIX-011 (PERSIST-001): Write header with file integrity HMAC (v3 format)
     // Format: [Magic][Version][Flags][HMAC-placeholder][Salt][Data...]
-    file.write(WALLET_FILE_MAGIC_V6, 8);  // "DILWLT06" - v6 adds sent tx persistence
+    // LP-7: write v7 ("DILWLT07") — encryption-at-rest fix (variable-length
+    // encrypted HD seed + per-record MACs). One-way: we always emit v7; legacy
+    // formats are read-only (for migration).
+    file.write(WALLET_FILE_MAGIC_V7, 8);  // "DILWLT07"
     if (!file.good()) return false;
 
-    uint32_t version = WALLET_FILE_VERSION_6;
+    uint32_t version = WALLET_FILE_VERSION_7;
     file.write(reinterpret_cast<const char*>(&version), sizeof(version));
     if (!file.good()) return false;
 
@@ -2389,26 +2607,83 @@ bool CWallet::SaveUnlocked(const std::string& filename) const {
             if (!file.good()) return false;
             file.write(reinterpret_cast<const char*>(vchMnemonicIV.data()), WALLET_CRYPTO_IV_SIZE);
             if (!file.good()) return false;
+
+            // LP-7 (v7): write the mnemonic MAC (variable-length; empty for the
+            // unencrypted-obfuscation case).
+            uint32_t mnMacLen = static_cast<uint32_t>(vchMnemonicMAC.size());
+            file.write(reinterpret_cast<const char*>(&mnMacLen), sizeof(mnMacLen));
+            if (!file.good()) return false;
+            if (mnMacLen > 0) {
+                file.write(reinterpret_cast<const char*>(vchMnemonicMAC.data()), mnMacLen);
+                if (!file.good()) return false;
+            }
         }
 
-        // Write HD master key (seed + chaincode = 64 bytes)
-        file.write(reinterpret_cast<const char*>(hdMasterKey.seed), 32);
-        if (!file.good()) return false;
-        file.write(reinterpret_cast<const char*>(hdMasterKey.chaincode), 32);
-        if (!file.good()) return false;
-        file.write(reinterpret_cast<const char*>(&hdMasterKey.depth), sizeof(hdMasterKey.depth));
-        if (!file.good()) return false;
-        file.write(reinterpret_cast<const char*>(&hdMasterKey.fingerprint), sizeof(hdMasterKey.fingerprint));
-        if (!file.good()) return false;
-        file.write(reinterpret_cast<const char*>(&hdMasterKey.child_index), sizeof(hdMasterKey.child_index));
-        if (!file.good()) return false;
-
-        // Write HD master key encryption flag and IV
+        // LP-7 (S-007 / S-001): NEVER write a plaintext seed for an encrypted
+        // wallet. The writer is one-way: if the HD master key is encrypted we
+        // emit ONLY the variable-length ciphertext; if (impossibly) the
+        // ciphertext is missing, refuse the save rather than fall back to
+        // plaintext.
         uint8_t encrypted_flag = fHDMasterKeyEncrypted ? 1 : 0;
-        file.write(reinterpret_cast<const char*>(&encrypted_flag), 1);
-        if (!file.good()) return false;
+
         if (fHDMasterKeyEncrypted) {
+            if (vchEncryptedHDMasterKey.empty()) {
+                // Encrypted-but-no-ciphertext is a programming error; refuse to
+                // persist rather than risk writing/keeping plaintext.
+                std::cerr << "[Wallet] CRITICAL: encrypted HD wallet has no seed ciphertext — refusing to save" << std::endl;
+                return false;
+            }
+            // Write the encryption flag, then the variable-length ciphertext +
+            // metadata. NO plaintext seed/chaincode slots are written.
+            file.write(reinterpret_cast<const char*>(&encrypted_flag), 1);
+            if (!file.good()) return false;
+
+            uint32_t hdEncLen = static_cast<uint32_t>(vchEncryptedHDMasterKey.size());
+            file.write(reinterpret_cast<const char*>(&hdEncLen), sizeof(hdEncLen));
+            if (!file.good()) return false;
+            file.write(reinterpret_cast<const char*>(vchEncryptedHDMasterKey.data()), hdEncLen);
+            if (!file.good()) return false;
+
+            // HD-master MAC (variable-length; required non-empty for v7)
+            uint32_t hdMacLen = static_cast<uint32_t>(vchHDMasterKeyMAC.size());
+            file.write(reinterpret_cast<const char*>(&hdMacLen), sizeof(hdMacLen));
+            if (!file.good()) return false;
+            if (hdMacLen > 0) {
+                file.write(reinterpret_cast<const char*>(vchHDMasterKeyMAC.data()), hdMacLen);
+                if (!file.good()) return false;
+            }
+
+            // Metadata (depth/fingerprint/child_index) — non-secret
+            file.write(reinterpret_cast<const char*>(&hdMasterKey.depth), sizeof(hdMasterKey.depth));
+            if (!file.good()) return false;
+            file.write(reinterpret_cast<const char*>(&hdMasterKey.fingerprint), sizeof(hdMasterKey.fingerprint));
+            if (!file.good()) return false;
+            file.write(reinterpret_cast<const char*>(&hdMasterKey.child_index), sizeof(hdMasterKey.child_index));
+            if (!file.good()) return false;
+
+            // IV
             file.write(reinterpret_cast<const char*>(vchHDMasterKeyIV.data()), WALLET_CRYPTO_IV_SIZE);
+            if (!file.good()) return false;
+        } else {
+            // Unencrypted HD wallet: seed is plaintext by design (no passphrase
+            // set). Write the fixed 32+32 plaintext slots + metadata. An
+            // unencrypted seed length of 0 (variable-length) marks "plaintext".
+            file.write(reinterpret_cast<const char*>(&encrypted_flag), 1);
+            if (!file.good()) return false;
+
+            uint32_t hdEncLen = 0;  // 0 ⇒ plaintext fixed-slot layout follows
+            file.write(reinterpret_cast<const char*>(&hdEncLen), sizeof(hdEncLen));
+            if (!file.good()) return false;
+
+            file.write(reinterpret_cast<const char*>(hdMasterKey.seed), 32);
+            if (!file.good()) return false;
+            file.write(reinterpret_cast<const char*>(hdMasterKey.chaincode), 32);
+            if (!file.good()) return false;
+            file.write(reinterpret_cast<const char*>(&hdMasterKey.depth), sizeof(hdMasterKey.depth));
+            if (!file.good()) return false;
+            file.write(reinterpret_cast<const char*>(&hdMasterKey.fingerprint), sizeof(hdMasterKey.fingerprint));
+            if (!file.good()) return false;
+            file.write(reinterpret_cast<const char*>(&hdMasterKey.child_index), sizeof(hdMasterKey.child_index));
             if (!file.good()) return false;
         }
 
@@ -2581,6 +2856,16 @@ bool CWallet::SaveUnlocked(const std::string& filename) const {
         if (!file.good()) return false;
         if (ivLen > 0) {
             file.write(reinterpret_cast<const char*>(vchMIKPrivKeyIV.data()), ivLen);
+            if (!file.good()) return false;
+        }
+
+        // LP-7 (v7): write the MIK private-key MAC (variable-length; empty when
+        // the wallet is unencrypted / no encrypted MIK present).
+        uint32_t mikMacLen = static_cast<uint32_t>(vchMIKPrivKeyMAC.size());
+        file.write(reinterpret_cast<const char*>(&mikMacLen), sizeof(mikMacLen));
+        if (!file.good()) return false;
+        if (mikMacLen > 0) {
+            file.write(reinterpret_cast<const char*>(vchMIKPrivKeyMAC.data()), mikMacLen);
             if (!file.good()) return false;
         }
 
@@ -2912,11 +3197,20 @@ void CWallet::Clear() {
         memory_cleanse(vchEncryptedMnemonic.data(), vchEncryptedMnemonic.size());
     }
     vchEncryptedMnemonic.clear();
+    vchMnemonicMAC.clear();   // LP-7
     vchMnemonicIV.clear();
 
     // Wipe HD master key
     hdMasterKey.Wipe();
     vchHDMasterKeyIV.clear();
+    // LP-7: clear v7 encrypted-seed material + migration state
+    if (!vchEncryptedHDMasterKey.empty()) {
+        memory_cleanse(vchEncryptedHDMasterKey.data(), vchEncryptedHDMasterKey.size());
+    }
+    vchEncryptedHDMasterKey.clear();
+    vchHDMasterKeyMAC.clear();
+    m_fNeedsSeedMigration = false;
+    m_loadedFileVersion = 0;
 
     // Clear HD chain state
     nHDAccountIndex = 0;
@@ -4774,11 +5068,188 @@ bool CWallet::DeriveAndCacheHDAddress(const CHDKeyPath& path) {
     return true;
 }
 
+// LP-7 (wallet-Inv-5 migration): re-encrypt a legacy plaintext HD seed + mnemonic
+// under the wallet master key and atomically rewrite the file at v7.
+//
+// Preconditions (asserted by caller Unlock): wallet is encrypted (masterKey valid),
+// unlocked (vMasterKey populated), HD wallet, and the seed is currently PLAINTEXT in
+// hdMasterKey.seed/chaincode (m_fHDMasterKeyEncrypted == false, loaded from a v3-v6
+// file). cs_wallet is held.
+//
+// Atomicity / no-data-loss (S-002/S-003):
+//   - The on-disk rewrite goes through SaveUnlocked, which writes a temp file,
+//     fsyncs, then atomically renames over the original (MoveFileEx / rename).
+//     The original is NEVER truncated; an interrupted rewrite leaves either the
+//     intact legacy file or the complete v7 file.
+//   - If ANY in-memory re-encryption step OR the save fails, we restore the
+//     in-memory HD state to its pre-migration plaintext-seed form so the wallet
+//     stays consistent with the still-on-disk legacy file, and return false. The
+//     caller does not fail the unlock; migration retries next unlock.
+bool CWallet::MigrateToEncryptedSeedV7Unlocked() {
+    if (!masterKey.IsValid() || !fWalletUnlocked || !fIsHDWallet) {
+        return false;
+    }
+    // Defensive: only migrate when the seed is actually plaintext.
+    if (fHDMasterKeyEncrypted) {
+        return false;
+    }
+
+    // --- Snapshot pre-migration in-memory state for rollback ---
+    CHDExtendedKey snap_hdMasterKey = hdMasterKey;
+    bool snap_fHDMasterKeyEncrypted = fHDMasterKeyEncrypted;
+    bool snap_fHDMasterKeyCached = fHDMasterKeyCached;
+    CHDExtendedKey snap_hdMasterKeyDecrypted = hdMasterKeyDecrypted;
+    std::vector<uint8_t> snap_vchEncryptedMnemonic = vchEncryptedMnemonic;
+    std::vector<uint8_t> snap_vchMnemonicMAC = vchMnemonicMAC;
+    std::vector<uint8_t> snap_vchMnemonicIV(vchMnemonicIV.begin(), vchMnemonicIV.end());
+    std::vector<uint8_t> snap_vchEncryptedHDMasterKey = vchEncryptedHDMasterKey;
+    std::vector<uint8_t> snap_vchHDMasterKeyMAC = vchHDMasterKeyMAC;
+    std::vector<uint8_t> snap_vchHDMasterKeyIV(vchHDMasterKeyIV.begin(), vchHDMasterKeyIV.end());
+    // MIK snapshot (re-MAC'd in Step 2b). Note: m_mik->privkey is kept cleared
+    // outside migration, so only the at-rest ciphertext/IV/MAC + flag matter for
+    // rollback consistency with the on-disk file.
+    bool snap_fHasMIK = fHasMIK;
+    std::vector<uint8_t> snap_vchEncryptedMIKPrivKey_all = vchEncryptedMIKPrivKey;
+    std::vector<uint8_t> snap_vchMIKPrivKeyMAC_all = vchMIKPrivKeyMAC;
+    std::vector<uint8_t> snap_vchMIKPrivKeyIV_all(vchMIKPrivKeyIV.begin(), vchMIKPrivKeyIV.end());
+    std::vector<uint8_t> snap_vchMIKPubKey = vchMIKPubKey;
+
+    auto rollback = [&]() {
+        hdMasterKey = snap_hdMasterKey;
+        fHDMasterKeyEncrypted = snap_fHDMasterKeyEncrypted;
+        fHDMasterKeyCached = snap_fHDMasterKeyCached;
+        hdMasterKeyDecrypted = snap_hdMasterKeyDecrypted;
+        vchEncryptedMnemonic = snap_vchEncryptedMnemonic;
+        vchMnemonicMAC = snap_vchMnemonicMAC;
+        vchMnemonicIV.assign(snap_vchMnemonicIV.begin(), snap_vchMnemonicIV.end());
+        vchEncryptedHDMasterKey = snap_vchEncryptedHDMasterKey;
+        vchHDMasterKeyMAC = snap_vchHDMasterKeyMAC;
+        vchHDMasterKeyIV.assign(snap_vchHDMasterKeyIV.begin(), snap_vchHDMasterKeyIV.end());
+        fHasMIK = snap_fHasMIK;
+        vchEncryptedMIKPrivKey = snap_vchEncryptedMIKPrivKey_all;
+        vchMIKPrivKeyMAC = snap_vchMIKPrivKeyMAC_all;
+        vchMIKPrivKeyIV.assign(snap_vchMIKPrivKeyIV_all.begin(), snap_vchMIKPrivKeyIV_all.end());
+        vchMIKPubKey = snap_vchMIKPubKey;
+    };
+
+    // --- Step 1: recover + re-encrypt the mnemonic under the master key ---
+    // Legacy HD-first wallets stored the mnemonic under an obfuscation key derived
+    // from the (plaintext) seed; EncryptWallet never re-encrypted it. We still hold
+    // the plaintext seed here, so derive that same obfuscation key, decrypt, then
+    // re-encrypt under the master key (which also attaches a MAC).
+    if (!vchEncryptedMnemonic.empty()) {
+        std::vector<uint8_t> ivVec(vchMnemonicIV.begin(), vchMnemonicIV.end());
+        std::vector<uint8_t> mnemonicPlain;
+        bool decOk = false;
+
+        // Primary case (legacy HD-first wallet): mnemonic under the obfuscation key
+        // derived from the still-plaintext seed.
+        {
+            std::vector<uint8_t> obfKey(WALLET_CRYPTO_KEY_SIZE);
+            std::vector<uint8_t> hdSeed(hdMasterKey.seed, hdMasterKey.seed + 32);
+            DeriveEncryptionKey(hdSeed, "mnemonic", obfKey);
+            memory_cleanse(hdSeed.data(), hdSeed.size());
+
+            CCrypter obfCrypter;
+            decOk = obfCrypter.SetKey(obfKey, ivVec) &&
+                    obfCrypter.Decrypt(vchEncryptedMnemonic, mnemonicPlain);
+            memory_cleanse(obfKey.data(), obfKey.size());
+        }
+
+        // Fallback: a legacy wallet whose mnemonic was encrypted under the master
+        // key directly (no MAC). Try the master key if the obfuscation key failed.
+        if (!decOk) {
+            std::vector<uint8_t> mkVec(vMasterKey.data_ptr(),
+                                       vMasterKey.data_ptr() + vMasterKey.size());
+            CCrypter mkCrypter;
+            mnemonicPlain.clear();
+            decOk = mkCrypter.SetKey(mkVec, ivVec) &&
+                    mkCrypter.Decrypt(vchEncryptedMnemonic, mnemonicPlain);
+            memory_cleanse(mkVec.data(), mkVec.size());
+        }
+
+        if (!decOk) {
+            // Could not recover the mnemonic plaintext under either key. Abort
+            // migration (leave everything byte-identical) rather than risk a wallet
+            // whose mnemonic becomes unreadable. Seed migration only proceeds when
+            // the mnemonic can be carried forward.
+            memory_cleanse(mnemonicPlain.data(), mnemonicPlain.size());
+            rollback();
+            return false;
+        }
+
+        std::string mnemonicStr(mnemonicPlain.begin(), mnemonicPlain.end());
+        memory_cleanse(mnemonicPlain.data(), mnemonicPlain.size());
+
+        bool reOk = EncryptMnemonic(mnemonicStr);  // master-key branch + MAC
+        memory_cleanse(&mnemonicStr[0], mnemonicStr.size());
+        if (!reOk) {
+            rollback();
+            return false;
+        }
+    }
+
+    // --- Step 2: encrypt the HD master seed (scrubs plaintext, sets ciphertext+MAC) ---
+    if (!EncryptHDMasterKey()) {
+        rollback();
+        return false;
+    }
+
+    // --- Step 2b: re-MAC the MIK private key (legacy encrypted MIK had no MAC) ---
+    // A legacy encrypted wallet stored the MIK ciphertext WITHOUT a MAC. Once we
+    // mark this wallet v7, DecryptMIKPrivKey requires a non-empty MAC, so recover
+    // the MIK plaintext (legacy path: empty MAC + pre-v7 version still set) and
+    // re-encrypt it under the master key with a MAC. If the MIK can't be recovered
+    // it is non-fatal (MIK is regenerable) — clear it so it regenerates on next use.
+    if (fHasMIK && !vchEncryptedMIKPrivKey.empty() && vchMIKPrivKeyMAC.empty()) {
+        std::vector<uint8_t, SecureAllocator<uint8_t>> mikPlain;
+        if (DecryptMIKPrivKey(mikPlain)) {
+            if (!m_mik) {
+                m_mik = std::make_unique<DFMP::CMiningIdentityKey>();
+                m_mik->pubkey = vchMIKPubKey;
+                m_mik->identity = DFMP::DeriveIdentityFromMIK(vchMIKPubKey);
+            }
+            m_mik->privkey.assign(mikPlain.begin(), mikPlain.end());
+            bool mikOk = EncryptMIKPrivKey();   // adds MAC under master key
+            m_mik->privkey.clear();
+            if (!mikOk) {
+                rollback();
+                return false;
+            }
+        } else {
+            // MIK plaintext unrecoverable — drop it (regenerated on next mining).
+            std::cerr << "[Wallet] LP-7: MIK private key unrecoverable during migration; "
+                         "will regenerate on next mining attempt" << std::endl;
+            fHasMIK = false;
+            vchEncryptedMIKPrivKey.clear();
+            vchMIKPrivKeyMAC.clear();
+            vchMIKPubKey.clear();
+            m_mikIdentity = DFMP::Identity();
+            m_mik.reset();
+        }
+    }
+
+    // --- Step 3: atomic v7 rewrite. SaveUnlocked never truncates the original. ---
+    if (m_autoSave && !m_walletFile.empty()) {
+        if (!SaveUnlocked()) {
+            // The on-disk legacy file is still intact (temp file was discarded).
+            // Roll back in-memory state to match it.
+            rollback();
+            return false;
+        }
+    }
+
+    return true;
+}
+
 bool CWallet::EncryptHDMasterKey() {
     // Assumes caller holds cs_wallet lock
 
     if (!masterKey.IsValid()) {
         return false;  // Wallet not encrypted
+    }
+    if (!fWalletUnlocked) {
+        return false;  // Need the in-memory master key to encrypt
     }
 
     // FIX-010: Generate unique IV for HD master key
@@ -4802,8 +5273,12 @@ bool CWallet::EncryptHDMasterKey() {
         return false;
     }
 
-    // Store encrypted data back in hdMasterKey structure
-    // We'll reuse the seed/chaincode fields to store encrypted data
+    // LP-7 (wallet-Inv-5): AES-256-CBC with PKCS#7 padding turns the 64-byte
+    // plaintext (an exact multiple of the 16-byte block) into an 80-byte
+    // ciphertext (a full extra padding block is appended). The old code rejected
+    // any size != 64 and tried to cram the result into the fixed 32+32 slots,
+    // which was unsatisfiable -> the encrypt path was dead. We now store the FULL
+    // variable-length ciphertext in vchEncryptedHDMasterKey.
     std::vector<uint8_t> encrypted;
     if (!crypter.Encrypt(masterKeyData, encrypted)) {
         memory_cleanse(vMasterKeyVec.data(), vMasterKeyVec.size());
@@ -4811,18 +5286,45 @@ bool CWallet::EncryptHDMasterKey() {
         return false;
     }
 
-    // Copy encrypted data to hdMasterKey (first 32 bytes in seed, rest in chaincode)
-    if (encrypted.size() != 64) {
+    // Sanity: AES-CBC ciphertext must be a non-empty multiple of the block size.
+    if (encrypted.empty() || (encrypted.size() % 16) != 0) {
         memory_cleanse(vMasterKeyVec.data(), vMasterKeyVec.size());
         memory_cleanse(masterKeyData.data(), masterKeyData.size());
         memory_cleanse(encrypted.data(), encrypted.size());
         return false;
     }
 
-    std::memcpy(hdMasterKey.seed, encrypted.data(), 32);
-    std::memcpy(hdMasterKey.chaincode, encrypted.data() + 32, 32);
+    // LP-7 (wallet-Inv-2): authenticate the ciphertext (encrypt-then-MAC) with a
+    // separately-derived MAC key (key separation, default keying).
+    std::vector<uint8_t> mac;
+    if (!crypter.ComputeMAC(encrypted, mac)) {
+        memory_cleanse(vMasterKeyVec.data(), vMasterKeyVec.size());
+        memory_cleanse(masterKeyData.data(), masterKeyData.size());
+        memory_cleanse(encrypted.data(), encrypted.size());
+        return false;
+    }
+
+    // Store the variable-length ciphertext + MAC.
+    vchEncryptedHDMasterKey = encrypted;
+    vchHDMasterKeyMAC = mac;
+
+    // LP-7 (S-001 / S-006): scrub the plaintext seed/chaincode from the in-memory
+    // struct now that the ciphertext is the storage-of-record. SaveUnlocked at v7
+    // persists vchEncryptedHDMasterKey, NOT these slots, so no plaintext can reach
+    // disk. The decrypted value lives only in hdMasterKeyDecrypted (re-cached below).
+    memory_cleanse(hdMasterKey.seed, sizeof(hdMasterKey.seed));
+    memory_cleanse(hdMasterKey.chaincode, sizeof(hdMasterKey.chaincode));
 
     fHDMasterKeyEncrypted = true;
+
+    // Refresh the decrypted cache so callers that read it (e.g. address
+    // derivation) keep working while unlocked.
+    std::memcpy(hdMasterKeyDecrypted.seed, masterKeyData.data(), 32);
+    std::memcpy(hdMasterKeyDecrypted.chaincode, masterKeyData.data() + 32, 32);
+    hdMasterKeyDecrypted.depth = hdMasterKey.depth;
+    hdMasterKeyDecrypted.fingerprint = hdMasterKey.fingerprint;
+    hdMasterKeyDecrypted.child_index = hdMasterKey.child_index;
+    fHDMasterKeyCached = true;
 
     // Wipe sensitive data
     memory_cleanse(vMasterKeyVec.data(), vMasterKeyVec.size());
@@ -4851,6 +5353,12 @@ bool CWallet::DecryptHDMasterKey(CHDExtendedKey& decrypted) const {
         return true;
     }
 
+    // LP-7 (wallet-Inv-5): the ciphertext must come from the variable-length
+    // field. A v7 wallet always populates vchEncryptedHDMasterKey on load.
+    if (vchEncryptedHDMasterKey.empty()) {
+        return false;
+    }
+
     // Cache miss - decrypt HD master key
     CCrypter crypter;
     std::vector<uint8_t> vMasterKeyVec(vMasterKey.data_ptr(),
@@ -4861,21 +5369,30 @@ bool CWallet::DecryptHDMasterKey(CHDExtendedKey& decrypted) const {
         return false;
     }
 
-    // Prepare encrypted data (64 bytes from seed + chaincode)
-    std::vector<uint8_t> encrypted(64);
-    std::memcpy(encrypted.data(), hdMasterKey.seed, 32);
-    std::memcpy(encrypted.data() + 32, hdMasterKey.chaincode, 32);
+    // LP-7 (S-004): verify the MAC BEFORE decrypting (authenticated-before-decrypt).
+    // v7 records carry a non-empty MAC; an empty MAC on a v7 wallet is rejected.
+    // Legacy v3-v6 records never had an HD-master MAC, so we only enforce the MAC
+    // when one is present (it always is for v7), selecting the keying by version.
+    if (!vchHDMasterKeyMAC.empty()) {
+        bool legacyKeying = (m_loadedFileVersion != 0 && m_loadedFileVersion < WALLET_FILE_VERSION_7);
+        if (!crypter.VerifyMAC(vchEncryptedHDMasterKey, vchHDMasterKeyMAC, legacyKeying)) {
+            memory_cleanse(vMasterKeyVec.data(), vMasterKeyVec.size());
+            return false;  // Tampered or wrong key
+        }
+    } else if (m_loadedFileVersion >= WALLET_FILE_VERSION_7) {
+        // A v7 wallet MUST carry a MAC on the HD-master record.
+        memory_cleanse(vMasterKeyVec.data(), vMasterKeyVec.size());
+        return false;
+    }
 
     std::vector<uint8_t> decrypted_data;
-    if (!crypter.Decrypt(encrypted, decrypted_data)) {
+    if (!crypter.Decrypt(vchEncryptedHDMasterKey, decrypted_data)) {
         memory_cleanse(vMasterKeyVec.data(), vMasterKeyVec.size());
-        memory_cleanse(encrypted.data(), encrypted.size());
         return false;
     }
 
     if (decrypted_data.size() != 64) {
         memory_cleanse(vMasterKeyVec.data(), vMasterKeyVec.size());
-        memory_cleanse(encrypted.data(), encrypted.size());
         memory_cleanse(decrypted_data.data(), decrypted_data.size());
         return false;
     }
@@ -4889,7 +5406,6 @@ bool CWallet::DecryptHDMasterKey(CHDExtendedKey& decrypted) const {
 
     // Wipe sensitive data
     memory_cleanse(vMasterKeyVec.data(), vMasterKeyVec.size());
-    memory_cleanse(encrypted.data(), encrypted.size());
     memory_cleanse(decrypted_data.data(), decrypted_data.size());
 
     return true;
@@ -4918,6 +5434,13 @@ bool CWallet::EncryptMnemonic(const std::string& mnemonic) {
         }
 
         if (!crypter.Encrypt(mnemonicBytes, vchEncryptedMnemonic)) {
+            memory_cleanse(vMasterKeyVec.data(), vMasterKeyVec.size());
+            memory_cleanse(mnemonicBytes.data(), mnemonicBytes.size());
+            return false;
+        }
+
+        // LP-7 (wallet-Inv-2): authenticate the mnemonic ciphertext (encrypt-then-MAC)
+        if (!crypter.ComputeMAC(vchEncryptedMnemonic, vchMnemonicMAC)) {
             memory_cleanse(vMasterKeyVec.data(), vMasterKeyVec.size());
             memory_cleanse(mnemonicBytes.data(), mnemonicBytes.size());
             return false;
@@ -4964,6 +5487,10 @@ bool CWallet::EncryptMnemonic(const std::string& mnemonic) {
             return false;
         }
 
+        // Obfuscation-only (unencrypted wallet): no authenticated MAC. Clear any
+        // stale MAC so it is never mistaken for an authenticated record.
+        vchMnemonicMAC.clear();
+
         memory_cleanse(tempKey.data(), tempKey.size());
     }
 
@@ -4991,6 +5518,22 @@ bool CWallet::DecryptMnemonic(std::string& mnemonic) const {
                                            vMasterKey.data_ptr() + vMasterKey.size());
 
         if (!crypter.SetKey(vMasterKeyVec, vchMnemonicIV)) {
+            memory_cleanse(vMasterKeyVec.data(), vMasterKeyVec.size());
+            return false;
+        }
+
+        // LP-7 (wallet-Inv-2 / S-004): authenticate BEFORE decrypt.
+        // - v7 wallet: a non-empty, valid MAC is REQUIRED (empty MAC rejected).
+        // - legacy v3-v6 encrypted mnemonic had no MAC: verify only if present,
+        //   selecting the legacy AES-keyed HMAC.
+        if (!vchMnemonicMAC.empty()) {
+            bool legacyKeying = (m_loadedFileVersion != 0 && m_loadedFileVersion < WALLET_FILE_VERSION_7);
+            if (!crypter.VerifyMAC(vchEncryptedMnemonic, vchMnemonicMAC, legacyKeying)) {
+                memory_cleanse(vMasterKeyVec.data(), vMasterKeyVec.size());
+                return false;  // Tampered or wrong key
+            }
+        } else if (m_loadedFileVersion >= WALLET_FILE_VERSION_7) {
+            // v7 wallet with a master-key-encrypted mnemonic MUST carry a MAC.
             memory_cleanse(vMasterKeyVec.data(), vMasterKeyVec.size());
             return false;
         }
@@ -5119,6 +5662,13 @@ bool CWallet::EncryptMIKPrivKey() {
         return false;
     }
 
+    // LP-7 (wallet-Inv-2): authenticate the MIK ciphertext (encrypt-then-MAC)
+    if (!crypter.ComputeMAC(vchEncryptedMIKPrivKey, vchMIKPrivKeyMAC)) {
+        memory_cleanse(vMasterKeyVec.data(), vMasterKeyVec.size());
+        memory_cleanse(plaintext.data(), plaintext.size());
+        return false;
+    }
+
     memory_cleanse(vMasterKeyVec.data(), vMasterKeyVec.size());
     memory_cleanse(plaintext.data(), plaintext.size());
 
@@ -5148,6 +5698,22 @@ bool CWallet::DecryptMIKPrivKey(std::vector<uint8_t, SecureAllocator<uint8_t>>& 
 
     if (!crypter.SetKey(vMasterKeyVec, iv)) {
         std::cerr << "[WALLET] DecryptMIKPrivKey: SetKey failed" << std::endl;
+        memory_cleanse(vMasterKeyVec.data(), vMasterKeyVec.size());
+        return false;
+    }
+
+    // LP-7 (wallet-Inv-2 / S-004): authenticate BEFORE decrypt.
+    // v7 requires a non-empty valid MAC; legacy v3-v6 MIK records had none, so
+    // verify only when present (legacy keying for pre-v7 files).
+    if (!vchMIKPrivKeyMAC.empty()) {
+        bool legacyKeying = (m_loadedFileVersion != 0 && m_loadedFileVersion < WALLET_FILE_VERSION_7);
+        if (!crypter.VerifyMAC(vchEncryptedMIKPrivKey, vchMIKPrivKeyMAC, legacyKeying)) {
+            std::cerr << "[WALLET] DecryptMIKPrivKey: MAC verification failed" << std::endl;
+            memory_cleanse(vMasterKeyVec.data(), vMasterKeyVec.size());
+            return false;
+        }
+    } else if (m_loadedFileVersion >= WALLET_FILE_VERSION_7) {
+        std::cerr << "[WALLET] DecryptMIKPrivKey: missing MAC on v7 wallet" << std::endl;
         memory_cleanse(vMasterKeyVec.data(), vMasterKeyVec.size());
         return false;
     }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -307,12 +307,29 @@ private:
     // re-encryption + v7 rewrite on the next successful unlock.
     bool m_fNeedsSeedMigration{false};
 
+    // LP-7 L1 (opt-in, default OFF): when true, refuse to SIGN spends while the HD
+    // seed is still plaintext-at-rest (NeedsSeedMigration()). Set once at node startup
+    // from the --require-seed-migration CLI flag. Default OFF preserves the warn-only
+    // behavior (operator surfaced but not blocked). Gated in SignTransaction (the
+    // single spend signing funnel). Coinbase/mining block signing does NOT route
+    // through SignTransaction; the mining refusal is enforced separately at startup.
+    bool m_requireSeedMigration{false};
+
     // LP-7 migration helper (assumes caller holds cs_wallet, wallet unlocked).
     // Re-encrypts the plaintext HD seed + mnemonic under the master key and
     // rewrites the wallet file at v7 atomically (via SaveUnlocked). Leaves the
     // original file byte-identical on any failure (SaveUnlocked only renames a
     // fully-written temp file into place; the original is never truncated).
-    bool MigrateToEncryptedSeedV7Unlocked();
+    //
+    // LP-7 (Cursor M1): in-memory re-encryption success is NOT the same as the
+    // plaintext seed leaving disk. When autosave is off (no m_walletFile), this
+    // re-encrypts in memory and returns true, but the on-disk file STILL carries
+    // the plaintext seed — so the migration flag must NOT be cleared. *persistedToDisk
+    // is set true ONLY when the migrated v7 (no-plaintext) file was actually written
+    // to disk via SaveUnlocked; the caller clears m_fNeedsSeedMigration / promotes
+    // m_loadedFileVersion to v7 ONLY on that signal. Invariant: NeedsSeedMigration()
+    // is true exactly while a plaintext seed is still at rest on disk.
+    bool MigrateToEncryptedSeedV7Unlocked(bool* persistedToDisk = nullptr);
 
     // LP-7 (HIGH-2): CENTRALIZED authenticated-decrypt gate for ALL five at-rest
     // encrypted record types (master key, per-address spending keys, HD-master
@@ -816,6 +833,15 @@ public:
      * @return true if an encrypted wallet's seed is still plaintext-at-rest
      */
     bool NeedsSeedMigration() const;
+
+    /**
+     * LP-7 L1 (opt-in): enable refuse-to-spend while NeedsSeedMigration() is true.
+     * Set once at node startup from --require-seed-migration. Default OFF (warn-only).
+     */
+    void SetRequireSeedMigration(bool require) {
+        std::lock_guard<std::mutex> lock(cs_wallet);
+        m_requireSeedMigration = require;
+    }
 
     /**
      * Change wallet passphrase

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -43,6 +43,16 @@ static const uint32_t WALLET_FILE_VERSION_5 = 5;
 // v6: Added sent transaction history persistence (mapSentTx)
 static const char WALLET_FILE_MAGIC_V6[] = "DILWLT06";
 static const uint32_t WALLET_FILE_VERSION_6 = 6;
+// LP-7 (wallet-Inv-5/4/2): encryption-at-rest fix.
+//   - HD master seed+chaincode stored as a VARIABLE-LENGTH AES-CBC+PKCS7
+//     ciphertext (not the fixed 32+32 plaintext slots) when encrypted.
+//   - Mnemonic / HD-master / MIK ciphertext records each carry an HMAC
+//     (encrypt-then-MAC), verified before decrypt; empty MAC rejected on v7.
+//   - HMAC keyed with a SEPARATELY-derived MAC key (key separation).
+// One-way: encrypted wallets are written ONLY at v7; legacy plaintext-seed
+// wallets are read for migration and rewritten at v7 on next unlock.
+static const char WALLET_FILE_MAGIC_V7[] = "DILWLT07";
+static const uint32_t WALLET_FILE_VERSION_7 = 7;
 static const size_t WALLET_FILE_HMAC_SIZE = 32;    // HMAC-SHA3-256 output
 static const size_t WALLET_FILE_SALT_SIZE = 32;    // Salt for HMAC
 static const size_t WALLET_FILE_HEADER_SIZE = 8 + 4 + 4 + 32 + 32;  // Magic + Version + Flags + HMAC + Salt = 80 bytes
@@ -269,6 +279,24 @@ private:
     std::string m_walletFile;  // Current wallet file path
     bool m_autoSave;           // Auto-save after changes
 
+    // LP-7: on-disk format version the wallet was loaded from (0 if never loaded
+    // / freshly created in memory). v3-v6 records used legacy AES-keyed HMAC and a
+    // plaintext HD seed; v7 uses key-separated HMAC and a variable-length encrypted
+    // HD seed. Used to (a) verify legacy MACs with the correct keying, and (b)
+    // detect a legacy plaintext-seed encrypted wallet that needs migration on unlock.
+    uint32_t m_loadedFileVersion{0};
+    // LP-7: set true at load when an encrypted wallet was read in a pre-v7 format
+    // with a plaintext HD seed at rest (the bug condition). Triggers atomic
+    // re-encryption + v7 rewrite on the next successful unlock.
+    bool m_fNeedsSeedMigration{false};
+
+    // LP-7 migration helper (assumes caller holds cs_wallet, wallet unlocked).
+    // Re-encrypts the plaintext HD seed + mnemonic under the master key and
+    // rewrites the wallet file at v7 atomically (via SaveUnlocked). Leaves the
+    // original file byte-identical on any failure (SaveUnlocked only renames a
+    // fully-written temp file into place; the original is never truncated).
+    bool MigrateToEncryptedSeedV7Unlocked();
+
     // UTXO set reference for balance validation in callbacks
     class CUTXOSet* m_utxo_set_ref{nullptr};
 
@@ -312,10 +340,18 @@ private:
 
     bool fIsHDWallet;                          // Is this an HD wallet?
     std::vector<uint8_t> vchEncryptedMnemonic; // Encrypted BIP39 mnemonic (already encrypted, can use normal allocator)
+    std::vector<uint8_t> vchMnemonicMAC;       // LP-7 (wallet-Inv-2): HMAC over the mnemonic ciphertext (v7+)
     // FIX-009: Use SecureAllocator for IVs to prevent leakage
     std::vector<uint8_t, SecureAllocator<uint8_t>> vchMnemonicIV;        // IV for mnemonic encryption
     CHDExtendedKey hdMasterKey;                // Master extended key (encrypted in memory)
     bool fHDMasterKeyEncrypted;                // Is master key encrypted?
+    // LP-7 (wallet-Inv-5): variable-length AES-CBC+PKCS7 ciphertext of the
+    // 64-byte seed+chaincode. Non-empty ONLY when fHDMasterKeyEncrypted is true
+    // and the wallet was written/migrated at v7. When set, the in-memory
+    // hdMasterKey.seed/chaincode hold THIS ciphertext (not plaintext) at rest,
+    // and the variable-length blob is what is persisted (NOT the fixed 32+32 slots).
+    std::vector<uint8_t> vchEncryptedHDMasterKey;
+    std::vector<uint8_t> vchHDMasterKeyMAC;    // LP-7 (wallet-Inv-2): HMAC over the HD-master ciphertext (v7+)
     // FIX-009: Use SecureAllocator for IVs to prevent leakage
     std::vector<uint8_t, SecureAllocator<uint8_t>> vchHDMasterKeyIV;     // IV for master key encryption
     // WL-010 FIX: Cache decrypted HD master key when wallet unlocked for performance
@@ -342,6 +378,9 @@ private:
 
     /** Encrypted MIK private key (when wallet is encrypted) */
     std::vector<uint8_t> vchEncryptedMIKPrivKey;
+
+    /** LP-7 (wallet-Inv-2): HMAC over the MIK private-key ciphertext (v7+) */
+    std::vector<uint8_t> vchMIKPrivKeyMAC;
 
     /** IV for MIK private key encryption */
     std::vector<uint8_t, SecureAllocator<uint8_t>> vchMIKPrivKeyIV;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -297,6 +297,37 @@ private:
     // fully-written temp file into place; the original is never truncated).
     bool MigrateToEncryptedSeedV7Unlocked();
 
+    // LP-7 (HIGH-2): CENTRALIZED authenticated-decrypt gate for ALL five at-rest
+    // encrypted record types (master key, per-address spending keys, HD-master
+    // seed, mnemonic, MIK private key). Every decrypt path MUST route its MAC
+    // check through this one helper so the version-keyed selection + empty-MAC
+    // policy cannot be applied to four-of-five and missed on the fifth (the exact
+    // shape of round-1 HIGH-1 and round-2 HIGH-2). Single source of truth for the
+    // policy:
+    //   (a) keying: v3-v6 records were MAC'd with the legacy AES-keyed HMAC; v7
+    //       records use the separately-derived MAC key. Selected by the on-disk
+    //       version (m_loadedFileVersion).
+    //   (b) empty-MAC: on a v7 wallet an empty MAC is CORRUPT — reject (no
+    //       unauthenticated decrypt of a root secret). On a pre-v7 wallet an
+    //       empty MAC is the genuine legacy record — allow the unauthenticated
+    //       decrypt so the wallet loads and can migrate.
+    //   (c) verify-before-decrypt: when a MAC is present it is verified with the
+    //       version-correct keying BEFORE the caller decrypts.
+    // Returns true iff the caller may proceed to decrypt. `crypter` must already
+    // have SetKey() called (same key the ciphertext was encrypted under).
+    // Assumes caller holds cs_wallet.
+    bool VerifyRecordMAC(CCrypter& crypter,
+                         const std::vector<uint8_t>& ciphertext,
+                         const std::vector<uint8_t>& mac) const;
+
+    // LP-7 (HIGH-2): CENTRALIZED MAC computation for WRITES / re-MAC. Always uses
+    // the v7 separated-key HMAC — new and migrated records are written ONLY at v7.
+    // Routing all writes through here keeps write-keying in lockstep with the
+    // read policy above. `crypter` must already have SetKey() called.
+    bool ComputeRecordMAC(CCrypter& crypter,
+                          const std::vector<uint8_t>& ciphertext,
+                          std::vector<uint8_t>& macOut) const;
+
     // UTXO set reference for balance validation in callbacks
     class CUTXOSet* m_utxo_set_ref{nullptr};
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -328,6 +328,22 @@ private:
                           const std::vector<uint8_t>& ciphertext,
                           std::vector<uint8_t>& macOut) const;
 
+    // LP-7 (round 3, MEDIUM-1): re-MAC EVERY present at-rest encrypted record
+    // (per-address spending keys, HD-master seed, mnemonic, MIK private key) with
+    // v7 separated keying, in place. The encrypt-then-MAC tag is over the ciphertext,
+    // which does NOT change when only the passphrase rotates (these records are
+    // keyed under the master key, not the passphrase), so no decrypt is needed — we
+    // re-key a crypter with the master key + each record's own IV and recompute the
+    // MAC via ComputeRecordMAC. Used by ChangePassphrase when it promotes a loaded
+    // legacy (v3-v6) wallet to v7: without this, the file would be re-saved as v7
+    // while its non-master records still carry legacy-keyed MACs, and they would
+    // fail VerifyRecordMAC (separated keying) on the next load — the same
+    // keying-mismatch class as HIGH-2 / MEDIUM-1. `vMasterKeyPlain` is the decrypted
+    // master key these records were encrypted under. Returns false (and leaves
+    // partial in-memory state for the caller to roll back) on any malformed record.
+    // Assumes caller holds cs_wallet.
+    bool ReMACAllRecordsToV7Unlocked(const std::vector<uint8_t>& vMasterKeyPlain);
+
     // UTXO set reference for balance validation in callbacks
     class CUTXOSet* m_utxo_set_ref{nullptr};
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -235,6 +235,14 @@ class CWallet {
     // CID 1675307 FIX: Friend declaration to allow recovery functions to use unlocked methods
     friend class CWalletRecovery;
 
+    // LP-7 (red-team LOW-1 hardening test): grants the encryption-at-rest test
+    // suite access to construct the otherwise-unreachable "scrubbed-seed but
+    // m_loadedFileVersion still v6" window and drive the private SaveUnlocked()
+    // writer directly, to prove the fail-closed guard in the legacy-v6 HD-master
+    // branch refuses to persist a zeroed seed. Test-only; no production code path
+    // can reach this state (Unlock promotes the version atomically under cs_wallet).
+    friend struct LP7FailClosedTester;
+
 private:
     // Key storage
     std::map<CDilithiumAddress, CKey> mapKeys;              // Unencrypted keys (when wallet not encrypted)

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -320,29 +320,23 @@ private:
                          const std::vector<uint8_t>& ciphertext,
                          const std::vector<uint8_t>& mac) const;
 
-    // LP-7 (HIGH-2): CENTRALIZED MAC computation for WRITES / re-MAC. Always uses
-    // the v7 separated-key HMAC — new and migrated records are written ONLY at v7.
-    // Routing all writes through here keeps write-keying in lockstep with the
-    // read policy above. `crypter` must already have SetKey() called.
+    // LP-7 (HIGH-2): CENTRALIZED MAC computation for WRITES / re-MAC. Routing all
+    // writes through here keeps write-keying in lockstep with the read policy above.
+    // `crypter` must already have SetKey() called.
+    //
+    // Keying:
+    //   - Default (useLegacyKeying == false): the v7 separated-key HMAC. Used by
+    //     EncryptWallet, the Unlock-path v6->v7 migration, and any record written
+    //     into a v7 file.
+    //   - useLegacyKeying == true: the legacy AES-keyed HMAC (pre-v7). Used ONLY when
+    //     persisting a record back into a file that STAYS at its existing v3-v6
+    //     version (LP-7 ratified design: ChangePassphrase rotates the passphrase in
+    //     place and does NOT promote the file to v7, so the rewritten master-key MAC
+    //     must match the on-disk legacy keying or it fails VerifyRecordMAC on reload).
     bool ComputeRecordMAC(CCrypter& crypter,
                           const std::vector<uint8_t>& ciphertext,
-                          std::vector<uint8_t>& macOut) const;
-
-    // LP-7 (round 3, MEDIUM-1): re-MAC EVERY present at-rest encrypted record
-    // (per-address spending keys, HD-master seed, mnemonic, MIK private key) with
-    // v7 separated keying, in place. The encrypt-then-MAC tag is over the ciphertext,
-    // which does NOT change when only the passphrase rotates (these records are
-    // keyed under the master key, not the passphrase), so no decrypt is needed — we
-    // re-key a crypter with the master key + each record's own IV and recompute the
-    // MAC via ComputeRecordMAC. Used by ChangePassphrase when it promotes a loaded
-    // legacy (v3-v6) wallet to v7: without this, the file would be re-saved as v7
-    // while its non-master records still carry legacy-keyed MACs, and they would
-    // fail VerifyRecordMAC (separated keying) on the next load — the same
-    // keying-mismatch class as HIGH-2 / MEDIUM-1. `vMasterKeyPlain` is the decrypted
-    // master key these records were encrypted under. Returns false (and leaves
-    // partial in-memory state for the caller to roll back) on any malformed record.
-    // Assumes caller holds cs_wallet.
-    bool ReMACAllRecordsToV7Unlocked(const std::vector<uint8_t>& vMasterKeyPlain);
+                          std::vector<uint8_t>& macOut,
+                          bool useLegacyKeying = false) const;
 
     // UTXO set reference for balance validation in callbacks
     class CUTXOSet* m_utxo_set_ref{nullptr};

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -803,6 +803,21 @@ public:
     bool IsCrypted() const;
 
     /**
+     * LP-7 (force-migrate / round-3 SURVIVING-LEAK): true exactly when this
+     * wallet is ENCRYPTED (has a passphrase master key) but was loaded from a
+     * pre-fix on-disk format that still holds the HD seed in PLAINTEXT at rest,
+     * and has not yet been migrated. While true, the seed is unencrypted on disk
+     * DESPITE the wallet reporting "encrypted" — the migration to the v7
+     * encrypted-seed format only runs on the next successful Unlock (it needs the
+     * passphrase). Surfaced so the UI / operators can be driven to unlock once,
+     * and so the wallet is never presented as safely-encrypted until migrated.
+     * Flips to false once the migration completes.
+     *
+     * @return true if an encrypted wallet's seed is still plaintext-at-rest
+     */
+    bool NeedsSeedMigration() const;
+
+    /**
      * Change wallet passphrase
      *
      * WL-015 FIX: Complete parameter documentation

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -243,6 +243,15 @@ class CWallet {
     // can reach this state (Unlock promotes the version atomically under cs_wallet).
     friend struct LP7FailClosedTester;
 
+    // LP-7 (Cursor HIGH-2 regression test): grants the encryption-at-rest test
+    // suite access to (a) corrupt the encrypted-mnemonic ciphertext so an
+    // EncryptWallet mid-HD-step fails, and (b) inspect post-failure invariants
+    // (masterKey validity, fHDMasterKeyEncrypted, the plaintext seed slots) to
+    // prove EncryptWallet rolls back to the original UNENCRYPTED state and a
+    // subsequent Save never persists a v7 plaintext seed for an encrypted wallet.
+    // Test-only.
+    friend struct LP7EncryptRollbackTester;
+
 private:
     // Key storage
     std::map<CDilithiumAddress, CKey> mapKeys;              // Unencrypted keys (when wallet not encrypted)


### PR DESCRIPTION
**LP-7 — HD master seed stored plaintext at rest in encrypted wallets. CRITICAL (user funds).**

Fixes the at-rest crypto cluster (Inv-5 + Inv-4 + Inv-2): the HD seed/chaincode + mnemonic are now encrypted at rest in encrypted wallets; mnemonic/HD/MIK records are authenticated (MAC, verify-before-decrypt, key-separation); existing plaintext-seed wallets **auto-migrate to a versioned v7 (`DILWLT07`) format on next unlock**, atomically.

**Design (post-review-ratified):**
- New `DILWLT07` format: variable-length encrypted seed field; per-record MACs.
- Centralized `VerifyRecordMAC`/`ComputeRecordMAC` — single MAC policy for all 5 record types (no scattered per-site logic).
- Migration owned solely by the Unlock path (atomic temp+fsync+rename, never-delete, full rollback).
- `ChangePassphrase` rotates the passphrase **in place** (no version promotion / no migration) — per Will's ratified design decision.
- Version-aware `SaveUnlocked` with an exhaustive reader/writer version-gate symmetry table (in-code invariant).

**Convergence (this took 6 review rounds — funds-bearing, so worth it):**
- red-team round 1 → HIGH-1 (MAC downgrade) → fold → round 2 HIGH-2 (per-address keying) → centralized → round 3 MED-1 → round 4 exhaustive MAC-consumer audit → **escalated to Will** (ChangePassphrase×migration seam) → **ratified redesign** → round 5 BLOCKER-5 (writer/reader field desync) → round 6 exhaustive version-gate symmetry audit → **final exit check CLEAN**.
- 156/156 tests; mutation self-checks at every fold; full history in `.claude/missions/wallet-encryption-at-rest/CONVERGENCE_STATUS.md` + `redteam_findings_round{1..6}.md`.

**Remaining gates before merge/tag (NOT ready — DRAFT):**
- [ ] **Zach** wallet-crypto sign-off (required reviewer)
- [ ] **Cursor** close-readiness (Will)
- [ ] external_consensus-4-seat (Will's ok — pre-disclosure security diff)
- [ ] formal mutation-testing pass (contract-mandatory; self-checks done per-fold)
- [ ] /evaluate before tag; release = separate **v4.4.7** after LP-5's v4.4.6; coordinated disclosure (fix → user advisory)

**Note:** two pre-existing test files (`wallet_persistence_tests`, `wallet_encryption_integration_tests`) don't compile on this base (stale `CAddress` rename) — NOT touched by this PR.

Contract + grill in the mission dir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)