### PR TITLE
fix(attestation): LP-13 — encrypt seed-attestation key at rest + 0600 + fail-loud auto-mint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -388,6 +388,7 @@ RPC_SSL_TEST_SOURCE := src/test/rpc_ssl_tests.cpp
 RPC_WEBSOCKET_TEST_SOURCE := src/test/rpc_websocket_tests.cpp
 TIMESTAMP_TEST_SOURCE := src/test/timestamp_tests.cpp
 CRYPTER_TEST_SOURCE := src/test/crypter_tests.cpp
+SEED_ATTESTATION_KEY_TEST_SOURCE := src/test/seed_attestation_key_tests.cpp
 WALLET_ENCRYPTION_INTEGRATION_TEST_SOURCE := src/test/wallet_encryption_integration_tests.cpp
 WALLET_PERSISTENCE_TEST_SOURCE := src/test/wallet_persistence_tests.cpp
 INTEGRATION_TEST_SOURCE := src/test/integration_tests.cpp
@@ -491,7 +492,7 @@ dilv-genesis-vdf: $(CORE_OBJECTS) $(OBJ_DIR)/tools/dilv_genesis_vdf.o $(DILITHIU
 # Test Binaries
 # ============================================================================
 
-tests: phase1_test miner_tests wallet_tests rpc_tests rpc_auth_tests rpc_host_header_tests ratelimiter_tests timestamp_tests crypter_tests wallet_encryption_integration_tests wallet_persistence_tests integration_tests net_tests connman_tests tx_validation_tests tx_relay_tests mining_integration_tests bug_003_block_size_tests dfmp_mik_tests mik_registration_persistence_tests dna_propagation_tests test_passphrase_validator script_tests addrman_v2_tests peer_scorer_tests peer_scorer_banman_integration_tests header_proof_checker_tests chain_selector_tests getchaintips_equivalence_tests chain_case_2_5_equivalence_tests chain_work_smoke_tests reorg_wal_crash_injection_tests competing_sibling_below_checkpoint_tests headers_manager_to_chain_selector_wiring_tests fast_path_2_boundary_tests v4_1_checkpoint_enforcement_tests v4_1_chain_selector_suppression_tests auto_rebuild_marker_mode_symmetry_tests add_block_index_flag_merge_tests port_chain_selector_invariants_tests legacy_vs_port_differential_tests chainstate_integrity_tests
+tests: phase1_test miner_tests wallet_tests rpc_tests rpc_auth_tests rpc_host_header_tests ratelimiter_tests timestamp_tests crypter_tests seed_attestation_key_tests wallet_encryption_integration_tests wallet_persistence_tests integration_tests net_tests connman_tests tx_validation_tests tx_relay_tests mining_integration_tests bug_003_block_size_tests dfmp_mik_tests mik_registration_persistence_tests dna_propagation_tests test_passphrase_validator script_tests addrman_v2_tests peer_scorer_tests peer_scorer_banman_integration_tests header_proof_checker_tests chain_selector_tests getchaintips_equivalence_tests chain_case_2_5_equivalence_tests chain_work_smoke_tests reorg_wal_crash_injection_tests competing_sibling_below_checkpoint_tests headers_manager_to_chain_selector_wiring_tests fast_path_2_boundary_tests v4_1_checkpoint_enforcement_tests v4_1_chain_selector_suppression_tests auto_rebuild_marker_mode_symmetry_tests add_block_index_flag_merge_tests port_chain_selector_invariants_tests legacy_vs_port_differential_tests chainstate_integrity_tests
 	@echo "$(COLOR_GREEN)✓ All tests built successfully$(COLOR_RESET)"
 
 phase1_test: $(CORE_OBJECTS) $(OBJ_DIR)/test/phase1_simple_test.o $(DILITHIUM_OBJECTS) $(CHIAVDF_OBJECTS)
@@ -530,6 +531,11 @@ timestamp_tests: $(CORE_OBJECTS) $(OBJ_DIR)/test/timestamp_tests.o $(DILITHIUM_O
 	@$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LIBS)
 
 crypter_tests: $(CORE_OBJECTS) $(OBJ_DIR)/test/crypter_tests.o $(DILITHIUM_OBJECTS) $(CHIAVDF_OBJECTS)
+	@echo "$(COLOR_BLUE)[LINK]$(COLOR_RESET) $@"
+	@$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LIBS)
+
+# LP-13: seed-attestation private key at-rest hardening tests
+seed_attestation_key_tests: $(CORE_OBJECTS) $(OBJ_DIR)/test/seed_attestation_key_tests.o $(DILITHIUM_OBJECTS) $(CHIAVDF_OBJECTS)
 	@echo "$(COLOR_BLUE)[LINK]$(COLOR_RESET) $@"
 	@$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LIBS)
 
@@ -1143,7 +1149,7 @@ clean:
 	@echo "$(COLOR_YELLOW)Cleaning build artifacts...$(COLOR_RESET)"
 	@rm -rf $(BUILD_DIR)
 	@rm -f dilithion-node genesis_gen
-	@rm -f phase1_test miner_tests wallet_tests rpc_tests rpc_auth_tests timestamp_tests crypter_tests wallet_encryption_integration_tests wallet_persistence_tests integration_tests net_tests tx_validation_tests tx_relay_tests mining_integration_tests dfmp_mik_tests mik_registration_persistence_tests registration_manager_tests dna_propagation_tests
+	@rm -f phase1_test miner_tests wallet_tests rpc_tests rpc_auth_tests timestamp_tests crypter_tests seed_attestation_key_tests wallet_encryption_integration_tests wallet_persistence_tests integration_tests net_tests tx_validation_tests tx_relay_tests mining_integration_tests dfmp_mik_tests mik_registration_persistence_tests registration_manager_tests dna_propagation_tests
 	@rm -f test_dilithion
 	@rm -f $(DILITHIUM_OBJECTS)
 	@echo "$(COLOR_GREEN)✓ Clean complete$(COLOR_RESET)"

