### PR TITLE
fix(api): LP-12 — mirror RPC wallet-HTML gate + real peer-IP + rate limiter on CHttpServer (--public-api)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -383,6 +383,7 @@ WALLET_TEST_SOURCE := src/test/wallet_tests.cpp
 RPC_TEST_SOURCE := src/test/rpc_tests.cpp
 RPC_AUTH_TEST_SOURCE := src/test/rpc_auth_tests.cpp
 RPC_HOST_HEADER_TEST_SOURCE := src/test/rpc_host_header_tests.cpp
+HTTP_SERVER_WALLET_GATE_TEST_SOURCE := src/test/http_server_wallet_gate_tests.cpp
 RPC_HD_WALLET_TEST_SOURCE := src/test/rpc_hd_wallet_tests.cpp
 RPC_SSL_TEST_SOURCE := src/test/rpc_ssl_tests.cpp
 RPC_WEBSOCKET_TEST_SOURCE := src/test/rpc_websocket_tests.cpp
@@ -491,7 +492,7 @@ dilv-genesis-vdf: $(CORE_OBJECTS) $(OBJ_DIR)/tools/dilv_genesis_vdf.o $(DILITHIU
 # Test Binaries
 # ============================================================================
 
-tests: phase1_test miner_tests wallet_tests rpc_tests rpc_auth_tests rpc_host_header_tests ratelimiter_tests timestamp_tests crypter_tests wallet_encryption_integration_tests wallet_persistence_tests integration_tests net_tests connman_tests tx_validation_tests tx_relay_tests mining_integration_tests bug_003_block_size_tests dfmp_mik_tests mik_registration_persistence_tests dna_propagation_tests test_passphrase_validator script_tests addrman_v2_tests peer_scorer_tests peer_scorer_banman_integration_tests header_proof_checker_tests chain_selector_tests getchaintips_equivalence_tests chain_case_2_5_equivalence_tests chain_work_smoke_tests reorg_wal_crash_injection_tests competing_sibling_below_checkpoint_tests headers_manager_to_chain_selector_wiring_tests fast_path_2_boundary_tests v4_1_checkpoint_enforcement_tests v4_1_chain_selector_suppression_tests auto_rebuild_marker_mode_symmetry_tests add_block_index_flag_merge_tests port_chain_selector_invariants_tests legacy_vs_port_differential_tests chainstate_integrity_tests
+tests: phase1_test miner_tests wallet_tests rpc_tests rpc_auth_tests rpc_host_header_tests http_server_wallet_gate_tests ratelimiter_tests timestamp_tests crypter_tests wallet_encryption_integration_tests wallet_persistence_tests integration_tests net_tests connman_tests tx_validation_tests tx_relay_tests mining_integration_tests bug_003_block_size_tests dfmp_mik_tests mik_registration_persistence_tests dna_propagation_tests test_passphrase_validator script_tests addrman_v2_tests peer_scorer_tests peer_scorer_banman_integration_tests header_proof_checker_tests chain_selector_tests getchaintips_equivalence_tests chain_case_2_5_equivalence_tests chain_work_smoke_tests reorg_wal_crash_injection_tests competing_sibling_below_checkpoint_tests headers_manager_to_chain_selector_wiring_tests fast_path_2_boundary_tests v4_1_checkpoint_enforcement_tests v4_1_chain_selector_suppression_tests auto_rebuild_marker_mode_symmetry_tests add_block_index_flag_merge_tests port_chain_selector_invariants_tests legacy_vs_port_differential_tests chainstate_integrity_tests
 	@echo "$(COLOR_GREEN)✓ All tests built successfully$(COLOR_RESET)"
 
 phase1_test: $(CORE_OBJECTS) $(OBJ_DIR)/test/phase1_simple_test.o $(DILITHIUM_OBJECTS) $(CHIAVDF_OBJECTS)
@@ -518,6 +519,13 @@ rpc_auth_tests: $(CORE_OBJECTS) $(OBJ_DIR)/test/rpc_auth_tests.o $(DILITHIUM_OBJ
 # Self-contained — links ONLY host_validator.o, so it builds and runs WITHOUT
 # the node's depends/ (libzmq/randomx/chiavdf). No CORE_OBJECTS dependency.
 rpc_host_header_tests: $(OBJ_DIR)/rpc/host_validator.o $(OBJ_DIR)/test/rpc_host_header_tests.o
+	@echo "$(COLOR_BLUE)[LINK]$(COLOR_RESET) $@"
+	@$(CXX) $(CXXFLAGS) -o $@ $^
+
+# LP-12: CHttpServer wallet-HTML serving-gate unit tests. Self-contained — links
+# ONLY host_validator.o (the IsLoopbackIP SSoT predicate), so it builds and runs
+# WITHOUT the node's depends/ (libzmq/randomx/chiavdf). No CORE_OBJECTS dependency.
+http_server_wallet_gate_tests: $(OBJ_DIR)/rpc/host_validator.o $(OBJ_DIR)/test/http_server_wallet_gate_tests.o
 	@echo "$(COLOR_BLUE)[LINK]$(COLOR_RESET) $@"
 	@$(CXX) $(CXXFLAGS) -o $@ $^
 
@@ -972,6 +980,9 @@ test: tests test_dilithion asert_test
 	@echo ""
 	@echo "$(COLOR_YELLOW)Running RPC Host-header allowlist + session-token tests...$(COLOR_RESET)"
 	@./rpc_host_header_tests
+	@echo ""
+	@echo "$(COLOR_YELLOW)Running LP-12 CHttpServer wallet-HTML gate tests...$(COLOR_RESET)"
+	@./http_server_wallet_gate_tests
 	@echo ""
 	@echo "$(COLOR_YELLOW)Running rate limiter regression tests...$(COLOR_RESET)"
 	@./ratelimiter_tests

--- a/src/api/http_server.cpp
+++ b/src/api/http_server.cpp
@@ -5,9 +5,11 @@
 #include <api/wallet_html.h>
 #include <net/sock.h>
 #include <rpc/host_validator.h>
+#include <rpc/ratelimiter.h>
 #include <iostream>
 #include <cstring>
 #include <sstream>
+#include <chrono>
 #ifndef _WIN32
 #include <errno.h>
 #endif
@@ -59,6 +61,16 @@ void CHttpServer::SetMetricsHandler(MetricsHandler handler) {
 // Set REST API handler function for /api/v1/* endpoints
 void CHttpServer::SetRestApiHandler(RestApiHandler handler) {
     m_rest_api_handler = handler;
+}
+
+// LP-12 (H-01): configure the anti-DNS-rebinding Host allowlist. Mirrors
+// CRPCServer::Start()'s m_hostValidator.Configure() exactly: the validator is
+// keyed to THIS server's port and the operator-explicit extra hosts; loopback
+// names are always allowed by the validator itself. Setting the ready flag last
+// keeps the fail-closed invariant (an un-configured validator rejects all REST).
+void CHttpServer::ConfigureHostAllowlist(const std::vector<std::string>& extraAllowedHosts) {
+    m_host_validator.Configure(static_cast<uint16_t>(m_port), extraAllowedHosts);
+    m_host_validator_ready.store(true);
 }
 
 // Start the HTTP server
@@ -123,6 +135,11 @@ bool CHttpServer::Start() {
 
         // Launch accept thread
         m_accept_thread = std::thread(&CHttpServer::AcceptThread, this);
+
+        // LP-12 (M-01): launch the rate-limiter maintenance thread so the per-IP
+        // record map is pruned on a cadence (bounded memory under rotating IPs).
+        m_cleanup_thread = std::thread(&CHttpServer::CleanupThread, this);
+
         std::cout << "[HttpServer] Started on port " << m_port << " with " << m_num_threads << " workers" << std::endl;
         return true;
     } catch (const std::exception& e) {
@@ -170,6 +187,11 @@ void CHttpServer::Stop() {
     // Wait for accept thread to finish
     if (m_accept_thread.joinable()) {
         m_accept_thread.join();
+    }
+
+    // LP-12 (M-01): wait for the rate-limiter maintenance thread to finish.
+    if (m_cleanup_thread.joinable()) {
+        m_cleanup_thread.join();
     }
 
     // Wait for worker threads to finish
@@ -245,6 +267,39 @@ void CHttpServer::WorkerThread() {
     }
 }
 
+// LP-12 (M-01): rate-limiter maintenance thread. Faithful mirror of
+// CRPCServer::CleanupThread() — 5-minute cadence, wakes every second to observe
+// m_running for prompt shutdown, wraps the body so a maintenance exception can
+// never take down the process. Without this, the REST limiter's per-IP record
+// map grows unbounded as source IPs rotate (slow memory-DoS), because the
+// standalone HTTP server (unlike the RPC server) never ran the cleanup before.
+void CHttpServer::CleanupThread() {
+    try {
+        const std::chrono::minutes CLEANUP_INTERVAL(5);
+        (void)CLEANUP_INTERVAL;  // documented cadence; loop below counts seconds
+
+        while (m_running.load()) {
+            // Sleep up to 5 minutes, waking each second to honor shutdown.
+            for (int i = 0; i < 300 && m_running.load(); i++) {
+                std::this_thread::sleep_for(std::chrono::seconds(1));
+            }
+
+            if (!m_running.load()) {
+                break;
+            }
+
+            // Prune stale per-IP records (no-op if no limiter registered).
+            if (m_rate_limiter) {
+                m_rate_limiter->CleanupOldRecords();
+            }
+        }
+    } catch (const std::exception& e) {
+        std::cerr << "[HttpServer] Cleanup thread exception: " << e.what() << std::endl;
+    } catch (...) {
+        std::cerr << "[HttpServer] Cleanup thread unknown exception" << std::endl;
+    }
+}
+
 // LP-12: extract the REAL kernel-reported peer IP from the connected socket
 // (getpeername), mirroring CRPCServer::GetClientIP. Used for (a) the loopback
 // wallet-HTML origin gate and (b) per-IP REST rate-limiting/attribution. Never
@@ -315,6 +370,41 @@ void CHttpServer::HandleRequest(SOCKET client_socket) {
         return;
     }
 
+    // ========================================================================
+    // LP-12 (H-01) — ANTI-DNS-REBINDING HOST-HEADER ALLOWLIST.
+    //
+    // Mirrors CRPCServer::HandleRequest (server.cpp:~1095-1139). The standalone
+    // CHttpServer routed /api/v1/* (incl. /api/v1/broadcast → mempool) and
+    // /x402/* with NO Host check, so a DNS-rebound page (evil.com → a
+    // --public-api seed IP) could POST a broadcast or scrape telemetry. This
+    // gate rejects a missing / empty / duplicate / non-allowlisted Host BEFORE
+    // any of those branches dispatch. The Host header is the only input here;
+    // we deliberately do NOT consult X-Forwarded-* (attacker-controlled).
+    //
+    // ORDERING: strictly ABOVE the REST, wallet-HTML, /api/stats and /metrics
+    // branches (every node-touching surface). Only /api/health (an intentional
+    // load-balancer probe) and OPTIONS (already a blanket 403) sit above it.
+    //
+    // FAIL-CLOSED: if the validator was never configured (ready flag false),
+    // REJECT rather than skip — an un-configured validator denies all REST, so
+    // a future reorder of Start() can never silently disable the gate. In
+    // production ConfigureHostAllowlist() runs before Start() spawns workers.
+    // ========================================================================
+    {
+        const bool sensitive_surface =
+            path.rfind("/api/v1/", 0) == 0 ||
+            path.rfind("/x402/", 0) == 0 ||
+            path == "/wallet" || path == "/wallet.html" || path == "/" ||
+            path == "/api/stats" || path == "/metrics";
+        if (sensitive_surface &&
+            (!m_host_validator_ready.load() ||
+             !m_host_validator.IsRequestHostAllowed(request))) {
+            SendResponse(client_socket, 403, "application/json",
+                R"({"error":"Forbidden: Host header not allowed (DNS-rebinding protection). Connect via 127.0.0.1/localhost or configure --rpcallowhost.","code":-32600})");
+            return;
+        }
+    }
+
     // Handle REST API requests for light wallet (/api/v1/*) and x402 facilitator (/x402/*)
     if (path.rfind("/api/v1/", 0) == 0 || path.rfind("/x402/", 0) == 0) {
         if (m_rest_api_handler) {
@@ -378,6 +468,20 @@ void CHttpServer::HandleRequest(SOCKET client_socket) {
         if (!rpc::HostValidator::IsLoopbackIP(clientIP)) {
             SendResponse(client_socket, 403, "application/json",
                 R"({"error":"Forbidden: the wallet UI is served to loopback connections only. Use an SSH tunnel for remote access.","code":-32600})");
+            return;
+        }
+        // ====================================================================
+        // LP-12 (M-03) — SECONDARY loopback-Host check, for parity with the RPC
+        // server's wallet gate (server.cpp:~1240-1261), which requires BOTH a
+        // loopback socket peer (above) AND a loopback Host. The socket-peer gate
+        // is the load-bearing loopback-ORIGIN assertion; this Host check is the
+        // belt-and-suspenders anti-rebinding layer. Fail-closed if the validator
+        // is not ready. Either failing rejects the token-minting page.
+        // ====================================================================
+        if (!m_host_validator_ready.load() ||
+            !m_host_validator.IsRequestLoopbackHost(request)) {
+            SendResponse(client_socket, 403, "application/json",
+                R"({"error":"Forbidden: the wallet UI is served on loopback only (127.0.0.1/localhost). Use an SSH tunnel for remote access.","code":-32600})");
             return;
         }
         try {

--- a/src/api/http_server.cpp
+++ b/src/api/http_server.cpp
@@ -4,6 +4,7 @@
 #include <api/http_server.h>
 #include <api/wallet_html.h>
 #include <net/sock.h>
+#include <rpc/host_validator.h>
 #include <iostream>
 #include <cstring>
 #include <sstream>
@@ -244,8 +245,30 @@ void CHttpServer::WorkerThread() {
     }
 }
 
+// LP-12: extract the REAL kernel-reported peer IP from the connected socket
+// (getpeername), mirroring CRPCServer::GetClientIP. Used for (a) the loopback
+// wallet-HTML origin gate and (b) per-IP REST rate-limiting/attribution. Never
+// trusts the client-supplied Host header. Returns "unknown" on failure, which
+// IsLoopbackIP treats as non-loopback (default-deny).
+static std::string GetPeerIP(SOCKET client_socket) {
+    struct sockaddr_storage ss;
+    socklen_t addr_size = sizeof(ss);
+    if (getpeername(client_socket, (struct sockaddr*)&ss, &addr_size) != 0) {
+        return "unknown";
+    }
+    std::string ip_str;
+    uint16_t port;
+    if (CSock::ExtractAddress(ss, ip_str, port)) {
+        return ip_str;
+    }
+    return "unknown";
+}
+
 // Handle a single HTTP request
 void CHttpServer::HandleRequest(SOCKET client_socket) {
+    // LP-12: resolve the real peer IP once, up front, from the kernel socket.
+    const std::string clientIP = GetPeerIP(client_socket);
+
     // Read request
     char buffer[4096];
 #ifdef _WIN32
@@ -306,8 +329,12 @@ void CHttpServer::HandleRequest(SOCKET client_socket) {
                     }
                 }
 
-                // Call REST API handler (returns full HTTP response)
-                std::string response = m_rest_api_handler(method, path, body, "0.0.0.0");
+                // Call REST API handler (returns full HTTP response).
+                // LP-12: pass the REAL peer IP (was hardcoded "0.0.0.0", which
+                // collapsed every client onto one rate-limit bucket and erased
+                // attribution). Per-IP limiting on the REST broadcast path now
+                // keys on the actual connection.
+                std::string response = m_rest_api_handler(method, path, body, clientIP);
 
                 // Send raw response (handler builds complete HTTP response)
 #ifdef _WIN32
@@ -329,6 +356,30 @@ void CHttpServer::HandleRequest(SOCKET client_socket) {
 
     // Handle GET /wallet or /wallet.html - serve embedded web wallet
     if (method == "GET" && (path == "/wallet" || path == "/wallet.html" || path == "/")) {
+        // ====================================================================
+        // LP-12 (mirrors server.cpp:1169-1232, C-01b/F-003) — the wallet UI is a
+        // token-minting desktop affordance, NOT a seed feature. Bring the
+        // standalone CHttpServer to parity with the RPC server, which previously
+        // protected this same HTML while this path served it unconditionally.
+        //
+        //  1. On a --public-api node (all-interfaces bind) the wallet UI is
+        //     DISABLED ENTIRELY — no page — regardless of socket peer. This
+        //     structurally removes the remote-admin-token / phishing-origin class
+        //     on network-bound seeds. Checked FIRST.
+        //  2. Otherwise (localhost default bind) require the REAL kernel socket
+        //     peer to be a loopback IP literal (IsLoopbackIP on getpeername's
+        //     result) — the Host header is never trusted for this decision.
+        // ====================================================================
+        if (m_public_api) {
+            SendResponse(client_socket, 403, "application/json",
+                R"({"error":"Forbidden: the wallet UI is disabled on a public-API node. SSH-tunnel to a loopback RPC to use the wallet.","code":-32600})");
+            return;
+        }
+        if (!rpc::HostValidator::IsLoopbackIP(clientIP)) {
+            SendResponse(client_socket, 403, "application/json",
+                R"({"error":"Forbidden: the wallet UI is served to loopback connections only. Use an SSH tunnel for remote access.","code":-32600})");
+            return;
+        }
         try {
             const std::string& html = GetWalletHTML();
             SendResponse(client_socket, 200, "text/html; charset=utf-8", html);
@@ -403,8 +454,10 @@ void CHttpServer::SendResponse(SOCKET client_socket,
     response << "HTTP/1.1 " << status_code << " ";
     switch (status_code) {
         case 200: response << "OK"; break;
+        case 403: response << "Forbidden"; break;
         case 404: response << "Not Found"; break;
         case 500: response << "Internal Server Error"; break;
+        case 503: response << "Service Unavailable"; break;
         default: response << "Unknown"; break;
     }
     response << "\r\n";

--- a/src/api/http_server.h
+++ b/src/api/http_server.h
@@ -14,6 +14,16 @@
 #include <vector>
 #include <memory>
 
+// LP-12 (H-01 / M-01 / M-03): the standalone HTTP server reuses the RPC
+// server's anti-DNS-rebinding Host-allowlist validator and the same per-IP
+// rate limiter, so the public REST surface (/api/v1/*, /x402/*) is brought to
+// parity with the RPC server. host_validator.h is intentionally dependency-free.
+#include <rpc/host_validator.h>
+
+// Forward declaration — CRateLimiter lives in rpc/ratelimiter.h. The server only
+// holds a borrowed pointer and drives its periodic CleanupOldRecords().
+class CRateLimiter;
+
 // Forward declare SOCKET type (cross-platform)
 #ifdef _WIN32
     #include <winsock2.h>
@@ -186,6 +196,28 @@ public:
     void SetRestApiHandler(RestApiHandler handler);
 
     /**
+     * LP-12 (H-01): configure the anti-DNS-rebinding Host-header allowlist for
+     * the public REST surface (/api/v1/*, /x402/*). Mirrors CRPCServer's
+     * m_hostValidator.Configure(): loopback names (127.0.0.1 / ::1 / localhost)
+     * are ALWAYS allowed; only operator-explicit --rpcallowhost entries are
+     * added. MUST be called before Start() so worker threads see a ready
+     * validator — the gate is fail-closed (un-configured => reject all REST).
+     *
+     * @param extraAllowedHosts operator --rpcallowhost entries (same source the
+     *                          RPC server uses; loopback added implicitly).
+     */
+    void ConfigureHostAllowlist(const std::vector<std::string>& extraAllowedHosts);
+
+    /**
+     * LP-12 (M-01): register the per-IP REST rate limiter so the server can run
+     * its own periodic CleanupOldRecords() (the limiter is also wired into the
+     * CRestAPI for enforcement). Without this, m_records grows unbounded from
+     * rotating source IPs (slow memory-DoS). Mirrors CRPCServer's cleanup
+     * thread. Borrowed pointer — caller retains ownership; must outlive Stop().
+     */
+    void SetRateLimiter(CRateLimiter* rate_limiter) { m_rate_limiter = rate_limiter; }
+
+    /**
      * Start the HTTP server
      * @return true if started successfully
      */
@@ -220,6 +252,15 @@ private:
      * Processes requests from the work queue
      */
     void WorkerThread();
+
+    /**
+     * LP-12 (M-01): rate-limiter maintenance thread. Mirrors
+     * CRPCServer::CleanupThread() — wakes on a 5-minute cadence (checking
+     * m_running each second) and calls m_rate_limiter->CleanupOldRecords() so
+     * the per-IP record map stays bounded under rotating-IP load. No-op when no
+     * limiter has been registered.
+     */
+    void CleanupThread();
 
     /**
      * Handle a single HTTP request
@@ -276,8 +317,19 @@ private:
     // Server state - STRESS TEST FIX: Thread pool pattern
     std::thread m_accept_thread;           // Accept thread (listens for connections)
     std::vector<std::thread> m_workers;    // Worker threads (process requests)
+    std::thread m_cleanup_thread;          // LP-12 (M-01): rate-limiter maintenance
     CHttpWorkQueue<SOCKET> m_work_queue;   // Work queue for pending requests
     std::atomic<bool> m_running{false};    // Running flag
+
+    // LP-12 (H-01): anti-DNS-rebinding Host allowlist for the public REST
+    // surface. Configured before Start(); the gate is fail-closed when not
+    // ready (mirrors CRPCServer::m_hostValidator / m_hostValidatorReady).
+    rpc::HostValidator m_host_validator;
+    std::atomic<bool> m_host_validator_ready{false};
+
+    // LP-12 (M-01): borrowed per-IP REST rate limiter (owned by the node main).
+    // The server drives its periodic cleanup; nullptr => cleanup is a no-op.
+    CRateLimiter* m_rate_limiter{nullptr};
 
 #ifdef _WIN32
     SOCKET m_server_socket{INVALID_SOCKET}; // Server socket file descriptor

--- a/src/node/dilithion-node.cpp
+++ b/src/node/dilithion-node.cpp
@@ -3850,6 +3850,17 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
         // the real peer IP (see http_server.cpp), so this limiter keys per-IP.
         static CRateLimiter http_rest_rate_limiter;
         rest_api.RegisterRateLimiter(&http_rest_rate_limiter);
+        // LP-12 (M-01): also hand the limiter to the HTTP server so it runs the
+        // periodic CleanupOldRecords() maintenance (mirrors the RPC server's
+        // cleanup thread). Without this the per-IP record map grows unbounded as
+        // source IPs rotate (slow memory-DoS) on a --public-api node.
+        http_server.SetRateLimiter(&http_rest_rate_limiter);
+
+        // LP-12 (H-01): configure the anti-DNS-rebinding Host allowlist on the
+        // HTTP server's REST surface, reusing the SAME source as the RPC server
+        // (config.rpc_allow_hosts / --rpcallowhost; loopback always allowed).
+        // Must run before Start() so worker threads see a ready, fail-closed gate.
+        http_server.ConfigureHostAllowlist(config.rpc_allow_hosts);
 
         http_server.SetRestApiHandler([](const std::string& method,
                                          const std::string& path,

--- a/src/node/dilithion-node.cpp
+++ b/src/node/dilithion-node.cpp
@@ -73,6 +73,7 @@
 #include <rpc/server.h>
 #include <rpc/auth.h>      // CVE-2026-RPC-AUTH: RPCAuth::InitializeAuth
 #include <rpc/rest_api.h>  // REST API for light wallet
+#include <rpc/ratelimiter.h>  // LP-12: per-IP rate limiter for the HTTP REST path
 #include <core/chainparams.h>
 #include <consensus/pow.h>
 #include <consensus/chain.h>
@@ -3842,7 +3843,13 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
         rest_api.RegisterUTXOSet(&utxo_set);
         rest_api.RegisterChainState(&g_chainstate);
         rest_api.SetTestnet(config.testnet);
-        // Note: Rate limiter is optional for HTTP server (RPC server has its own)
+        // LP-12: wire a per-IP rate limiter onto the standalone HTTP server's
+        // REST instance. Previously this was left null ("optional"), so the
+        // public REST broadcast endpoint (ENDPOINT_BROADCAST) returned "allow"
+        // for every request on a --public-api node. The CHttpServer now plumbs
+        // the real peer IP (see http_server.cpp), so this limiter keys per-IP.
+        static CRateLimiter http_rest_rate_limiter;
+        rest_api.RegisterRateLimiter(&http_rest_rate_limiter);
 
         http_server.SetRestApiHandler([](const std::string& method,
                                          const std::string& path,

--- a/src/node/dilv-node.cpp
+++ b/src/node/dilv-node.cpp
@@ -73,6 +73,7 @@
 #include <rpc/server.h>
 #include <rpc/auth.h>      // CVE-2026-RPC-AUTH: RPCAuth::InitializeAuth
 #include <rpc/rest_api.h>  // REST API for light wallet
+#include <rpc/ratelimiter.h>  // LP-12: per-IP rate limiter for the HTTP REST path
 #include <x402/facilitator.h>  // x402 payment facilitator
 #include <core/chainparams.h>
 #include <consensus/pow.h>
@@ -3695,7 +3696,13 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
         rest_api.RegisterUTXOSet(&utxo_set);
         rest_api.RegisterChainState(&g_chainstate);
         rest_api.SetTestnet(config.testnet);
-        // Note: Rate limiter is optional for HTTP server (RPC server has its own)
+        // LP-12: wire a per-IP rate limiter onto the standalone HTTP server's
+        // REST instance. Previously this was left null ("optional"), so the
+        // public REST broadcast endpoint (ENDPOINT_BROADCAST) returned "allow"
+        // for every request on a --public-api node. The CHttpServer now plumbs
+        // the real peer IP (see http_server.cpp), so this limiter keys per-IP.
+        static CRateLimiter http_rest_rate_limiter;
+        rest_api.RegisterRateLimiter(&http_rest_rate_limiter);
 
         // x402 Payment Facilitator — enables HTTP 402 micropayments on DilV
         static x402::CFacilitator x402_facilitator;

--- a/src/node/dilv-node.cpp
+++ b/src/node/dilv-node.cpp
@@ -3703,6 +3703,18 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
         // the real peer IP (see http_server.cpp), so this limiter keys per-IP.
         static CRateLimiter http_rest_rate_limiter;
         rest_api.RegisterRateLimiter(&http_rest_rate_limiter);
+        // LP-12 (M-01): also hand the limiter to the HTTP server so it runs the
+        // periodic CleanupOldRecords() maintenance (mirrors the RPC server's
+        // cleanup thread). Without this the per-IP record map grows unbounded as
+        // source IPs rotate (slow memory-DoS) on a --public-api node.
+        http_server.SetRateLimiter(&http_rest_rate_limiter);
+
+        // LP-12 (H-01): configure the anti-DNS-rebinding Host allowlist on the
+        // HTTP server's REST surface (/api/v1/*, /x402/*), reusing the SAME
+        // source as the RPC server (config.rpc_allow_hosts / --rpcallowhost;
+        // loopback always allowed). Must run before Start() so worker threads see
+        // a ready, fail-closed gate.
+        http_server.ConfigureHostAllowlist(config.rpc_allow_hosts);
 
         // x402 Payment Facilitator — enables HTTP 402 micropayments on DilV
         static x402::CFacilitator x402_facilitator;

--- a/src/test/http_server_wallet_gate_tests.cpp
+++ b/src/test/http_server_wallet_gate_tests.cpp
@@ -21,8 +21,11 @@
 
 #include <rpc/host_validator.h>
 
+#include <cstdint>
 #include <iostream>
+#include <map>
 #include <string>
+#include <vector>
 
 using rpc::HostValidator;
 
@@ -114,11 +117,197 @@ static void TestNoHostHeaderTrust() {
     CHECK(SimulateWalletGate(true, "198.51.100.23") == WalletGate::Disabled);
 }
 
+// Build a minimal raw HTTP request with an optional Host header (mirrors the
+// helper in rpc_host_header_tests.cpp). includeHost=false omits the header so we
+// can exercise the default-deny "missing Host" path.
+static std::string MakeRequest(const std::string& method,
+                               const std::string& path,
+                               const std::string& hostHeader,
+                               bool includeHost = true) {
+    std::string r = method + " " + path + " HTTP/1.1\r\n";
+    if (includeHost) r += "Host: " + hostHeader + "\r\n";
+    r += "Content-Type: application/json\r\n";
+    r += "\r\n";
+    return r;
+}
+
+// --------------------------------------------------------------------------
+// 4. H-01 — the REST surface (/api/v1/*, /x402/*) enforces the Host-allowlist
+//    gate, fail-closed. Models CHttpServer::HandleRequest's H-01 branch: the
+//    request is dispatched ONLY if the validator is ready AND the Host is
+//    allowed. The live code uses the SAME HostValidator instance + predicate.
+// --------------------------------------------------------------------------
+//
+// `validatorReady=false` models the fail-closed pre-Configure state.
+static bool SimulateRestGateAllows(const HostValidator& hv,
+                                   bool validatorReady,
+                                   const std::string& request) {
+    if (!validatorReady) return false;                // fail-closed
+    return hv.IsRequestHostAllowed(request);
+}
+
+static void TestRestHostAllowlistGate() {
+    std::cout << "LP-12 H-01: REST /api/v1/* enforces Host-allowlist, fail-closed..." << std::endl;
+
+    // Public-API seed: api_port 9334, operator allowlists its DNS name + IP.
+    HostValidator hv;
+    hv.Configure(9334, {"seed.dilithion.org", "203.0.113.7"});
+
+    // Loopback is ALWAYS allowed (desktop wallet hitting its own node).
+    CHECK(SimulateRestGateAllows(hv, true,
+        MakeRequest("POST", "/api/v1/broadcast", "127.0.0.1:9334")));
+    CHECK(SimulateRestGateAllows(hv, true,
+        MakeRequest("POST", "/api/v1/broadcast", "localhost")));
+
+    // Operator-allowlisted hosts pass (REST is a legitimate public surface).
+    CHECK(SimulateRestGateAllows(hv, true,
+        MakeRequest("POST", "/api/v1/broadcast", "seed.dilithion.org:9334")));
+    CHECK(SimulateRestGateAllows(hv, true,
+        MakeRequest("GET", "/api/v1/info", "203.0.113.7")));
+
+    // DNS-rebinding: an attacker page on evil.com that rebinds to the seed IP
+    // sends Host: evil.com — NOT in the allowlist — REJECTED before /broadcast.
+    CHECK(!SimulateRestGateAllows(hv, true,
+        MakeRequest("POST", "/api/v1/broadcast", "evil.com")));
+    // Substring / suffix tricks are rejected (exact host-token match).
+    CHECK(!SimulateRestGateAllows(hv, true,
+        MakeRequest("POST", "/api/v1/broadcast", "seed.dilithion.org.evil.com")));
+    CHECK(!SimulateRestGateAllows(hv, true,
+        MakeRequest("POST", "/api/v1/broadcast", "127.0.0.1.evil.com")));
+    // Missing Host header => default-deny REJECT.
+    CHECK(!SimulateRestGateAllows(hv, true,
+        MakeRequest("POST", "/api/v1/broadcast", "", /*includeHost=*/false)));
+    // x402 surface is gated by the same check.
+    CHECK(!SimulateRestGateAllows(hv, true,
+        MakeRequest("POST", "/x402/pay", "evil.com")));
+    CHECK(SimulateRestGateAllows(hv, true,
+        MakeRequest("POST", "/x402/pay", "127.0.0.1")));
+
+    // FAIL-CLOSED: before ConfigureHostAllowlist() runs (validatorReady=false),
+    // even a loopback Host is rejected — the gate is never open-by-omission.
+    CHECK(!SimulateRestGateAllows(hv, /*validatorReady=*/false,
+        MakeRequest("POST", "/api/v1/broadcast", "127.0.0.1:9334")));
+}
+
+// --------------------------------------------------------------------------
+// 5. M-03 — the wallet gate requires BOTH a loopback socket peer AND a loopback
+//    Host (RPC parity). Models the full CHttpServer wallet branch including the
+//    secondary loopback-Host check added by LP-12 M-03.
+// --------------------------------------------------------------------------
+static WalletGate SimulateWalletGateFull(const HostValidator& hv,
+                                         bool validatorReady,
+                                         bool publicApi,
+                                         const std::string& peerIP,
+                                         const std::string& request) {
+    if (publicApi) {
+        return WalletGate::Disabled;
+    }
+    if (!HostValidator::IsLoopbackIP(peerIP)) {
+        return WalletGate::Rejected;   // socket-peer gate (primary)
+    }
+    // M-03 secondary loopback-Host check, fail-closed.
+    if (!validatorReady || !hv.IsRequestLoopbackHost(request)) {
+        return WalletGate::Rejected;
+    }
+    return WalletGate::Served;
+}
+
+static void TestWalletGateSecondaryHostCheck() {
+    std::cout << "LP-12 M-03: wallet gate needs loopback peer AND loopback Host..." << std::endl;
+    HostValidator hv;
+    // Even an operator that allowlists a public name for REST does NOT loosen
+    // the wallet gate — IsRequestLoopbackHost is independent of the allowlist.
+    hv.Configure(8334, {"seed.dilithion.org"});
+
+    // Loopback peer + loopback Host => served (the legitimate desktop case).
+    CHECK(SimulateWalletGateFull(hv, true, false, "127.0.0.1",
+        MakeRequest("GET", "/wallet", "127.0.0.1:8334")) == WalletGate::Served);
+    CHECK(SimulateWalletGateFull(hv, true, false, "::1",
+        MakeRequest("GET", "/", "localhost")) == WalletGate::Served);
+
+    // Loopback socket peer but NON-loopback Host (e.g. a rebound page that
+    // somehow rode a loopback connection, or an allowlisted public name) =>
+    // REJECTED by the M-03 secondary check. Pre-LP-12 this branch served it.
+    CHECK(SimulateWalletGateFull(hv, true, false, "127.0.0.1",
+        MakeRequest("GET", "/wallet", "seed.dilithion.org")) == WalletGate::Rejected);
+    CHECK(SimulateWalletGateFull(hv, true, false, "127.0.0.1",
+        MakeRequest("GET", "/wallet", "evil.com")) == WalletGate::Rejected);
+    // Missing Host => fail-closed reject even on a loopback peer.
+    CHECK(SimulateWalletGateFull(hv, true, false, "127.0.0.1",
+        MakeRequest("GET", "/wallet", "", /*includeHost=*/false)) == WalletGate::Rejected);
+    // Validator not ready => fail-closed reject.
+    CHECK(SimulateWalletGateFull(hv, /*validatorReady=*/false, false, "127.0.0.1",
+        MakeRequest("GET", "/wallet", "127.0.0.1")) == WalletGate::Rejected);
+
+    // Non-loopback peer is still rejected at the primary gate regardless of Host.
+    CHECK(SimulateWalletGateFull(hv, true, false, "203.0.113.7",
+        MakeRequest("GET", "/wallet", "127.0.0.1")) == WalletGate::Rejected);
+    // public-api disables entirely (primary, before any Host parse).
+    CHECK(SimulateWalletGateFull(hv, true, true, "127.0.0.1",
+        MakeRequest("GET", "/wallet", "127.0.0.1")) == WalletGate::Disabled);
+}
+
+// --------------------------------------------------------------------------
+// 6. M-01 — the per-IP record map stays BOUNDED under rotating source IPs once
+//    a periodic cleanup runs. Models the maintenance mechanism the HTTP server's
+//    CleanupThread drives: stale records (older than the retention window) are
+//    evicted, so an attacker rotating IPs cannot grow the map without bound.
+//
+// This is a structural model of CRateLimiter::CleanupOldRecords()'s contract
+// (evict records whose age >= retention) without linking the full limiter (which
+// pulls in chainparams/depends). The live limiter's eviction correctness is
+// covered by ratelimiter_tests; here we pin that the HTTP server's PERIODIC
+// invocation is what bounds the map — the property M-01 introduces.
+// --------------------------------------------------------------------------
+namespace {
+struct ModelRecord { int64_t createdAt; };
+// Mirror of CleanupOldRecords: drop records older than the 1-hour retention.
+static void ModelCleanup(std::map<std::string, ModelRecord>& recs,
+                         int64_t now, int64_t retentionSecs) {
+    for (auto it = recs.begin(); it != recs.end(); ) {
+        if (now - it->second.createdAt >= retentionSecs) it = recs.erase(it);
+        else ++it;
+    }
+}
+} // namespace
+
+static void TestRateLimiterRecordsStayBounded() {
+    std::cout << "LP-12 M-01: per-IP records stay bounded under rotating IPs..." << std::endl;
+    const int64_t RETENTION = 3600;       // 1h, mirrors CleanupOldRecords()
+    const int64_t CLEAN_EVERY = 300;      // 5-min cadence, mirrors CleanupThread()
+    std::map<std::string, ModelRecord> recs;
+
+    // Adversary rotates through a fresh source IP every second for 24h, with the
+    // cleanup thread firing every 5 minutes. Without periodic cleanup the map
+    // would hold 86400 entries; with it, it stays bounded by ~retention window.
+    size_t peak = 0;
+    int64_t lastClean = 0;
+    for (int64_t t = 0; t < 86400; ++t) {
+        recs["10.0." + std::to_string((t / 256) % 256) + "." + std::to_string(t % 256)]
+            = ModelRecord{t};
+        if (t - lastClean >= CLEAN_EVERY) {
+            ModelCleanup(recs, t, RETENTION);
+            lastClean = t;
+        }
+        if (recs.size() > peak) peak = recs.size();
+    }
+    // Bound: at most one retention window plus one cleanup cadence of arrivals.
+    // (3600 + 300 = 3900 distinct second-keyed IPs.) Far below the 86400 an
+    // un-pruned map would hold — the periodic cleanup is doing its job.
+    CHECK(peak <= RETENTION + CLEAN_EVERY + 1);
+    // A final cleanup well past the last arrival drains everything.
+    ModelCleanup(recs, 86400 + RETENTION, RETENTION);
+    CHECK(recs.empty());
+}
+
 int main() {
     std::cout << "=== LP-12 CHttpServer wallet-HTML gate tests ===" << std::endl;
     TestPublicApiDisablesWalletEntirely();
     TestLocalhostDefaultGate();
     TestNoHostHeaderTrust();
+    TestRestHostAllowlistGate();             // H-01
+    TestWalletGateSecondaryHostCheck();      // M-03
+    TestRateLimiterRecordsStayBounded();     // M-01
     std::cout << "All " << g_checks << " checks passed." << std::endl;
     return 0;
 }

--- a/src/test/http_server_wallet_gate_tests.cpp
+++ b/src/test/http_server_wallet_gate_tests.cpp
@@ -1,0 +1,124 @@
+// Copyright (c) 2026 The Dilithion Core developers
+// Distributed under the MIT software license
+//
+// LP-12 unit tests — the standalone CHttpServer (dashboard / light-wallet HTTP
+// server on the api_port, NOT the RPC port) wallet-HTML serving gate.
+//
+// Background: the C-01b/F-003 hardening disabled the token-minting wallet UI on
+// a --public-api node and otherwise gated it on the REAL kernel socket peer
+// (IsLoopbackIP), but that protection was applied ONLY to the RPC server
+// (server.cpp). The parallel CHttpServer served the same wallet HTML
+// UNCONDITIONALLY. LP-12 mirrors the RPC gate onto CHttpServer:
+//   1. m_public_api  => 403, no page (regardless of peer);
+//   2. else          => serve ONLY if the real socket peer is a loopback IP
+//                       literal (IsLoopbackIP), Host header NEVER trusted.
+//
+// This test models that exact dispatch ordering (the same modelling approach as
+// rpc_host_header_tests.cpp), so it links ONLY against rpc/host_validator.{h,cpp}
+// and the C++ stdlib — no node depends/ required. It is the SSoT predicate
+// (IsLoopbackIP) plus the public-api branch that the test pins; the live code in
+// http_server.cpp calls the same predicate in the same order.
+
+#include <rpc/host_validator.h>
+
+#include <iostream>
+#include <string>
+
+using rpc::HostValidator;
+
+static int g_checks = 0;
+#define CHECK(cond) do { \
+    g_checks++; \
+    if (!(cond)) { \
+        std::cerr << "  FAIL: " #cond " (line " << __LINE__ << ")" << std::endl; \
+        std::exit(1); \
+    } \
+} while (0)
+
+// What the CHttpServer wallet-HTML branch did with a given request.
+enum class WalletGate {
+    Disabled,   // 403: --public-api node, UI disabled entirely
+    Rejected,   // 403: non-loopback socket peer
+    Served,     // 200: wallet HTML served
+};
+
+// Faithful model of the CHttpServer::HandleRequest wallet-HTML branch
+// (http_server.cpp). `peerIP` is the kernel-reported getpeername() result
+// (GetPeerIP); `publicApi` is the constructor's --public-api flag. The ordering
+// mirrors the live code exactly: public-api check FIRST, then the loopback
+// socket-peer gate. NOTE: there is intentionally NO Host-header dimension here —
+// the CHttpServer decision rests solely on the real socket peer, never on a
+// client-supplied header.
+static WalletGate SimulateWalletGate(bool publicApi, const std::string& peerIP) {
+    if (publicApi) {
+        return WalletGate::Disabled;
+    }
+    if (!HostValidator::IsLoopbackIP(peerIP)) {
+        return WalletGate::Rejected;
+    }
+    return WalletGate::Served;
+}
+
+// --------------------------------------------------------------------------
+// 1. --public-api disables the wallet UI for ANY peer, loopback or not.
+// --------------------------------------------------------------------------
+static void TestPublicApiDisablesWalletEntirely() {
+    std::cout << "LP-12: --public-api disables wallet UI for every peer..." << std::endl;
+    // Even a loopback peer is refused on a public-API node (belt-and-suspenders:
+    // the operator SSH-tunnels to a loopback RPC instead).
+    CHECK(SimulateWalletGate(/*publicApi=*/true, "127.0.0.1") == WalletGate::Disabled);
+    CHECK(SimulateWalletGate(true, "::1") == WalletGate::Disabled);
+    // Remote peers are likewise refused — this is the core LP-12 fix: a remote
+    // attacker hitting :9334/wallet on a --public-api seed gets a 403, not the
+    // token-minting page.
+    CHECK(SimulateWalletGate(true, "203.0.113.7") == WalletGate::Disabled);
+    CHECK(SimulateWalletGate(true, "8.8.8.8") == WalletGate::Disabled);
+    CHECK(SimulateWalletGate(true, "unknown") == WalletGate::Disabled);
+}
+
+// --------------------------------------------------------------------------
+// 2. Localhost-default: loopback peer served, non-loopback peer rejected.
+//    (This is the pre-LP-12 default behavior, now made explicit/enforced.)
+// --------------------------------------------------------------------------
+static void TestLocalhostDefaultGate() {
+    std::cout << "LP-12: localhost-default serves loopback, rejects remote..." << std::endl;
+    // Loopback peers (the desktop wallet case) ARE served — default behavior
+    // is unchanged for the legitimate localhost user.
+    CHECK(SimulateWalletGate(/*publicApi=*/false, "127.0.0.1") == WalletGate::Served);
+    CHECK(SimulateWalletGate(false, "127.1.2.3") == WalletGate::Served);
+    CHECK(SimulateWalletGate(false, "::1") == WalletGate::Served);
+    CHECK(SimulateWalletGate(false, "::ffff:127.0.0.1") == WalletGate::Served);
+
+    // A non-loopback peer on the default (localhost-bound) server should never
+    // reach this branch in practice, but if it does (e.g. misconfigured proxy /
+    // future bind change), the socket-peer gate refuses it — defense in depth.
+    CHECK(SimulateWalletGate(false, "10.0.0.5") == WalletGate::Rejected);
+    CHECK(SimulateWalletGate(false, "203.0.113.7") == WalletGate::Rejected);
+    // getpeername failure ("unknown") is treated as non-loopback (default-deny).
+    CHECK(SimulateWalletGate(false, "unknown") == WalletGate::Rejected);
+    CHECK(SimulateWalletGate(false, "") == WalletGate::Rejected);
+}
+
+// --------------------------------------------------------------------------
+// 3. The decision rests on the SOCKET PEER, not a Host header. There is no
+//    Host dimension in the model precisely because the live code does not read
+//    one for this decision — a non-loopback peer cannot smuggle a loopback Host
+//    to be served the page.
+// --------------------------------------------------------------------------
+static void TestNoHostHeaderTrust() {
+    std::cout << "LP-12: a remote peer cannot be served via any header trick..." << std::endl;
+    // The only inputs are publicApi + peerIP; no request string is consulted.
+    // A remote peer is Rejected on a localhost-default node and Disabled on a
+    // public-API node — there is no input by which it is ever Served.
+    CHECK(SimulateWalletGate(false, "198.51.100.23") == WalletGate::Rejected);
+    CHECK(SimulateWalletGate(true, "198.51.100.23") == WalletGate::Disabled);
+}
+
+int main() {
+    std::cout << "=== LP-12 CHttpServer wallet-HTML gate tests ===" << std::endl;
+    TestPublicApiDisablesWalletEntirely();
+    TestLocalhostDefaultGate();
+    TestNoHostHeaderTrust();
+    std::cout << "All " << g_checks << " checks passed." << std::endl;
+    return 0;
+}


### PR DESCRIPTION
**LP-12 — `--public-api` serving asymmetry. HIGH.**

Under `--public-api`, `CHttpServer` served the token-minting wallet HTML **unconditionally** and its REST broadcast was **un-rate-limited + unattributed** (client IP hardcoded `"0.0.0.0"`), while the RPC server correctly gated the same surface. The C-01b hardening had landed on one of two servers.

Fix: mirror the RPC wallet-HTML gate on `CHttpServer` (403 under `--public-api`; else loopback-socket-peer only, Host never trusted), plumb the real `getpeername` peer IP, and register the rate limiter on the HTTP `CRestAPI` — in both node binaries.

**Reviews:** red-team-validator **no load-bearing defects** (15/15 new gate tests, 143/143 host-validator regression). Follow-up boarded: the sibling **x402 POST surface** has the same un-rate-limited gap (pre-existing, separate).

DRAFT. Remaining: red-team folded, `/evaluate`, a real-socket behavioral check before tag. Contract in `.claude/missions/public-api-hardening/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)