--- a/src/attestation/seed_attestation.cpp
+++ b/src/attestation/seed_attestation.cpp
@@ -472,8 +472,10 @@ bool CSeedAttestationKey::Save(const std::string& dataDir, bool requireEncryptio
     // already has WRITE access to the seed's root-owned 0600/0700 data dir (i.e. is
     // already root-equivalent and can destroy the key directly), and this atomic
     // temp+rename mirrors the audited CWallet::SaveUnlocked, which carries the same
-    // accepted residual under the same operator-owned-datadir threat model. Tracked
-    // for follow-up in missions/seed-key-at-rest/FOLLOWUPS.md; not a #113 blocker.
+    // accepted residual under the same operator-owned-datadir threat model. Accepted
+    // as a deferred follow-up (not a #113 blocker); the deferred items are tracked
+    // out-of-tree in the project's security record rather than enumerated here, to
+    // avoid expanding public detail on un-deployed fixes during the disclosure window.
     int fd = ::open(tmpPath.c_str(), O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW, S_IRUSR | S_IWUSR);
     if (fd < 0) {
         std::cerr << "[Attestation] Failed to open temp key file for writing: " << tmpPath

--- a/src/attestation/seed_attestation.cpp
+++ b/src/attestation/seed_attestation.cpp
@@ -17,6 +17,7 @@
 #ifdef _WIN32
 #include <winsock2.h>
 #include <ws2tcpip.h>
+#include <windows.h>   // LP-13 H-2: MoveFileExW for atomic key-file replace
 #pragma comment(lib, "ws2_32.lib")
 #else
 #include <sys/socket.h>
@@ -73,17 +74,35 @@ static std::string GetSeedKeyPassphrase() {
 
 // Restrict a key file to owner read/write only. POSIX: chmod 0600. Windows:
 // best-effort no-op (NTFS confines the per-user profile data dir; documented).
-static void RestrictKeyFilePerms(const std::string& path) {
+// Returns true if perms are owner-only after the call (Windows: always true).
+static bool RestrictKeyFilePerms(const std::string& path) {
 #ifndef _WIN32
-    // 0600 = owner rw, no group/other. Failure is logged but non-fatal: the
-    // secret is still written; an operator on an exotic FS can harden manually.
+    // 0600 = owner rw, no group/other. Failure is logged; the caller decides
+    // whether it is fatal (Save M-4 fail-closed) or merely a warning.
     if (chmod(path.c_str(), S_IRUSR | S_IWUSR) != 0) {
         std::cerr << "[Attestation] WARNING: could not chmod 0600 key file: " << path << std::endl;
+        return false;
     }
+    return true;
 #else
     (void)path;  // Windows: relies on NTFS ACL of the user profile data dir.
+    return true;
 #endif
 }
+
+// LP-13 M-3: on Load, report whether a pre-existing file is group/other-readable
+// (a legacy v1 file may have been written 0644 before this hardening landed).
+// POSIX only; Windows relies on the NTFS ACL of the profile dir.
+#ifndef _WIN32
+static bool KeyFileIsPermissive(const std::string& path) {
+    struct stat st;
+    if (stat(path.c_str(), &st) != 0) return false;  // can't tell; don't warn
+    return (st.st_mode & (S_IRWXG | S_IRWXO)) != 0;   // any group/other bit set
+}
+#endif
+
+// LP-13 H-2 atomic-save test seam (see header). nullptr in production.
+bool (*g_seedKeySaveFailpoint)() = nullptr;
 
 // ============================================================================
 // CSeedAttestationKey
@@ -99,6 +118,7 @@ void CSeedAttestationKey::Clear() {
     }
     m_privkey.clear();
     m_pubkey.clear();
+    m_loadedV1Plaintext = false;
 }
 
 bool CSeedAttestationKey::Generate() {
@@ -115,6 +135,22 @@ bool CSeedAttestationKey::Generate() {
 
 bool CSeedAttestationKey::Load(const std::string& dataDir) {
     std::string path = dataDir + "/" + SEED_KEY_FILENAME;
+    m_loadedV1Plaintext = false;
+
+    // LP-13 M-3: repair perms on a pre-existing key file BEFORE reading its
+    // secret bytes. A legacy v1 file may have been written world/group-readable
+    // (0644) prior to this hardening; chmod it back to 0600 and warn loudly so
+    // the operator knows the key was exposed at rest.
+#ifndef _WIN32
+    if (KeyFileIsPermissive(path)) {
+        std::cerr << "[Attestation] WARNING: key file " << path
+                  << " was group/other-readable; repairing to 0600. The consensus"
+                     " signing key may have been exposed — consider rotating it."
+                  << std::endl;
+        RestrictKeyFilePerms(path);
+    }
+#endif
+
     // Read the whole file up front so v2 length/format checks are robust against
     // truncation, and so we never leave a half-read secret in memory on error.
     std::ifstream file(path, std::ios::binary);
@@ -153,6 +189,7 @@ bool CSeedAttestationKey::Load(const std::string& dataDir) {
         m_privkey.assign(buf.begin() + off, buf.begin() + off + DFMP::MIK_PRIVKEY_SIZE);
         // Wipe the plaintext private key out of the read buffer.
         memory_cleanse(buf.data() + off, DFMP::MIK_PRIVKEY_SIZE);
+        m_loadedV1Plaintext = true;  // LP-13 H-1: provenance for require-encryption gate
         std::cout << "[Attestation] Loaded seed attestation key (v1 plaintext): "
                   << GetPubKeyHex().substr(0, 16) << "..." << std::endl;
         std::cerr << "[Attestation] NOTE: key file is unencrypted (v1). Set "
@@ -256,10 +293,20 @@ void CleanseSeedKeyBuffer(std::vector<uint8_t>& buf) {
     if (!buf.empty()) memory_cleanse(buf.data(), buf.size());
 }
 
-bool CSeedAttestationKey::Save(const std::string& dataDir) const {
+bool CSeedAttestationKey::Save(const std::string& dataDir, bool requireEncryption) const {
     if (!IsValid()) return false;
 
     std::string path = dataDir + "/" + SEED_KEY_FILENAME;
+
+    // LP-13 H-1: when the operator demands encryption-at-rest, refuse to write a
+    // v1 (plaintext) key. Fail loud so the misconfiguration is impossible to miss
+    // rather than silently persisting an unencrypted consensus signing key.
+    if (requireEncryption && GetSeedKeyPassphrase().empty()) {
+        std::cerr << "[Attestation] FATAL: --require-seed-key-encryption is set but "
+                  << SEED_KEY_PASSPHRASE_ENV << " is unset. Refusing to write an"
+                     " UNENCRYPTED (v1) seed consensus signing key." << std::endl;
+        return false;
+    }
 
     // LP-13: assemble the full serialized blob in memory first, then write it
     // in one shot. This lets us harden file permissions BEFORE any secret bytes
@@ -349,23 +396,30 @@ bool CSeedAttestationKey::Save(const std::string& dataDir) const {
         out.insert(out.end(), ciphertext.begin(), ciphertext.end());
     }
 
+    // LP-13 H-2: ATOMIC SAVE. Mirror the wallet's proven temp+fsync+rename
+    // pattern (CWallet::SaveUnlocked). A failed/partial write hits "<file>.tmp"
+    // only — the live "<file>" is left byte-intact and replaced ONLY by an
+    // atomic rename of a fully-written, fsync'd temp. A copy of the prior key is
+    // first staged at "<file>.bak" so even a botched rename has a fallback. A
+    // crash / partial write / full disk therefore can NEVER destroy the only
+    // copy of the consensus signing key.
+    std::string tmpPath = path + ".tmp";
+    std::string bakPath = path + ".bak";
+
 #ifndef _WIN32
-    // POSIX: create the file with 0600 from the outset (no world-readable
-    // window between create and chmod). open() honors the mode on creation.
-    int fd = ::open(path.c_str(), O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
+    // Create the temp with 0600 from the outset (no world-readable window).
+    int fd = ::open(tmpPath.c_str(), O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
     if (fd < 0) {
-        std::cerr << "[Attestation] Failed to open key file for writing: " << path << std::endl;
+        std::cerr << "[Attestation] Failed to open temp key file for writing: " << tmpPath << std::endl;
         return finish(false);
     }
-    // LP-13 LOW-2: O_TRUNC does NOT reset the mode of a PRE-EXISTING file, so a
-    // stale 0644 file would hold fresh secret bytes between ::write and the
-    // post-write chmod. fchmod the open fd to 0600 BEFORE writing any secret,
-    // closing that microsecond window (the open-with-mode above only covers the
-    // freshly-created case). Non-fatal on failure — the post-write re-assert below
-    // and the warning in RestrictKeyFilePerms still apply.
-    if (::fchmod(fd, S_IRUSR | S_IWUSR) != 0) {
-        std::cerr << "[Attestation] WARNING: fchmod 0600 on key file failed (errno "
-                  << errno << "); proceeding, will re-assert perms after write." << std::endl;
+    // LP-13 M-4: re-assert 0600 on the open fd. O_TRUNC does NOT reset the mode
+    // of a pre-existing temp. Track whether owner-only perms were established;
+    // if BOTH this and the post-write chmod fail we fail-closed below.
+    bool permOk = (::fchmod(fd, S_IRUSR | S_IWUSR) == 0);
+    if (!permOk) {
+        std::cerr << "[Attestation] WARNING: fchmod 0600 on temp key file failed (errno "
+                  << errno << "); will re-assert after write." << std::endl;
     }
     size_t written = 0;
     bool writeOk = true;
@@ -374,27 +428,132 @@ bool CSeedAttestationKey::Save(const std::string& dataDir) const {
         if (n <= 0) { writeOk = false; break; }
         written += static_cast<size_t>(n);
     }
+    // fsync the data to physical disk BEFORE the rename, so a power loss after
+    // rename cannot expose a zero-length/partial file as the live key.
+    if (writeOk && ::fsync(fd) != 0) {
+        std::cerr << "[Attestation] WARNING: fsync of temp key file failed (errno "
+                  << errno << ")" << std::endl;
+    }
     ::close(fd);
-    // Belt-and-braces: re-assert 0600 in case a pre-existing file kept old perms.
-    RestrictKeyFilePerms(path);
+
+    // Belt-and-braces: re-assert 0600 on the path in case fchmod was unsupported.
+    bool permOk2 = RestrictKeyFilePerms(tmpPath);
+
     if (!writeOk) {
-        std::cerr << "[Attestation] Key file write error" << std::endl;
+        std::cerr << "[Attestation] Key file write error (temp)" << std::endl;
+        ::unlink(tmpPath.c_str());
         return finish(false);
+    }
+    // LP-13 M-4 fail-closed: if owner-only perms could NOT be set by either
+    // mechanism, refuse to publish a possibly group/other-readable consensus key.
+    if (!permOk && !permOk2) {
+        std::cerr << "[Attestation] FATAL: could not set 0600 perms on key file; "
+                     "refusing to publish a possibly readable consensus key." << std::endl;
+        ::unlink(tmpPath.c_str());
+        return finish(false);
+    }
+
+    // H-2 test seam: simulate a crash between temp-write and rename.
+    if (g_seedKeySaveFailpoint && g_seedKeySaveFailpoint()) {
+        std::cerr << "[Attestation] (test) save failpoint fired before rename" << std::endl;
+        ::unlink(tmpPath.c_str());
+        return finish(false);
+    }
+
+    // Stage a .bak of the EXISTING key before we clobber it. Best-effort: if
+    // there is no prior file (first provision) there is nothing to back up.
+    {
+        std::ifstream src(path, std::ios::binary);
+        if (src.is_open()) {
+            std::vector<uint8_t> prior((std::istreambuf_iterator<char>(src)),
+                                        std::istreambuf_iterator<char>());
+            src.close();
+            int bfd = ::open(bakPath.c_str(), O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
+            if (bfd >= 0) {
+                size_t bw = 0; bool bok = true;
+                while (bw < prior.size()) {
+                    ssize_t n = ::write(bfd, prior.data() + bw, prior.size() - bw);
+                    if (n <= 0) { bok = false; break; }
+                    bw += static_cast<size_t>(n);
+                }
+                if (bok) ::fsync(bfd);
+                ::close(bfd);
+                if (!bok) std::cerr << "[Attestation] WARNING: failed to write key .bak" << std::endl;
+            }
+        }
+    }
+
+    // Atomic publish: rename(2) over the target is atomic on POSIX.
+    if (::rename(tmpPath.c_str(), path.c_str()) != 0) {
+        std::cerr << "[Attestation] Key file atomic rename failed (errno " << errno
+                  << "); original key left intact at " << path << std::endl;
+        ::unlink(tmpPath.c_str());
+        return finish(false);
+    }
+    RestrictKeyFilePerms(path);  // perms ride with rename, but re-assert defensively
+
+    // fsync the directory so the rename metadata is durable across power loss.
+    {
+        size_t lastSlash = path.find_last_of("/\\");
+        std::string parentDir = (lastSlash == std::string::npos) ? "." : path.substr(0, lastSlash);
+        if (parentDir.empty()) parentDir = ".";
+        int dirfd = ::open(parentDir.c_str(), O_RDONLY);
+        if (dirfd >= 0) { ::fsync(dirfd); ::close(dirfd); }
     }
 #else
-    std::ofstream file(path, std::ios::binary | std::ios::trunc);
-    if (!file.is_open()) {
-        std::cerr << "[Attestation] Failed to open key file for writing: " << path << std::endl;
+    // Windows: write temp, stage .bak, then MoveFileEx atomic replace.
+    {
+        std::ofstream tf(tmpPath, std::ios::binary | std::ios::trunc);
+        if (!tf.is_open()) {
+            std::cerr << "[Attestation] Failed to open temp key file for writing: " << tmpPath << std::endl;
+            return finish(false);
+        }
+        tf.write(reinterpret_cast<const char*>(out.data()), out.size());
+        bool writeOk = tf.good();
+        tf.flush();
+        tf.close();
+        if (!writeOk) {
+            std::cerr << "[Attestation] Key file write error (temp)" << std::endl;
+            std::remove(tmpPath.c_str());
+            return finish(false);
+        }
+    }
+
+    // H-2 test seam: simulate a crash between temp-write and rename.
+    if (g_seedKeySaveFailpoint && g_seedKeySaveFailpoint()) {
+        std::cerr << "[Attestation] (test) save failpoint fired before rename" << std::endl;
+        std::remove(tmpPath.c_str());
         return finish(false);
     }
-    file.write(reinterpret_cast<const char*>(out.data()), out.size());
-    bool writeOk = file.good();
-    file.close();
+
+    // Stage a .bak of the existing key (best-effort).
+    {
+        std::ifstream src(path, std::ios::binary);
+        if (src.is_open()) {
+            std::vector<uint8_t> prior((std::istreambuf_iterator<char>(src)),
+                                        std::istreambuf_iterator<char>());
+            src.close();
+            std::ofstream bf(bakPath, std::ios::binary | std::ios::trunc);
+            if (bf.is_open()) {
+                bf.write(reinterpret_cast<const char*>(prior.data()), prior.size());
+                if (!bf.good()) std::cerr << "[Attestation] WARNING: failed to write key .bak" << std::endl;
+                bf.close();
+            }
+        }
+    }
+
+    // Atomic publish via MoveFileExW (REPLACE_EXISTING | WRITE_THROUGH): either
+    // fully succeeds or fully fails — never a partial/corrupt live key file.
+    std::wstring wTmp(tmpPath.begin(), tmpPath.end());
+    std::wstring wDst(path.begin(), path.end());
+    if (!MoveFileExW(wTmp.c_str(), wDst.c_str(),
+                     MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)) {
+        std::cerr << "[Attestation] Key file atomic move failed; original key left intact at "
+                  << path << std::endl;
+        std::remove(tmpPath.c_str());
+        return finish(false);
+    }
     RestrictKeyFilePerms(path);  // best-effort no-op on Windows (NTFS ACL governs)
-    if (!writeOk) {
-        std::cerr << "[Attestation] Key file write error" << std::endl;
-        return finish(false);
-    }
 #endif
 
     std::cout << "[Attestation] Saved seed attestation key to: " << path
@@ -402,8 +561,20 @@ bool CSeedAttestationKey::Save(const std::string& dataDir) const {
     return finish(true);
 }
 
-bool CSeedAttestationKey::LoadOrGenerate(const std::string& dataDir, bool allowGenerate) {
+bool CSeedAttestationKey::LoadOrGenerate(const std::string& dataDir, bool allowGenerate,
+                                         bool requireEncryption) {
     if (Load(dataDir)) {
+        // LP-13 H-1: if encryption-at-rest is required but the key on disk is a
+        // v1 plaintext file, refuse to run on it. The operator must re-provision
+        // with the passphrase set (which re-saves it as v2 encrypted).
+        if (requireEncryption && LoadedPlaintext()) {
+            std::cerr << "[Attestation] FATAL: --require-seed-key-encryption is set but the"
+                         " on-disk key is UNENCRYPTED (v1). Set "
+                      << SEED_KEY_PASSPHRASE_ENV << " and re-provision to encrypt it at rest."
+                      << std::endl;
+            Clear();
+            return false;
+        }
         return true;
     }
 
@@ -428,9 +599,16 @@ bool CSeedAttestationKey::LoadOrGenerate(const std::string& dataDir, bool allowG
         return false;
     }
 
-    if (!Save(dataDir)) {
-        std::cerr << "[Attestation] WARNING: Generated key but failed to save to disk" << std::endl;
-        // Key is still valid in memory, so don't fail
+    // LP-13 M-2: a freshly minted key that cannot be PERSISTED is worthless — on
+    // the next restart the node would have a different (or no) key that does not
+    // match chainparams. Do NOT run on a non-persisted ephemeral key: fail loud.
+    if (!Save(dataDir, requireEncryption)) {
+        std::cerr << "[Attestation] FATAL: generated a new seed key but failed to save it"
+                     " to disk. Refusing to run on a non-persisted (ephemeral) consensus"
+                     " signing key — fix the data dir / perms / passphrase and retry."
+                  << std::endl;
+        Clear();
+        return false;
     }
 
     std::cout << "[Attestation] Generated new seed attestation key: " << GetPubKeyHex().substr(0, 16) << "..." << std::endl;

--- a/src/attestation/seed_attestation.cpp
+++ b/src/attestation/seed_attestation.cpp
@@ -7,6 +7,7 @@
 #include <wallet/crypter.h>  // For memory_cleanse() + CCrypter/DeriveKey (LP-13 encrypt-at-rest)
 
 #include <algorithm>
+#include <cerrno>
 #include <cstdlib>
 #include <cstring>
 #include <fstream>
@@ -247,6 +248,14 @@ bool CSeedAttestationKey::Load(const std::string& dataDir) {
     return false;
 }
 
+// LP-13 MEDIUM-1: zero a transient buffer that may hold the plaintext private
+// key on the v1 Save path. Exposed (declared in the header) so the test suite
+// can assert the wipe actually happens — deleting the memory_cleanse below is
+// the mutation the cleanse test is designed to catch.
+void CleanseSeedKeyBuffer(std::vector<uint8_t>& buf) {
+    if (!buf.empty()) memory_cleanse(buf.data(), buf.size());
+}
+
 bool CSeedAttestationKey::Save(const std::string& dataDir) const {
     if (!IsValid()) return false;
 
@@ -271,6 +280,18 @@ bool CSeedAttestationKey::Save(const std::string& dataDir) const {
     std::string passphrase = GetSeedKeyPassphrase();
     bool encrypt = !passphrase.empty();
 
+    // LP-13 MEDIUM-1: on the v1 (default, un-passphrased) path `out` holds the
+    // plaintext Dilithium3 private key; on the v2 path it holds only ciphertext.
+    // Cleanse `out` UNCONDITIONALLY before every return so the plaintext key is
+    // never left in freed heap (cleansing the non-secret v2 buffer is harmless).
+    // The actual wipe lives in CleanseSeedKeyBuffer (a test seam — see
+    // seed_attestation_key_tests.cpp); this lambda is the single exit gate for
+    // all returns past this point.
+    auto finish = [&out](bool ok) -> bool {
+        CleanseSeedKeyBuffer(out);
+        return ok;
+    };
+
     if (!encrypt) {
         // ---- Legacy v1 plaintext (no passphrase configured) ----
         out.push_back(KEY_FILE_VERSION_V1);
@@ -285,14 +306,14 @@ bool CSeedAttestationKey::Save(const std::string& dataDir) const {
         if (!GenerateSalt(salt) || !GenerateIV(iv)) {
             std::cerr << "[Attestation] ERROR: failed to generate salt/IV" << std::endl;
             memory_cleanse(&passphrase[0], passphrase.size());
-            return false;
+            return finish(false);
         }
 
         std::vector<uint8_t> aesKey;
         if (!DeriveKey(passphrase, salt, SEED_KEY_PBKDF2_ROUNDS, aesKey)) {
             std::cerr << "[Attestation] ERROR: key derivation failed" << std::endl;
             memory_cleanse(&passphrase[0], passphrase.size());
-            return false;
+            return finish(false);
         }
         memory_cleanse(&passphrase[0], passphrase.size());
 
@@ -300,15 +321,22 @@ bool CSeedAttestationKey::Save(const std::string& dataDir) const {
         if (!crypter.SetKey(aesKey, iv)) {
             std::cerr << "[Attestation] ERROR: failed to set encryption key" << std::endl;
             memory_cleanse(aesKey.data(), aesKey.size());
-            return false;
+            return finish(false);
         }
         memory_cleanse(aesKey.data(), aesKey.size());
 
+        // LP-13 LOW-1: ComputeMAC keys the HMAC with the SAME 32-byte AES key
+        // (no separate k_mac). This is a DELIBERATE reuse of the audited wallet
+        // CCrypter construction (encrypt-then-MAC, MAC verified BEFORE decrypt at
+        // Load → no padding-oracle surface), not an oversight. AES-256-CBC and
+        // HMAC-SHA3-512 are independent constructions with no known cross-protocol
+        // interaction under shared keying, so this is no weaker than the wallet's
+        // at-rest format. Documented here so it is not re-litigated in review.
         std::vector<uint8_t> ciphertext, mac;
         if (!crypter.Encrypt(m_privkey, ciphertext) ||
             !crypter.ComputeMAC(ciphertext, mac)) {
             std::cerr << "[Attestation] ERROR: encryption/MAC failed" << std::endl;
-            return false;
+            return finish(false);
         }
 
         // magic(4) version(1) pubkey(1952) salt(16) iv(16) mac(64) ctlen(4) ct
@@ -327,8 +355,17 @@ bool CSeedAttestationKey::Save(const std::string& dataDir) const {
     int fd = ::open(path.c_str(), O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
     if (fd < 0) {
         std::cerr << "[Attestation] Failed to open key file for writing: " << path << std::endl;
-        if (encrypt) memory_cleanse(out.data(), out.size());
-        return false;
+        return finish(false);
+    }
+    // LP-13 LOW-2: O_TRUNC does NOT reset the mode of a PRE-EXISTING file, so a
+    // stale 0644 file would hold fresh secret bytes between ::write and the
+    // post-write chmod. fchmod the open fd to 0600 BEFORE writing any secret,
+    // closing that microsecond window (the open-with-mode above only covers the
+    // freshly-created case). Non-fatal on failure — the post-write re-assert below
+    // and the warning in RestrictKeyFilePerms still apply.
+    if (::fchmod(fd, S_IRUSR | S_IWUSR) != 0) {
+        std::cerr << "[Attestation] WARNING: fchmod 0600 on key file failed (errno "
+                  << errno << "); proceeding, will re-assert perms after write." << std::endl;
     }
     size_t written = 0;
     bool writeOk = true;
@@ -342,13 +379,13 @@ bool CSeedAttestationKey::Save(const std::string& dataDir) const {
     RestrictKeyFilePerms(path);
     if (!writeOk) {
         std::cerr << "[Attestation] Key file write error" << std::endl;
-        return false;
+        return finish(false);
     }
 #else
     std::ofstream file(path, std::ios::binary | std::ios::trunc);
     if (!file.is_open()) {
         std::cerr << "[Attestation] Failed to open key file for writing: " << path << std::endl;
-        return false;
+        return finish(false);
     }
     file.write(reinterpret_cast<const char*>(out.data()), out.size());
     bool writeOk = file.good();
@@ -356,13 +393,13 @@ bool CSeedAttestationKey::Save(const std::string& dataDir) const {
     RestrictKeyFilePerms(path);  // best-effort no-op on Windows (NTFS ACL governs)
     if (!writeOk) {
         std::cerr << "[Attestation] Key file write error" << std::endl;
-        return false;
+        return finish(false);
     }
 #endif
 
     std::cout << "[Attestation] Saved seed attestation key to: " << path
               << (encrypt ? " (v2 encrypted)" : " (v1 plaintext)") << std::endl;
-    return true;
+    return finish(true);
 }
 
 bool CSeedAttestationKey::LoadOrGenerate(const std::string& dataDir, bool allowGenerate) {

--- a/src/attestation/seed_attestation.cpp
+++ b/src/attestation/seed_attestation.cpp
@@ -4,9 +4,10 @@
 #include <attestation/seed_attestation.h>
 #include <crypto/sha3.h>
 #include <util/strencodings.h>
-#include <wallet/crypter.h>  // For memory_cleanse()
+#include <wallet/crypter.h>  // For memory_cleanse() + CCrypter/DeriveKey (LP-13 encrypt-at-rest)
 
 #include <algorithm>
+#include <cstdlib>
 #include <cstring>
 #include <fstream>
 #include <iostream>
@@ -22,6 +23,8 @@
 #include <arpa/inet.h>
 #include <unistd.h>
 #include <netdb.h>
+#include <sys/stat.h>   // LP-13: chmod/fchmod for 0600 key file perms
+#include <fcntl.h>
 #endif
 
 // Dilithium3 reference implementation
@@ -41,7 +44,45 @@ namespace Attestation {
 
 // File format magic and version
 static constexpr uint32_t KEY_FILE_MAGIC = 0x444C4154;  // "DLAT" (Dilithion Attestation)
-static constexpr uint8_t KEY_FILE_VERSION = 1;
+// v1: plaintext private key (legacy — still readable for backward-compat migration)
+// v2 (LP-13): private key encrypted at rest (AES-256-CBC, PBKDF2-SHA3, encrypt-then-MAC)
+static constexpr uint8_t KEY_FILE_VERSION_V1 = 1;
+static constexpr uint8_t KEY_FILE_VERSION_V2 = 2;
+
+// LP-13 v2 on-disk sizes (bytes)
+static constexpr size_t SEED_KEY_SALT_SIZE = 16;  // PBKDF2 salt (== WALLET_CRYPTO_SALT_SIZE)
+static constexpr size_t SEED_KEY_IV_SIZE   = 16;  // AES-CBC IV     (== WALLET_CRYPTO_IV_SIZE)
+static constexpr size_t SEED_KEY_MAC_SIZE  = 64;  // HMAC-SHA3-512  (encrypt-then-MAC)
+
+// LP-13: PBKDF2 rounds for the seed-key passphrase. Reuse the wallet constant
+// for a single hardened KDF cost across the codebase.
+static constexpr unsigned int SEED_KEY_PBKDF2_ROUNDS = WALLET_CRYPTO_PBKDF2_ROUNDS;
+
+// ============================================================================
+// LP-13 helpers
+// ============================================================================
+
+// Read the operator passphrase from the environment. Empty => not configured
+// (Save falls back to legacy v1 plaintext; Load cannot decrypt a v2 file).
+static std::string GetSeedKeyPassphrase() {
+    const char* env = std::getenv(Attestation::SEED_KEY_PASSPHRASE_ENV);
+    if (env == nullptr) return std::string();
+    return std::string(env);
+}
+
+// Restrict a key file to owner read/write only. POSIX: chmod 0600. Windows:
+// best-effort no-op (NTFS confines the per-user profile data dir; documented).
+static void RestrictKeyFilePerms(const std::string& path) {
+#ifndef _WIN32
+    // 0600 = owner rw, no group/other. Failure is logged but non-fatal: the
+    // secret is still written; an operator on an exotic FS can harden manually.
+    if (chmod(path.c_str(), S_IRUSR | S_IWUSR) != 0) {
+        std::cerr << "[Attestation] WARNING: could not chmod 0600 key file: " << path << std::endl;
+    }
+#else
+    (void)path;  // Windows: relies on NTFS ACL of the user profile data dir.
+#endif
+}
 
 // ============================================================================
 // CSeedAttestationKey
@@ -73,84 +114,278 @@ bool CSeedAttestationKey::Generate() {
 
 bool CSeedAttestationKey::Load(const std::string& dataDir) {
     std::string path = dataDir + "/" + SEED_KEY_FILENAME;
+    // Read the whole file up front so v2 length/format checks are robust against
+    // truncation, and so we never leave a half-read secret in memory on error.
     std::ifstream file(path, std::ios::binary);
     if (!file.is_open()) {
         return false;
     }
+    std::vector<uint8_t> buf((std::istreambuf_iterator<char>(file)),
+                              std::istreambuf_iterator<char>());
+    file.close();
 
-    // Read and verify magic
+    // magic(4) + version(1) header
+    if (buf.size() < 5) {
+        std::cerr << "[Attestation] Key file too short" << std::endl;
+        return false;
+    }
+
     uint32_t magic = 0;
-    file.read(reinterpret_cast<char*>(&magic), 4);
+    std::memcpy(&magic, buf.data(), 4);
     if (magic != KEY_FILE_MAGIC) {
         std::cerr << "[Attestation] Invalid key file magic" << std::endl;
         return false;
     }
 
-    // Read and verify version
-    uint8_t version = 0;
-    file.read(reinterpret_cast<char*>(&version), 1);
-    if (version != KEY_FILE_VERSION) {
-        std::cerr << "[Attestation] Unsupported key file version: " << (int)version << std::endl;
-        return false;
+    uint8_t version = buf[4];
+    size_t off = 5;
+
+    if (version == KEY_FILE_VERSION_V1) {
+        // Legacy plaintext format (backward compat for un-migrated seeds):
+        //   magic(4) version(1) pubkey(1952) privkey(4032)
+        if (buf.size() < off + DFMP::MIK_PUBKEY_SIZE + DFMP::MIK_PRIVKEY_SIZE) {
+            std::cerr << "[Attestation] v1 key file truncated" << std::endl;
+            return false;
+        }
+        m_pubkey.assign(buf.begin() + off, buf.begin() + off + DFMP::MIK_PUBKEY_SIZE);
+        off += DFMP::MIK_PUBKEY_SIZE;
+        m_privkey.assign(buf.begin() + off, buf.begin() + off + DFMP::MIK_PRIVKEY_SIZE);
+        // Wipe the plaintext private key out of the read buffer.
+        memory_cleanse(buf.data() + off, DFMP::MIK_PRIVKEY_SIZE);
+        std::cout << "[Attestation] Loaded seed attestation key (v1 plaintext): "
+                  << GetPubKeyHex().substr(0, 16) << "..." << std::endl;
+        std::cerr << "[Attestation] NOTE: key file is unencrypted (v1). Set "
+                  << SEED_KEY_PASSPHRASE_ENV << " to re-save it encrypted (v2)." << std::endl;
+        return true;
     }
 
-    // Read public key
-    m_pubkey.resize(DFMP::MIK_PUBKEY_SIZE);
-    file.read(reinterpret_cast<char*>(m_pubkey.data()), DFMP::MIK_PUBKEY_SIZE);
+    if (version == KEY_FILE_VERSION_V2) {
+        // LP-13 encrypted format:
+        //   magic(4) version(1) pubkey(1952) salt(16) iv(16) mac(64)
+        //   ctlen(4 LE) ciphertext(ctlen)
+        size_t headerEnd = off + DFMP::MIK_PUBKEY_SIZE + SEED_KEY_SALT_SIZE +
+                           SEED_KEY_IV_SIZE + SEED_KEY_MAC_SIZE + 4;
+        if (buf.size() < headerEnd) {
+            std::cerr << "[Attestation] v2 key file truncated (header)" << std::endl;
+            return false;
+        }
 
-    // Read private key
-    m_privkey.resize(DFMP::MIK_PRIVKEY_SIZE);
-    file.read(reinterpret_cast<char*>(m_privkey.data()), DFMP::MIK_PRIVKEY_SIZE);
+        m_pubkey.assign(buf.begin() + off, buf.begin() + off + DFMP::MIK_PUBKEY_SIZE);
+        off += DFMP::MIK_PUBKEY_SIZE;
 
-    if (!file.good()) {
-        std::cerr << "[Attestation] Key file read error" << std::endl;
-        Clear();
-        return false;
+        std::vector<uint8_t> salt(buf.begin() + off, buf.begin() + off + SEED_KEY_SALT_SIZE);
+        off += SEED_KEY_SALT_SIZE;
+        std::vector<uint8_t> iv(buf.begin() + off, buf.begin() + off + SEED_KEY_IV_SIZE);
+        off += SEED_KEY_IV_SIZE;
+        std::vector<uint8_t> mac(buf.begin() + off, buf.begin() + off + SEED_KEY_MAC_SIZE);
+        off += SEED_KEY_MAC_SIZE;
+
+        uint32_t ctlen = static_cast<uint32_t>(buf[off]) |
+                         (static_cast<uint32_t>(buf[off + 1]) << 8) |
+                         (static_cast<uint32_t>(buf[off + 2]) << 16) |
+                         (static_cast<uint32_t>(buf[off + 3]) << 24);
+        off += 4;
+
+        if (buf.size() != off + ctlen || ctlen == 0 || (ctlen % 16) != 0) {
+            std::cerr << "[Attestation] v2 key file truncated or malformed ciphertext" << std::endl;
+            return false;
+        }
+        std::vector<uint8_t> ciphertext(buf.begin() + off, buf.begin() + off + ctlen);
+
+        std::string passphrase = GetSeedKeyPassphrase();
+        if (passphrase.empty()) {
+            std::cerr << "[Attestation] ERROR: key file is encrypted (v2) but "
+                      << SEED_KEY_PASSPHRASE_ENV << " is not set. Cannot decrypt." << std::endl;
+            Clear();
+            return false;
+        }
+
+        // Derive AES key from passphrase + salt, then encrypt-then-MAC verify.
+        std::vector<uint8_t> aesKey;
+        if (!DeriveKey(passphrase, salt, SEED_KEY_PBKDF2_ROUNDS, aesKey)) {
+            std::cerr << "[Attestation] ERROR: key derivation failed" << std::endl;
+            memory_cleanse(&passphrase[0], passphrase.size());
+            Clear();
+            return false;
+        }
+        memory_cleanse(&passphrase[0], passphrase.size());
+
+        CCrypter crypter;
+        if (!crypter.SetKey(aesKey, iv)) {
+            std::cerr << "[Attestation] ERROR: failed to set decryption key" << std::endl;
+            memory_cleanse(aesKey.data(), aesKey.size());
+            Clear();
+            return false;
+        }
+        memory_cleanse(aesKey.data(), aesKey.size());
+
+        // Verify MAC BEFORE decrypt (prevents padding-oracle / tamper). A wrong
+        // passphrase yields a different derived key => MAC mismatch => reject.
+        if (!crypter.VerifyMAC(ciphertext, mac)) {
+            std::cerr << "[Attestation] ERROR: key file MAC verification failed "
+                      << "(wrong passphrase or tampered/corrupt file)." << std::endl;
+            Clear();
+            return false;
+        }
+
+        std::vector<uint8_t> plain;
+        if (!crypter.Decrypt(ciphertext, plain) || plain.size() != DFMP::MIK_PRIVKEY_SIZE) {
+            std::cerr << "[Attestation] ERROR: key file decryption failed" << std::endl;
+            if (!plain.empty()) memory_cleanse(plain.data(), plain.size());
+            Clear();
+            return false;
+        }
+        m_privkey.assign(plain.begin(), plain.end());
+        memory_cleanse(plain.data(), plain.size());
+
+        std::cout << "[Attestation] Loaded seed attestation key (v2 encrypted): "
+                  << GetPubKeyHex().substr(0, 16) << "..." << std::endl;
+        return true;
     }
 
-    std::cout << "[Attestation] Loaded seed attestation key: " << GetPubKeyHex().substr(0, 16) << "..." << std::endl;
-    return true;
+    std::cerr << "[Attestation] Unsupported key file version: " << (int)version << std::endl;
+    return false;
 }
 
 bool CSeedAttestationKey::Save(const std::string& dataDir) const {
     if (!IsValid()) return false;
 
     std::string path = dataDir + "/" + SEED_KEY_FILENAME;
+
+    // LP-13: assemble the full serialized blob in memory first, then write it
+    // in one shot. This lets us harden file permissions BEFORE any secret bytes
+    // hit the disk (POSIX: create with 0600), avoiding a world-readable window.
+    std::vector<uint8_t> out;
+    auto putU32 = [&out](uint32_t v) {
+        out.push_back(static_cast<uint8_t>(v & 0xff));
+        out.push_back(static_cast<uint8_t>((v >> 8) & 0xff));
+        out.push_back(static_cast<uint8_t>((v >> 16) & 0xff));
+        out.push_back(static_cast<uint8_t>((v >> 24) & 0xff));
+    };
+
+    // magic(4, native order to match Load's memcpy) + version(1)
+    uint32_t magic = KEY_FILE_MAGIC;
+    const uint8_t* magicBytes = reinterpret_cast<const uint8_t*>(&magic);
+    out.insert(out.end(), magicBytes, magicBytes + 4);
+
+    std::string passphrase = GetSeedKeyPassphrase();
+    bool encrypt = !passphrase.empty();
+
+    if (!encrypt) {
+        // ---- Legacy v1 plaintext (no passphrase configured) ----
+        out.push_back(KEY_FILE_VERSION_V1);
+        out.insert(out.end(), m_pubkey.begin(), m_pubkey.end());
+        out.insert(out.end(), m_privkey.begin(), m_privkey.end());
+        std::cerr << "[Attestation] WARNING: " << SEED_KEY_PASSPHRASE_ENV
+                  << " not set — writing UNENCRYPTED (v1) key file. Set it to "
+                     "encrypt the consensus signing key at rest." << std::endl;
+    } else {
+        // ---- LP-13 v2 encrypted: AES-256-CBC, PBKDF2-SHA3, encrypt-then-MAC ----
+        std::vector<uint8_t> salt, iv;
+        if (!GenerateSalt(salt) || !GenerateIV(iv)) {
+            std::cerr << "[Attestation] ERROR: failed to generate salt/IV" << std::endl;
+            memory_cleanse(&passphrase[0], passphrase.size());
+            return false;
+        }
+
+        std::vector<uint8_t> aesKey;
+        if (!DeriveKey(passphrase, salt, SEED_KEY_PBKDF2_ROUNDS, aesKey)) {
+            std::cerr << "[Attestation] ERROR: key derivation failed" << std::endl;
+            memory_cleanse(&passphrase[0], passphrase.size());
+            return false;
+        }
+        memory_cleanse(&passphrase[0], passphrase.size());
+
+        CCrypter crypter;
+        if (!crypter.SetKey(aesKey, iv)) {
+            std::cerr << "[Attestation] ERROR: failed to set encryption key" << std::endl;
+            memory_cleanse(aesKey.data(), aesKey.size());
+            return false;
+        }
+        memory_cleanse(aesKey.data(), aesKey.size());
+
+        std::vector<uint8_t> ciphertext, mac;
+        if (!crypter.Encrypt(m_privkey, ciphertext) ||
+            !crypter.ComputeMAC(ciphertext, mac)) {
+            std::cerr << "[Attestation] ERROR: encryption/MAC failed" << std::endl;
+            return false;
+        }
+
+        // magic(4) version(1) pubkey(1952) salt(16) iv(16) mac(64) ctlen(4) ct
+        out.push_back(KEY_FILE_VERSION_V2);
+        out.insert(out.end(), m_pubkey.begin(), m_pubkey.end());
+        out.insert(out.end(), salt.begin(), salt.end());
+        out.insert(out.end(), iv.begin(), iv.end());
+        out.insert(out.end(), mac.begin(), mac.end());
+        putU32(static_cast<uint32_t>(ciphertext.size()));
+        out.insert(out.end(), ciphertext.begin(), ciphertext.end());
+    }
+
+#ifndef _WIN32
+    // POSIX: create the file with 0600 from the outset (no world-readable
+    // window between create and chmod). open() honors the mode on creation.
+    int fd = ::open(path.c_str(), O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
+    if (fd < 0) {
+        std::cerr << "[Attestation] Failed to open key file for writing: " << path << std::endl;
+        if (encrypt) memory_cleanse(out.data(), out.size());
+        return false;
+    }
+    size_t written = 0;
+    bool writeOk = true;
+    while (written < out.size()) {
+        ssize_t n = ::write(fd, out.data() + written, out.size() - written);
+        if (n <= 0) { writeOk = false; break; }
+        written += static_cast<size_t>(n);
+    }
+    ::close(fd);
+    // Belt-and-braces: re-assert 0600 in case a pre-existing file kept old perms.
+    RestrictKeyFilePerms(path);
+    if (!writeOk) {
+        std::cerr << "[Attestation] Key file write error" << std::endl;
+        return false;
+    }
+#else
     std::ofstream file(path, std::ios::binary | std::ios::trunc);
     if (!file.is_open()) {
         std::cerr << "[Attestation] Failed to open key file for writing: " << path << std::endl;
         return false;
     }
-
-    // Write magic
-    uint32_t magic = KEY_FILE_MAGIC;
-    file.write(reinterpret_cast<const char*>(&magic), 4);
-
-    // Write version
-    uint8_t version = KEY_FILE_VERSION;
-    file.write(reinterpret_cast<const char*>(&version), 1);
-
-    // Write public key
-    file.write(reinterpret_cast<const char*>(m_pubkey.data()), m_pubkey.size());
-
-    // Write private key
-    file.write(reinterpret_cast<const char*>(m_privkey.data()), m_privkey.size());
-
-    if (!file.good()) {
+    file.write(reinterpret_cast<const char*>(out.data()), out.size());
+    bool writeOk = file.good();
+    file.close();
+    RestrictKeyFilePerms(path);  // best-effort no-op on Windows (NTFS ACL governs)
+    if (!writeOk) {
         std::cerr << "[Attestation] Key file write error" << std::endl;
         return false;
     }
+#endif
 
-    std::cout << "[Attestation] Saved seed attestation key to: " << path << std::endl;
+    std::cout << "[Attestation] Saved seed attestation key to: " << path
+              << (encrypt ? " (v2 encrypted)" : " (v1 plaintext)") << std::endl;
     return true;
 }
 
-bool CSeedAttestationKey::LoadOrGenerate(const std::string& dataDir) {
+bool CSeedAttestationKey::LoadOrGenerate(const std::string& dataDir, bool allowGenerate) {
     if (Load(dataDir)) {
         return true;
     }
 
-    std::cout << "[Attestation] No existing attestation key found, generating new keypair..." << std::endl;
+    // LP-13: a missing/unreadable key file must NOT silently mint a fresh
+    // consensus signing key on a production seed. Auto-mint is gated behind the
+    // explicit --generate-seed-key operator flag (allowGenerate).
+    if (!allowGenerate) {
+        std::cerr << "[Attestation] FATAL: no usable seed attestation key at "
+                  << dataDir << "/" << SEED_KEY_FILENAME
+                  << " and --generate-seed-key was NOT given. Refusing to mint a"
+                     " new consensus signing key. If this is a first-time"
+                     " provision, restart with --generate-seed-key; if the key"
+                     " was expected to exist, investigate (wrong data dir,"
+                     " missing/encrypted file, or unset "
+                  << SEED_KEY_PASSPHRASE_ENV << ")." << std::endl;
+        return false;
+    }
+
+    std::cout << "[Attestation] No existing attestation key found, generating new keypair (--generate-seed-key)..." << std::endl;
     if (!Generate()) {
         std::cerr << "[Attestation] Failed to generate attestation keypair" << std::endl;
         return false;

--- a/src/attestation/seed_attestation.cpp
+++ b/src/attestation/seed_attestation.cpp
@@ -10,6 +10,7 @@
 #include <cerrno>
 #include <cstdlib>
 #include <cstring>
+#include <filesystem>  // LP-13 (extreview HIGH): presence test, not readability
 #include <fstream>
 #include <iostream>
 #include <sstream>
@@ -100,6 +101,16 @@ static bool KeyFileIsPermissive(const std::string& path) {
     return (st.st_mode & (S_IRWXG | S_IRWXO)) != 0;   // any group/other bit set
 }
 #endif
+
+// LP-13 (extreview HIGH): presence test (stat), not readability. See header.
+bool SeedKeyFilePresent(const std::string& dataDir) {
+    std::error_code ec;
+    bool present = std::filesystem::exists(dataDir + "/" + SEED_KEY_FILENAME, ec);
+    // A stat error (ec set) means we cannot prove ABSENCE; fail closed (report
+    // present) so an unstattable-but-genuine key still drives fail-loud startup.
+    if (ec) return true;
+    return present;
+}
 
 // LP-13 H-2 atomic-save test seam (see header). nullptr in production.
 bool (*g_seedKeySaveFailpoint)() = nullptr;

--- a/src/attestation/seed_attestation.cpp
+++ b/src/attestation/seed_attestation.cpp
@@ -340,6 +340,23 @@ bool CSeedAttestationKey::Save(const std::string& dataDir, bool requireEncryptio
     std::string passphrase = GetSeedKeyPassphrase();
     bool encrypt = !passphrase.empty();
 
+    // LP-13 (exception-safety fold, convergent across red-team + extreview grok/
+    // qwen3/nemotron): the finish() lambda below + the inline memory_cleanse calls
+    // only run on EXPLICIT returns. A std::bad_alloc thrown mid-assembly (e.g. an
+    // out.insert / DeriveKey allocation) would unwind PAST them, leaving the
+    // plaintext private key (v1 `out`) or the passphrase in freed heap. This RAII
+    // guard makes the wipe exception-safe: it cleanses both on EVERY scope exit,
+    // including a throw. (Double-cleansing already-zeroed bytes on the normal path
+    // is harmless.)
+    struct SecretScopeWipe {
+        std::vector<uint8_t>& buf;
+        std::string& pass;
+        ~SecretScopeWipe() {
+            CleanseSeedKeyBuffer(buf);
+            if (!pass.empty()) memory_cleanse(&pass[0], pass.size());
+        }
+    } secretScopeWipe{out, passphrase};
+
     // LP-13 MEDIUM-1: on the v1 (default, un-passphrased) path `out` holds the
     // plaintext Dilithium3 private key; on the v2 path it holds only ciphertext.
     // Cleanse `out` UNCONDITIONALLY before every return so the plaintext key is
@@ -425,9 +442,18 @@ bool CSeedAttestationKey::Save(const std::string& dataDir, bool requireEncryptio
 
 #ifndef _WIN32
     // Create the temp with 0600 from the outset (no world-readable window).
-    int fd = ::open(tmpPath.c_str(), O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
+    // LP-13 (symlink-hardening fold, nemotron extreview finding): O_NOFOLLOW
+    // refuses to open the temp if its final path component is a symlink — closing
+    // a symlink-swap vector where an attacker pre-plants "<file>.tmp" as a symlink
+    // to redirect the consensus key write or clobber an unintended file. (We do
+    // NOT add O_EXCL: a stale ".tmp" from a prior crashed save is legitimately
+    // re-truncated; O_EXCL would wedge the save. The seed datadir is operator-
+    // owned, so this is defense-in-depth, and it fails closed — a symlinked temp
+    // aborts Save with the canonical key left intact.)
+    int fd = ::open(tmpPath.c_str(), O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW, S_IRUSR | S_IWUSR);
     if (fd < 0) {
-        std::cerr << "[Attestation] Failed to open temp key file for writing: " << tmpPath << std::endl;
+        std::cerr << "[Attestation] Failed to open temp key file for writing: " << tmpPath
+                  << " (errno " << errno << "; O_NOFOLLOW rejects a symlinked temp)" << std::endl;
         return finish(false);
     }
     // LP-13 M-4: re-assert 0600 on the open fd. O_TRUNC does NOT reset the mode
@@ -505,7 +531,8 @@ bool CSeedAttestationKey::Save(const std::string& dataDir, bool requireEncryptio
             std::vector<uint8_t> prior((std::istreambuf_iterator<char>(src)),
                                         std::istreambuf_iterator<char>());
             src.close();
-            int bfd = ::open(bakPath.c_str(), O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
+            // LP-13 symlink-hardening (nemotron extreview): O_NOFOLLOW on the .bak too.
+            int bfd = ::open(bakPath.c_str(), O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW, S_IRUSR | S_IWUSR);
             if (bfd >= 0) {
                 size_t bw = 0; bool bok = true;
                 while (bw < prior.size()) {

--- a/src/attestation/seed_attestation.cpp
+++ b/src/attestation/seed_attestation.cpp
@@ -555,6 +555,10 @@ bool CSeedAttestationKey::Save(const std::string& dataDir, bool requireEncryptio
             std::vector<uint8_t> prior((std::istreambuf_iterator<char>(src)),
                                         std::istreambuf_iterator<char>());
             src.close();
+            // LP-13 L-2 (RAII, qwen3 extreview): wipe the prior key bytes (v1 plaintext
+            // private key for a v1 file) on EVERY scope exit incl. a throw, matching
+            // M-3/Save's exception-safe pattern (consistency over the manual cleanse).
+            struct PriorWipe { std::vector<uint8_t>& v; ~PriorWipe(){ if (!v.empty()) memory_cleanse(v.data(), v.size()); } } priorWipe{prior};
             // LP-13 symlink-hardening (nemotron extreview): O_NOFOLLOW on the .bak too.
             int bfd = ::open(bakPath.c_str(), O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW, S_IRUSR | S_IWUSR);
             if (bfd >= 0) {
@@ -579,9 +583,6 @@ bool CSeedAttestationKey::Save(const std::string& dataDir, bool requireEncryptio
                               << std::endl;
                 }
             }
-            // LP-13 L-2 (Cursor): `prior` holds the prior key file bytes (the v1
-            // plaintext private key for a v1 file); wipe before it leaves scope.
-            if (!prior.empty()) memory_cleanse(prior.data(), prior.size());
         }
     }
 
@@ -680,14 +681,14 @@ bool CSeedAttestationKey::Save(const std::string& dataDir, bool requireEncryptio
             std::vector<uint8_t> prior((std::istreambuf_iterator<char>(src)),
                                         std::istreambuf_iterator<char>());
             src.close();
+            // LP-13 L-2 (RAII, qwen3 extreview): wipe prior (v1 plaintext for a v1 file) on any exit incl. throw.
+            struct PriorWipe { std::vector<uint8_t>& v; ~PriorWipe(){ if (!v.empty()) memory_cleanse(v.data(), v.size()); } } priorWipe{prior};
             std::ofstream bf(bakPath, std::ios::binary | std::ios::trunc);
             if (bf.is_open()) {
                 bf.write(reinterpret_cast<const char*>(prior.data()), prior.size());
                 if (!bf.good()) std::cerr << "[Attestation] WARNING: failed to write key .bak" << std::endl;
                 bf.close();
             }
-            // LP-13 L-2 (Cursor): wipe the prior-key bytes (v1 plaintext for a v1 file).
-            if (!prior.empty()) memory_cleanse(prior.data(), prior.size());
         }
     }
 

--- a/src/attestation/seed_attestation.cpp
+++ b/src/attestation/seed_attestation.cpp
@@ -525,6 +525,7 @@ bool CSeedAttestationKey::Save(const std::string& dataDir, bool requireEncryptio
         std::cerr << "[Attestation] Key file atomic rename failed (errno " << errno
                   << "); original key left intact at " << path << std::endl;
         ::unlink(tmpPath.c_str());
+        ::unlink(bakPath.c_str());  // LOW-3: don't leave a stale (plaintext-for-v1) .bak copy
         return finish(false);
     }
     RestrictKeyFilePerms(path);  // perms ride with rename, but re-assert defensively
@@ -537,6 +538,13 @@ bool CSeedAttestationKey::Save(const std::string& dataDir, bool requireEncryptio
         int dirfd = ::open(parentDir.c_str(), O_RDONLY);
         if (dirfd >= 0) { ::fsync(dirfd); ::close(dirfd); }
     }
+
+    // LP-13 LOW-3: the .bak was a fallback for a botched rename. The publish
+    // succeeded, so it's now a stale copy of the OLD key — and for a v1
+    // (unencrypted) key it would be a second plaintext copy of the consensus
+    // signing key lingering at rest. Remove it. (rename atomicity already
+    // guarantees the no-key-loss property without a persisted .bak.)
+    ::unlink(bakPath.c_str());
 #else
     // Windows: write temp with a durable flush, stage .bak, then MoveFileEx
     // atomic replace.
@@ -625,9 +633,13 @@ bool CSeedAttestationKey::Save(const std::string& dataDir, bool requireEncryptio
         std::cerr << "[Attestation] Key file atomic move failed; original key left intact at "
                   << path << std::endl;
         std::remove(tmpPath.c_str());
+        std::remove(bakPath.c_str());  // LOW-3: don't leave a stale (plaintext-for-v1) .bak copy
         return finish(false);
     }
     RestrictKeyFilePerms(path);  // best-effort no-op on Windows (NTFS ACL governs)
+    // LP-13 LOW-3: publish succeeded — remove the now-stale .bak (a second copy
+    // of the OLD key; plaintext for a v1 key). See the POSIX path for rationale.
+    std::remove(bakPath.c_str());
 #endif
 
     std::cout << "[Attestation] Saved seed attestation key to: " << path

--- a/src/attestation/seed_attestation.cpp
+++ b/src/attestation/seed_attestation.cpp
@@ -103,6 +103,8 @@ static bool KeyFileIsPermissive(const std::string& path) {
 
 // LP-13 H-2 atomic-save test seam (see header). nullptr in production.
 bool (*g_seedKeySaveFailpoint)() = nullptr;
+// LP-13 B-1 fsync-failure test seam (see header). nullptr in production.
+bool (*g_seedKeyFsyncFailpoint)() = nullptr;
 
 // ============================================================================
 // CSeedAttestationKey
@@ -396,13 +398,17 @@ bool CSeedAttestationKey::Save(const std::string& dataDir, bool requireEncryptio
         out.insert(out.end(), ciphertext.begin(), ciphertext.end());
     }
 
-    // LP-13 H-2: ATOMIC SAVE. Mirror the wallet's proven temp+fsync+rename
-    // pattern (CWallet::SaveUnlocked). A failed/partial write hits "<file>.tmp"
-    // only — the live "<file>" is left byte-intact and replaced ONLY by an
-    // atomic rename of a fully-written, fsync'd temp. A copy of the prior key is
-    // first staged at "<file>.bak" so even a botched rename has a fallback. A
-    // crash / partial write / full disk therefore can NEVER destroy the only
-    // copy of the consensus signing key.
+    // LP-13 H-2 / B-1: ATOMIC, FAIL-CLOSED-DURABLE SAVE. Mirror the wallet's
+    // proven temp+fsync+rename pattern (CWallet::SaveUnlocked), but make the
+    // durability fatal: the consensus signing key is irreplaceable (not derivable
+    // from chainparams), so a failed/partial write hits "<file>.tmp" only — the
+    // live "<file>" is left byte-intact and replaced ONLY by an atomic rename of
+    // a fully-written, fsync'd temp; if the fsync (POSIX) / FlushFileBuffers
+    // (Windows) cannot be confirmed, Save deletes the temp and returns WITHOUT
+    // renaming. A copy of the prior key is first staged at "<file>.bak" so even a
+    // botched rename has a fallback. The guarantee that a crash / partial write /
+    // power loss cannot destroy the only copy rests on fsync-before-rename being
+    // fatal + the atomic rename + the post-rename dir-fsync below.
     std::string tmpPath = path + ".tmp";
     std::string bakPath = path + ".bak";
 
@@ -430,11 +436,31 @@ bool CSeedAttestationKey::Save(const std::string& dataDir, bool requireEncryptio
     }
     // fsync the data to physical disk BEFORE the rename, so a power loss after
     // rename cannot expose a zero-length/partial file as the live key.
-    if (writeOk && ::fsync(fd) != 0) {
-        std::cerr << "[Attestation] WARNING: fsync of temp key file failed (errno "
-                  << errno << ")" << std::endl;
+    // LP-13 B-1 (fail-closed durability): a failed fsync means the temp's bytes
+    // are NOT guaranteed on stable storage. The consensus signing key is NOT
+    // recoverable if lost (not derivable from chainparams), so — unlike
+    // wallet.cpp's warn-and-continue (the wallet is seed-recoverable) — we treat
+    // fsync failure as FATAL: close, remove the temp, and return WITHOUT
+    // renaming. The canonical "<file>" is left byte-intact rather than risk
+    // publishing un-flushed (possibly zero-length/partial) data as the live key.
+    bool fsyncOk = writeOk && (::fsync(fd) == 0);
+    if (writeOk && !fsyncOk) {
+        std::cerr << "[Attestation] FATAL: fsync of temp key file failed (errno "
+                  << errno << "); refusing to publish un-flushed consensus key. "
+                     "Canonical key at " << path << " left untouched." << std::endl;
+    }
+    // LP-13 B-1 TEST SEAM: let a test force the "fsync failed" branch without a
+    // real disk fault (checked here, mirroring g_seedKeySaveFailpoint). nullptr
+    // in production (no overhead, no behavior change).
+    if (writeOk && fsyncOk && g_seedKeyFsyncFailpoint && g_seedKeyFsyncFailpoint()) {
+        std::cerr << "[Attestation] (test) fsync failpoint fired — treating as FATAL fsync failure" << std::endl;
+        fsyncOk = false;
     }
     ::close(fd);
+    if (writeOk && !fsyncOk) {
+        ::unlink(tmpPath.c_str());
+        return finish(false);
+    }
 
     // Belt-and-braces: re-assert 0600 on the path in case fchmod was unsupported.
     bool permOk2 = RestrictKeyFilePerms(tmpPath);
@@ -476,9 +502,20 @@ bool CSeedAttestationKey::Save(const std::string& dataDir, bool requireEncryptio
                     if (n <= 0) { bok = false; break; }
                     bw += static_cast<size_t>(n);
                 }
-                if (bok) ::fsync(bfd);
+                // LP-13 B-1: surface a .bak fsync failure honestly rather than
+                // swallow it. NOT fatal — with fsync(tmp) now fatal above and the
+                // dir-fsync below, the NEW key is durable before Save returns; the
+                // .bak is belt-and-braces. But on an UPDATE save (a prior key
+                // existed) a non-durable fallback copy is worth logging clearly.
+                bool bsync = bok && (::fsync(bfd) == 0);
                 ::close(bfd);
-                if (!bok) std::cerr << "[Attestation] WARNING: failed to write key .bak" << std::endl;
+                if (!bok) {
+                    std::cerr << "[Attestation] WARNING: failed to write key .bak" << std::endl;
+                } else if (!bsync) {
+                    std::cerr << "[Attestation] WARNING: fsync of key .bak failed (errno "
+                              << errno << "); fallback copy may not be durable across power loss."
+                              << std::endl;
+                }
             }
         }
     }
@@ -501,19 +538,56 @@ bool CSeedAttestationKey::Save(const std::string& dataDir, bool requireEncryptio
         if (dirfd >= 0) { ::fsync(dirfd); ::close(dirfd); }
     }
 #else
-    // Windows: write temp, stage .bak, then MoveFileEx atomic replace.
+    // Windows: write temp with a durable flush, stage .bak, then MoveFileEx
+    // atomic replace.
+    //
+    // LP-13 B-1 (fail-closed durability, Windows): ofstream::flush()/close() only
+    // pushes bytes into the OS cache — NOT to stable storage. We must
+    // FlushFileBuffers() the temp BEFORE the MoveFileEx, matching the POSIX
+    // fsync-before-rename guarantee. If the durable flush cannot be confirmed we
+    // fail-closed (delete temp, leave canonical key untouched) rather than
+    // MoveFileEx un-flushed data over the irreplaceable consensus key.
     {
-        std::ofstream tf(tmpPath, std::ios::binary | std::ios::trunc);
-        if (!tf.is_open()) {
-            std::cerr << "[Attestation] Failed to open temp key file for writing: " << tmpPath << std::endl;
+        std::wstring wTmpW(tmpPath.begin(), tmpPath.end());
+        HANDLE hTmp = CreateFileW(wTmpW.c_str(), GENERIC_WRITE, 0, nullptr,
+                                  CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
+        if (hTmp == INVALID_HANDLE_VALUE) {
+            std::cerr << "[Attestation] Failed to open temp key file for writing: " << tmpPath
+                      << " (GetLastError " << GetLastError() << ")" << std::endl;
             return finish(false);
         }
-        tf.write(reinterpret_cast<const char*>(out.data()), out.size());
-        bool writeOk = tf.good();
-        tf.flush();
-        tf.close();
+        bool writeOk = true;
+        size_t written = 0;
+        while (written < out.size()) {
+            DWORD toWrite = static_cast<DWORD>(
+                std::min<size_t>(out.size() - written, 1u << 20));
+            DWORD wrote = 0;
+            if (!WriteFile(hTmp, out.data() + written, toWrite, &wrote, nullptr) || wrote == 0) {
+                writeOk = false;
+                break;
+            }
+            written += wrote;
+        }
+        // Durable flush to stable storage before the atomic replace.
+        bool flushOk = writeOk && (FlushFileBuffers(hTmp) != 0);
+        if (writeOk && !flushOk) {
+            std::cerr << "[Attestation] FATAL: FlushFileBuffers of temp key file failed "
+                         "(GetLastError " << GetLastError() << "); refusing to publish "
+                         "un-flushed consensus key. Canonical key at " << path
+                      << " left untouched." << std::endl;
+        }
+        // LP-13 B-1 TEST SEAM (Windows): force the "flush failed" branch.
+        if (writeOk && flushOk && g_seedKeyFsyncFailpoint && g_seedKeyFsyncFailpoint()) {
+            std::cerr << "[Attestation] (test) fsync failpoint fired — treating as FATAL flush failure" << std::endl;
+            flushOk = false;
+        }
+        CloseHandle(hTmp);
         if (!writeOk) {
             std::cerr << "[Attestation] Key file write error (temp)" << std::endl;
+            std::remove(tmpPath.c_str());
+            return finish(false);
+        }
+        if (!flushOk) {
             std::remove(tmpPath.c_str());
             return finish(false);
         }

--- a/src/attestation/seed_attestation.cpp
+++ b/src/attestation/seed_attestation.cpp
@@ -251,8 +251,23 @@ bool CSeedAttestationKey::Load(const std::string& dataDir) {
             return false;
         }
 
+        // LP-13 M-3 (Cursor): RAII exception-safe wipe of the v2 decrypt secrets —
+        // mirrors Save()'s SecretScopeWipe (Cursor flagged the asymmetry). passphrase
+        // / aesKey / plain are cleansed on EVERY exit from here including a thrown
+        // std::bad_alloc, not just the explicit returns below (which keep their
+        // earlier inline cleanses for minimal live-window hygiene; double-cleansing
+        // already-zeroed bytes is harmless).
+        std::vector<uint8_t> aesKey, plain;
+        struct LoadSecretWipe {
+            std::string& p; std::vector<uint8_t>& k; std::vector<uint8_t>& pl;
+            ~LoadSecretWipe() {
+                if (!p.empty()) memory_cleanse(&p[0], p.size());
+                if (!k.empty()) memory_cleanse(k.data(), k.size());
+                if (!pl.empty()) memory_cleanse(pl.data(), pl.size());
+            }
+        } loadSecretWipe{passphrase, aesKey, plain};
+
         // Derive AES key from passphrase + salt, then encrypt-then-MAC verify.
-        std::vector<uint8_t> aesKey;
         if (!DeriveKey(passphrase, salt, SEED_KEY_PBKDF2_ROUNDS, aesKey)) {
             std::cerr << "[Attestation] ERROR: key derivation failed" << std::endl;
             memory_cleanse(&passphrase[0], passphrase.size());
@@ -279,7 +294,6 @@ bool CSeedAttestationKey::Load(const std::string& dataDir) {
             return false;
         }
 
-        std::vector<uint8_t> plain;
         if (!crypter.Decrypt(ciphertext, plain) || plain.size() != DFMP::MIK_PRIVKEY_SIZE) {
             std::cerr << "[Attestation] ERROR: key file decryption failed" << std::endl;
             if (!plain.empty()) memory_cleanse(plain.data(), plain.size());
@@ -442,14 +456,24 @@ bool CSeedAttestationKey::Save(const std::string& dataDir, bool requireEncryptio
 
 #ifndef _WIN32
     // Create the temp with 0600 from the outset (no world-readable window).
-    // LP-13 (symlink-hardening fold, nemotron extreview finding): O_NOFOLLOW
-    // refuses to open the temp if its final path component is a symlink — closing
-    // a symlink-swap vector where an attacker pre-plants "<file>.tmp" as a symlink
-    // to redirect the consensus key write or clobber an unintended file. (We do
-    // NOT add O_EXCL: a stale ".tmp" from a prior crashed save is legitimately
-    // re-truncated; O_EXCL would wedge the save. The seed datadir is operator-
-    // owned, so this is defense-in-depth, and it fails closed — a symlinked temp
-    // aborts Save with the canonical key left intact.)
+    // LP-13 (PARTIAL symlink-hardening, nemotron extreview finding): O_NOFOLLOW
+    // refuses to open the temp if its final path component is ALREADY a symlink at
+    // open() time — closing the pre-open half of the symlink-swap vector (an
+    // attacker pre-planting "<file>.tmp" as a symlink to redirect the key write).
+    // We do NOT add O_EXCL: a stale ".tmp" from a prior crashed save is
+    // legitimately re-truncated; O_EXCL would wedge the save.
+    //
+    // SCOPE / KNOWN RESIDUAL (Cursor C-1, accepted out-of-scope): O_NOFOLLOW does
+    // NOT close the close()->rename() TOCTOU — between this fd being closed and the
+    // ::rename below, a writer in the data dir could swap "<file>.tmp" for a symlink
+    // and have rename publish that symlink over the canonical key. Closing that
+    // fully needs an O_TMPFILE+linkat (POSIX) / reparse-point (Windows) restructure.
+    // It is deliberately NOT done here: it defends only against an attacker who
+    // already has WRITE access to the seed's root-owned 0600/0700 data dir (i.e. is
+    // already root-equivalent and can destroy the key directly), and this atomic
+    // temp+rename mirrors the audited CWallet::SaveUnlocked, which carries the same
+    // accepted residual under the same operator-owned-datadir threat model. Tracked
+    // for follow-up in missions/seed-key-at-rest/FOLLOWUPS.md; not a #113 blocker.
     int fd = ::open(tmpPath.c_str(), O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW, S_IRUSR | S_IWUSR);
     if (fd < 0) {
         std::cerr << "[Attestation] Failed to open temp key file for writing: " << tmpPath
@@ -555,6 +579,9 @@ bool CSeedAttestationKey::Save(const std::string& dataDir, bool requireEncryptio
                               << std::endl;
                 }
             }
+            // LP-13 L-2 (Cursor): `prior` holds the prior key file bytes (the v1
+            // plaintext private key for a v1 file); wipe before it leaves scope.
+            if (!prior.empty()) memory_cleanse(prior.data(), prior.size());
         }
     }
 
@@ -659,6 +686,8 @@ bool CSeedAttestationKey::Save(const std::string& dataDir, bool requireEncryptio
                 if (!bf.good()) std::cerr << "[Attestation] WARNING: failed to write key .bak" << std::endl;
                 bf.close();
             }
+            // LP-13 L-2 (Cursor): wipe the prior-key bytes (v1 plaintext for a v1 file).
+            if (!prior.empty()) memory_cleanse(prior.data(), prior.size());
         }
     }
 

--- a/src/attestation/seed_attestation.h
+++ b/src/attestation/seed_attestation.h
@@ -79,6 +79,11 @@ constexpr const char* SEED_KEY_PASSPHRASE_ENV = "DILITHION_SEED_KEY_PASSPHRASE";
 // SEED ATTESTATION KEY
 // ============================================================================
 
+/** LP-13: securely zero a transient buffer that may hold plaintext key bytes
+ *  (used by CSeedAttestationKey::Save on every exit path). Declared here so the
+ *  test suite can verify the wipe; not intended for general use. */
+void CleanseSeedKeyBuffer(std::vector<uint8_t>& buf);
+
 /**
  * Seed node's Dilithium3 keypair for signing attestations.
  *

--- a/src/attestation/seed_attestation.h
+++ b/src/attestation/seed_attestation.h
@@ -84,6 +84,17 @@ constexpr const char* SEED_KEY_PASSPHRASE_ENV = "DILITHION_SEED_KEY_PASSPHRASE";
  *  test suite can verify the wipe; not intended for general use. */
 void CleanseSeedKeyBuffer(std::vector<uint8_t>& buf);
 
+/** LP-13 (extreview HIGH): true if the seed attestation key FILE is present in
+ *  dataDir, testing PRESENCE (stat) — NOT readability. The earlier node glue
+ *  used std::ifstream::good(), which returns false for a present-but-UNREADABLE
+ *  key, misclassifying a genuine key as absent and letting the node run WITHOUT
+ *  attestation (defeating the M-1 fail-loud guarantee). std::filesystem::exists()
+ *  stats the path, so a present-but-unreadable file still reports present.
+ *  Fail-closed: an indeterminate stat (e.g. EACCES traversing dataDir) also
+ *  reports present, so an unstattable-but-genuine key still drives fail-loud
+ *  startup. Both node binaries call this to classify a LoadOrGenerate failure. */
+bool SeedKeyFilePresent(const std::string& dataDir);
+
 /** LP-13 H-2 (atomic-save) TEST SEAM. When set to a non-null function, Save()
  *  invokes it immediately after the temp file has been fully written + fsynced
  *  but BEFORE the atomic rename over the target. If the hook returns true, Save

--- a/src/attestation/seed_attestation.h
+++ b/src/attestation/seed_attestation.h
@@ -69,6 +69,12 @@ constexpr size_t ATTESTATION_ENTRY_SIZE = 1 + 4 + DFMP::MIK_SIGNATURE_SIZE;
 /** Seed attestation key file name (stored in data directory) */
 constexpr const char* SEED_KEY_FILENAME = "seed_attestation_key.dat";
 
+/** LP-13: Env var supplying the operator passphrase used to encrypt the seed
+ *  attestation private key at rest. When set, Save() writes the v2 encrypted
+ *  format and Load() requires it to decrypt v2 files. When unset, the legacy
+ *  v1 plaintext format is used (backward compatible). NEVER hardcode a value. */
+constexpr const char* SEED_KEY_PASSPHRASE_ENV = "DILITHION_SEED_KEY_PASSPHRASE";
+
 // ============================================================================
 // SEED ATTESTATION KEY
 // ============================================================================
@@ -103,6 +109,14 @@ public:
 
     /**
      * Save keypair to file in data directory.
+     *
+     * LP-13: The file is written with owner-only permissions (POSIX 0600;
+     * Windows best-effort — NTFS already confines the user profile dir).
+     * If the env var DILITHION_SEED_KEY_PASSPHRASE is set, the private key is
+     * encrypted at rest (AES-256-CBC, PBKDF2-SHA3, encrypt-then-MAC) in the v2
+     * file format. If absent, the legacy v1 plaintext format is written so
+     * existing un-passphrased operators are not silently broken.
+     *
      * @param dataDir Path to data directory
      * @return true on success
      */
@@ -110,10 +124,18 @@ public:
 
     /**
      * Load or generate: tries Load first, generates + saves if not found.
+     *
+     * LP-13: Auto-minting a fresh consensus key is gated behind allowGenerate.
+     * On a production seed a missing key file with allowGenerate=false FAILS
+     * LOUD (returns false) instead of silently minting an unrecognized key.
+     *
      * @param dataDir Path to data directory
+     * @param allowGenerate If false and no key file exists, fail loudly instead
+     *        of generating a new keypair. Set true via the --generate-seed-key
+     *        operator flag for first-time key provisioning.
      * @return true on success
      */
-    bool LoadOrGenerate(const std::string& dataDir);
+    bool LoadOrGenerate(const std::string& dataDir, bool allowGenerate = false);
 
     /**
      * Sign an attestation message.

--- a/src/attestation/seed_attestation.h
+++ b/src/attestation/seed_attestation.h
@@ -92,6 +92,16 @@ void CleanseSeedKeyBuffer(std::vector<uint8_t>& buf);
  *  production (no overhead, no behavior change). Not for general use. */
 extern bool (*g_seedKeySaveFailpoint)();
 
+/** LP-13 B-1 (fail-closed durability) TEST SEAM. When set to a non-null
+ *  function, Save() invokes it right after the temp file's fsync (POSIX) /
+ *  FlushFileBuffers (Windows) reports success. If the hook returns true, Save
+ *  treats it as a FATAL fsync/flush failure: it removes the temp and returns
+ *  false WITHOUT renaming, leaving the canonical key byte-intact — exactly the
+ *  power-loss-before-durable case. Lets the load-bearing B-1 test exercise that
+ *  branch without a real disk fault. nullptr in production (no overhead, no
+ *  behavior change). Not for general use. */
+extern bool (*g_seedKeyFsyncFailpoint)();
+
 /**
  * Seed node's Dilithium3 keypair for signing attestations.
  *
@@ -130,10 +140,18 @@ public:
      * file format. If absent, the legacy v1 plaintext format is written so
      * existing un-passphrased operators are not silently broken.
      *
-     * LP-13 H-2: the write is ATOMIC — the blob is written to "<file>.tmp",
-     * fsync'd, the prior key (if any) is copied to "<file>.bak", then the temp
-     * is atomically renamed over the target. A crash / partial write / full disk
-     * therefore can NEVER destroy the only copy of the consensus signing key.
+     * LP-13 H-2 / B-1: the write is ATOMIC and fail-closed-durable — the blob is
+     * written to "<file>.tmp", the prior key (if any) is copied to "<file>.bak",
+     * then the temp is atomically renamed over the target. The durability
+     * guarantee — that a crash / partial write / power loss cannot destroy the
+     * only copy of the consensus signing key — rests on THREE properties, not an
+     * absolute claim: (1) the temp's fsync (POSIX) / FlushFileBuffers (Windows)
+     * is FATAL — on failure Save removes the temp and returns false WITHOUT
+     * renaming, so un-flushed data is never published over the live key; (2) the
+     * publish is an atomic rename(2) / MoveFileExW replace; (3) the parent
+     * directory is fsync'd after the rename so the rename metadata is durable.
+     * If any of these cannot be confirmed, Save fails-closed and the canonical
+     * key is left byte-intact.
      *
      * LP-13 M-4: if BOTH the create-time mode and the post-write chmod fail to
      * set 0600 (POSIX), Save REFUSES to publish a possibly group/other-readable

--- a/src/attestation/seed_attestation.h
+++ b/src/attestation/seed_attestation.h
@@ -84,6 +84,14 @@ constexpr const char* SEED_KEY_PASSPHRASE_ENV = "DILITHION_SEED_KEY_PASSPHRASE";
  *  test suite can verify the wipe; not intended for general use. */
 void CleanseSeedKeyBuffer(std::vector<uint8_t>& buf);
 
+/** LP-13 H-2 (atomic-save) TEST SEAM. When set to a non-null function, Save()
+ *  invokes it immediately after the temp file has been fully written + fsynced
+ *  but BEFORE the atomic rename over the target. If the hook returns true, Save
+ *  aborts as if the rename leg failed (returns false, removes the temp file) so
+ *  the test can assert the ORIGINAL key file survived byte-intact. nullptr in
+ *  production (no overhead, no behavior change). Not for general use. */
+extern bool (*g_seedKeySaveFailpoint)();
+
 /**
  * Seed node's Dilithium3 keypair for signing attestations.
  *
@@ -122,10 +130,23 @@ public:
      * file format. If absent, the legacy v1 plaintext format is written so
      * existing un-passphrased operators are not silently broken.
      *
+     * LP-13 H-2: the write is ATOMIC — the blob is written to "<file>.tmp",
+     * fsync'd, the prior key (if any) is copied to "<file>.bak", then the temp
+     * is atomically renamed over the target. A crash / partial write / full disk
+     * therefore can NEVER destroy the only copy of the consensus signing key.
+     *
+     * LP-13 M-4: if BOTH the create-time mode and the post-write chmod fail to
+     * set 0600 (POSIX), Save REFUSES to publish a possibly group/other-readable
+     * consensus key (fail-closed) and returns false.
+     *
+     * LP-13 H-1: when requireEncryption is true, Save REFUSES to write a v1
+     * (plaintext) key — the passphrase env MUST be set or Save fails loud.
+     *
      * @param dataDir Path to data directory
+     * @param requireEncryption If true, refuse to write a plaintext (v1) key.
      * @return true on success
      */
-    bool Save(const std::string& dataDir) const;
+    bool Save(const std::string& dataDir, bool requireEncryption = false) const;
 
     /**
      * Load or generate: tries Load first, generates + saves if not found.
@@ -134,13 +155,25 @@ public:
      * On a production seed a missing key file with allowGenerate=false FAILS
      * LOUD (returns false) instead of silently minting an unrecognized key.
      *
+     * LP-13 M-2: if a fresh key is generated but cannot be PERSISTED, this
+     * returns false. The node must never run on an in-memory-only key that
+     * would not match chainparams after a restart.
+     *
+     * LP-13 H-1: when requireEncryption is true, a loaded v1 (plaintext) key is
+     * REJECTED (returns false) and a generated key is only saved encrypted —
+     * enforcing encryption-at-rest end to end.
+     *
      * @param dataDir Path to data directory
      * @param allowGenerate If false and no key file exists, fail loudly instead
      *        of generating a new keypair. Set true via the --generate-seed-key
      *        operator flag for first-time key provisioning.
+     * @param requireEncryption If true, refuse to load/save a plaintext (v1)
+     *        key (--require-seed-key-encryption). Default false preserves the
+     *        backward-compatible loadable behavior.
      * @return true on success
      */
-    bool LoadOrGenerate(const std::string& dataDir, bool allowGenerate = false);
+    bool LoadOrGenerate(const std::string& dataDir, bool allowGenerate = false,
+                        bool requireEncryption = false);
 
     /**
      * Sign an attestation message.
@@ -160,9 +193,15 @@ public:
     /** Get public key as hex string (for display/logging) */
     std::string GetPubKeyHex() const;
 
+    /** LP-13 H-1: true if the key currently in memory was loaded from a v1
+     *  (plaintext) on-disk file. Lets the node enforce
+     *  --require-seed-key-encryption end to end. */
+    bool LoadedPlaintext() const { return m_loadedV1Plaintext; }
+
 private:
     std::vector<uint8_t> m_pubkey;   // 1952 bytes
     std::vector<uint8_t> m_privkey;  // 4032 bytes (should use SecureAllocator in production)
+    bool m_loadedV1Plaintext = false;  // LP-13 H-1: provenance of the in-memory key
 
     void Clear();
 };

--- a/src/attestation/seed_attestation.h
+++ b/src/attestation/seed_attestation.h
@@ -142,16 +142,21 @@ public:
      *
      * LP-13 H-2 / B-1: the write is ATOMIC and fail-closed-durable — the blob is
      * written to "<file>.tmp", the prior key (if any) is copied to "<file>.bak",
-     * then the temp is atomically renamed over the target. The durability
-     * guarantee — that a crash / partial write / power loss cannot destroy the
-     * only copy of the consensus signing key — rests on THREE properties, not an
-     * absolute claim: (1) the temp's fsync (POSIX) / FlushFileBuffers (Windows)
-     * is FATAL — on failure Save removes the temp and returns false WITHOUT
-     * renaming, so un-flushed data is never published over the live key; (2) the
-     * publish is an atomic rename(2) / MoveFileExW replace; (3) the parent
-     * directory is fsync'd after the rename so the rename metadata is durable.
-     * If any of these cannot be confirmed, Save fails-closed and the canonical
-     * key is left byte-intact.
+     * then the temp is atomically renamed over the target and the "<file>.bak"
+     * is removed on success. The guarantee that a crash / partial write / power
+     * loss cannot destroy the only copy of the consensus signing key rests on TWO
+     * fail-closed properties: (1) the temp's fsync (POSIX) / FlushFileBuffers
+     * (Windows) is FATAL — on failure Save removes the temp and returns false
+     * WITHOUT renaming, so un-flushed data is never published over the live key;
+     * (2) the publish is an atomic rename(2) / MoveFileExW(MOVEFILE_WRITE_THROUGH)
+     * replace, so an observer (and a post-crash reader) sees either the old key or
+     * the fully-flushed new key, never a partial/absent file. After the rename the
+     * POSIX path also fsync's the parent directory to make the rename metadata
+     * durable sooner; that step is best-effort (its failure is logged, not fatal)
+     * and is NOT load-bearing for the no-key-loss guarantee — rename atomicity
+     * already bounds the worst case to "old key still on disk." (Windows relies on
+     * MOVEFILE_WRITE_THROUGH for the same metadata durability; there is no
+     * directory-fsync on that path.)
      *
      * LP-13 M-4: if BOTH the create-time mode and the post-write chmod fail to
      * set 0600 (POSIX), Save REFUSES to publish a possibly group/other-readable

--- a/src/node/dilithion-node.cpp
+++ b/src/node/dilithion-node.cpp
@@ -7009,8 +7009,18 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
             // relay simply doesn't attest.
             bool keyFileExists = false;
             {
-                std::ifstream kf(dataDir + "/" + Attestation::SEED_KEY_FILENAME, std::ios::binary);
-                keyFileExists = kf.good();
+                // LP-13 (extreview HIGH): test PRESENCE, not readability. An
+                // ifstream::good() on a present-but-UNREADABLE key returns false,
+                // misclassifying a genuine key as absent and letting the node run
+                // WITHOUT attestation silently — defeating the M-1 fail-loud
+                // guarantee. std::filesystem::exists() stats the path, so a
+                // present-but-unreadable file still reports as existing.
+                std::error_code ec;
+                keyFileExists = std::filesystem::exists(
+                    dataDir + "/" + Attestation::SEED_KEY_FILENAME, ec);
+                // A stat error (ec set) means we cannot prove ABSENCE; fail closed
+                // (treat as present) so an unstattable-but-genuine key still aborts.
+                if (ec) keyFileExists = true;
             }
             bool attestOk = seedAttestKey.LoadOrGenerate(
                 dataDir, config.generate_seed_key, config.require_seed_key_encryption);

--- a/src/node/dilithion-node.cpp
+++ b/src/node/dilithion-node.cpp
@@ -7007,21 +7007,10 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
             // The ONLY benign (non-fatal) case is: NO key file, no
             // --generate-seed-key, AND no --require-seed-key-encryption — the
             // relay simply doesn't attest.
-            bool keyFileExists = false;
-            {
-                // LP-13 (extreview HIGH): test PRESENCE, not readability. An
-                // ifstream::good() on a present-but-UNREADABLE key returns false,
-                // misclassifying a genuine key as absent and letting the node run
-                // WITHOUT attestation silently — defeating the M-1 fail-loud
-                // guarantee. std::filesystem::exists() stats the path, so a
-                // present-but-unreadable file still reports as existing.
-                std::error_code ec;
-                keyFileExists = std::filesystem::exists(
-                    dataDir + "/" + Attestation::SEED_KEY_FILENAME, ec);
-                // A stat error (ec set) means we cannot prove ABSENCE; fail closed
-                // (treat as present) so an unstattable-but-genuine key still aborts.
-                if (ec) keyFileExists = true;
-            }
+            // LP-13 (extreview HIGH): PRESENCE test (stat), not ifstream::good()
+            // readability — a present-but-unreadable key must still be treated as
+            // present so genuineFailure fires (fail loud, M-1). See SeedKeyFilePresent.
+            bool keyFileExists = Attestation::SeedKeyFilePresent(dataDir);
             bool attestOk = seedAttestKey.LoadOrGenerate(
                 dataDir, config.generate_seed_key, config.require_seed_key_encryption);
             if (!attestOk) {

--- a/src/node/dilithion-node.cpp
+++ b/src/node/dilithion-node.cpp
@@ -565,6 +565,7 @@ struct NodeConfig {
     bool upnp_prompted = false;     // True if user was already prompted or used explicit flag
     std::string external_ip = "";   // --externalip: Manual external IP (for manual port forwarding)
     bool public_api = false;        // --public-api: Enable public REST API for light wallets (seed nodes only)
+    bool generate_seed_key = false; // --generate-seed-key: LP-13 — explicitly permit minting a NEW seed attestation consensus key when none exists (first-time provision only; otherwise fail loud)
     int max_connections = 0;         // --maxconnections: Maximum peer connections (0 = default 125)
     int max_connections_per_ip = 2;  // --max-connections-per-ip: Max inbound per IP (default 2, range 1-64)
     int attestation_rate_limit = 1;  // --attestation-rate-limit: Max attestations per /24 subnet per day
@@ -759,6 +760,12 @@ struct NodeConfig {
                 // Public REST API: bind to 0.0.0.0 for light wallet access (seed nodes only)
                 public_api = true;
             }
+            else if (arg == "--generate-seed-key") {
+                // LP-13: explicit opt-in to mint a NEW seed attestation consensus
+                // key if none exists. Without this flag a missing key fails loud
+                // instead of silently minting an unrecognized signing key.
+                generate_seed_key = true;
+            }
             else if (arg.find("--rpcallowhost=") == 0) {
                 // wallet-rpc-login-restore: add an allowed Host header to the
                 // anti-DNS-rebinding allowlist. Repeatable. Loopback
@@ -885,6 +892,9 @@ struct NodeConfig {
         std::cout << "                          Add --yes to skip the confirmation prompt." << std::endl;
         std::cout << "  --relay-only          Relay-only mode: skip wallet (for seed nodes)" << std::endl;
         std::cout << "  --public-api          Enable public REST API for light wallets (seed nodes)" << std::endl;
+        std::cout << "  --generate-seed-key   Permit minting a NEW seed attestation key if none exists" << std::endl;
+        std::cout << "                          (first-time provision only; otherwise the node fails loud)." << std::endl;
+        std::cout << "                          Set " << Attestation::SEED_KEY_PASSPHRASE_ENV << " to encrypt it at rest." << std::endl;
         std::cout << "  --rpcallowhost=<host> Allow this Host header on the RPC/HTTP server" << std::endl;
         std::cout << "                          (anti-DNS-rebinding allowlist; repeatable)." << std::endl;
         std::cout << "                          Loopback (127.0.0.1/::1/localhost) is always" << std::endl;
@@ -6957,8 +6967,9 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                           << " datacenter ASNs)" << std::endl;
             }
 
-            // Load or generate attestation key
-            if (seedAttestKey.LoadOrGenerate(dataDir)) {
+            // Load or generate attestation key (LP-13: minting gated behind
+            // --generate-seed-key so a reprovisioned seed fails loud).
+            if (seedAttestKey.LoadOrGenerate(dataDir, config.generate_seed_key)) {
                 int seedId = -1;
                 const auto& seedIPs = Dilithion::g_chainParams->seedAttestationIPs;
                 if (!config.external_ip.empty()) {

--- a/src/node/dilithion-node.cpp
+++ b/src/node/dilithion-node.cpp
@@ -6982,12 +6982,17 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
             // --generate-seed-key so a reprovisioned seed fails loud).
             //
             // LP-13 M-1 (fail-stop on GENUINE failure): a key file PRESENT but
-            // unusable (corrupt / wrong-or-missing passphrase / 0600-repair
-            // failure / plaintext-when-encryption-required), OR a requested mint
-            // that could not be persisted, is a real attestation outage. On a
-            // seed-capable node we ABORT startup rather than run silently without
-            // attestation. The benign case — a non-seed relay with NO key file
-            // and no --generate-seed-key — is NOT fatal (it just doesn't attest).
+            // unusable (corrupt / decrypt-or-parse failure / wrong-or-missing
+            // passphrase / plaintext-when-encryption-required), OR a requested
+            // mint that could not be persisted, is a real attestation outage. On
+            // a seed-capable node we ABORT startup rather than run silently
+            // without attestation. genuineFailure also fires when
+            // --require-seed-key-encryption is set even with NO key file present:
+            // fail-closed is intended — an operator who demanded at-rest
+            // encryption must not be left running with no usable encrypted key.
+            // The ONLY benign (non-fatal) case is: NO key file, no
+            // --generate-seed-key, AND no --require-seed-key-encryption — the
+            // relay simply doesn't attest.
             bool keyFileExists = false;
             {
                 std::ifstream kf(dataDir + "/" + Attestation::SEED_KEY_FILENAME, std::ios::binary);
@@ -7000,8 +7005,10 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                                       || config.require_seed_key_encryption;
                 if (genuineFailure) {
                     std::cerr << "[Attestation] FATAL: seed attestation key initialization FAILED "
-                                 "(corrupt key, wrong/missing " << Attestation::SEED_KEY_PASSPHRASE_ENV
-                              << ", permission repair failure, or save failure). A seed must not run "
+                                 "(key file present but unreadable/corrupt, decrypt/parse failure, "
+                                 "wrong/missing " << Attestation::SEED_KEY_PASSPHRASE_ENV
+                              << ", plaintext key when --require-seed-key-encryption is set, or a "
+                                 "requested mint that could not be persisted). A seed must not run "
                                  "without a usable consensus signing key. Aborting startup." << std::endl;
                     return 1;
                 }

--- a/src/node/dilithion-node.cpp
+++ b/src/node/dilithion-node.cpp
@@ -566,6 +566,7 @@ struct NodeConfig {
     std::string external_ip = "";   // --externalip: Manual external IP (for manual port forwarding)
     bool public_api = false;        // --public-api: Enable public REST API for light wallets (seed nodes only)
     bool generate_seed_key = false; // --generate-seed-key: LP-13 — explicitly permit minting a NEW seed attestation consensus key when none exists (first-time provision only; otherwise fail loud)
+    bool require_seed_key_encryption = false; // --require-seed-key-encryption: LP-13 H-1 — refuse to load/save a plaintext (v1) seed key; requires DILITHION_SEED_KEY_PASSPHRASE. Default OFF preserves backward-compatible loadable behavior.
     int max_connections = 0;         // --maxconnections: Maximum peer connections (0 = default 125)
     int max_connections_per_ip = 2;  // --max-connections-per-ip: Max inbound per IP (default 2, range 1-64)
     int attestation_rate_limit = 1;  // --attestation-rate-limit: Max attestations per /24 subnet per day
@@ -766,6 +767,13 @@ struct NodeConfig {
                 // instead of silently minting an unrecognized signing key.
                 generate_seed_key = true;
             }
+            else if (arg == "--require-seed-key-encryption") {
+                // LP-13 H-1: enforce encryption-at-rest for the seed consensus
+                // signing key. Refuses to load/save a plaintext (v1) key; the
+                // DILITHION_SEED_KEY_PASSPHRASE env MUST be set. Default OFF keeps
+                // the backward-compatible loadable behavior for rolling deploys.
+                require_seed_key_encryption = true;
+            }
             else if (arg.find("--rpcallowhost=") == 0) {
                 // wallet-rpc-login-restore: add an allowed Host header to the
                 // anti-DNS-rebinding allowlist. Repeatable. Loopback
@@ -895,6 +903,9 @@ struct NodeConfig {
         std::cout << "  --generate-seed-key   Permit minting a NEW seed attestation key if none exists" << std::endl;
         std::cout << "                          (first-time provision only; otherwise the node fails loud)." << std::endl;
         std::cout << "                          Set " << Attestation::SEED_KEY_PASSPHRASE_ENV << " to encrypt it at rest." << std::endl;
+        std::cout << "  --require-seed-key-encryption" << std::endl;
+        std::cout << "                          Refuse to load/save a plaintext (v1) seed key; requires" << std::endl;
+        std::cout << "                          " << Attestation::SEED_KEY_PASSPHRASE_ENV << ". Default OFF (backward compatible)." << std::endl;
         std::cout << "  --rpcallowhost=<host> Allow this Host header on the RPC/HTTP server" << std::endl;
         std::cout << "                          (anti-DNS-rebinding allowlist; repeatable)." << std::endl;
         std::cout << "                          Loopback (127.0.0.1/::1/localhost) is always" << std::endl;
@@ -6969,7 +6980,34 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
 
             // Load or generate attestation key (LP-13: minting gated behind
             // --generate-seed-key so a reprovisioned seed fails loud).
-            if (seedAttestKey.LoadOrGenerate(dataDir, config.generate_seed_key)) {
+            //
+            // LP-13 M-1 (fail-stop on GENUINE failure): a key file PRESENT but
+            // unusable (corrupt / wrong-or-missing passphrase / 0600-repair
+            // failure / plaintext-when-encryption-required), OR a requested mint
+            // that could not be persisted, is a real attestation outage. On a
+            // seed-capable node we ABORT startup rather than run silently without
+            // attestation. The benign case — a non-seed relay with NO key file
+            // and no --generate-seed-key — is NOT fatal (it just doesn't attest).
+            bool keyFileExists = false;
+            {
+                std::ifstream kf(dataDir + "/" + Attestation::SEED_KEY_FILENAME, std::ios::binary);
+                keyFileExists = kf.good();
+            }
+            bool attestOk = seedAttestKey.LoadOrGenerate(
+                dataDir, config.generate_seed_key, config.require_seed_key_encryption);
+            if (!attestOk) {
+                bool genuineFailure = keyFileExists || config.generate_seed_key
+                                      || config.require_seed_key_encryption;
+                if (genuineFailure) {
+                    std::cerr << "[Attestation] FATAL: seed attestation key initialization FAILED "
+                                 "(corrupt key, wrong/missing " << Attestation::SEED_KEY_PASSPHRASE_ENV
+                              << ", permission repair failure, or save failure). A seed must not run "
+                                 "without a usable consensus signing key. Aborting startup." << std::endl;
+                    return 1;
+                }
+                std::cerr << "[Attestation] No seed attestation key and minting not requested; "
+                             "this relay will not serve attestations." << std::endl;
+            } else {
                 int seedId = -1;
                 const auto& seedIPs = Dilithion::g_chainParams->seedAttestationIPs;
                 if (!config.external_ip.empty()) {

--- a/src/node/dilithion-node.cpp
+++ b/src/node/dilithion-node.cpp
@@ -6949,12 +6949,26 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                 CRPCServer::NotifyBlockTipChanged();
             });
 
-        // Phase 2+3: Seed attestation initialization (relay-only seed nodes only)
+        // Phase 2+3: Seed attestation initialization (DIL seed-capable nodes)
         // Loads ASN database and attestation signing key so seeds can serve
         // getmikattestation RPC requests from miners.
+        //
+        // LP-13 (DIL parity with the dilv-node H-3 fix): gate on
+        // `relay_only || public_api`, NOT bare `relay_only`. Verified live
+        // 2026-06-14: NYC's DIL node runs `--public-api` WITHOUT `--relay-only`
+        // (it is the bridge host), so under the prior bare-relay_only gate NYC's
+        // seed_attestation_key.dat existed on disk but was never loaded —
+        // getmikattestation returned "only available on seed nodes" — leaving DIL
+        // at exactly 3-of-4 functional attestation (MIN_ATTESTATIONS=3) with ZERO
+        // margin. This is the SAME failure mode the DilV v4.3 fix (2026-05-04)
+        // addressed for DilV but which was never applied to DIL. Every DIL seed
+        // runs --public-api (NYC included) to serve light wallets; a plain miner
+        // runs neither flag. Bridge ops are unaffected: init only registers an RPC
+        // handler + loads keys.
+        const bool seedCapable = config.relay_only || config.public_api;
         static Attestation::CSeedAttestationKey seedAttestKey;
         static CASNDatabase asnDatabase;
-        if (config.relay_only && Dilithion::g_chainParams) {
+        if (seedCapable && Dilithion::g_chainParams) {
             std::string dataDir = Dilithion::g_chainParams->dataDir;
 
             // Load ASN database from data directory (or project root)

--- a/src/node/dilithion-node.cpp
+++ b/src/node/dilithion-node.cpp
@@ -770,6 +770,7 @@ struct NodeConfig {
                 // LP-7 L1 (opt-in, default OFF): refuse mining/spending while the HD
                 // seed is still plaintext-at-rest. Default behavior is warn-only.
                 require_seed_migration = true;
+            }
             else if (arg == "--generate-seed-key") {
                 // LP-13: explicit opt-in to mint a NEW seed attestation consensus
                 // key if none exists. Without this flag a missing key fails loud

--- a/src/node/dilv-node.cpp
+++ b/src/node/dilv-node.cpp
@@ -562,6 +562,7 @@ struct NodeConfig {
     std::string external_ip = "";   // --externalip: Manual external IP (for manual port forwarding)
     bool public_api = false;        // --public-api: Enable public REST API for light wallets (seed nodes only)
     bool generate_seed_key = false; // --generate-seed-key: LP-13 — explicitly permit minting a NEW seed attestation consensus key when none exists (first-time provision only; otherwise fail loud)
+    bool require_seed_key_encryption = false; // --require-seed-key-encryption: LP-13 H-1 — refuse to load/save a plaintext (v1) seed key; requires DILITHION_SEED_KEY_PASSPHRASE. Default OFF preserves backward-compatible loadable behavior.
     int max_connections = 0;         // --maxconnections: Maximum peer connections (0 = default 125)
     int max_connections_per_ip = 2;  // --max-connections-per-ip: Max inbound per IP (default 2, range 1-64)
     int attestation_rate_limit = 1;  // --attestation-rate-limit: Max attestations per /24 subnet per day (Sybil defense)
@@ -758,6 +759,13 @@ struct NodeConfig {
                 // instead of silently minting an unrecognized signing key.
                 generate_seed_key = true;
             }
+            else if (arg == "--require-seed-key-encryption") {
+                // LP-13 H-1: enforce encryption-at-rest for the seed consensus
+                // signing key. Refuses to load/save a plaintext (v1) key; the
+                // DILITHION_SEED_KEY_PASSPHRASE env MUST be set. Default OFF keeps
+                // the backward-compatible loadable behavior for rolling deploys.
+                require_seed_key_encryption = true;
+            }
             else if (arg.find("--rpcallowhost=") == 0) {
                 // wallet-rpc-login-restore: anti-DNS-rebinding Host allowlist.
                 // Repeatable. Loopback is always allowed implicitly.
@@ -870,6 +878,9 @@ struct NodeConfig {
         std::cout << "  --generate-seed-key   Permit minting a NEW seed attestation key if none exists" << std::endl;
         std::cout << "                          (first-time provision only; otherwise the node fails loud)." << std::endl;
         std::cout << "                          Set " << Attestation::SEED_KEY_PASSPHRASE_ENV << " to encrypt it at rest." << std::endl;
+        std::cout << "  --require-seed-key-encryption" << std::endl;
+        std::cout << "                          Refuse to load/save a plaintext (v1) seed key; requires" << std::endl;
+        std::cout << "                          " << Attestation::SEED_KEY_PASSPHRASE_ENV << ". Default OFF (backward compatible)." << std::endl;
         std::cout << "  --rpcallowhost=<host> Allow this Host header on the RPC/HTTP server" << std::endl;
         std::cout << "                          (anti-DNS-rebinding allowlist; repeatable)." << std::endl;
         std::cout << "                          Loopback is always allowed. Under --public-api," << std::endl;
@@ -6858,7 +6869,33 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
 
             // Load or generate attestation key (LP-13: minting gated behind
             // --generate-seed-key so a reprovisioned seed fails loud).
-            if (seedAttestKey.LoadOrGenerate(dataDir, config.generate_seed_key)) {
+            // LP-13 M-1 (fail-stop on GENUINE failure): a key file PRESENT but
+            // unusable (corrupt / wrong-or-missing passphrase / 0600-repair
+            // failure / plaintext-when-encryption-required), OR a requested mint
+            // that could not be persisted, is a real attestation outage. On a
+            // seed-capable node we ABORT startup rather than run silently without
+            // attestation. The benign case — a non-seed relay with NO key file
+            // and no --generate-seed-key — is NOT fatal (it just doesn't attest).
+            bool keyFileExists = false;
+            {
+                std::ifstream kf(dataDir + "/" + Attestation::SEED_KEY_FILENAME, std::ios::binary);
+                keyFileExists = kf.good();
+            }
+            bool attestOk = seedAttestKey.LoadOrGenerate(
+                dataDir, config.generate_seed_key, config.require_seed_key_encryption);
+            if (!attestOk) {
+                bool genuineFailure = keyFileExists || config.generate_seed_key
+                                      || config.require_seed_key_encryption;
+                if (genuineFailure) {
+                    std::cerr << "[Attestation] FATAL: seed attestation key initialization FAILED "
+                                 "(corrupt key, wrong/missing " << Attestation::SEED_KEY_PASSPHRASE_ENV
+                              << ", permission repair failure, or save failure). A seed must not run "
+                                 "without a usable consensus signing key. Aborting startup." << std::endl;
+                    return 1;
+                }
+                std::cerr << "[Attestation] No seed attestation key and minting not requested; "
+                             "this relay will not serve attestations." << std::endl;
+            } else {
                 // Determine seed ID by matching our IP against known seed IPs
                 // For now, use a simple index. In production, compare external IP.
                 int seedId = -1;

--- a/src/node/dilv-node.cpp
+++ b/src/node/dilv-node.cpp
@@ -6890,21 +6890,10 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
             // file, no --generate-seed-key, AND no --require-seed-key-encryption —
             // the seed-capable relay simply doesn't attest. (This whole block is
             // already gated on `seedCapable` above, so miners never reach here.)
-            bool keyFileExists = false;
-            {
-                // LP-13 (extreview HIGH): test PRESENCE, not readability. An
-                // ifstream::good() on a present-but-UNREADABLE key returns false,
-                // misclassifying a genuine key as absent and letting the node run
-                // WITHOUT attestation silently — defeating the M-1 fail-loud
-                // guarantee. std::filesystem::exists() stats the path, so a
-                // present-but-unreadable file still reports as existing.
-                std::error_code ec;
-                keyFileExists = std::filesystem::exists(
-                    dataDir + "/" + Attestation::SEED_KEY_FILENAME, ec);
-                // A stat error (ec set) means we cannot prove ABSENCE; fail closed
-                // (treat as present) so an unstattable-but-genuine key still aborts.
-                if (ec) keyFileExists = true;
-            }
+            // LP-13 (extreview HIGH): PRESENCE test (stat), not ifstream::good()
+            // readability — a present-but-unreadable key must still be treated as
+            // present so genuineFailure fires (fail loud, M-1). See SeedKeyFilePresent.
+            bool keyFileExists = Attestation::SeedKeyFilePresent(dataDir);
             bool attestOk = seedAttestKey.LoadOrGenerate(
                 dataDir, config.generate_seed_key, config.require_seed_key_encryption);
             if (!attestOk) {

--- a/src/node/dilv-node.cpp
+++ b/src/node/dilv-node.cpp
@@ -6892,8 +6892,18 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
             // already gated on `seedCapable` above, so miners never reach here.)
             bool keyFileExists = false;
             {
-                std::ifstream kf(dataDir + "/" + Attestation::SEED_KEY_FILENAME, std::ios::binary);
-                keyFileExists = kf.good();
+                // LP-13 (extreview HIGH): test PRESENCE, not readability. An
+                // ifstream::good() on a present-but-UNREADABLE key returns false,
+                // misclassifying a genuine key as absent and letting the node run
+                // WITHOUT attestation silently — defeating the M-1 fail-loud
+                // guarantee. std::filesystem::exists() stats the path, so a
+                // present-but-unreadable file still reports as existing.
+                std::error_code ec;
+                keyFileExists = std::filesystem::exists(
+                    dataDir + "/" + Attestation::SEED_KEY_FILENAME, ec);
+                // A stat error (ec set) means we cannot prove ABSENCE; fail closed
+                // (treat as present) so an unstattable-but-genuine key still aborts.
+                if (ec) keyFileExists = true;
             }
             bool attestOk = seedAttestKey.LoadOrGenerate(
                 dataDir, config.generate_seed_key, config.require_seed_key_encryption);

--- a/src/node/dilv-node.cpp
+++ b/src/node/dilv-node.cpp
@@ -561,6 +561,7 @@ struct NodeConfig {
     bool upnp_prompted = false;     // True if user was already prompted or used explicit flag
     std::string external_ip = "";   // --externalip: Manual external IP (for manual port forwarding)
     bool public_api = false;        // --public-api: Enable public REST API for light wallets (seed nodes only)
+    bool generate_seed_key = false; // --generate-seed-key: LP-13 — explicitly permit minting a NEW seed attestation consensus key when none exists (first-time provision only; otherwise fail loud)
     int max_connections = 0;         // --maxconnections: Maximum peer connections (0 = default 125)
     int max_connections_per_ip = 2;  // --max-connections-per-ip: Max inbound per IP (default 2, range 1-64)
     int attestation_rate_limit = 1;  // --attestation-rate-limit: Max attestations per /24 subnet per day (Sybil defense)
@@ -751,6 +752,12 @@ struct NodeConfig {
                 // Public REST API: bind to 0.0.0.0 for light wallet access (seed nodes only)
                 public_api = true;
             }
+            else if (arg == "--generate-seed-key") {
+                // LP-13: explicit opt-in to mint a NEW seed attestation consensus
+                // key if none exists. Without this flag a missing key fails loud
+                // instead of silently minting an unrecognized signing key.
+                generate_seed_key = true;
+            }
             else if (arg.find("--rpcallowhost=") == 0) {
                 // wallet-rpc-login-restore: anti-DNS-rebinding Host allowlist.
                 // Repeatable. Loopback is always allowed implicitly.
@@ -860,6 +867,9 @@ struct NodeConfig {
         std::cout << "                          Add --yes to skip the confirmation prompt." << std::endl;
         std::cout << "  --relay-only          Relay-only mode: skip wallet (for seed nodes)" << std::endl;
         std::cout << "  --public-api          Enable public REST API for light wallets (seed nodes)" << std::endl;
+        std::cout << "  --generate-seed-key   Permit minting a NEW seed attestation key if none exists" << std::endl;
+        std::cout << "                          (first-time provision only; otherwise the node fails loud)." << std::endl;
+        std::cout << "                          Set " << Attestation::SEED_KEY_PASSPHRASE_ENV << " to encrypt it at rest." << std::endl;
         std::cout << "  --rpcallowhost=<host> Allow this Host header on the RPC/HTTP server" << std::endl;
         std::cout << "                          (anti-DNS-rebinding allowlist; repeatable)." << std::endl;
         std::cout << "                          Loopback is always allowed. Under --public-api," << std::endl;
@@ -6846,8 +6856,9 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                           << " datacenter ASNs)" << std::endl;
             }
 
-            // Load or generate attestation key
-            if (seedAttestKey.LoadOrGenerate(dataDir)) {
+            // Load or generate attestation key (LP-13: minting gated behind
+            // --generate-seed-key so a reprovisioned seed fails loud).
+            if (seedAttestKey.LoadOrGenerate(dataDir, config.generate_seed_key)) {
                 // Determine seed ID by matching our IP against known seed IPs
                 // For now, use a simple index. In production, compare external IP.
                 int seedId = -1;

--- a/src/node/dilv-node.cpp
+++ b/src/node/dilv-node.cpp
@@ -6826,23 +6826,32 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                 CRPCServer::NotifyBlockTipChanged();
             });
 
-        // Phase 2+3: Seed attestation initialization (ALL DilV mainnet seeds)
+        // Phase 2+3: Seed attestation initialization (DilV seed-capable nodes)
         // Loads ASN database and attestation signing key so seeds can serve
         // getmikattestation RPC requests from miners.
         //
-        // v4.3 fix 2026-05-04: removed `config.relay_only` gate. NYC runs
-        // without --relay-only because it's the bridge host. Under the prior
-        // gate, NYC's seed_attestation_key.dat existed on disk but was never
-        // loaded — RegisterSeedAttestation() never called — making NYC
+        // v4.3 fix 2026-05-04: removed the original `config.relay_only` gate. NYC
+        // runs WITHOUT --relay-only because it's the bridge host. Under the prior
+        // relay_only-only gate, NYC's seed_attestation_key.dat existed on disk but
+        // was never loaded — RegisterSeedAttestation() never called — making NYC
         // unable to serve getmikattestation RPCs ("is only available on seed
         // nodes" error). Network attestation capacity dropped from 4-of-4
-        // baked-in seed pubkeys to 3-of-4 functional. Fix: gate attestation
-        // init only on IsDilV() (the chain semantic), not on a CLI flag
-        // unrelated to attestation. Bridge ops are unaffected because
-        // attestation init only registers an RPC handler + loads keys.
+        // baked-in seed pubkeys to 3-of-4 functional.
+        //
+        // LP-13 H-3/L-3: gating purely on IsDilV() over-broadened the LP-13 FATAL
+        // abort below to EVERY DilV node, including miners — a DilV miner with a
+        // stray/corrupt seed_attestation_key.dat would abort on startup even
+        // though a miner never attests. We do NOT revert to relay_only-only (that
+        // re-introduces the v4.3 NYC outage: NYC is a non-relay-only seed). The
+        // correct seed-capability predicate that includes NYC and excludes plain
+        // miners is `relay_only || public_api` — every seed runs --public-api to
+        // serve light wallets (NYC included), while a miner runs neither. Init AND
+        // the abort are gated on that predicate. Bridge ops are unaffected: init
+        // only registers an RPC handler + loads keys.
+        const bool seedCapable = config.relay_only || config.public_api;
         static Attestation::CSeedAttestationKey seedAttestKey;
         static CASNDatabase asnDatabase;
-        if (Dilithion::g_chainParams && Dilithion::g_chainParams->IsDilV()) {
+        if (Dilithion::g_chainParams && Dilithion::g_chainParams->IsDilV() && seedCapable) {
             std::string dataDir = Dilithion::g_chainParams->dataDir;
 
             // Load ASN database from data directory (or project root)
@@ -6870,12 +6879,17 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
             // Load or generate attestation key (LP-13: minting gated behind
             // --generate-seed-key so a reprovisioned seed fails loud).
             // LP-13 M-1 (fail-stop on GENUINE failure): a key file PRESENT but
-            // unusable (corrupt / wrong-or-missing passphrase / 0600-repair
-            // failure / plaintext-when-encryption-required), OR a requested mint
-            // that could not be persisted, is a real attestation outage. On a
-            // seed-capable node we ABORT startup rather than run silently without
-            // attestation. The benign case — a non-seed relay with NO key file
-            // and no --generate-seed-key — is NOT fatal (it just doesn't attest).
+            // unusable (corrupt / decrypt-or-parse failure / wrong-or-missing
+            // passphrase / plaintext-when-encryption-required), OR a requested
+            // mint that could not be persisted, is a real attestation outage. We
+            // ABORT startup rather than run silently without attestation.
+            // genuineFailure also fires when --require-seed-key-encryption is set
+            // even with NO key file present: fail-closed is intended — an operator
+            // who demanded at-rest encryption must not be left running with no
+            // usable encrypted key. The ONLY benign (non-fatal) case is: NO key
+            // file, no --generate-seed-key, AND no --require-seed-key-encryption —
+            // the seed-capable relay simply doesn't attest. (This whole block is
+            // already gated on `seedCapable` above, so miners never reach here.)
             bool keyFileExists = false;
             {
                 std::ifstream kf(dataDir + "/" + Attestation::SEED_KEY_FILENAME, std::ios::binary);
@@ -6888,8 +6902,10 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                                       || config.require_seed_key_encryption;
                 if (genuineFailure) {
                     std::cerr << "[Attestation] FATAL: seed attestation key initialization FAILED "
-                                 "(corrupt key, wrong/missing " << Attestation::SEED_KEY_PASSPHRASE_ENV
-                              << ", permission repair failure, or save failure). A seed must not run "
+                                 "(key file present but unreadable/corrupt, decrypt/parse failure, "
+                                 "wrong/missing " << Attestation::SEED_KEY_PASSPHRASE_ENV
+                              << ", plaintext key when --require-seed-key-encryption is set, or a "
+                                 "requested mint that could not be persisted). A seed must not run "
                                  "without a usable consensus signing key. Aborting startup." << std::endl;
                     return 1;
                 }

--- a/src/test/seed_attestation_key_tests.cpp
+++ b/src/test/seed_attestation_key_tests.cpp
@@ -515,6 +515,49 @@ static void TestPosixPerms() {
     CHECK(stat(KeyPath(dir2).c_str(), &st2) == 0, "stat v1 key file");
     CHECK((st2.st_mode & 0777) == (S_IRUSR | S_IWUSR), "v1 perms == 0600");
 }
+
+// LP-13 (symlink-hardening, nemotron extreview finding): the temp key file is
+// opened O_NOFOLLOW, so a pre-planted "<key>.tmp" symlink cannot redirect the
+// consensus key write. Save must FAIL (fail-closed), leave the canonical key
+// byte-intact, and NOT write the key through the symlink to its target.
+// Mutation self-check: removing O_NOFOLLOW lets the open follow the symlink, the
+// victim file receives the key bytes, and the "victim untouched" assertion fails.
+static void TestTempSymlinkRejected() {
+    std::cout << "[Test] symlink-hardening: O_NOFOLLOW rejects a symlinked temp (POSIX)" << std::endl;
+    std::string dir = MakeTempDir();
+    SetPass("symlink-pass");
+
+    // 1) Establish the canonical key.
+    CSeedAttestationKey k1;
+    CHECK(k1.Generate(), "generate original keypair");
+    std::vector<uint8_t> origPub = k1.GetPubKey();
+    CHECK(k1.Save(dir), "save original key");
+    std::vector<uint8_t> origBytes = ReadFileBytes(KeyPath(dir));
+    CHECK(!origBytes.empty(), "original key file non-empty");
+
+    // 2) Plant "<key>.tmp" as a symlink to a victim file the attacker wants written.
+    std::string tmpPath = KeyPath(dir) + ".tmp";
+    std::string victimPath = dir + "/victim.bin";
+    WriteFileBytes(victimPath, std::vector<uint8_t>{0xCC, 0xCC, 0xCC});
+    std::vector<uint8_t> victimBefore = ReadFileBytes(victimPath);
+    ::unlink(tmpPath.c_str());  // ensure no stale temp
+    CHECK(symlink(victimPath.c_str(), tmpPath.c_str()) == 0, "plant symlink at <key>.tmp -> victim");
+
+    // 3) Attempt to Save a DIFFERENT key. O_NOFOLLOW must make the temp open fail.
+    CSeedAttestationKey k2;
+    CHECK(k2.Generate(), "generate replacement keypair");
+    CHECK(k2.GetPubKey() != origPub, "replacement differs");
+    CHECK(!k2.Save(dir), "Save FAILS when temp path is a symlink (O_NOFOLLOW)");
+
+    // 4) Canonical key untouched, and the victim was NOT written through the symlink.
+    std::vector<uint8_t> afterBytes = ReadFileBytes(KeyPath(dir));
+    CHECK(afterBytes == origBytes, "canonical key byte-intact after rejected symlink save");
+    std::vector<uint8_t> victimAfter = ReadFileBytes(victimPath);
+    CHECK(victimAfter == victimBefore, "victim file NOT written through the symlink");
+
+    ::unlink(tmpPath.c_str());  // cleanup the planted symlink
+    SetPass(nullptr);
+}
 #endif
 
 // LP-13 (extreview HIGH): SeedKeyFilePresent must test PRESENCE, not readability.
@@ -581,6 +624,7 @@ int main() {
     TestLoadRepairsPerms();                  // M-3
     TestFailClosedPerms();                   // M-4 (best-effort/informational)
     TestPosixPerms();
+    TestTempSymlinkRejected();               // O_NOFOLLOW symlink-hardening (nemotron extreview)
 #endif
 
     std::cout << "=========================================" << std::endl;

--- a/src/test/seed_attestation_key_tests.cpp
+++ b/src/test/seed_attestation_key_tests.cpp
@@ -254,6 +254,32 @@ static void TestAutoMintGate() {
     CHECK(k3.GetPubKey() == k2.GetPubKey(), "loaded key matches minted key");
 }
 
+// LP-13 MEDIUM-1: the v1 (un-passphrased) Save path holds the plaintext private
+// key in a transient `out` buffer; the fix cleanses it on every return via
+// CleanseSeedKeyBuffer. This test proves the cleanse primitive actually zeroes
+// the buffer. Mutation self-check: deleting the memory_cleanse inside
+// CleanseSeedKeyBuffer leaves the non-zero bytes intact and fails this test.
+static void TestSecretBufferCleansed() {
+    std::cout << "[Test] transient key buffer is cleansed (MEDIUM-1)" << std::endl;
+
+    // Fill a buffer the size of a v1 blob (magic+ver+pubkey+privkey) with a
+    // recognizable non-zero pattern, as if it held a real plaintext key.
+    const size_t n = 5 + DFMP::MIK_PUBKEY_SIZE + DFMP::MIK_PRIVKEY_SIZE;
+    std::vector<uint8_t> buf(n, 0xAB);
+
+    CleanseSeedKeyBuffer(buf);
+
+    CHECK(buf.size() == n, "buffer size unchanged after cleanse");
+    bool allZero = true;
+    for (uint8_t b : buf) { if (b != 0) { allZero = false; break; } }
+    CHECK(allZero, "every byte of the secret buffer is zeroed");
+
+    // Empty-buffer path must be a safe no-op (Save's early returns hit this).
+    std::vector<uint8_t> empty;
+    CleanseSeedKeyBuffer(empty);
+    CHECK(empty.empty(), "cleanse of empty buffer is a safe no-op");
+}
+
 #ifndef _WIN32
 static void TestPosixPerms() {
     std::cout << "[Test] POSIX key file is 0600 (AC1)" << std::endl;
@@ -290,6 +316,7 @@ int main() {
     TestTruncatedAndEmptyMac();
     TestV1BackwardCompat();
     TestAutoMintGate();
+    TestSecretBufferCleansed();
 #ifndef _WIN32
     TestPosixPerms();
 #endif

--- a/src/test/seed_attestation_key_tests.cpp
+++ b/src/test/seed_attestation_key_tests.cpp
@@ -329,6 +329,55 @@ static void TestAtomicSaveOriginalSurvives() {
     SetPass(nullptr);
 }
 
+// LP-13 B-1 (BLOCKER, THE load-bearing test): an fsync/flush failure of the temp
+// must be FATAL — Save returns false, NO rename happens, and the ORIGINAL key
+// file is left byte-intact. If the fix were reverted to warn-and-continue, the
+// rename would publish (possibly un-flushed) data and this test must FAIL.
+static bool g_fsyncFailActive = false;
+static bool FsyncFailpoint() { return g_fsyncFailActive; }
+
+static void TestFsyncFailureIsFatalBeforeRename() {
+    std::cout << "[Test] B-1: fsync failure is FATAL before rename, original key survives" << std::endl;
+    std::string dir = MakeTempDir();
+    SetPass("fsync-pass");  // exercise the v2 (encrypted) path
+
+    // 1) Establish the live key file.
+    CSeedAttestationKey k1;
+    CHECK(k1.Generate(), "generate original keypair");
+    std::vector<uint8_t> origPub = k1.GetPubKey();
+    CHECK(k1.Save(dir), "save original key");
+    std::vector<uint8_t> origBytes = ReadFileBytes(KeyPath(dir));
+    CHECK(!origBytes.empty(), "original key file non-empty");
+
+    // 2) Arm the fsync failpoint and attempt an UPDATE save with a DIFFERENT key.
+    g_seedKeyFsyncFailpoint = FsyncFailpoint;
+    g_fsyncFailActive = true;
+
+    CSeedAttestationKey k2;
+    CHECK(k2.Generate(), "generate replacement keypair");
+    CHECK(k2.GetPubKey() != origPub, "replacement differs from original");
+    // (a) Save returns false on fsync failure.
+    CHECK(!k2.Save(dir), "Save returns false when fsync fails");
+
+    g_fsyncFailActive = false;
+    g_seedKeyFsyncFailpoint = nullptr;
+
+    // (b)+(c) NO rename happened: the live key file is byte-identical to the
+    // original, still loads, and still signs with the original key.
+    std::vector<uint8_t> afterBytes = ReadFileBytes(KeyPath(dir));
+    CHECK(afterBytes == origBytes, "ORIGINAL key file byte-intact after fatal fsync failure");
+    CSeedAttestationKey k3;
+    CHECK(k3.Load(dir), "original key still loads after fatal fsync failure");
+    CHECK(k3.GetPubKey() == origPub, "loaded pubkey == original");
+    CHECK(PrivKeyRoundTrips(k3, origPub), "original private key still signs/verifies");
+
+    // (d) No leftover .tmp occupying the path.
+    std::ifstream tmp(KeyPath(dir) + ".tmp", std::ios::binary);
+    CHECK(!tmp.good(), "no leftover .tmp after fatal fsync failure");
+
+    SetPass(nullptr);
+}
+
 // LP-13 M-2: a generated key that cannot be PERSISTED must make LoadOrGenerate
 // return false (never run on an ephemeral key that won't survive restart).
 static void TestSaveFailMakesLoadOrGenerateFail() {
@@ -480,6 +529,7 @@ int main() {
     TestAutoMintGate();
     TestSecretBufferCleansed();
     TestAtomicSaveOriginalSurvives();        // H-2 (THE load-bearing test)
+    TestFsyncFailureIsFatalBeforeRename();   // B-1 (THE load-bearing test)
     TestSaveFailMakesLoadOrGenerateFail();   // M-2
     TestRequireEncryptionPolicy();           // H-1
 #ifndef _WIN32

--- a/src/test/seed_attestation_key_tests.cpp
+++ b/src/test/seed_attestation_key_tests.cpp
@@ -1,0 +1,304 @@
+// Copyright (c) 2026 The Dilithion Core developers
+// Distributed under the MIT software license
+//
+// LP-13: seed-attestation private key at-rest hardening tests.
+//
+// Covers (per contract AC2-AC6, AC9):
+//   - v2 encrypt -> decrypt round-trip (private key usable after reload)
+//   - tampered ciphertext rejected (MAC fail)
+//   - truncated file / empty MAC rejected
+//   - wrong passphrase rejected cleanly
+//   - v1 plaintext backward-compat load
+//   - LoadOrGenerate auto-mint REFUSED without the flag, allowed with it
+//   - (POSIX) saved key file is chmod 0600
+
+#include <attestation/seed_attestation.h>
+#include <dfmp/dfmp.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#ifndef _WIN32
+#include <sys/stat.h>
+#include <unistd.h>
+#else
+#include <windows.h>
+#include <direct.h>
+#endif
+
+using namespace Attestation;
+
+// Dilithium3 verify (same extern the production .cpp uses) — lets us prove the
+// private key round-tripped by checking a signature it produced verifies under
+// the saved public key.
+extern "C" {
+    int pqcrystals_dilithium3_ref_verify(const uint8_t* sig, size_t siglen,
+                                          const uint8_t* m, size_t mlen,
+                                          const uint8_t* ctx, size_t ctxlen,
+                                          const uint8_t* pk);
+}
+
+static int g_failures = 0;
+#define CHECK(cond, msg) do { \
+    if (!(cond)) { std::cerr << "  [FAIL] " << msg << std::endl; ++g_failures; } \
+    else { std::cout << "  [ok] " << msg << std::endl; } \
+} while (0)
+
+// ---- temp dir helpers -------------------------------------------------------
+
+static std::string MakeTempDir() {
+#ifndef _WIN32
+    char tmpl[] = "/tmp/lp13_seedkeyXXXXXX";
+    char* d = mkdtemp(tmpl);
+    if (!d) { std::cerr << "mkdtemp failed" << std::endl; std::exit(2); }
+    return std::string(d);
+#else
+    // Windows: unique subdir under the system temp. A monotonic counter
+    // guarantees uniqueness even when called faster than the clock resolution.
+    static unsigned long s_counter = 0;
+    std::string d = std::string(std::getenv("TEMP") ? std::getenv("TEMP") : ".")
+                  + "\\lp13_seedkey_" + std::to_string(::GetCurrentProcessId())
+                  + "_" + std::to_string((unsigned long long)::GetTickCount64())
+                  + "_" + std::to_string(++s_counter);
+    _mkdir(d.c_str());
+    return d;
+#endif
+}
+
+static std::string KeyPath(const std::string& dir) {
+    return dir + "/" + SEED_KEY_FILENAME;
+}
+
+static std::vector<uint8_t> ReadFileBytes(const std::string& path) {
+    std::ifstream f(path, std::ios::binary);
+    return std::vector<uint8_t>((std::istreambuf_iterator<char>(f)),
+                                 std::istreambuf_iterator<char>());
+}
+
+static void WriteFileBytes(const std::string& path, const std::vector<uint8_t>& b) {
+    std::ofstream f(path, std::ios::binary | std::ios::trunc);
+    f.write(reinterpret_cast<const char*>(b.data()), b.size());
+}
+
+static void SetPass(const char* v) {
+#ifndef _WIN32
+    if (v) setenv(SEED_KEY_PASSPHRASE_ENV, v, 1);
+    else   unsetenv(SEED_KEY_PASSPHRASE_ENV);
+#else
+    std::string s = std::string(SEED_KEY_PASSPHRASE_ENV) + "=" + (v ? v : "");
+    _putenv(s.c_str());
+#endif
+}
+
+// Sign with `signer` and verify under `pubkey`. Proves the private key is intact.
+static bool PrivKeyRoundTrips(const CSeedAttestationKey& signer,
+                              const std::vector<uint8_t>& pubkey) {
+    if (!signer.IsValid()) return false;
+    std::vector<uint8_t> msg = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+    std::vector<uint8_t> sig;
+    if (!signer.Sign(msg, sig)) return false;
+    int r = pqcrystals_dilithium3_ref_verify(sig.data(), sig.size(),
+                                              msg.data(), msg.size(),
+                                              nullptr, 0, pubkey.data());
+    return r == 0;
+}
+
+// ---- tests ------------------------------------------------------------------
+
+static void TestEncryptedRoundTrip() {
+    std::cout << "[Test] v2 encrypted round-trip (AC2)" << std::endl;
+    std::string dir = MakeTempDir();
+    SetPass("correct horse battery staple");
+
+    CSeedAttestationKey k1;
+    CHECK(k1.Generate(), "generate keypair");
+    std::vector<uint8_t> pub = k1.GetPubKey();
+    CHECK(k1.Save(dir), "save v2");
+
+    // On-disk private key bytes must NOT appear in plaintext.
+    std::vector<uint8_t> raw = ReadFileBytes(KeyPath(dir));
+    CHECK(raw.size() > 5 && raw[4] == 2, "file version byte == 2 (encrypted)");
+
+    CSeedAttestationKey k2;
+    CHECK(k2.Load(dir), "load v2 with correct passphrase");
+    CHECK(k2.GetPubKey() == pub, "pubkey matches after reload");
+    CHECK(PrivKeyRoundTrips(k2, pub), "private key round-trips (sign+verify)");
+
+    SetPass(nullptr);
+}
+
+static void TestWrongPassphrase() {
+    std::cout << "[Test] wrong passphrase rejected (AC4)" << std::endl;
+    std::string dir = MakeTempDir();
+    SetPass("right-passphrase");
+    CSeedAttestationKey k1;
+    k1.Generate();
+    CHECK(k1.Save(dir), "save v2");
+
+    SetPass("WRONG-passphrase");
+    CSeedAttestationKey k2;
+    CHECK(!k2.Load(dir), "load fails (MAC mismatch) with wrong passphrase");
+    CHECK(!k2.IsValid(), "key not partially loaded");
+    SetPass(nullptr);
+}
+
+static void TestMissingPassphraseOnV2() {
+    std::cout << "[Test] v2 file + no passphrase rejected (AC3 variant)" << std::endl;
+    std::string dir = MakeTempDir();
+    SetPass("a-passphrase");
+    CSeedAttestationKey k1;
+    k1.Generate();
+    CHECK(k1.Save(dir), "save v2");
+
+    SetPass(nullptr);  // unset
+    CSeedAttestationKey k2;
+    CHECK(!k2.Load(dir), "load fails when v2 but passphrase unset");
+    CHECK(!k2.IsValid(), "key not loaded");
+}
+
+static void TestTamperedCiphertext() {
+    std::cout << "[Test] tampered ciphertext rejected (AC3)" << std::endl;
+    std::string dir = MakeTempDir();
+    SetPass("tamper-pass");
+    CSeedAttestationKey k1;
+    k1.Generate();
+    CHECK(k1.Save(dir), "save v2");
+
+    std::vector<uint8_t> raw = ReadFileBytes(KeyPath(dir));
+    CHECK(!raw.empty(), "read raw file");
+    raw[raw.size() - 1] ^= 0xFF;  // flip last ciphertext byte
+    WriteFileBytes(KeyPath(dir), raw);
+
+    CSeedAttestationKey k2;
+    CHECK(!k2.Load(dir), "load fails on tampered ciphertext");
+    CHECK(!k2.IsValid(), "key not loaded after tamper");
+    SetPass(nullptr);
+}
+
+static void TestTruncatedAndEmptyMac() {
+    std::cout << "[Test] truncated / zeroed-MAC rejected (AC3)" << std::endl;
+    std::string dir = MakeTempDir();
+    SetPass("trunc-pass");
+    CSeedAttestationKey k1;
+    k1.Generate();
+    CHECK(k1.Save(dir), "save v2");
+
+    std::vector<uint8_t> full = ReadFileBytes(KeyPath(dir));
+
+    // Truncate to half -> header/length checks must reject.
+    std::vector<uint8_t> trunc(full.begin(), full.begin() + full.size() / 2);
+    WriteFileBytes(KeyPath(dir), trunc);
+    CSeedAttestationKey kt;
+    CHECK(!kt.Load(dir), "load fails on truncated file");
+
+    // Zero out the 64-byte MAC field (offset 5 + 1952 pubkey + 16 salt + 16 iv).
+    std::vector<uint8_t> zmac = full;
+    size_t macOff = 5 + DFMP::MIK_PUBKEY_SIZE + 16 + 16;
+    if (zmac.size() >= macOff + 64) {
+        for (size_t i = 0; i < 64; ++i) zmac[macOff + i] = 0;
+        WriteFileBytes(KeyPath(dir), zmac);
+        CSeedAttestationKey kz;
+        CHECK(!kz.Load(dir), "load fails on zeroed MAC");
+    } else {
+        std::cerr << "  [FAIL] file too small to locate MAC" << std::endl;
+        ++g_failures;
+    }
+    SetPass(nullptr);
+}
+
+static void TestV1BackwardCompat() {
+    std::cout << "[Test] v1 plaintext backward-compat load (AC5)" << std::endl;
+    std::string dir = MakeTempDir();
+    SetPass(nullptr);  // no passphrase => Save writes v1 plaintext
+    CSeedAttestationKey k1;
+    k1.Generate();
+    std::vector<uint8_t> pub = k1.GetPubKey();
+    CHECK(k1.Save(dir), "save v1 (no passphrase)");
+
+    std::vector<uint8_t> raw = ReadFileBytes(KeyPath(dir));
+    CHECK(raw.size() > 5 && raw[4] == 1, "file version byte == 1 (plaintext)");
+
+    CSeedAttestationKey k2;
+    CHECK(k2.Load(dir), "load v1 plaintext");
+    CHECK(k2.GetPubKey() == pub, "pubkey matches");
+    CHECK(PrivKeyRoundTrips(k2, pub), "v1 private key round-trips");
+}
+
+static void TestAutoMintGate() {
+    std::cout << "[Test] auto-mint refused without flag (AC6)" << std::endl;
+    std::string dir = MakeTempDir();  // empty dir, no key file
+    SetPass(nullptr);
+
+    CSeedAttestationKey k1;
+    CHECK(!k1.LoadOrGenerate(dir, /*allowGenerate=*/false),
+          "LoadOrGenerate(false) on missing key FAILS LOUD");
+    CHECK(!k1.IsValid(), "no key minted when flag absent");
+
+    std::ifstream chk(KeyPath(dir), std::ios::binary);
+    CHECK(!chk.good(), "no key file written when flag absent");
+
+    CSeedAttestationKey k2;
+    CHECK(k2.LoadOrGenerate(dir, /*allowGenerate=*/true),
+          "LoadOrGenerate(true) mints + saves");
+    CHECK(k2.IsValid(), "key valid after permitted mint");
+
+    // Second call now LOADS the persisted key even without the flag.
+    CSeedAttestationKey k3;
+    CHECK(k3.LoadOrGenerate(dir, /*allowGenerate=*/false),
+          "subsequent LoadOrGenerate(false) loads the existing key");
+    CHECK(k3.GetPubKey() == k2.GetPubKey(), "loaded key matches minted key");
+}
+
+#ifndef _WIN32
+static void TestPosixPerms() {
+    std::cout << "[Test] POSIX key file is 0600 (AC1)" << std::endl;
+    std::string dir = MakeTempDir();
+    SetPass("perms-pass");
+    CSeedAttestationKey k1;
+    k1.Generate();
+    CHECK(k1.Save(dir), "save v2");
+
+    struct stat st;
+    CHECK(stat(KeyPath(dir).c_str(), &st) == 0, "stat key file");
+    mode_t perms = st.st_mode & 0777;
+    CHECK(perms == (S_IRUSR | S_IWUSR), "perms == 0600");
+
+    // Also verify v1 path sets 0600.
+    SetPass(nullptr);
+    std::string dir2 = MakeTempDir();
+    CSeedAttestationKey k2;
+    k2.Generate();
+    CHECK(k2.Save(dir2), "save v1");
+    struct stat st2;
+    CHECK(stat(KeyPath(dir2).c_str(), &st2) == 0, "stat v1 key file");
+    CHECK((st2.st_mode & 0777) == (S_IRUSR | S_IWUSR), "v1 perms == 0600");
+}
+#endif
+
+int main() {
+    std::cout << "=== LP-13 seed_attestation_key_tests ===" << std::endl;
+
+    TestEncryptedRoundTrip();
+    TestWrongPassphrase();
+    TestMissingPassphraseOnV2();
+    TestTamperedCiphertext();
+    TestTruncatedAndEmptyMac();
+    TestV1BackwardCompat();
+    TestAutoMintGate();
+#ifndef _WIN32
+    TestPosixPerms();
+#endif
+
+    std::cout << "=========================================" << std::endl;
+    if (g_failures == 0) {
+        std::cout << "ALL TESTS PASSED" << std::endl;
+        return 0;
+    }
+    std::cerr << g_failures << " CHECK(S) FAILED" << std::endl;
+    return 1;
+}

--- a/src/test/seed_attestation_key_tests.cpp
+++ b/src/test/seed_attestation_key_tests.cpp
@@ -517,6 +517,50 @@ static void TestPosixPerms() {
 }
 #endif
 
+// LP-13 (extreview HIGH): SeedKeyFilePresent must test PRESENCE, not readability.
+// The earlier node glue used ifstream::good(), which is FALSE for a present-but-
+// UNREADABLE key — so a genuine key was misclassified as absent and the node ran
+// WITHOUT attestation (defeating M-1 fail-loud). This pins the distinction:
+//   - absent           => NOT present
+//   - readable file    => present
+//   - unreadable file  => STILL present (the fix), while ifstream::good()==false
+// The unreadable leg needs a uid that cannot bypass DAC: under root (e.g. the CI
+// build box) chmod-000 does NOT make a file unreadable, so the probe self-detects
+// that case and reports [info]/SKIP rather than a false pass (M-4 precedent). Run
+// the binary as a non-root user (e.g. `sudo -u nobody`) to exercise the real
+// mutation-killing assertion. Mutation self-check: reverting SeedKeyFilePresent to
+// ifstream::good() fails the unreadable assertion under a non-root run.
+static void TestSeedKeyFilePresentDetectsUnreadable() {
+    std::cout << "[Test] extreview-HIGH: present-but-unreadable key reports PRESENT" << std::endl;
+    std::string dir = MakeTempDir();
+
+    CHECK(!SeedKeyFilePresent(dir), "empty dir => key file NOT present");
+
+    SetPass(nullptr);
+    CSeedAttestationKey k1;
+    CHECK(k1.Generate(), "generate key");
+    CHECK(k1.Save(dir), "save key file");
+    CHECK(SeedKeyFilePresent(dir), "readable key file => present");
+
+#ifndef _WIN32
+    if (chmod(KeyPath(dir).c_str(), 0) == 0) {
+        std::ifstream probe(KeyPath(dir), std::ios::binary);
+        if (probe.good()) {
+            // Caller bypasses DAC (root): cannot induce unreadable. Honest SKIP.
+            std::cout << "  [info] cannot revoke read (running as root?); "
+                         "unreadable-distinction assertion skipped — run as non-root to exercise it"
+                      << std::endl;
+        } else {
+            CHECK(SeedKeyFilePresent(dir),
+                  "present-but-UNREADABLE key reports PRESENT (the fix; ifstream::good()==false here)");
+        }
+        chmod(KeyPath(dir).c_str(), S_IRUSR | S_IWUSR);  // restore for clean temp teardown
+    } else {
+        std::cout << "  [info] chmod 000 failed; unreadable leg skipped" << std::endl;
+    }
+#endif
+}
+
 int main() {
     std::cout << "=== LP-13 seed_attestation_key_tests ===" << std::endl;
 
@@ -532,6 +576,7 @@ int main() {
     TestFsyncFailureIsFatalBeforeRename();   // B-1 (THE load-bearing test)
     TestSaveFailMakesLoadOrGenerateFail();   // M-2
     TestRequireEncryptionPolicy();           // H-1
+    TestSeedKeyFilePresentDetectsUnreadable(); // extreview HIGH (presence vs readability)
 #ifndef _WIN32
     TestLoadRepairsPerms();                  // M-3
     TestFailClosedPerms();                   // M-4 (best-effort/informational)

--- a/src/test/seed_attestation_key_tests.cpp
+++ b/src/test/seed_attestation_key_tests.cpp
@@ -280,7 +280,169 @@ static void TestSecretBufferCleansed() {
     CHECK(empty.empty(), "cleanse of empty buffer is a safe no-op");
 }
 
+// LP-13 H-2 (CRITICAL, THE load-bearing test): an atomic Save that fails AFTER
+// the temp file is written but BEFORE the rename must leave the ORIGINAL key
+// file byte-for-byte intact. A bug here loses a seed's only consensus key.
+static bool g_failpointActive = false;
+static bool SaveFailpoint() { return g_failpointActive; }
+
+static void TestAtomicSaveOriginalSurvives() {
+    std::cout << "[Test] atomic save: injected write failure preserves original key (H-2)" << std::endl;
+    std::string dir = MakeTempDir();
+    SetPass("atomic-pass");  // exercise the v2 (encrypted) path
+
+    // 1) Establish the live key file.
+    CSeedAttestationKey k1;
+    CHECK(k1.Generate(), "generate original keypair");
+    std::vector<uint8_t> origPub = k1.GetPubKey();
+    CHECK(k1.Save(dir), "save original key");
+    std::vector<uint8_t> origBytes = ReadFileBytes(KeyPath(dir));
+    CHECK(!origBytes.empty(), "original key file non-empty");
+
+    // 2) Arm the failpoint and try to overwrite with a DIFFERENT key. Save must
+    //    fail (the simulated crash between temp-write and rename).
+    g_seedKeySaveFailpoint = SaveFailpoint;
+    g_failpointActive = true;
+
+    CSeedAttestationKey k2;
+    CHECK(k2.Generate(), "generate replacement keypair");
+    CHECK(k2.GetPubKey() != origPub, "replacement differs from original");
+    CHECK(!k2.Save(dir), "Save returns false when failpoint fires before rename");
+
+    g_failpointActive = false;
+    g_seedKeySaveFailpoint = nullptr;
+
+    // 3) THE assertion: the live key file is byte-identical to the original.
+    std::vector<uint8_t> afterBytes = ReadFileBytes(KeyPath(dir));
+    CHECK(afterBytes == origBytes, "ORIGINAL key file is byte-intact after failed save");
+
+    // 4) And it still loads + the original private key still round-trips.
+    CSeedAttestationKey k3;
+    CHECK(k3.Load(dir), "original key still loads after failed save");
+    CHECK(k3.GetPubKey() == origPub, "loaded pubkey == original");
+    CHECK(PrivKeyRoundTrips(k3, origPub), "original private key still usable");
+
+    // 5) No stray .tmp left occupying the live path.
+    std::ifstream tmp(KeyPath(dir) + ".tmp", std::ios::binary);
+    CHECK(!tmp.good(), "no leftover .tmp after failed save");
+
+    SetPass(nullptr);
+}
+
+// LP-13 M-2: a generated key that cannot be PERSISTED must make LoadOrGenerate
+// return false (never run on an ephemeral key that won't survive restart).
+static void TestSaveFailMakesLoadOrGenerateFail() {
+    std::cout << "[Test] M-2: Save-fail => LoadOrGenerate(false) returns false" << std::endl;
+    std::string dir = MakeTempDir();  // empty: forces the generate-then-save path
+    SetPass(nullptr);
+
+    g_seedKeySaveFailpoint = SaveFailpoint;
+    g_failpointActive = true;
+
+    CSeedAttestationKey k;
+    CHECK(!k.LoadOrGenerate(dir, /*allowGenerate=*/true),
+          "LoadOrGenerate returns false when the freshly minted key can't be saved");
+    CHECK(!k.IsValid(), "no ephemeral key left valid in memory after save failure");
+
+    g_failpointActive = false;
+    g_seedKeySaveFailpoint = nullptr;
+
+    // No persisted file (the temp was removed on the failed save).
+    std::ifstream chk(KeyPath(dir), std::ios::binary);
+    CHECK(!chk.good(), "no key file persisted after save failure");
+}
+
+// LP-13 H-1: --require-seed-key-encryption refuses plaintext (v1) keys, while the
+// DEFAULT (off) still loads a v1 file unchanged (backward-compatible rolling deploy).
+static void TestRequireEncryptionPolicy() {
+    std::cout << "[Test] H-1: require-encryption refuses plaintext; default-off still loads v1" << std::endl;
+    std::string dir = MakeTempDir();
+
+    // Write a v1 plaintext key (no passphrase).
+    SetPass(nullptr);
+    CSeedAttestationKey k1;
+    CHECK(k1.Generate(), "generate key");
+    CHECK(k1.Save(dir), "save v1 plaintext");
+    std::vector<uint8_t> raw = ReadFileBytes(KeyPath(dir));
+    CHECK(raw.size() > 5 && raw[4] == 1, "on-disk file is v1 plaintext");
+
+    // Default OFF: a v1 file still loads (backward-compatible).
+    CSeedAttestationKey kDefault;
+    CHECK(kDefault.LoadOrGenerate(dir, /*allowGenerate=*/false, /*requireEncryption=*/false),
+          "default-off LoadOrGenerate loads the v1 key");
+    CHECK(kDefault.IsValid(), "v1 key valid under default policy");
+
+    // require-encryption ON: refuse the v1 key (fail loud).
+    CSeedAttestationKey kReq;
+    CHECK(!kReq.LoadOrGenerate(dir, /*allowGenerate=*/false, /*requireEncryption=*/true),
+          "require-encryption refuses the plaintext v1 key");
+    CHECK(!kReq.IsValid(), "no key loaded when require-encryption rejects v1");
+
+    // require-encryption ON, passphrase UNSET, on Save: refuse to write plaintext.
+    std::string dir2 = MakeTempDir();
+    SetPass(nullptr);
+    CSeedAttestationKey k2;
+    CHECK(k2.Generate(), "generate key for save-refusal");
+    CHECK(!k2.Save(dir2, /*requireEncryption=*/true),
+          "Save(requireEncryption=true) refuses to write plaintext when passphrase unset");
+    std::ifstream chk(KeyPath(dir2), std::ios::binary);
+    CHECK(!chk.good(), "no plaintext file written when encryption required but unset");
+
+    // require-encryption ON, passphrase SET: Save writes v2 and load enforces it.
+    SetPass("enc-required-pass");
+    std::string dir3 = MakeTempDir();
+    CSeedAttestationKey k3;
+    CHECK(k3.Generate(), "generate key for encrypted save");
+    CHECK(k3.Save(dir3, /*requireEncryption=*/true), "Save(requireEncryption) writes v2 when passphrase set");
+    std::vector<uint8_t> raw3 = ReadFileBytes(KeyPath(dir3));
+    CHECK(raw3.size() > 5 && raw3[4] == 2, "on-disk file is v2 encrypted");
+    CSeedAttestationKey k4;
+    CHECK(k4.LoadOrGenerate(dir3, false, /*requireEncryption=*/true),
+          "require-encryption accepts the v2 key");
+    CHECK(k4.IsValid(), "v2 key valid under require-encryption");
+    SetPass(nullptr);
+}
+
 #ifndef _WIN32
+// LP-13 M-3: Load repairs the perms of a pre-existing world/group-readable key
+// file (a legacy v1 written 0644 before this hardening) back to 0600.
+static void TestLoadRepairsPerms() {
+    std::cout << "[Test] M-3: Load repairs permissive perms to 0600 (POSIX)" << std::endl;
+    std::string dir = MakeTempDir();
+    SetPass(nullptr);
+    CSeedAttestationKey k1;
+    k1.Generate();
+    CHECK(k1.Save(dir), "save v1 key");
+
+    // Deliberately loosen perms to simulate a legacy 0644 file.
+    CHECK(chmod(KeyPath(dir).c_str(), S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH) == 0,
+          "loosen perms to 0644");
+    struct stat st0;
+    CHECK(stat(KeyPath(dir).c_str(), &st0) == 0 && (st0.st_mode & 0777) != (S_IRUSR | S_IWUSR),
+          "perms are permissive before load");
+
+    CSeedAttestationKey k2;
+    CHECK(k2.Load(dir), "load the (permissive) key file");
+    struct stat st1;
+    CHECK(stat(KeyPath(dir).c_str(), &st1) == 0, "stat after load");
+    CHECK((st1.st_mode & 0777) == (S_IRUSR | S_IWUSR), "Load repaired perms to 0600");
+}
+
+// LP-13 M-4: if 0600 perms cannot be set on the (temp) key file, Save fails
+// closed rather than publishing a possibly group/other-readable consensus key.
+// Inducing a chmod/fchmod failure portably is hard; we use a best-effort trigger
+// (a data dir on a filesystem that ignores chmod is the real-world case). This
+// test runs as root-aware: if it cannot induce the failure it reports SKIP
+// rather than a false pass/fail.
+static void TestFailClosedPerms() {
+    std::cout << "[Test] M-4: fail-closed when 0600 cannot be set (POSIX, best-effort)" << std::endl;
+    // We cannot reliably force fchmod+chmod to BOTH fail on a normal tmpfs as an
+    // unprivileged user without an exotic mount. Document the path is covered by
+    // code review + the explicit !permOk && !permOk2 guard; mark informational.
+    std::cout << "  [info] M-4 fail-closed guard is exercised by code path "
+                 "(!permOk && !permOk2 => return false); no portable injection here." << std::endl;
+}
+
 static void TestPosixPerms() {
     std::cout << "[Test] POSIX key file is 0600 (AC1)" << std::endl;
     std::string dir = MakeTempDir();
@@ -317,7 +479,12 @@ int main() {
     TestV1BackwardCompat();
     TestAutoMintGate();
     TestSecretBufferCleansed();
+    TestAtomicSaveOriginalSurvives();        // H-2 (THE load-bearing test)
+    TestSaveFailMakesLoadOrGenerateFail();   // M-2
+    TestRequireEncryptionPolicy();           // H-1
 #ifndef _WIN32
+    TestLoadRepairsPerms();                  // M-3
+    TestFailClosedPerms();                   // M-4 (best-effort/informational)
     TestPosixPerms();
 #endif
 


### PR DESCRIPTION
**LP-13 — seed-attestation private key stored PLAINTEXT at rest, auto-minted on first run, no file permissions. HIGH.** A leaked key forges attestations that bypass the datacenter ban (live-only, never re-checked in consensus) → unlimited Sybil MIKs on BOTH chains (shared keys).

Fix: chmod 0600 on save (POSIX `O_CREAT` 0600 + `fchmod`); encrypt-at-rest reusing the audited `wallet/crypter` (AES-256-CBC + PBKDF2-SHA3 500k + encrypt-then-MAC, verify-before-decrypt), `KEY_FILE_VERSION_V2`, passphrase from `DILITHION_SEED_KEY_PASSPHRASE`, v1 plaintext still read for migration; auto-mint gated behind `--generate-seed-key` (fail-loud on a reprovisioned seed).

**Reviews:** red-team-validator found one MEDIUM (v1 plaintext buffer not cleansed) → **folded + mutation-verified**; 2 LOWs folded. Remaining: red-team-on-fold + `/evaluate`.

**Ops (yours):** migrating EXISTING plaintext key files on the live seeds is an operator step, out of this code-only PR. DRAFT. Contract in `.claude/missions/seed-key-at-rest/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)