### PR TITLE
fix(wallet): LP-9 — browser wallet migrate-then-require (no plaintext seed at rest)

### DIFF
--- a/src/api/wallet_html.h
+++ b/src/api/wallet_html.h
@@ -5532,7 +5532,15 @@ inline const std::string& GetWalletHTML() {
                     try { await handleModeChange(); } catch (e) { /* connection handled elsewhere */ }
                 }
             } catch (e) {
-                showErr('Could not encrypt wallet: ' + (e && e.message ? e.message : 'unknown error') + ' — your wallet is unchanged. Please try again.');
+                const msg = (e && e.message) ? e.message : 'unknown error';
+                // The "raced" case (another tab encrypted this wallet first) DID change the
+                // stored wallet, so the "your wallet is unchanged" reassurance would be wrong.
+                // That error message already explains the situation; surface it as-is. Only
+                // append "unchanged" for genuine failures where the wallet is truly untouched.
+                const raced = /encrypted in another tab/i.test(msg);
+                showErr(raced
+                    ? ('Could not encrypt wallet: ' + msg)
+                    : ('Could not encrypt wallet: ' + msg + ' — your wallet is unchanged. Please try again.'));
                 if (btn) { btn.disabled = false; btn.textContent = 'Encrypt & Continue'; }
                 return;
             }

--- a/src/api/wallet_html.h
+++ b/src/api/wallet_html.h
@@ -46,10 +46,17 @@ inline const std::string& GetWalletHTML() {
     <script>!function(t){if("object"==typeof exports&&"undefined"!=typeof module)module.exports=t();else if("function"==typeof define&&define.amd)define([],t);else{var e;e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:this,e.QRCode=t()}}(function(){return function(){function t(e,r,n){function o(a,u){if(!r[a]){if(!e[a]){var s="function"==typeof require&&require;if(!u&&s)return s(a,!0);if(i)return i(a,!0);var f=new Error("Cannot find module '"+a+"'");throw f.code="MODULE_NOT_FOUND",f}var l=r[a]={exports:{}};e[a][0].call(l.exports,function(t){return o(e[a][1][t]||t)},l,l.exports,t,e,r,n)}return r[a].exports}for(var i="function"==typeof require&&require,a=0;a<n.length;a++)o(n[a]);return o}return t}()({1:[function(t,e,r){var n=t("./utils").getSymbolSize;r.getRowColCoords=function(t){if(1===t)return[];for(var e=Math.floor(t/7)+2,r=n(t),o=145===r?26:2*Math.ceil((r-13)/(2*e-2)),i=[r-7],a=1;a<e-1;a++)i[a]=i[a-1]-o;return i.push(6),i.reverse()},r.getPositions=function(t){for(var e=[],n=r.getRowColCoords(t),o=n.length,i=0;i<o;i++)for(var a=0;a<o;a++)0===i&&0===a||0===i&&a===o-1||i===o-1&&0===a||e.push([n[i],n[a]]);return e}},{"./utils":20}],2:[function(t,e,r){function n(t){this.mode=o.ALPHANUMERIC,this.data=t}var o=t("./mode"),i=["0","1","2","3","4","5","6","7","8","9","A","B","C","D","E","F","G","H","I","J","K","L","M","N","O","P","Q","R","S","T","U","V","W","X","Y","Z"," ","$","%","*","+","-",".","/",":"];n.getBitsLength=function(t){return 11*Math.floor(t/2)+t%2*6},n.prototype.getLength=function(){return this.data.length},n.prototype.getBitsLength=function(){return n.getBitsLength(this.data.length)},n.prototype.write=function(t){var e;for(e=0;e+2<=this.data.length;e+=2){var r=45*i.indexOf(this.data[e]);r+=i.indexOf(this.data[e+1]),t.put(r,11)}this.data.length%2&&t.put(i.indexOf(this.data[e]),6)},e.exports=n},{"./mode":13}],3:[function(t,e,r){function n(){this.buffer=[],this.length=0}n.prototype={get:function(t){var e=Math.floor(t/8);return 1==(this.buffer[e]>>>7-t%8&1)},put:function(t,e){for(var r=0;r<e;r++)this.putBit(1==(t>>>e-r-1&1))},getLengthInBits:function(){return this.length},putBit:function(t){var e=Math.floor(this.length/8);this.buffer.length<=e&&this.buffer.push(0),t&&(this.buffer[e]|=128>>>this.length%8),this.length++}},e.exports=n},{}],4:[function(t,e,r){function n(t){if(!t||t<1)throw new Error("BitMatrix size must be defined and greater than 0");this.size=t,this.data=new o(t*t),this.data.fill(0),this.reservedBit=new o(t*t),this.reservedBit.fill(0)}var o=t("../utils/buffer");n.prototype.set=function(t,e,r,n){var o=t*this.size+e;this.data[o]=r,n&&(this.reservedBit[o]=!0)},n.prototype.get=function(t,e){return this.data[t*this.size+e]},n.prototype.xor=function(t,e,r){this.data[t*this.size+e]^=r},n.prototype.isReserved=function(t,e){return this.reservedBit[t*this.size+e]},e.exports=n},{"../utils/buffer":27}],5:[function(t,e,r){function n(t){this.mode=i.BYTE,this.data=new o(t)}var o=t("../utils/buffer"),i=t("./mode");n.getBitsLength=function(t){return 8*t},n.prototype.getLength=function(){return this.data.length},n.prototype.getBitsLength=function(){return n.getBitsLength(this.data.length)},n.prototype.write=function(t){for(var e=0,r=this.data.length;e<r;e++)t.put(this.data[e],8)},e.exports=n},{"../utils/buffer":27,"./mode":13}],6:[function(t,e,r){var n=t("./error-correction-level"),o=[1,1,1,1,1,1,1,1,1,1,2,2,1,2,2,4,1,2,4,4,2,4,4,4,2,4,6,5,2,4,6,6,2,5,8,8,4,5,8,8,4,5,8,11,4,8,10,11,4,9,12,16,4,9,16,16,6,10,12,18,6,10,17,16,6,11,16,19,6,13,18,21,7,14,21,25,8,16,20,25,8,17,23,25,9,17,23,34,9,18,25,30,10,20,27,32,12,21,29,35,12,23,34,37,12,25,34,40,13,26,35,42,14,28,38,45,15,29,40,48,16,31,43,51,17,33,45,54,18,35,48,57,19,37,51,60,19,38,53,63,20,40,56,66,21,43,59,70,22,45,62,74,24,47,65,77,25,49,68,81],i=[7,10,13,17,10,16,22,28,15,26,36,44,20,36,52,64,26,48,72,88,36,64,96,112,40,72,108,130,48,88,132,156,60,110,160,192,72,130,192,224,80,150,224,264,96,176,260,308,104,198,288,352,120,216,320,384,132,240,360,432,144,280,408,480,168,308,448,532,180,338,504,588,196,364,546,650,224,416,600,700,224,442,644,750,252,476,690,816,270,504,750,900,300,560,810,960,312,588,870,1050,336,644,952,1110,360,700,1020,1200,390,728,1050,1260,420,784,1140,1350,450,812,1200,1440,480,868,1290,1530,510,924,1350,1620,540,980,1440,1710,570,1036,1530,1800,570,1064,1590,1890,600,1120,1680,1980,630,1204,1770,2100,660,1260,1860,2220,720,1316,1950,2310,750,1372,2040,2430];r.getBlocksCount=function(t,e){switch(e){case n.L:return o[4*(t-1)+0];case n.M:return o[4*(t-1)+1];case n.Q:return o[4*(t-1)+2];case n.H:return o[4*(t-1)+3];default:return}},r.getTotalCodewordsCount=function(t,e){switch(e){case n.L:return i[4*(t-1)+0];case n.M:return i[4*(t-1)+1];case n.Q:return i[4*(t-1)+2];case n.H:return i[4*(t-1)+3];default:return}}},{"./error-correction-level":7}],7:[function(t,e,r){function n(t){if("string"!=typeof t)throw new Error("Param is not a string");switch(t.toLowerCase()){case"l":case"low":return r.L;case"m":case"medium":return r.M;case"q":case"quartile":return r.Q;case"h":case"high":return r.H;default:throw new Error("Unknown EC Level: "+t)}}r.L={bit:1},r.M={bit:0},r.Q={bit:3},r.H={bit:2},r.isValid=function(t){return t&&void 0!==t.bit&&t.bit>=0&&t.bit<4},r.from=function(t,e){if(r.isValid(t))return t;try{return n(t)}catch(t){return e}}},{}],8:[function(t,e,r){var n=t("./utils").getSymbolSize;r.getPositions=function(t){var e=n(t);return[[0,0],[e-7,0],[0,e-7]]}},{"./utils":20}],9:[function(t,e,r){var n=t("./utils"),o=n.getBCHDigit(1335);r.getEncodedBits=function(t,e){for(var r=t.bit<<3|e,i=r<<10;n.getBCHDigit(i)-o>=0;)i^=1335<<n.getBCHDigit(i)-o;return 21522^(r<<10|i)}},{"./utils":20}],10:[function(t,e,r){var n=t("../utils/buffer"),o=new n(512),i=new n(256);!function(){for(var t=1,e=0;e<255;e++)o[e]=t,i[t]=e,256&(t<<=1)&&(t^=285);for(e=255;e<512;e++)o[e]=o[e-255]}(),r.log=function(t){if(t<1)throw new Error("log("+t+")");return i[t]},r.exp=function(t){return o[t]},r.mul=function(t,e){return 0===t||0===e?0:o[i[t]+i[e]]}},{"../utils/buffer":27}],11:[function(t,e,r){function n(t){this.mode=o.KANJI,this.data=t}var o=t("./mode"),i=t("./utils");n.getBitsLength=function(t){return 13*t},n.prototype.getLength=function(){return this.data.length},n.prototype.getBitsLength=function(){return n.getBitsLength(this.data.length)},n.prototype.write=function(t){var e;for(e=0;e<this.data.length;e++){var r=i.toSJIS(this.data[e]);if(r>=33088&&r<=40956)r-=33088;else{if(!(r>=57408&&r<=60351))throw new Error("Invalid SJIS character: "+this.data[e]+"\nMake sure your charset is UTF-8");r-=49472}r=192*(r>>>8&255)+(255&r),t.put(r,13)}},e.exports=n},{"./mode":13,"./utils":20}],12:[function(t,e,r){function n(t,e,n){switch(t){case r.Patterns.PATTERN000:return(e+n)%2==0;case r.Patterns.PATTERN001:return e%2==0;case r.Patterns.PATTERN010:return n%3==0;case r.Patterns.PATTERN011:return(e+n)%3==0;case r.Patterns.PATTERN100:return(Math.floor(e/2)+Math.floor(n/3))%2==0;case r.Patterns.PATTERN101:return e*n%2+e*n%3==0;case r.Patterns.PATTERN110:return(e*n%2+e*n%3)%2==0;case r.Patterns.PATTERN111:return(e*n%3+(e+n)%2)%2==0;default:throw new Error("bad maskPattern:"+t)}}r.Patterns={PATTERN000:0,PATTERN001:1,PATTERN010:2,PATTERN011:3,PATTERN100:4,PATTERN101:5,PATTERN110:6,PATTERN111:7};var o={N1:3,N2:3,N3:40,N4:10};r.isValid=function(t){return null!=t&&""!==t&&!isNaN(t)&&t>=0&&t<=7},r.from=function(t){return r.isValid(t)?parseInt(t,10):void 0},r.getPenaltyN1=function(t){for(var e=t.size,r=0,n=0,i=0,a=null,u=null,s=0;s<e;s++){n=i=0,a=u=null;for(var f=0;f<e;f++){var l=t.get(s,f);l===a?n++:(n>=5&&(r+=o.N1+(n-5)),a=l,n=1),l=t.get(f,s),l===u?i++:(i>=5&&(r+=o.N1+(i-5)),u=l,i=1)}n>=5&&(r+=o.N1+(n-5)),i>=5&&(r+=o.N1+(i-5))}return r},r.getPenaltyN2=function(t){for(var e=t.size,r=0,n=0;n<e-1;n++)for(var i=0;i<e-1;i++){var a=t.get(n,i)+t.get(n,i+1)+t.get(n+1,i)+t.get(n+1,i+1);4!==a&&0!==a||r++}return r*o.N2},r.getPenaltyN3=function(t){for(var e=t.size,r=0,n=0,i=0,a=0;a<e;a++){n=i=0;for(var u=0;u<e;u++)n=n<<1&2047|t.get(a,u),u>=10&&(1488===n||93===n)&&r++,i=i<<1&2047|t.get(u,a),u>=10&&(1488===i||93===i)&&r++}return r*o.N3},r.getPenaltyN4=function(t){for(var e=0,r=t.data.length,n=0;n<r;n++)e+=t.data[n];return Math.abs(Math.ceil(100*e/r/5)-10)*o.N4},r.applyMask=function(t,e){for(var r=e.size,o=0;o<r;o++)for(var i=0;i<r;i++)e.isReserved(i,o)||e.xor(i,o,n(t,i,o))},r.getBestMask=function(t,e){for(var n=Object.keys(r.Patterns).length,o=0,i=1/0,a=0;a<n;a++){e(a),r.applyMask(a,t);var u=r.getPenaltyN1(t)+r.getPenaltyN2(t)+r.getPenaltyN3(t)+r.getPenaltyN4(t);r.applyMask(a,t),u<i&&(i=u,o=a)}return o}},{}],13:[function(t,e,r){function n(t){if("string"!=typeof t)throw new Error("Param is not a string");switch(t.toLowerCase()){case"numeric":return r.NUMERIC;case"alphanumeric":return r.ALPHANUMERIC;case"kanji":return r.KANJI;case"byte":return r.BYTE;default:throw new Error("Unknown mode: "+t)}}var o=t("./version-check"),i=t("./regex");r.NUMERIC={id:"Numeric",bit:1,ccBits:[10,12,14]},r.ALPHANUMERIC={id:"Alphanumeric",bit:2,ccBits:[9,11,13]},r.BYTE={id:"Byte",bit:4,ccBits:[8,16,16]},r.KANJI={id:"Kanji",bit:8,ccBits:[8,10,12]},r.MIXED={bit:-1},r.getCharCountIndicator=function(t,e){if(!t.ccBits)throw new Error("Invalid mode: "+t);if(!o.isValid(e))throw new Error("Invalid version: "+e);return e>=1&&e<10?t.ccBits[0]:e<27?t.ccBits[1]:t.ccBits[2]},r.getBestModeForData=function(t){return i.testNumeric(t)?r.NUMERIC:i.testAlphanumeric(t)?r.ALPHANUMERIC:i.testKanji(t)?r.KANJI:r.BYTE},r.toString=function(t){if(t&&t.id)return t.id;throw new Error("Invalid mode")},r.isValid=function(t){return t&&t.bit&&t.ccBits},r.from=function(t,e){if(r.isValid(t))return t;try{return n(t)}catch(t){return e}}},{"./regex":18,"./version-check":21}],14:[function(t,e,r){function n(t){this.mode=o.NUMERIC,this.data=t.toString()}var o=t("./mode");n.getBitsLength=function(t){return 10*Math.floor(t/3)+(t%3?t%3*3+1:0)},n.prototype.getLength=function(){return this.data.length},n.prototype.getBitsLength=function(){return n.getBitsLength(this.data.length)},n.prototype.write=function(t){var e,r,n;for(e=0;e+3<=this.data.length;e+=3)r=this.data.substr(e,3),n=parseInt(r,10),t.put(n,10);var o=this.data.length-e;o>0&&(r=this.data.substr(e),n=parseInt(r,10),t.put(n,3*o+1))},e.exports=n},{"./mode":13}],15:[function(t,e,r){var n=t("../utils/buffer"),o=t("./galois-field");r.mul=function(t,e){var r=new n(t.length+e.length-1);r.fill(0);for(var i=0;i<t.length;i++)for(var a=0;a<e.length;a++)r[i+a]^=o.mul(t[i],e[a]);return r},r.mod=function(t,e){for(var r=new n(t);r.length-e.length>=0;){for(var i=r[0],a=0;a<e.length;a++)r[a]^=o.mul(e[a],i);for(var u=0;u<r.length&&0===r[u];)u++;r=r.slice(u)}return r},r.generateECPolynomial=function(t){for(var e=new n([1]),i=0;i<t;i++)e=r.mul(e,[1,o.exp(i)]);return e}},{"../utils/buffer":27,"./galois-field":10}],16:[function(t,e,r){function n(t,e){for(var r=t.size,n=m.getPositions(e),o=0;o<n.length;o++)for(var i=n[o][0],a=n[o][1],u=-1;u<=7;u++)if(!(i+u<=-1||r<=i+u))for(var s=-1;s<=7;s++)a+s<=-1||r<=a+s||(u>=0&&u<=6&&(0===s||6===s)||s>=0&&s<=6&&(0===u||6===u)||u>=2&&u<=4&&s>=2&&s<=4?t.set(i+u,a+s,!0,!0):t.set(i+u,a+s,!1,!0))}function o(t){for(var e=t.size,r=8;r<e-8;r++){var n=r%2==0;t.set(r,6,n,!0),t.set(6,r,n,!0)}}function i(t,e){for(var r=w.getPositions(e),n=0;n<r.length;n++)for(var o=r[n][0],i=r[n][1],a=-2;a<=2;a++)for(var u=-2;u<=2;u++)-2===a||2===a||-2===u||2===u||0===a&&0===u?t.set(o+a,i+u,!0,!0):t.set(o+a,i+u,!1,!0)}function a(t,e){for(var r,n,o,i=t.size,a=A.getEncodedBits(e),u=0;u<18;u++)r=Math.floor(u/3),n=u%3+i-8-3,o=1==(a>>u&1),t.set(r,n,o,!0),t.set(n,r,o,!0)}function u(t,e,r){var n,o,i=t.size,a=B.getEncodedBits(e,r);for(n=0;n<15;n++)o=1==(a>>n&1),n<6?t.set(n,8,o,!0):n<8?t.set(n+1,8,o,!0):t.set(i-15+n,8,o,!0),n<8?t.set(8,i-n-1,o,!0):n<9?t.set(8,15-n-1+1,o,!0):t.set(8,15-n-1,o,!0);t.set(i-8,8,1,!0)}function s(t,e){for(var r=t.size,n=-1,o=r-1,i=7,a=0,u=r-1;u>0;u-=2)for(6===u&&u--;;){for(var s=0;s<2;s++)if(!t.isReserved(o,u-s)){var f=!1;a<e.length&&(f=1==(e[a]>>>i&1)),t.set(o,u-s,f),i--,-1===i&&(a++,i=7)}if((o+=n)<0||r<=o){o-=n,n=-n;break}}}function f(t,e,r){var n=new p;r.forEach(function(e){n.put(e.mode.bit,4),n.put(e.getLength(),R.getCharCountIndicator(e.mode,t)),e.write(n)});var o=d.getSymbolTotalCodewords(t),i=E.getTotalCodewordsCount(t,e),a=8*(o-i);for(n.getLengthInBits()+4<=a&&n.put(0,4);n.getLengthInBits()%8!=0;)n.putBit(0);for(var u=(a-n.getLengthInBits())/8,s=0;s<u;s++)n.put(s%2?17:236,8);return l(n,t,e)}function l(t,e,r){for(var n=d.getSymbolTotalCodewords(e),o=E.getTotalCodewordsCount(e,r),i=n-o,a=E.getBlocksCount(e,r),u=n%a,s=a-u,f=Math.floor(n/a),l=Math.floor(i/a),c=l+1,g=f-l,p=new b(g),v=0,w=new Array(a),m=new Array(a),y=0,A=new h(t.buffer),B=0;B<a;B++){var R=B<s?l:c;w[B]=A.slice(v,v+R),m[B]=p.encode(w[B]),v+=R,y=Math.max(y,R)}var P,T,C=new h(n),N=0;for(P=0;P<y;P++)for(T=0;T<a;T++)P<w[T].length&&(C[N++]=w[T][P]);for(P=0;P<g;P++)for(T=0;T<a;T++)C[N++]=m[T][P];return C}function c(t,e,r,l){var c;if(T(t))c=P.fromArray(t);else{if("string"!=typeof t)throw new Error("Invalid data");var h=e;if(!h){var g=P.rawSplit(t);h=A.getBestVersionForData(g,r)}c=P.fromString(t,h||40)}var p=A.getBestVersionForData(c,r);if(!p)throw new Error("The amount of data is too big to be stored in a QR Code");if(e){if(e<p)throw new Error("\nThe chosen QR Code version cannot contain this amount of data.\nMinimum version required to store current data is: "+p+".\n")}else e=p;var w=f(e,r,c),m=d.getSymbolSize(e),E=new v(m);return n(E,e),o(E),i(E,e),u(E,r,0),e>=7&&a(E,e),s(E,w),isNaN(l)&&(l=y.getBestMask(E,u.bind(null,E,r))),y.applyMask(l,E),u(E,r,l),{modules:E,version:e,errorCorrectionLevel:r,maskPattern:l,segments:c}}var h=t("../utils/buffer"),d=t("./utils"),g=t("./error-correction-level"),p=t("./bit-buffer"),v=t("./bit-matrix"),w=t("./alignment-pattern"),m=t("./finder-pattern"),y=t("./mask-pattern"),E=t("./error-correction-code"),b=t("./reed-solomon-encoder"),A=t("./version"),B=t("./format-info"),R=t("./mode"),P=t("./segments"),T=t("isarray");r.create=function(t,e){if(void 0===t||""===t)throw new Error("No input text");var r,n,o=g.M;return void 0!==e&&(o=g.from(e.errorCorrectionLevel,g.M),r=A.from(e.version),n=y.from(e.maskPattern),e.toSJISFunc&&d.setToSJISFunction(e.toSJISFunc)),c(t,r,o,n)}},{"../utils/buffer":27,"./alignment-pattern":1,"./bit-buffer":3,"./bit-matrix":4,"./error-correction-code":6,"./error-correction-level":7,"./finder-pattern":8,"./format-info":9,"./mask-pattern":12,"./mode":13,"./reed-solomon-encoder":17,"./segments":19,"./utils":20,"./version":22,isarray:30}],17:[function(t,e,r){function n(t){this.genPoly=void 0,this.degree=t,this.degree&&this.initialize(this.degree)}var o=t("../utils/buffer"),i=t("./polynomial");n.prototype.initialize=function(t){this.degree=t,this.genPoly=i.generateECPolynomial(this.degree)},n.prototype.encode=function(t){if(!this.genPoly)throw new Error("Encoder not initialized");var e=new o(this.degree);e.fill(0);var r=o.concat([t,e],t.length+this.degree),n=i.mod(r,this.genPoly),a=this.degree-n.length;if(a>0){var u=new o(this.degree);return u.fill(0),n.copy(u,a),u}return n},e.exports=n},{"../utils/buffer":27,"./polynomial":15}],18:[function(t,e,r){var n="(?:[u3000-u303F]|[u3040-u309F]|[u30A0-u30FF]|[uFF00-uFFEF]|[u4E00-u9FAF]|[u2605-u2606]|[u2190-u2195]|u203B|[u2010u2015u2018u2019u2025u2026u201Cu201Du2225u2260]|[u0391-u0451]|[u00A7u00A8u00B1u00B4u00D7u00F7])+";n=n.replace(/u/g,"\\u");var o="(?:(?![A-Z0-9 $%*+\\-./:]|"+n+").)+";r.KANJI=new RegExp(n,"g"),r.BYTE_KANJI=new RegExp("[^A-Z0-9 $%*+\\-./:]+","g"),r.BYTE=new RegExp(o,"g"),r.NUMERIC=new RegExp("[0-9]+","g"),r.ALPHANUMERIC=new RegExp("[A-Z $%*+\\-./:]+","g");var i=new RegExp("^"+n+"$"),a=new RegExp("^[0-9]+$"),u=new RegExp("^[A-Z0-9 $%*+\\-./:]+$");r.testKanji=function(t){return i.test(t)},r.testNumeric=function(t){return a.test(t)},r.testAlphanumeric=function(t){return u.test(t)}},{}],19:[function(t,e,r){function n(t){return unescape(encodeURIComponent(t)).length}function o(t,e,r){for(var n,o=[];null!==(n=t.exec(r));)o.push({data:n[0],index:n.index,mode:e,length:n[0].length});return o}function i(t){var e,r,n=o(v.NUMERIC,c.NUMERIC,t),i=o(v.ALPHANUMERIC,c.ALPHANUMERIC,t);return w.isKanjiModeEnabled()?(e=o(v.BYTE,c.BYTE,t),r=o(v.KANJI,c.KANJI,t)):(e=o(v.BYTE_KANJI,c.BYTE,t),r=[]),n.concat(i,e,r).sort(function(t,e){return t.index-e.index}).map(function(t){return{data:t.data,mode:t.mode,length:t.length}})}function a(t,e){switch(e){case c.NUMERIC:return h.getBitsLength(t);case c.ALPHANUMERIC:return d.getBitsLength(t);case c.KANJI:return p.getBitsLength(t);case c.BYTE:return g.getBitsLength(t)}}function u(t){return t.reduce(function(t,e){var r=t.length-1>=0?t[t.length-1]:null;return r&&r.mode===e.mode?(t[t.length-1].data+=e.data,t):(t.push(e),t)},[])}function s(t){for(var e=[],r=0;r<t.length;r++){var o=t[r];switch(o.mode){case c.NUMERIC:e.push([o,{data:o.data,mode:c.ALPHANUMERIC,length:o.length},{data:o.data,mode:c.BYTE,length:o.length}]);break;case c.ALPHANUMERIC:e.push([o,{data:o.data,mode:c.BYTE,length:o.length}]);break;case c.KANJI:e.push([o,{data:o.data,mode:c.BYTE,length:n(o.data)}]);break;case c.BYTE:e.push([{data:o.data,mode:c.BYTE,length:n(o.data)}])}}return e}function f(t,e){for(var r={},n={start:{}},o=["start"],i=0;i<t.length;i++){for(var u=t[i],s=[],f=0;f<u.length;f++){var l=u[f],h=""+i+f;s.push(h),r[h]={node:l,lastCount:0},n[h]={};for(var d=0;d<o.length;d++){var g=o[d];r[g]&&r[g].node.mode===l.mode?(n[g][h]=a(r[g].lastCount+l.length,l.mode)-a(r[g].lastCount,l.mode),r[g].lastCount+=l.length):(r[g]&&(r[g].lastCount=l.length),n[g][h]=a(l.length,l.mode)+4+c.getCharCountIndicator(l.mode,e))}}o=s}for(d=0;d<o.length;d++)n[o[d]].end=0;return{map:n,table:r}}function l(t,e){var r,n=c.getBestModeForData(t);if((r=c.from(e,n))!==c.BYTE&&r.bit<n.bit)throw new Error('"'+t+'" cannot be encoded with mode '+c.toString(r)+".\n Suggested mode is: "+c.toString(n));switch(r!==c.KANJI||w.isKanjiModeEnabled()||(r=c.BYTE),r){case c.NUMERIC:return new h(t);case c.ALPHANUMERIC:return new d(t);case c.KANJI:return new p(t);case c.BYTE:return new g(t)}}var c=t("./mode"),h=t("./numeric-data"),d=t("./alphanumeric-data"),g=t("./byte-data"),p=t("./kanji-data"),v=t("./regex"),w=t("./utils"),m=t("dijkstrajs");r.fromArray=function(t){return t.reduce(function(t,e){return"string"==typeof e?t.push(l(e,null)):e.data&&t.push(l(e.data,e.mode)),t},[])},r.fromString=function(t,e){for(var n=i(t,w.isKanjiModeEnabled()),o=s(n),a=f(o,e),l=m.find_path(a.map,"start","end"),c=[],h=1;h<l.length-1;h++)c.push(a.table[l[h]].node);return r.fromArray(u(c))},r.rawSplit=function(t){return r.fromArray(i(t,w.isKanjiModeEnabled()))}},{"./alphanumeric-data":2,"./byte-data":5,"./kanji-data":11,"./mode":13,"./numeric-data":14,"./regex":18,"./utils":20,dijkstrajs:29}],20:[function(t,e,r){var n,o=[0,26,44,70,100,134,172,196,242,292,346,404,466,532,581,655,733,815,901,991,1085,1156,1258,1364,1474,1588,1706,1828,1921,2051,2185,2323,2465,2611,2761,2876,3034,3196,3362,3532,3706];r.getSymbolSize=function(t){if(!t)throw new Error('"version" cannot be null or undefined');if(t<1||t>40)throw new Error('"version" should be in range from 1 to 40');return 4*t+17},r.getSymbolTotalCodewords=function(t){return o[t]},r.getBCHDigit=function(t){for(var e=0;0!==t;)e++,t>>>=1;return e},r.setToSJISFunction=function(t){if("function"!=typeof t)throw new Error('"toSJISFunc" is not a valid function.');n=t},r.isKanjiModeEnabled=function(){return void 0!==n},r.toSJIS=function(t){return n(t)}},{}],21:[function(t,e,r){r.isValid=function(t){return!isNaN(t)&&t>=1&&t<=40}},{}],22:[function(t,e,r){function n(t,e,n){for(var o=1;o<=40;o++)if(e<=r.getCapacity(o,n,t))return o}function o(t,e){return l.getCharCountIndicator(t,e)+4}function i(t,e){var r=0;return t.forEach(function(t){var n=o(t.mode,e);r+=n+t.getBitsLength()}),r}function a(t,e){for(var n=1;n<=40;n++){if(i(t,n)<=r.getCapacity(n,e,l.MIXED))return n}}var u=t("./utils"),s=t("./error-correction-code"),f=t("./error-correction-level"),l=t("./mode"),c=t("./version-check"),h=t("isarray"),d=u.getBCHDigit(7973);r.from=function(t,e){return c.isValid(t)?parseInt(t,10):e},r.getCapacity=function(t,e,r){if(!c.isValid(t))throw new Error("Invalid QR Code version");void 0===r&&(r=l.BYTE);var n=u.getSymbolTotalCodewords(t),i=s.getTotalCodewordsCount(t,e),a=8*(n-i);if(r===l.MIXED)return a;var f=a-o(r,t);switch(r){case l.NUMERIC:return Math.floor(f/10*3);case l.ALPHANUMERIC:return Math.floor(f/11*2);case l.KANJI:return Math.floor(f/13);case l.BYTE:default:return Math.floor(f/8)}},r.getBestVersionForData=function(t,e){var r,o=f.from(e,f.M);if(h(t)){if(t.length>1)return a(t,o);if(0===t.length)return 1;r=t[0]}else r=t;return n(r.mode,r.getLength(),o)},r.getEncodedBits=function(t){if(!c.isValid(t)||t<7)throw new Error("Invalid QR Code version");for(var e=t<<12;u.getBCHDigit(e)-d>=0;)e^=7973<<u.getBCHDigit(e)-d;return t<<12|e}},{"./error-correction-code":6,"./error-correction-level":7,"./mode":13,"./utils":20,"./version-check":21,isarray:30}],23:[function(t,e,r){function n(t,e,r,n,a){var u=[].slice.call(arguments,1),s=u.length,f="function"==typeof u[s-1];if(!f&&!o())throw new Error("Callback required as last argument");if(!f){if(s<1)throw new Error("Too few arguments provided");return 1===s?(r=e,e=n=void 0):2!==s||e.getContext||(n=r,r=e,e=void 0),new Promise(function(o,a){try{var u=i.create(r,n);o(t(u,e,n))}catch(t){a(t)}})}if(s<2)throw new Error("Too few arguments provided");2===s?(a=r,r=e,e=n=void 0):3===s&&(e.getContext&&void 0===a?(a=n,n=void 0):(a=n,n=r,r=e,e=void 0));try{var l=i.create(r,n);a(null,t(l,e,n))}catch(t){a(t)}}var o=t("can-promise"),i=t("./core/qrcode"),a=t("./renderer/canvas"),u=t("./renderer/svg-tag.js");r.create=i.create,r.toCanvas=n.bind(null,a.render),r.toDataURL=n.bind(null,a.renderToDataURL),r.toString=n.bind(null,function(t,e,r){return u.render(t,r)})},{"./core/qrcode":16,"./renderer/canvas":24,"./renderer/svg-tag.js":25,"can-promise":28}],24:[function(t,e,r){function n(t,e,r){t.clearRect(0,0,e.width,e.height),e.style||(e.style={}),e.height=r,e.width=r,e.style.height=r+"px",e.style.width=r+"px"}function o(){try{return document.createElement("canvas")}catch(t){throw new Error("You need to specify a canvas element")}}var i=t("./utils");r.render=function(t,e,r){var a=r,u=e;void 0!==a||e&&e.getContext||(a=e,e=void 0),e||(u=o()),a=i.getOptions(a);var s=i.getImageWidth(t.modules.size,a),f=u.getContext("2d"),l=f.createImageData(s,s);return i.qrToImageData(l.data,t,a),n(f,u,s),f.putImageData(l,0,0),u},r.renderToDataURL=function(t,e,n){var o=n;void 0!==o||e&&e.getContext||(o=e,e=void 0),o||(o={});var i=r.render(t,e,o),a=o.type||"image/png",u=o.rendererOpts||{};return i.toDataURL(a,u.quality)}},{"./utils":26}],25:[function(t,e,r){function n(t,e){var r=t.a/255,n=e+'="'+t.hex+'"';return r<1?n+" "+e+'-opacity="'+r.toFixed(2).slice(1)+'"':n}function o(t,e,r){var n=t+e;return void 0!==r&&(n+=" "+r),n}function i(t,e,r){for(var n="",i=0,a=!1,u=0,s=0;s<t.length;s++){var f=Math.floor(s%e),l=Math.floor(s/e);f||a||(a=!0),t[s]?(u++,s>0&&f>0&&t[s-1]||(n+=a?o("M",f+r,.5+l+r):o("m",i,0),i=0,a=!1),f+1<e&&t[s+1]||(n+=o("h",u),u=0)):i++}return n}var a=t("./utils");r.render=function(t,e,r){var o=a.getOptions(e),u=t.modules.size,s=t.modules.data,f=u+2*o.margin,l=o.color.light.a?"<path "+n(o.color.light,"fill")+' d="M0 0h'+f+"v"+f+'H0z"/>':"",c="<path "+n(o.color.dark,"stroke")+' d="'+i(s,u,o.margin)+'"/>',h='viewBox="0 0 '+f+" "+f+'"',d=o.width?'width="'+o.width+'" height="'+o.width+'" ':"",g='<svg xmlns="http://www.w3.org/2000/svg" '+d+h+' shape-rendering="crispEdges">'+l+c+"</svg>";return"function"==typeof r&&r(null,g),g}},{"./utils":26}],26:[function(t,e,r){function n(t){if("string"!=typeof t)throw new Error("Color should be defined as hex string");var e=t.slice().replace("#","").split("");if(e.length<3||5===e.length||e.length>8)throw new Error("Invalid hex color: "+t);3!==e.length&&4!==e.length||(e=Array.prototype.concat.apply([],e.map(function(t){return[t,t]}))),6===e.length&&e.push("F","F");var r=parseInt(e.join(""),16);return{r:r>>24&255,g:r>>16&255,b:r>>8&255,a:255&r,hex:"#"+e.slice(0,6).join("")}}r.getOptions=function(t){t||(t={}),t.color||(t.color={});var e=void 0===t.margin||null===t.margin||t.margin<0?4:t.margin,r=t.width&&t.width>=21?t.width:void 0,o=t.scale||4;return{width:r,scale:r?4:o,margin:e,color:{dark:n(t.color.dark||"#000000ff"),light:n(t.color.light||"#ffffffff")},type:t.type,rendererOpts:t.rendererOpts||{}}},r.getScale=function(t,e){return e.width&&e.width>=t+2*e.margin?e.width/(t+2*e.margin):e.scale},r.getImageWidth=function(t,e){var n=r.getScale(t,e);return Math.floor((t+2*e.margin)*n)},r.qrToImageData=function(t,e,n){for(var o=e.modules.size,i=e.modules.data,a=r.getScale(o,n),u=Math.floor((o+2*n.margin)*a),s=n.margin*a,f=[n.color.light,n.color.dark],l=0;l<u;l++)for(var c=0;c<u;c++){var h=4*(l*u+c),d=n.color.light;if(l>=s&&c>=s&&l<u-s&&c<u-s){var g=Math.floor((l-s)/a),p=Math.floor((c-s)/a);d=f[i[g*o+p]?1:0]}t[h++]=d.r,t[h++]=d.g,t[h++]=d.b,t[h]=d.a}}},{}],27:[function(t,e,r){"use strict";function n(t,e,r){return n.TYPED_ARRAY_SUPPORT||this instanceof n?"number"==typeof t?u(this,t):v(this,t,e,r):new n(t,e,r)}function o(t){if(t>=m)throw new RangeError("Attempt to allocate Buffer larger than maximum size: 0x"+m.toString(16)+" bytes");return 0|t}function i(t){return t!==t}function a(t,e){var r;return n.TYPED_ARRAY_SUPPORT?(r=new Uint8Array(e),r.__proto__=n.prototype):(r=t,null===r&&(r=new n(e)),r.length=e),r}function u(t,e){var r=a(t,e<0?0:0|o(e));if(!n.TYPED_ARRAY_SUPPORT)for(var i=0;i<e;++i)r[i]=0;return r}function s(t,e){var r=0|d(e),n=a(t,r),o=n.write(e);return o!==r&&(n=n.slice(0,o)),n}function f(t,e){for(var r=e.length<0?0:0|o(e.length),n=a(t,r),i=0;i<r;i+=1)n[i]=255&e[i];return n}function l(t,e,r,o){if(r<0||e.byteLength<r)throw new RangeError("'offset' is out of bounds");if(e.byteLength<r+(o||0))throw new RangeError("'length' is out of bounds");var i;return i=void 0===r&&void 0===o?new Uint8Array(e):void 0===o?new Uint8Array(e,r):new Uint8Array(e,r,o),n.TYPED_ARRAY_SUPPORT?i.__proto__=n.prototype:i=f(t,i),i}function c(t,e){if(n.isBuffer(e)){var r=0|o(e.length),u=a(t,r);return 0===u.length?u:(e.copy(u,0,0,r),u)}if(e){if("undefined"!=typeof ArrayBuffer&&e.buffer instanceof ArrayBuffer||"length"in e)return"number"!=typeof e.length||i(e.length)?a(t,0):f(t,e);if("Buffer"===e.type&&Array.isArray(e.data))return f(t,e.data)}throw new TypeError("First argument must be a string, Buffer, ArrayBuffer, Array, or array-like object.")}function h(t,e){e=e||1/0;for(var r,n=t.length,o=null,i=[],a=0;a<n;++a){if((r=t.charCodeAt(a))>55295&&r<57344){if(!o){if(r>56319){(e-=3)>-1&&i.push(239,191,189);continue}if(a+1===n){(e-=3)>-1&&i.push(239,191,189);continue}o=r;continue}if(r<56320){(e-=3)>-1&&i.push(239,191,189),o=r;continue}r=65536+(o-55296<<10|r-56320)}else o&&(e-=3)>-1&&i.push(239,191,189);if(o=null,r<128){if((e-=1)<0)break;i.push(r)}else if(r<2048){if((e-=2)<0)break;i.push(r>>6|192,63&r|128)}else if(r<65536){if((e-=3)<0)break;i.push(r>>12|224,r>>6&63|128,63&r|128)}else{if(!(r<1114112))throw new Error("Invalid code point");if((e-=4)<0)break;i.push(r>>18|240,r>>12&63|128,r>>6&63|128,63&r|128)}}return i}function d(t){return n.isBuffer(t)?t.length:"undefined"!=typeof ArrayBuffer&&"function"==typeof ArrayBuffer.isView&&(ArrayBuffer.isView(t)||t instanceof ArrayBuffer)?t.byteLength:("string"!=typeof t&&(t=""+t),0===t.length?0:h(t).length)}function g(t,e,r,n){for(var o=0;o<n&&!(o+r>=e.length||o>=t.length);++o)e[o+r]=t[o];return o}function p(t,e,r,n){return g(h(e,t.length-r),t,r,n)}function v(t,e,r,n){if("number"==typeof e)throw new TypeError('"value" argument must not be a number');return"undefined"!=typeof ArrayBuffer&&e instanceof ArrayBuffer?l(t,e,r,n):"string"==typeof e?s(t,e,r):c(t,e)}var w=t("isarray");n.TYPED_ARRAY_SUPPORT=function(){try{var t=new Uint8Array(1);return t.__proto__={__proto__:Uint8Array.prototype,foo:function(){return 42}},42===t.foo()}catch(t){return!1}}();var m=n.TYPED_ARRAY_SUPPORT?2147483647:1073741823;n.TYPED_ARRAY_SUPPORT&&(n.prototype.__proto__=Uint8Array.prototype,n.__proto__=Uint8Array,"undefined"!=typeof Symbol&&Symbol.species&&n[Symbol.species]===n&&Object.defineProperty(n,Symbol.species,{value:null,configurable:!0,enumerable:!1,writable:!1})),n.prototype.write=function(t,e,r){void 0===e?(r=this.length,e=0):void 0===r&&"string"==typeof e?(r=this.length,e=0):isFinite(e)&&(e|=0,isFinite(r)?r|=0:r=void 0);var n=this.length-e;if((void 0===r||r>n)&&(r=n),t.length>0&&(r<0||e<0)||e>this.length)throw new RangeError("Attempt to write outside buffer bounds");return p(this,t,e,r)},n.prototype.slice=function(t,e){var r=this.length;t=~~t,e=void 0===e?r:~~e,t<0?(t+=r)<0&&(t=0):t>r&&(t=r),e<0?(e+=r)<0&&(e=0):e>r&&(e=r),e<t&&(e=t);var o;if(n.TYPED_ARRAY_SUPPORT)o=this.subarray(t,e),o.__proto__=n.prototype;else{var i=e-t;o=new n(i,void 0);for(var a=0;a<i;++a)o[a]=this[a+t]}return o},n.prototype.copy=function(t,e,r,o){if(r||(r=0),o||0===o||(o=this.length),e>=t.length&&(e=t.length),e||(e=0),o>0&&o<r&&(o=r),o===r)return 0;if(0===t.length||0===this.length)return 0;if(e<0)throw new RangeError("targetStart out of bounds");if(r<0||r>=this.length)throw new RangeError("sourceStart out of bounds");if(o<0)throw new RangeError("sourceEnd out of bounds");o>this.length&&(o=this.length),t.length-e<o-r&&(o=t.length-e+r);var i,a=o-r;if(this===t&&r<e&&e<o)for(i=a-1;i>=0;--i)t[i+e]=this[i+r];else if(a<1e3||!n.TYPED_ARRAY_SUPPORT)for(i=0;i<a;++i)t[i+e]=this[i+r];else Uint8Array.prototype.set.call(t,this.subarray(r,r+a),e);return a},n.prototype.fill=function(t,e,r){if("string"==typeof t){if("string"==typeof e?(e=0,r=this.length):"string"==typeof r&&(r=this.length),1===t.length){var o=t.charCodeAt(0);o<256&&(t=o)}}else"number"==typeof t&&(t&=255);if(e<0||this.length<e||this.length<r)throw new RangeError("Out of range index");if(r<=e)return this;e>>>=0,r=void 0===r?this.length:r>>>0,t||(t=0);var i;if("number"==typeof t)for(i=e;i<r;++i)this[i]=t;else{var a=n.isBuffer(t)?t:new n(t),u=a.length;for(i=0;i<r-e;++i)this[i+e]=a[i%u]}return this},n.concat=function(t,e){if(!w(t))throw new TypeError('"list" argument must be an Array of Buffers');if(0===t.length)return a(null,0);var r;if(void 0===e)for(e=0,r=0;r<t.length;++r)e+=t[r].length;var o=u(null,e),i=0;for(r=0;r<t.length;++r){var s=t[r];if(!n.isBuffer(s))throw new TypeError('"list" argument must be an Array of Buffers');s.copy(o,i),i+=s.length}return o},n.byteLength=d,n.prototype._isBuffer=!0,n.isBuffer=function(t){return!(null==t||!t._isBuffer)},e.exports=n},{isarray:30}],28:[function(t,e,r){"use strict";var n=t("window-or-global");e.exports=function(){return"function"==typeof n.Promise&&"function"==typeof n.Promise.prototype.then}},{"window-or-global":31}],29:[function(t,e,r){"use strict";var n={single_source_shortest_paths:function(t,e,r){var o={},i={};i[e]=0;var a=n.PriorityQueue.make();a.push(e,0);for(var u,s,f,l,c,h,d,g;!a.empty();){u=a.pop(),s=u.value,l=u.cost,c=t[s]||{};for(f in c)c.hasOwnProperty(f)&&(h=c[f],d=l+h,g=i[f],(void 0===i[f]||g>d)&&(i[f]=d,a.push(f,d),o[f]=s))}if(void 0!==r&&void 0===i[r]){var p=["Could not find a path from ",e," to ",r,"."].join("");throw new Error(p)}return o},extract_shortest_path_from_predecessor_list:function(t,e){for(var r=[],n=e;n;)r.push(n),t[n],n=t[n];return r.reverse(),r},find_path:function(t,e,r){var o=n.single_source_shortest_paths(t,e,r);return n.extract_shortest_path_from_predecessor_list(o,r)},PriorityQueue:{make:function(t){var e,r=n.PriorityQueue,o={};t=t||{};for(e in r)r.hasOwnProperty(e)&&(o[e]=r[e]);return o.queue=[],o.sorter=t.sorter||r.default_sorter,o},default_sorter:function(t,e){return t.cost-e.cost},push:function(t,e){var r={value:t,cost:e};this.queue.push(r),this.queue.sort(this.sorter)},pop:function(){return this.queue.shift()},empty:function(){return 0===this.queue.length}}};void 0!==e&&(e.exports=n)},{}],30:[function(t,e,r){var n={}.toString;e.exports=Array.isArray||function(t){return"[object Array]"==n.call(t)}},{}],31:[function(t,e,r){
 (function(t){"use strict";e.exports="object"==typeof self&&self.self===self&&self||"object"==typeof t&&t.global===t&&t||this}).call(this,"undefined"!=typeof global?global:"undefined"!=typeof self?self:"undefined"!=typeof window?window:{})},{}]},{},[23])(23)});
 //# sourceMappingURL=qrcode.min.js.map</script>
-    <!-- SHA3 library for Light Wallet -->
-    <script src="https://cdn.jsdelivr.net/npm/js-sha3@0.9.3/src/sha3.min.js"></script>
-    <!-- Ethers.js for MetaMask / Base bridge integration -->
-    <script src="https://cdn.jsdelivr.net/npm/ethers@5.7.2/dist/ethers.umd.min.js"></script>
+    <!-- SHA3 library for Light Wallet.
+         NOTE: pinned to the package's pre-built /build/ asset (NOT /src/, which jsDelivr
+         minifies on-the-fly and explicitly marks "Do NOT use SRI"). SRI hash is over the
+         exact pinned bytes of js-sha3@0.9.3/build/sha3.min.js. -->
+    <script src="https://cdn.jsdelivr.net/npm/js-sha3@0.9.3/build/sha3.min.js"
+            integrity="sha384-+JAeTqUiH9WuByObPHouP4rQKYUTLQ9AQW4HHJZ4uNmkA2+nkDpbssQNGsVXnJpe"
+            crossorigin="anonymous"></script>
+    <!-- Ethers.js for MetaMask / Base bridge integration (pre-built /dist/ → SRI-safe) -->
+    <script src="https://cdn.jsdelivr.net/npm/ethers@5.7.2/dist/ethers.umd.min.js"
+            integrity="sha384-Htz1SE4Sl5aitpvFgr2j0sfsGUIuSXI6t8hEyrlQ93zflEF3a29bH2AvkUROUw7J"
+            crossorigin="anonymous"></script>
     <!-- Dilithium WASM Module (must load before dilithium-crypto.js) -->
     <script src="js/dilithium.js"></script>
     <!-- Light Wallet Modules -->
@@ -1860,8 +1867,8 @@ inline const std::string& GetWalletHTML() {
                                       placeholder="Enter your 24 words separated by spaces"></textarea>
                         </div>
                         <div class="form-group">
-                            <label class="form-label">Password <span style="color: var(--text-muted); font-weight: normal;">(optional)</span></label>
-                            <input type="password" class="form-input" id="restoreLightPassword" placeholder="Leave blank to restore without encryption">
+                            <label class="form-label">Password</label>
+                            <input type="password" class="form-input" id="restoreLightPassword" placeholder="Minimum 8 characters — encrypts your wallet">
                         </div>
                         <div style="display: flex; gap: 12px;">
                             <button class="btn btn-primary" onclick="restoreLightWallet()">Restore Wallet</button>
@@ -1885,6 +1892,33 @@ inline const std::string& GetWalletHTML() {
                         </div>
                         <button class="btn btn-primary" onclick="confirmMnemonicBackup()">I've Written Them Down</button>
                     </div>
+                </div>
+            </div>
+
+            <!-- LP-9: Blocking "Secure your wallet" migration modal.
+                 Shown when a legacy UNENCRYPTED browser wallet is detected at load.
+                 Has NO cancel/close button: the wallet cannot be used until the seed
+                 is encrypted at rest. Dismissing (Escape/click-out is disabled) just
+                 re-presents it on the next load. -->
+            <div id="walletMigrationModal" style="display: none; position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0,0,0,0.92); z-index: 2000; align-items: center; justify-content: center;">
+                <div style="background: var(--bg-card); padding: 32px; border-radius: 16px; max-width: 480px; width: 90%; max-height: 90vh; overflow-y: auto;">
+                    <h3 style="margin-bottom: 8px;">🔒 Secure your wallet</h3>
+                    <p style="color: var(--text-secondary); margin-bottom: 16px; font-size: 0.9rem;">
+                        Your wallet is currently stored <strong style="color: var(--error, #ef4444);">unencrypted</strong> in this browser, which means anyone with access to this device could read your recovery seed. Set a password now to encrypt it. This uses the <em>same wallet and the same addresses</em> — you do not need to re-enter your recovery phrase.
+                    </p>
+                    <div class="form-group">
+                        <label class="form-label">New Password</label>
+                        <input type="password" class="form-input" id="migrationPassword" placeholder="Minimum 8 characters">
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label">Confirm Password</label>
+                        <input type="password" class="form-input" id="migrationPasswordConfirm" placeholder="Re-enter password">
+                    </div>
+                    <div id="migrationError" style="display:none; color: var(--error, #ef4444); font-size: 0.85rem; margin-bottom: 12px;"></div>
+                    <button class="btn btn-primary" id="migrationSubmitBtn" onclick="submitWalletMigration()" style="width: 100%;">Encrypt &amp; Continue</button>
+                    <p style="color: var(--text-muted); font-size: 0.75rem; margin-top: 12px; text-align: center;">
+                        You must encrypt your wallet to continue.
+                    </p>
                 </div>
             </div>
 
@@ -2182,6 +2216,10 @@ inline const std::string& GetWalletHTML() {
                 updateLightWalletUI();
                 refreshAll();
             } catch (e) {
+                if (e && e.message === 'WALLET_NEEDS_ENCRYPTION') {
+                    presentWalletMigration();
+                    return;
+                }
                 showNotification('Wrong password', 'error');
             }
         }
@@ -5301,13 +5339,15 @@ inline const std::string& GetWalletHTML() {
                 unlockSection.style.display = 'none';
                 unlockedSection.style.display = 'none';
             } else if (!localWallet.isWalletUnlocked()) {
-                // Wallet exists but locked — auto-unlock if unencrypted
+                // Wallet exists but locked.
                 const isEncrypted = await localWallet.isWalletEncrypted();
                 if (!isEncrypted) {
-                    await localWallet.unlock(null);
+                    // LP-9: legacy unencrypted (plaintext-at-rest) wallet — do NOT
+                    // silently unlock. Present the BLOCKING "secure your wallet" step.
                     createSection.style.display = 'none';
                     unlockSection.style.display = 'none';
-                    unlockedSection.style.display = 'block';
+                    unlockedSection.style.display = 'none';
+                    presentWalletMigration();
                 } else {
                     createSection.style.display = 'none';
                     unlockSection.style.display = 'block';
@@ -5398,8 +5438,9 @@ inline const std::string& GetWalletHTML() {
                 return;
             }
 
-            // If password provided, validate minimum length
-            if (password && password.length > 0 && password.length < 8) {
+            // LP-9: a password is mandatory — a blank/short password is rejected,
+            // never silently coerced to an unencrypted (plaintext-at-rest) wallet.
+            if (!password || password.length < 8) {
                 showNotification('Password must be at least 8 characters', 'error');
                 return;
             }
@@ -5412,21 +5453,89 @@ inline const std::string& GetWalletHTML() {
 
             try {
                 showNotification('Restoring wallet...', 'info');
-                const usePassword = password && password.length >= 8 ? password : null;
-                await localWallet.importWallet(usePassword, mnemonic);
+                await localWallet.importWallet(password, mnemonic);
 
                 closeLightWalletModal();
                 updateLightWalletUI();
 
-                if (usePassword) {
-                    showNotification('Wallet restored and encrypted successfully!', 'success');
-                } else {
-                    showNotification('Wallet restored! Consider encrypting your wallet for added security.', 'warning');
-                }
+                showNotification('Wallet restored and encrypted successfully!', 'success');
 
             } catch (e) {
                 showNotification('Failed to restore wallet: ' + e.message, 'error');
             }
+        }
+
+        // LP-9: present the blocking "secure your wallet" migration step for a legacy
+        // unencrypted wallet. Idempotent — safe to call from multiple chokepoints.
+        function presentWalletMigration() {
+            const modal = document.getElementById('walletMigrationModal');
+            if (!modal) return;
+            // Hide any welcome screen so the migration is the only visible surface.
+            const welcome = document.getElementById('page-welcome');
+            if (welcome) welcome.style.display = 'none';
+            const errEl = document.getElementById('migrationError');
+            if (errEl) { errEl.style.display = 'none'; errEl.textContent = ''; }
+            modal.style.display = 'flex';
+            const pw = document.getElementById('migrationPassword');
+            if (pw) pw.focus();
+        }
+
+        // LP-9: perform the in-place encryption migration. Hard-blocks until success.
+        async function submitWalletMigration() {
+            const btn = document.getElementById('migrationSubmitBtn');
+            const errEl = document.getElementById('migrationError');
+            const showErr = (msg) => {
+                if (errEl) { errEl.textContent = msg; errEl.style.display = 'block'; }
+            };
+
+            const pw = document.getElementById('migrationPassword').value;
+            const pw2 = document.getElementById('migrationPasswordConfirm').value;
+
+            if (!pw || pw.length < 8) { showErr('Password must be at least 8 characters'); return; }
+            if (pw !== pw2) { showErr('Passwords do not match'); return; }
+
+            if (btn) { btn.disabled = true; btn.textContent = 'Encrypting…'; }
+            try {
+                // Race-tolerant: if another tab already encrypted, encryptExisting returns
+                // false — fall back to unlocking with the supplied password.
+                const migrated = await localWallet.encryptExisting(pw);
+                if (!migrated) {
+                    // Already encrypted elsewhere; try to unlock with this password.
+                    try {
+                        await localWallet.unlock(pw);
+                    } catch (e) {
+                        showErr('This wallet was already secured in another tab. Please reload and enter your password.');
+                        if (btn) { btn.disabled = false; btn.textContent = 'Encrypt & Continue'; }
+                        return;
+                    }
+                }
+
+                // Clear the password fields from the DOM.
+                document.getElementById('migrationPassword').value = '';
+                document.getElementById('migrationPasswordConfirm').value = '';
+
+                // Close the modal and proceed into the wallet.
+                document.getElementById('walletMigrationModal').style.display = 'none';
+                showNotification('Wallet encrypted successfully. Your addresses are unchanged.', 'success');
+
+                // Show sidebar + dashboard, mirror the welcomeFinish() entry path.
+                const welcome = document.getElementById('page-welcome');
+                if (welcome) welcome.style.display = 'none';
+                document.querySelectorAll('.nav-item').forEach(i => i.style.display = '');
+                await updateLightWalletUI();
+                navigateTo('dashboard');
+
+                // Establish connection if needed.
+                const savedMode = localStorage.getItem('dilithionWalletMode');
+                if (savedMode === 'light') {
+                    try { await handleModeChange(); } catch (e) { /* connection handled elsewhere */ }
+                }
+            } catch (e) {
+                showErr('Could not encrypt wallet: ' + (e && e.message ? e.message : 'unknown error') + ' — your wallet is unchanged. Please try again.');
+                if (btn) { btn.disabled = false; btn.textContent = 'Encrypt & Continue'; }
+                return;
+            }
+            if (btn) { btn.disabled = false; btn.textContent = 'Encrypt & Continue'; }
         }
 
         // Unlock light wallet
@@ -5459,6 +5568,11 @@ inline const std::string& GetWalletHTML() {
                 }
 
             } catch (e) {
+                if (e && e.message === 'WALLET_NEEDS_ENCRYPTION') {
+                    // LP-9: legacy unencrypted wallet — route to the blocking migration.
+                    presentWalletMigration();
+                    return;
+                }
                 showNotification('Failed to unlock: ' + e.message, 'error');
             }
         }
@@ -5801,6 +5915,10 @@ inline const std::string& GetWalletHTML() {
                 showNotification('Wallet unlocked', 'success');
                 welcomeFinish();
             } catch (e) {
+                if (e && e.message === 'WALLET_NEEDS_ENCRYPTION') {
+                    presentWalletMigration();
+                    return;
+                }
                 showNotification('Wrong password', 'error');
             }
         }
@@ -5941,7 +6059,15 @@ inline const std::string& GetWalletHTML() {
                         const hasBrowserWallet = await localWallet.hasWallet();
                         if (hasBrowserWallet && localWallet.isWalletUnlocked()) return false;
                         if (hasBrowserWallet) {
-                            // Wallet exists but locked — show welcome with unlock option
+                            // LP-9: a legacy UNENCRYPTED wallet must be migrated before
+                            // anything else — present the blocking encrypt step instead
+                            // of the welcome/unlock screen, and do not show welcome.
+                            const isEncrypted = await localWallet.isWalletEncrypted();
+                            if (isEncrypted === false) {
+                                presentWalletMigration();
+                                return false;
+                            }
+                            // Encrypted wallet, locked — show welcome with unlock option
                             document.getElementById('welcomeUnlockCard').style.display = 'block';
                         }
                     } catch (e) {

--- a/src/api/wallet_html.h
+++ b/src/api/wallet_html.h
@@ -1897,9 +1897,10 @@ inline const std::string& GetWalletHTML() {
 
             <!-- LP-9: Blocking "Secure your wallet" migration modal.
                  Shown when a legacy UNENCRYPTED browser wallet is detected at load.
-                 Has NO cancel/close button: the wallet cannot be used until the seed
-                 is encrypted at rest. Dismissing (Escape/click-out is disabled) just
-                 re-presents it on the next load. -->
+                 Has NO cancel/close button and no close-wiring (no Escape/backdrop-click
+                 handler exists), so it cannot be dismissed; the wallet cannot be used until
+                 the seed is encrypted at rest. Even if the element were hidden, the next
+                 load re-presents it because the stored record is still encrypted:false. -->
             <div id="walletMigrationModal" style="display: none; position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0,0,0,0.92); z-index: 2000; align-items: center; justify-content: center;">
                 <div style="background: var(--bg-card); padding: 32px; border-radius: 16px; max-width: 480px; width: 90%; max-height: 90vh; overflow-y: auto;">
                     <h3 style="margin-bottom: 8px;">🔒 Secure your wallet</h3>

--- a/website/.htaccess
+++ b/website/.htaccess
@@ -1,7 +1,10 @@
 # Disable restrictive CSP for dashboard functionality
 <IfModule mod_headers.c>
     # Allow inline scripts and external resources for dashboard
-    Header always set Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://explorer.dilithion.org http://138.197.68.128:8334 http://167.172.56.119:8334 http://165.22.103.114:8334 https://mainnet.base.org https://api.coingecko.com"
+    # LP-9 (MEDIUM-1): dropped 'unsafe-eval' — no wallet/dashboard code uses eval()/new Function().
+    # Kept 'wasm-unsafe-eval' so the Dilithium WASM module still compiles on browsers that
+    # gate WebAssembly behind a CSP directive (without re-opening JS eval()).
+    Header always set Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://explorer.dilithion.org http://138.197.68.128:8334 http://167.172.56.119:8334 http://165.22.103.114:8334 https://mainnet.base.org https://api.coingecko.com"
 
     # Serve WASM files with correct MIME type
     AddType application/wasm .wasm

--- a/website/js/local-wallet.js
+++ b/website/js/local-wallet.js
@@ -113,7 +113,11 @@ class LocalWallet {
 
     /**
      * Create a new wallet
-     * @param {string|null} password - Wallet password (null for unencrypted)
+     *
+     * A passphrase is MANDATORY (min 8 chars). The unencrypted-at-rest path was
+     * removed (LP-9): the raw HD seed is never persisted in plaintext to IndexedDB.
+     *
+     * @param {string} password - Wallet password (required, min 8 chars)
      * @param {string[]} mnemonic - Optional mnemonic (generates new if not provided)
      * @returns {Promise<Object>} {walletId, mnemonic, addresses}
      */
@@ -124,10 +128,8 @@ class LocalWallet {
             throw new Error('Crypto module not available');
         }
 
-        const isEncrypted = password && password.length > 0;
-
-        // Validate password if provided
-        if (isEncrypted && password.length < 8) {
+        // LP-9: passphrase is mandatory — never persist a plaintext seed at rest.
+        if (!password || password.length < 8) {
             throw new Error('Password must be at least 8 characters');
         }
 
@@ -141,14 +143,9 @@ class LocalWallet {
         // Convert mnemonic to seed
         const seed = await this.crypto.mnemonicToSeed(mnemonic);
 
-        // Encrypt seed with password, or store raw for unencrypted wallets
-        let storedSeed;
-        if (isEncrypted) {
-            storedSeed = await this.crypto.encrypt(seed, password);
-        } else {
-            // Store raw seed bytes (Uint8Array is stored directly in IndexedDB)
-            storedSeed = new Uint8Array(seed);
-        }
+        // Encrypt seed with password (AES-256-GCM via PBKDF2). Plaintext seed is
+        // never written to persistent storage.
+        const storedSeed = await this.crypto.encrypt(seed, password);
 
         // Generate wallet ID
         const walletId = this.generateUUID();
@@ -162,7 +159,7 @@ class LocalWallet {
         const wallet = {
             id: walletId,
             version: 1,
-            encrypted: isEncrypted,
+            encrypted: true,
             encryptedSeed: storedSeed,
             createdAt: Date.now(),
             accounts: [{
@@ -191,11 +188,9 @@ class LocalWallet {
         this.decryptedSeed = seed;
         this.isUnlocked = true;
         this.accounts = wallet.accounts;
-        if (isEncrypted) {
-            this.startLockTimer();
-        }
+        this.startLockTimer();
 
-        console.log('[LocalWallet] Wallet created:', walletId, isEncrypted ? '(encrypted)' : '(unencrypted)');
+        console.log('[LocalWallet] Wallet created:', walletId, '(encrypted)');
 
         return {
             walletId,
@@ -334,16 +329,19 @@ class LocalWallet {
             throw new Error('No wallet found');
         }
 
-        if (wallet.encrypted) {
-            // Decrypt seed
-            try {
-                this.decryptedSeed = await this.crypto.decrypt(wallet.encryptedSeed, password);
-            } catch (e) {
-                throw new Error('Wrong password');
-            }
-        } else {
-            // Unencrypted wallet - seed is stored directly
-            this.decryptedSeed = new Uint8Array(wallet.encryptedSeed);
+        if (!wallet.encrypted) {
+            // LP-9: legacy unencrypted wallets must be migrated to encrypted-at-rest
+            // before they can be unlocked. The UI routes these through
+            // encryptExisting() (a blocking "secure your wallet" step) — there is no
+            // silent unlock path for a plaintext-at-rest seed.
+            throw new Error('WALLET_NEEDS_ENCRYPTION');
+        }
+
+        // Decrypt seed
+        try {
+            this.decryptedSeed = await this.crypto.decrypt(wallet.encryptedSeed, password);
+        } catch (e) {
+            throw new Error('Wrong password');
         }
 
         // Update state
@@ -351,16 +349,123 @@ class LocalWallet {
         this.isUnlocked = true;
         this.accounts = wallet.accounts;
 
-        // Start auto-lock timer (only for encrypted wallets)
-        if (wallet.encrypted) {
-            this.startLockTimer();
-        }
+        // Start auto-lock timer
+        this.startLockTimer();
 
         // Emit event
         this.emit('unlock', { walletId: this.walletId });
 
         console.log('[LocalWallet] Wallet unlocked');
         return true;
+    }
+
+    /**
+     * Encrypt an already-existing UNENCRYPTED wallet in place (LP-9 migration).
+     *
+     * Reads the plaintext seed currently stored in IndexedDB, AES-256-GCM-encrypts
+     * it with `newPassword` (PBKDF2/100k), and atomically replaces the wallet record
+     * with the ciphertext-only version (`encrypted:true`). On success the wallet is
+     * left unlocked.
+     *
+     * Safety properties:
+     *  - Interruption-safe: the ciphertext is round-trip VERIFIED (decrypt back to the
+     *    exact original seed bytes) BEFORE the plaintext record is replaced. The replace
+     *    is a single IndexedDB `put` of the same keyPath, so the store transitions
+     *    plaintext -> ciphertext in one atomic write — there is no intermediate
+     *    "no seed" state. A crash before the put leaves the original plaintext intact
+     *    (next load re-prompts migration); a crash after leaves a fully-encrypted,
+     *    verified record.
+     *  - Race-tolerant: state is re-read inside the call; if another tab already
+     *    encrypted the wallet, this returns without clobbering it.
+     *  - Zeroizing: the in-memory plaintext working copies are wiped, and the stored
+     *    record no longer carries the raw seed (the old value is overwritten, not kept).
+     *
+     * @param {string} newPassword - New password (min 8 chars)
+     * @returns {Promise<boolean>} True on success (wallet now encrypted + unlocked)
+     */
+    async encryptExisting(newPassword) {
+        await this.init();
+
+        if (!newPassword || newPassword.length < 8) {
+            throw new Error('Password must be at least 8 characters');
+        }
+
+        // Re-read current state (race-tolerant: another tab may have migrated already)
+        const wallet = await this.getWallet();
+        if (!wallet) {
+            throw new Error('No wallet found');
+        }
+        if (wallet.encrypted === true) {
+            // Already migrated by another tab/process — nothing to do here.
+            // Caller should fall back to a normal unlock.
+            return false;
+        }
+
+        // The plaintext seed is stored directly as bytes for legacy unencrypted wallets.
+        // Make a private working copy we control (so we can zeroize it).
+        const plaintextSeed = new Uint8Array(wallet.encryptedSeed);
+
+        let encrypted;
+        try {
+            // Encrypt (AES-256-GCM via PBKDF2).
+            encrypted = await this.crypto.encrypt(plaintextSeed, newPassword);
+
+            // VERIFY before we destroy the plaintext: decrypt the ciphertext back and
+            // confirm it equals the original seed byte-for-byte. If this fails we throw
+            // and leave the original plaintext record untouched (no data loss).
+            const roundTrip = await this.crypto.decrypt(encrypted, newPassword);
+            if (!this._bytesEqual(roundTrip, plaintextSeed)) {
+                roundTrip.fill(0);
+                throw new Error('Encryption self-check failed; wallet left unchanged');
+            }
+            roundTrip.fill(0);
+        } catch (e) {
+            plaintextSeed.fill(0);
+            throw e;
+        }
+
+        // Atomic replace: single put of the same keyPath swaps plaintext -> ciphertext.
+        const migrated = {
+            ...wallet,
+            encrypted: true,
+            encryptedSeed: encrypted
+        };
+        try {
+            await this.saveWallet(migrated);
+        } catch (e) {
+            // Write/quota failure: original plaintext record is still intact.
+            plaintextSeed.fill(0);
+            throw new Error('Could not save encrypted wallet (storage error). Your wallet is unchanged — please try again. ' + (e && e.message ? e.message : ''));
+        }
+
+        // Establish unlocked in-memory state from the (now verified) seed.
+        this.walletId = wallet.id;
+        this.decryptedSeed = new Uint8Array(plaintextSeed);
+        this.isUnlocked = true;
+        this.accounts = wallet.accounts;
+        this.startLockTimer();
+
+        // Wipe the working copy.
+        plaintextSeed.fill(0);
+
+        this.emit('unlock', { walletId: this.walletId });
+        console.log('[LocalWallet] Wallet migrated to encrypted-at-rest');
+        return true;
+    }
+
+    /**
+     * Constant-ish byte-array equality (length + per-byte).
+     * @param {Uint8Array} a
+     * @param {Uint8Array} b
+     * @returns {boolean}
+     */
+    _bytesEqual(a, b) {
+        if (!a || !b || a.length !== b.length) return false;
+        let diff = 0;
+        for (let i = 0; i < a.length; i++) {
+            diff |= a[i] ^ b[i];
+        }
+        return diff === 0;
     }
 
     /**

--- a/website/js/local-wallet.js
+++ b/website/js/local-wallet.js
@@ -201,7 +201,7 @@ class LocalWallet {
 
     /**
      * Import wallet from mnemonic
-     * @param {string|null} password - New password (null for unencrypted)
+     * @param {string} password - New password (REQUIRED, min 8 chars; LP-9: no plaintext-at-rest path)
      * @param {string[]} mnemonic - 24-word mnemonic
      * @returns {Promise<Object>} {walletId, addresses}
      */
@@ -317,7 +317,8 @@ class LocalWallet {
 
     /**
      * Unlock wallet with password
-     * @param {string|null} password - Wallet password (null for unencrypted wallets)
+     * @param {string} password - Wallet password (REQUIRED; legacy unencrypted wallets are
+     *   rejected with WALLET_NEEDS_ENCRYPTION — there is no null/unencrypted unlock path)
      * @returns {Promise<boolean>} True if unlocked successfully
      */
     async unlock(password) {
@@ -375,8 +376,12 @@ class LocalWallet {
      *    "no seed" state. A crash before the put leaves the original plaintext intact
      *    (next load re-prompts migration); a crash after leaves a fully-encrypted,
      *    verified record.
-     *  - Race-tolerant: state is re-read inside the call; if another tab already
-     *    encrypted the wallet, this returns without clobbering it.
+     *  - Race-tolerant (M-1): the final check-and-write is a SINGLE atomic IndexedDB
+     *    readwrite transaction (re-read the record, verify still unencrypted, put the
+     *    ciphertext). If a concurrent tab encrypted the wallet first — even with a
+     *    different password — this aborts the put (never clobbering the other tab's
+     *    ciphertext) and throws a clear "encrypted in another tab" message. An early
+     *    pre-check still short-circuits the common already-migrated case via `return false`.
      *  - Zeroizing: the in-memory plaintext working copies are wiped, and the stored
      *    record no longer carries the raw seed (the old value is overwritten, not kept).
      *
@@ -424,18 +429,32 @@ class LocalWallet {
             throw e;
         }
 
-        // Atomic replace: single put of the same keyPath swaps plaintext -> ciphertext.
+        // Atomic check-and-replace (M-1): re-read the record and write the ciphertext
+        // INSIDE A SINGLE IndexedDB readwrite transaction. IndexedDB transactions are
+        // atomic, so if another tab already encrypted this wallet (possibly with a
+        // DIFFERENT password) between our initial read and now, the in-transaction
+        // re-check sees encrypted===true and ABORTS the put — we never clobber the
+        // other tab's ciphertext (which would lock the user out with this password).
+        // A plain re-read-then-put outside a transaction would still leave that gap.
         const migrated = {
             ...wallet,
             encrypted: true,
             encryptedSeed: encrypted
         };
+        let putResult;
         try {
-            await this.saveWallet(migrated);
+            putResult = await this._atomicMigratePut(wallet.id, migrated);
         } catch (e) {
             // Write/quota failure: original plaintext record is still intact.
             plaintextSeed.fill(0);
             throw new Error('Could not save encrypted wallet (storage error). Your wallet is unchanged — please try again. ' + (e && e.message ? e.message : ''));
+        }
+        if (putResult === 'raced') {
+            // Another tab encrypted this wallet first. Do NOT overwrite it and do NOT
+            // unlock from our plaintext copy — the stored ciphertext now belongs to the
+            // OTHER tab's password. Surface a clear, recoverable message.
+            plaintextSeed.fill(0);
+            throw new Error('This wallet was just encrypted in another tab. Use that tab\'s password to unlock, or reload this page and unlock there.');
         }
 
         // Establish unlocked in-memory state from the (now verified) seed.
@@ -709,12 +728,25 @@ class LocalWallet {
 
     /**
      * Delete wallet (irreversible!)
-     * @param {string} password - Password to confirm (ignored for unencrypted wallets)
+     *
+     * L-1: a delete is NEVER performed without password proof, regardless of the stored
+     * `encrypted` flag. A legacy unencrypted (`encrypted:false`) record has no password to
+     * verify against — and its `encryptedSeed` is raw plaintext bytes, not a decryptable
+     * ciphertext — so rather than allow a password-free delete (the L-1 hole), we refuse
+     * with WALLET_NEEDS_ENCRYPTION, mirroring unlock(): the wallet must be migrated to
+     * encrypted-at-rest first, after which a normal password-verified delete applies.
+     *
+     * @param {string} password - Password to confirm (required for any delete).
      */
     async deleteWallet(password) {
-        // Verify password for encrypted wallets
         const wallet = await this.getWallet();
-        if (wallet && wallet.encrypted) {
+        if (wallet) {
+            if (wallet.encrypted !== true) {
+                // Legacy plaintext record: no password exists to verify. Force migration
+                // first instead of permitting a password-free destructive delete.
+                throw new Error('WALLET_NEEDS_ENCRYPTION');
+            }
+            // Encrypted record: require correct password before destroying anything.
             try {
                 await this.crypto.decrypt(wallet.encryptedSeed, password);
             } catch (e) {
@@ -797,6 +829,46 @@ class LocalWallet {
 
             request.onsuccess = () => resolve();
             request.onerror = () => reject(request.error);
+        });
+    }
+
+    /**
+     * Atomic check-and-write for the LP-9 plaintext->ciphertext migration (M-1).
+     *
+     * Inside a SINGLE IndexedDB readwrite transaction: re-read the wallet record by id,
+     * verify it is still NOT encrypted, then put the encrypted record. IndexedDB
+     * transactions are atomic, so a concurrent tab cannot interleave between the re-read
+     * and the put. If the record is already `encrypted===true` (another tab won the race),
+     * the put is skipped and the call resolves 'raced' WITHOUT overwriting it.
+     *
+     * @param {string} walletId - id (keyPath) of the wallet record to migrate.
+     * @param {Object} migrated - the encrypted wallet record to write.
+     * @returns {Promise<'ok'|'raced'>} 'ok' if written, 'raced' if already encrypted.
+     */
+    async _atomicMigratePut(walletId, migrated) {
+        await this.init();
+
+        return new Promise((resolve, reject) => {
+            const tx = this.db.transaction(WALLET_STORE, 'readwrite');
+            const store = tx.objectStore(WALLET_STORE);
+            let outcome = 'ok';
+
+            const getReq = store.get(walletId);
+            getReq.onsuccess = () => {
+                const current = getReq.result;
+                if (current && current.encrypted === true) {
+                    // Lost the race: another tab already encrypted. Do not clobber it.
+                    outcome = 'raced';
+                    return;  // skip the put; let the (empty) transaction complete
+                }
+                // Still unencrypted (or record vanished — recreate it): write ciphertext.
+                store.put(migrated);
+            };
+            getReq.onerror = () => reject(getReq.error);
+
+            tx.oncomplete = () => resolve(outcome);
+            tx.onerror = () => reject(tx.error);
+            tx.onabort = () => reject(tx.error || new Error('migration transaction aborted'));
         });
     }
 

--- a/website/tests/lp9-at-rest/.gitignore
+++ b/website/tests/lp9-at-rest/.gitignore
@@ -1,0 +1,7 @@
+# Downloaded-on-first-run CDN fixtures (pinned bytes; fetched from jsDelivr)
+sha3.build.min.js
+ethers.umd.min.js
+node_modules/
+package.json
+package-lock.json
+run.out

--- a/website/tests/lp9-at-rest/README.md
+++ b/website/tests/lp9-at-rest/README.md
@@ -19,7 +19,7 @@ cd tests/lp9-at-rest && npm init -y && npm i playwright-core@1.60.0
 node lp9.test.mjs
 ```
 
-Exit 0 = all assertions pass. Expected: `27 passed, 0 failed`.
+Exit 0 = all assertions pass. Expected: `45 passed, 0 failed`.
 
 ## What it covers
 - AC-1: blank/null/short password rejected on create + import; valid create stays `encrypted:true`.
@@ -30,6 +30,15 @@ Exit 0 = all assertions pass. Expected: `27 passed, 0 failed`.
   silent unlock; after migration the record is `encrypted:true` and the modal never re-shows.
 - AC-4: SRI-pinned js-sha3 `/build/sha3.min.js` loads under the integrity check and address
   derivation works (a wrong hash makes `sha3_256` undefined → first assertion fails).
+- M-1 (Cursor): concurrent multi-tab migration race — two tabs read the same plaintext legacy
+  wallet and both attempt to migrate with DIFFERENT passwords; the atomic check-and-write in
+  `_atomicMigratePut()` lets exactly one commit, the loser aborts as `raced` without
+  overwriting, no plaintext is left, and the would-be lockout (loser's password stored) is
+  averted. `encryptExisting()` reports already-migrated rather than clobbering.
+- L-1 (Cursor): `deleteWallet()` requires password proof regardless of the `encrypted` flag —
+  encrypted wallets reject a wrong password (record survives) and delete on the correct one;
+  legacy unencrypted records refuse with `WALLET_NEEDS_ENCRYPTION` (no password-free
+  destructive bypass) and survive the refused delete.
 
 The two CDN fixtures are git-ignored and fetched from jsDelivr on first run; their bytes match
 the sha384 the page pins, so serving them locally still enforces SRI.

--- a/website/tests/lp9-at-rest/README.md
+++ b/website/tests/lp9-at-rest/README.md
@@ -19,7 +19,7 @@ cd tests/lp9-at-rest && npm init -y && npm i playwright-core@1.60.0
 node lp9.test.mjs
 ```
 
-Exit 0 = all assertions pass. Expected: `45 passed, 0 failed`.
+Exit 0 = all assertions pass. Expected: `53 passed, 0 failed`.
 
 ## What it covers
 - AC-1: blank/null/short password rejected on create + import; valid create stays `encrypted:true`.
@@ -34,7 +34,11 @@ Exit 0 = all assertions pass. Expected: `45 passed, 0 failed`.
   wallet and both attempt to migrate with DIFFERENT passwords; the atomic check-and-write in
   `_atomicMigratePut()` lets exactly one commit, the loser aborts as `raced` without
   overwriting, no plaintext is left, and the would-be lockout (loser's password stored) is
-  averted. `encryptExisting()` reports already-migrated rather than clobbering.
+  averted. `encryptExisting()` reports already-migrated rather than clobbering. A further
+  case fires TWO concurrent `encryptExisting()` calls (different passwords) on the same wallet
+  via `Promise.allSettled`: exactly one resolves, the other REJECTS with the "encrypted in
+  another tab" error (the `raced` throw), the loser never unlocks from its stale plaintext, and
+  the persisted ciphertext is the winner's (decrypts with the winner pw, not the loser's).
 - L-1 (Cursor): `deleteWallet()` requires password proof regardless of the `encrypted` flag —
   encrypted wallets reject a wrong password (record survives) and delete on the correct one;
   legacy unencrypted records refuse with `WALLET_NEEDS_ENCRYPTION` (no password-free

--- a/website/tests/lp9-at-rest/README.md
+++ b/website/tests/lp9-at-rest/README.md
@@ -1,0 +1,35 @@
+# LP-9 browser-wallet at-rest test
+
+Headless Playwright test for the "migrate-then-require" fix (LP-9): the browser wallet must
+never persist a plaintext HD seed in IndexedDB. Drives a real Chromium against the served
+`wallet.html` and asserts the encryption-mandatory create/restore path, the `encryptExisting`
+migration primitive (interruption-safe, zeroizing), the blocking migrate-on-load UI, and that
+the SRI-pinned CDN scripts load + execute.
+
+## Run
+
+```bash
+# 1. serve the website
+cd website && python -m http.server 8799 --bind 127.0.0.1 &
+
+# 2. install playwright-core (browsers from the ms-playwright cache are reused)
+cd tests/lp9-at-rest && npm init -y && npm i playwright-core@1.60.0
+
+# 3. run (downloads the two pinned CDN fixtures on first run, then deterministic)
+node lp9.test.mjs
+```
+
+Exit 0 = all assertions pass. Expected: `27 passed, 0 failed`.
+
+## What it covers
+- AC-1: blank/null/short password rejected on create + import; valid create stays `encrypted:true`.
+- AC-2/AC-7: `encryptExisting` round-trips + verifies before evicting plaintext, evicts the raw
+  seed (deep byte-scan of the stored record), keeps addresses identical, new pw unlocks,
+  re-migrate returns false (multi-tab race).
+- AC-3: the real `updateLightWalletUI()` chokepoint presents the BLOCKING modal instead of a
+  silent unlock; after migration the record is `encrypted:true` and the modal never re-shows.
+- AC-4: SRI-pinned js-sha3 `/build/sha3.min.js` loads under the integrity check and address
+  derivation works (a wrong hash makes `sha3_256` undefined → first assertion fails).
+
+The two CDN fixtures are git-ignored and fetched from jsDelivr on first run; their bytes match
+the sha384 the page pins, so serving them locally still enforces SRI.

--- a/website/tests/lp9-at-rest/lp9.test.mjs
+++ b/website/tests/lp9-at-rest/lp9.test.mjs
@@ -1,0 +1,250 @@
+import { chromium } from 'playwright-core';
+import { readFileSync, existsSync, writeFileSync } from 'node:fs';
+
+const BASE = 'http://127.0.0.1:8799/wallet.html?mode=light';
+
+// The test serves the EXACT pinned CDN bytes (same sha384 the page's SRI pins) locally so
+// the run is deterministic AND still exercises SRI: if the bytes didn't match the pinned
+// hash the browser would refuse to run them. The fixtures are NOT committed (git-ignored);
+// they are downloaded once from jsDelivr on first run.
+const CDN = {
+  sha3: { file: new URL('./sha3.build.min.js', import.meta.url), url: 'https://cdn.jsdelivr.net/npm/js-sha3@0.9.3/build/sha3.min.js' },
+  ethers: { file: new URL('./ethers.umd.min.js', import.meta.url), url: 'https://cdn.jsdelivr.net/npm/ethers@5.7.2/dist/ethers.umd.min.js' },
+};
+async function ensureFixture(spec) {
+  if (existsSync(spec.file)) return readFileSync(spec.file);
+  const buf = Buffer.from(await (await fetch(spec.url)).arrayBuffer());
+  writeFileSync(spec.file, buf);
+  return buf;
+}
+const SHA3_BYTES = await ensureFixture(CDN.sha3);
+const ETHERS_BYTES = await ensureFixture(CDN.ethers);
+let pass = 0, fail = 0;
+const results = [];
+const log = (...a) => console.log('[t]', ...a);
+function check(name, cond, detail = '') {
+  if (cond) { pass++; results.push(`PASS  ${name}`); }
+  else { fail++; results.push(`FAIL  ${name}${detail ? ' :: ' + detail : ''}`); }
+}
+
+const browser = await chromium.launch({ headless: true });
+const ctx = await browser.newContext();
+await ctx.route('**/*', (route) => {
+  const u = route.request().url();
+  // Fulfill the pinned CDN scripts from local copies (deterministic; SRI still enforced).
+  if (u.includes('js-sha3@0.9.3/build/sha3.min.js')) {
+    return route.fulfill({ status: 200, contentType: 'application/javascript', body: SHA3_BYTES });
+  }
+  if (u.includes('ethers@5.7.2/dist/ethers.umd.min.js')) {
+    return route.fulfill({ status: 200, contentType: 'application/javascript', body: ETHERS_BYTES });
+  }
+  if (u.startsWith('http://127.0.0.1:8799')) return route.continue();
+  return route.abort();
+});
+const page = await ctx.newPage();
+const pageErrs = [];
+page.on('console', m => { if (m.type() === 'error') pageErrs.push(m.text()); });
+page.on('pageerror', e => pageErrs.push('PAGEERROR: ' + e.message));
+
+log('navigating (single load, no mid-test reloads)...');
+await page.goto(BASE, { waitUntil: 'domcontentloaded' });
+// NOTE: the page declares `localWallet` as a SCRIPT-SCOPED let (not on window), so the
+// test cannot reference it by name. The LocalWallet *class* IS global (window.LocalWallet)
+// and all instances share the same IndexedDB, so unit-style scenarios use a self-made
+// instance; the UI scenario drives the global functions and asserts on DOM + IndexedDB.
+await page.waitForFunction(() => window.LocalWallet && window.DilithiumCrypto && typeof sha3_256 !== 'undefined', null, { timeout: 30000 });
+await page.evaluate(async () => { await window.DilithiumCrypto.init(); });
+log('loaded.');
+
+// Clear the wallet/address object stores WITHOUT deleteDatabase (clear() does not block).
+const clearStores = `async () => {
+  const lw = new window.LocalWallet(window.DilithiumCrypto);
+  await lw.init();
+  await new Promise((resolve, reject) => {
+    const tx = lw.db.transaction(['wallets','addresses'], 'readwrite');
+    tx.objectStore('wallets').clear();
+    tx.objectStore('addresses').clear();
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+  lw.db.close();
+}`;
+
+// ---- Scenario 1: SRI/crypto sanity + AC-1 blank-password rejection ----
+log('scenario 1: SRI + reject');
+const sriOk = await page.evaluate(async () => {
+  try {
+    if (typeof sha3_256 === 'undefined' || typeof sha3_512 === 'undefined') return { ok: false, why: 'sha3 globals missing' };
+    const m = await window.DilithiumCrypto.generateMnemonic();
+    const seed = await window.DilithiumCrypto.mnemonicToSeed(m);
+    const { publicKey } = await window.DilithiumCrypto.deriveChildKey(seed, "m/44'/573'/0'/0'/0'");
+    const addr = window.DilithiumCrypto.deriveAddress(publicKey);
+    return { ok: typeof addr === 'string' && addr.length > 0, addr };
+  } catch (e) { return { ok: false, why: e.message }; }
+});
+check('SRI-pinned sha3 (/build/) loads & address derivation works', sriOk.ok, JSON.stringify(sriOk));
+
+const reject = await page.evaluate(async () => {
+  const out = {}; const lw = new window.LocalWallet(window.DilithiumCrypto); await lw.init();
+  try { await lw.createWallet(''); out.empty = 'NO-THROW'; } catch (e) { out.empty = e.message; }
+  try { await lw.createWallet(null); out.null = 'NO-THROW'; } catch (e) { out.null = e.message; }
+  try { await lw.createWallet('short7!'); out.short = 'NO-THROW'; } catch (e) { out.short = e.message; }
+  try { await lw.importWallet(null, ['a','b']); out.import = 'NO-THROW'; } catch (e) { out.import = e.message; }
+  return out;
+});
+check('createWallet("") rejected', /at least 8/.test(reject.empty), reject.empty);
+check('createWallet(null) rejected', /at least 8/.test(reject.null), reject.null);
+check('createWallet(short) rejected', /at least 8/.test(reject.short), reject.short);
+check('importWallet(null,...) rejected', /at least 8/.test(reject.import), reject.import);
+
+// Also verify a VALID create stays encrypted at rest (no plaintext path remains).
+const validCreate = await page.evaluate(clearStores).then(() => page.evaluate(async () => {
+  const lw = new window.LocalWallet(window.DilithiumCrypto); await lw.init();
+  const res = await lw.createWallet('valid-pass-12');
+  const rec = await new Promise((resolve) => { const r = indexedDB.open('dilithion_wallet',1); r.onsuccess = () => { const db=r.result; const g=db.transaction('wallets','readonly').objectStore('wallets').getAll(); g.onsuccess=()=>{db.close();resolve(g.result[0]);}; }; });
+  return { encrypted: rec.encrypted, hasCipher: !!(rec.encryptedSeed && rec.encryptedSeed.ciphertext), mnemonicLen: res.mnemonic.length };
+}));
+check('valid createWallet stores encrypted:true (no plaintext path)', validCreate.encrypted === true && validCreate.hasCipher === true, JSON.stringify(validCreate));
+
+// ---- Scenario 2: encryptExisting() AC-2 + AC-7 ----
+log('scenario 2: encryptExisting');
+await page.evaluate(clearStores);
+const enc = await page.evaluate(async () => {
+  const out = {}; const crypto = window.DilithiumCrypto;
+  const lw = new window.LocalWallet(crypto); await lw.init();
+  // Clear any prior wallet on THIS connection, then seed, so getWallet() sees only ours.
+  await new Promise((resolve, reject) => { const tx = lw.db.transaction(['wallets','addresses'],'readwrite'); tx.objectStore('wallets').clear(); tx.objectStore('addresses').clear(); tx.oncomplete = () => resolve(); tx.onerror = () => reject(tx.error); });
+  // Seed a legacy unencrypted record via raw put on this instance's DB connection.
+  const seed = await crypto.mnemonicToSeed(await crypto.generateMnemonic());
+  const seedArr = Array.from(seed);
+  const keyPath = "m/44'/573'/0'/0'/0'";
+  const { publicKey: pk0 } = await crypto.deriveChildKey(seed, keyPath);
+  const addr0 = crypto.deriveAddress(pk0);
+  await new Promise((resolve, reject) => {
+    const tx = lw.db.transaction(['wallets','addresses'],'readwrite');
+    tx.objectStore('wallets').put({ id:'legacy-1', version:1, encrypted:false, encryptedSeed:new Uint8Array(seed), createdAt:Date.now(), accounts:[{index:0,name:'Main Account',nextAddressIndex:1}] });
+    tx.objectStore('addresses').put({ walletId:'legacy-1', address:addr0, path:keyPath, accountIndex:0, addressIndex:0, label:'Primary', createdAt:Date.now() });
+    tx.oncomplete = () => resolve(); tx.onerror = () => reject(tx.error);
+  });
+
+  out.isEncryptedBefore = await lw.isWalletEncrypted();
+  out.unlockThrows = await lw.unlock('whatever').then(() => 'NO-THROW').catch(e => e.message);
+  out.badPw = await lw.encryptExisting('short').then(() => 'NO-THROW').catch(e => e.message);
+
+  const before = await new Promise((resolve) => { const r=indexedDB.open('dilithion_wallet',1); r.onsuccess=()=>{const db=r.result; const g=db.transaction('wallets','readonly').objectStore('wallets').getAll(); g.onsuccess=()=>{db.close();resolve(g.result[0]);};}; });
+  out.plaintextPresentBefore = before.encrypted === false && before.encryptedSeed && before.encryptedSeed.length > 0;
+
+  out.migrated = await lw.encryptExisting('correct-horse-8');
+  out.isEncryptedAfter = await lw.isWalletEncrypted();
+  out.unlockedAfter = lw.isWalletUnlocked();
+
+  const after = await new Promise((resolve) => { const r=indexedDB.open('dilithion_wallet',1); r.onsuccess=()=>{const db=r.result; const g=db.transaction('wallets','readonly').objectStore('wallets').getAll(); g.onsuccess=()=>{db.close();resolve(g.result[0]);};}; });
+  out.afterEncryptedFlag = after.encrypted === true;
+  out.afterHasCiphertextObj = after.encryptedSeed && typeof after.encryptedSeed === 'object' && typeof after.encryptedSeed.ciphertext === 'string' && typeof after.encryptedSeed.salt === 'string' && typeof after.encryptedSeed.iv === 'string';
+  let storedRaw = false;
+  if (after.encryptedSeed instanceof Uint8Array || Array.isArray(after.encryptedSeed)) storedRaw = Array.from(after.encryptedSeed).join(',') === seedArr.join(',');
+  out.seedEvicted = !storedRaw;
+  const hay = JSON.stringify(after, (k, v) => (v instanceof Uint8Array ? Array.from(v) : v));
+  out.seedBytesAbsentFromRecord = !hay.includes(seedArr.join(','));
+
+  out.decryptedSeedPresent = lw.decryptedSeed != null && lw.decryptedSeed.length > 0;
+  if (out.decryptedSeedPresent) {
+    const { publicKey: pk2 } = await crypto.deriveChildKey(lw.decryptedSeed, keyPath);
+    out.addrUnchanged = crypto.deriveAddress(pk2) === addr0;
+  } else { out.addrUnchanged = false; }
+
+  lw.lock();
+  out.newPwUnlocks = await lw.unlock('correct-horse-8').then(() => true).catch(() => false);
+  out.raceReturnsFalse = await lw.encryptExisting('another-pass-9').then(v => v).catch(e => 'THREW:' + e.message);
+  return out;
+});
+check('legacy wallet reports encrypted:false', enc.isEncryptedBefore === false, JSON.stringify(enc.isEncryptedBefore));
+check('unlock() on legacy throws WALLET_NEEDS_ENCRYPTION', enc.unlockThrows === 'WALLET_NEEDS_ENCRYPTION', enc.unlockThrows);
+check('encryptExisting rejects short password', /at least 8/.test(enc.badPw), enc.badPw);
+check('plaintext seed present before migration (precondition)', enc.plaintextPresentBefore === true);
+check('encryptExisting returns true', enc.migrated === true, JSON.stringify(enc.migrated));
+check('wallet encrypted:true after migration', enc.isEncryptedAfter === true);
+check('wallet unlocked after migration', enc.unlockedAfter === true);
+check('stored record flag encrypted:true', enc.afterEncryptedFlag === true);
+check('stored seed is now {ciphertext,salt,iv}', enc.afterHasCiphertextObj === true);
+check('AC-7 zeroization: raw seed evicted from stored field', enc.seedEvicted === true);
+check('AC-7 zeroization: seed bytes absent anywhere in record', enc.seedBytesAbsentFromRecord === true);
+check('addresses unchanged after migration', enc.addrUnchanged === true);
+check('new password unlocks post-migration', enc.newPwUnlocks === true);
+check('AC-7 race: re-migrate returns false (already encrypted)', enc.raceReturnsFalse === false, JSON.stringify(enc.raceReturnsFalse));
+
+// ---- Scenario 3: AC-3 blocking migrate-on-load via real UI ----
+// Seed legacy, then call the page's own UI entrypoints directly (no navigation):
+// updateLightWalletUI() must present the blocking modal instead of unlock(null).
+// Drives the REAL global UI functions (updateLightWalletUI / submitWalletMigration),
+// which operate on the page's script-scoped `localWallet`. We seed via a fresh DB
+// connection (the UI re-reads the DB) and assert on OBSERVABLE state: the modal DOM
+// and the IndexedDB `encrypted` flag — not the unreachable script-scoped instance.
+log('scenario 3: migrate-on-load UI');
+await page.evaluate(clearStores);
+// Helper: read the stored wallet record's encrypted flag.
+const readEncryptedFlag = async () => page.evaluate(() => new Promise((resolve) => {
+  const r = indexedDB.open('dilithion_wallet', 1);
+  r.onsuccess = () => { const db = r.result; const g = db.transaction('wallets','readonly').objectStore('wallets').getAll(); g.onsuccess = () => { db.close(); resolve(g.result[0] ? g.result[0].encrypted : null); }; };
+}));
+
+const onload = await page.evaluate(async () => {
+  const crypto = window.DilithiumCrypto;
+  const seed = await crypto.mnemonicToSeed(await crypto.generateMnemonic());
+  const keyPath = "m/44'/573'/0'/0'/0'";
+  const { publicKey } = await crypto.deriveChildKey(seed, keyPath);
+  const addr0 = crypto.deriveAddress(publicKey);
+  // Clear any prior wallet, then seed a legacy unencrypted record (fresh connection).
+  await new Promise((resolve, reject) => {
+    const req = indexedDB.open('dilithion_wallet', 1);
+    req.onsuccess = () => { const db = req.result; const tx = db.transaction(['wallets','addresses'],'readwrite');
+      tx.objectStore('wallets').clear();
+      tx.objectStore('addresses').clear();
+      tx.objectStore('wallets').put({ id:'legacy-2', version:1, encrypted:false, encryptedSeed:new Uint8Array(seed), createdAt:Date.now(), accounts:[{index:0,name:'Main Account',nextAddressIndex:1}] });
+      tx.objectStore('addresses').put({ walletId:'legacy-2', address:addr0, path:keyPath, accountIndex:0, addressIndex:0, label:'Primary', createdAt:Date.now() });
+      tx.oncomplete = () => { db.close(); resolve(); }; tx.onerror = () => reject(tx.error); };
+    req.onerror = () => reject(req.error);
+  });
+  // Invoke the real load-time UI routine (the chokepoint that used to silently unlock).
+  await window.updateLightWalletUI();
+  const m = document.getElementById('walletMigrationModal');
+  const unlockedSection = document.getElementById('lightWalletUnlocked');
+  return {
+    modalVisible: m && getComputedStyle(m).display !== 'none',
+    unlockedSectionShown: unlockedSection && getComputedStyle(unlockedSection).display !== 'none',
+  };
+});
+check('AC-3 updateLightWalletUI presents blocking modal (no silent unlock)', onload.modalVisible === true, JSON.stringify(onload));
+check('AC-3 unlocked wallet UI NOT shown pre-migration', onload.unlockedSectionShown === false, JSON.stringify(onload));
+check('AC-3 stored wallet still encrypted:false before migration', (await readEncryptedFlag()) === false);
+
+const afterSubmit = await page.evaluate(async () => {
+  document.getElementById('migrationPassword').value = 'brandnew-pass-9';
+  document.getElementById('migrationPasswordConfirm').value = 'brandnew-pass-9';
+  await window.submitWalletMigration();
+  // small settle for any async UI work
+  await new Promise(r => setTimeout(r, 300));
+  const m = document.getElementById('walletMigrationModal');
+  return { modalHidden: !m || getComputedStyle(m).display === 'none' };
+});
+check('AC-3 modal closes after successful migration', afterSubmit.modalHidden === true, JSON.stringify(afterSubmit));
+check('AC-3 stored wallet encrypted:true after UI migration', (await readEncryptedFlag()) === true);
+
+// Re-running updateLightWalletUI on the now-encrypted wallet must NOT re-present the modal.
+const afterReuiState = await page.evaluate(async () => {
+  await window.updateLightWalletUI();
+  const m = document.getElementById('walletMigrationModal');
+  return m ? getComputedStyle(m).display !== 'none' : false;
+});
+check('AC-3 no migration modal once encrypted', afterReuiState === false, 'modalVisible=' + afterReuiState);
+
+await browser.close();
+
+const realErrs = pageErrs.filter(e => !/explorer\.dilithion\.org|Failed to fetch|net::ERR|ERR_|getblockchaininfo|seed node|No seed|Connection|favicon/i.test(e));
+check('no unexpected console/page errors', realErrs.length === 0, realErrs.slice(0,5).join(' | '));
+
+console.log('\n===== LP-9 TEST RESULTS =====');
+for (const r of results) console.log(r);
+console.log(`\n${pass} passed, ${fail} failed`);
+if (pageErrs.length) console.log('\n[filtered page errors]:', realErrs.length ? realErrs.join(' | ') : '(only benign network noise)');
+process.exit(fail === 0 ? 0 : 1);

--- a/website/tests/lp9-at-rest/lp9.test.mjs
+++ b/website/tests/lp9-at-rest/lp9.test.mjs
@@ -238,6 +238,132 @@ const afterReuiState = await page.evaluate(async () => {
 });
 check('AC-3 no migration modal once encrypted', afterReuiState === false, 'modalVisible=' + afterReuiState);
 
+// ---- Scenario 4: M-1 concurrent multi-tab migration race ----
+// Two tabs migrating the SAME legacy wallet with DIFFERENT passwords must not both
+// commit: the atomic check-and-write in _atomicMigratePut() means exactly one write
+// survives and the loser aborts cleanly (no overwrite => no lockout, no plaintext left).
+log('scenario 4: M-1 multi-tab race');
+await page.evaluate(clearStores);
+const race = await page.evaluate(async () => {
+  const out = {}; const crypto = window.DilithiumCrypto;
+  const seed = await crypto.mnemonicToSeed(await crypto.generateMnemonic());
+  const seedArr = Array.from(seed);
+  const keyPath = "m/44'/573'/0'/0'/0'";
+  const { publicKey } = await crypto.deriveChildKey(seed, keyPath);
+  const addr0 = crypto.deriveAddress(publicKey);
+
+  // Helper: (re)seed a fresh legacy unencrypted record.
+  const seedLegacy = async () => {
+    const lw = new window.LocalWallet(crypto); await lw.init();
+    await new Promise((res, rej) => { const tx = lw.db.transaction(['wallets','addresses'],'readwrite');
+      tx.objectStore('wallets').clear(); tx.objectStore('addresses').clear();
+      tx.objectStore('wallets').put({ id:'race-1', version:1, encrypted:false, encryptedSeed:new Uint8Array(seed), createdAt:Date.now(), accounts:[{index:0,name:'Main Account',nextAddressIndex:1}] });
+      tx.objectStore('addresses').put({ walletId:'race-1', address:addr0, path:keyPath, accountIndex:0, addressIndex:0, label:'Primary', createdAt:Date.now() });
+      tx.oncomplete = () => res(); tx.onerror = () => rej(tx.error); });
+    lw.db.close();
+  };
+  const readRec = () => new Promise((res) => { const r=indexedDB.open('dilithion_wallet',1); r.onsuccess=()=>{const db=r.result; const g=db.transaction('wallets','readonly').objectStore('wallets').getAll(); g.onsuccess=()=>{db.close();res(g.result[0]);};}; });
+
+  // --- 4a: TRUE race window. Both tabs pass the early encrypted-check, then BOTH
+  // attempt the atomic put with different passwords. Tab A wins; tab B must see the
+  // in-transaction re-check and ABORT (return 'raced'), never overwriting A's ciphertext.
+  await seedLegacy();
+  const tabA = new window.LocalWallet(crypto); await tabA.init();
+  const tabB = new window.LocalWallet(crypto); await tabB.init();
+  const wA = await tabA.getWallet();
+  const wB = await tabB.getWallet();           // both read plaintext (pre-check passes for both)
+  out.bothSawUnencrypted = wA.encrypted === false && wB.encrypted === false;
+
+  const cipherA = await crypto.encrypt(new Uint8Array(wA.encryptedSeed), 'tab-A-password-1');
+  const cipherB = await crypto.encrypt(new Uint8Array(wB.encryptedSeed), 'tab-B-password-2');
+  const resA = await tabA._atomicMigratePut('race-1', { ...wA, encrypted:true, encryptedSeed:cipherA });
+  const resB = await tabB._atomicMigratePut('race-1', { ...wB, encrypted:true, encryptedSeed:cipherB }); // races AFTER A committed
+  out.resA = resA; out.resB = resB;
+
+  const afterRace = await readRec();
+  out.storedEncrypted = afterRace.encrypted === true;
+  // A's ciphertext must be the survivor: decrypts with A's pw, NOT B's.
+  out.aPwDecrypts = await crypto.decrypt(afterRace.encryptedSeed, 'tab-A-password-1').then(s => Array.from(s).join(',') === seedArr.join(',')).catch(() => false);
+  out.bPwRejected = await crypto.decrypt(afterRace.encryptedSeed, 'tab-B-password-2').then(() => false).catch(() => true);
+  // No plaintext seed bytes anywhere in the stored record.
+  const hay = JSON.stringify(afterRace, (k, v) => (v instanceof Uint8Array ? Array.from(v) : v));
+  out.noPlaintextLeft = !hay.includes(seedArr.join(','));
+  tabA.db.close(); tabB.db.close();
+
+  // --- 4b: end-to-end via encryptExisting(): seed legacy, pre-encrypt out-of-band
+  // (simulating the other tab having won), then encryptExisting() must NOT clobber and
+  // must surface the "another tab" condition rather than unlocking from our plaintext.
+  await seedLegacy();
+  const winner = new window.LocalWallet(crypto); await winner.init();
+  const wRec = await winner.getWallet();
+  const winnerCipher = await crypto.encrypt(new Uint8Array(wRec.encryptedSeed), 'winner-pass-9');
+  // Out-of-band atomic commit by the "winner" using a separate instance.
+  await winner._atomicMigratePut('race-1', { ...wRec, encrypted:true, encryptedSeed:winnerCipher });
+  winner.db.close();
+
+  // Now a stale tab tries encryptExisting() — it already read plaintext before the win.
+  // Because the stored record is encrypted, the early pre-check OR the atomic re-check
+  // must stop it. We force the atomic-path by calling _atomicMigratePut directly with a
+  // loser ciphertext, AND verify encryptExisting() itself reports already-migrated.
+  const loser = new window.LocalWallet(crypto); await loser.init();
+  out.encryptExistingReturnsFalse = await loser.encryptExisting('loser-pass-9').then(v => v).catch(e => 'THREW:' + e.message);
+  const loserCipher = await crypto.encrypt(seed, 'loser-pass-9');
+  out.directRaced = await loser._atomicMigratePut('race-1', { id:'race-1', encrypted:true, encryptedSeed:loserCipher });
+  const finalRec = await readRec();
+  out.winnerSurvived = await crypto.decrypt(finalRec.encryptedSeed, 'winner-pass-9').then(() => true).catch(() => false);
+  out.loserPwRejected = await crypto.decrypt(finalRec.encryptedSeed, 'loser-pass-9').then(() => false).catch(() => true);
+  loser.db.close();
+  return out;
+});
+check('M-1 both tabs read plaintext (true race precondition)', race.bothSawUnencrypted === true, JSON.stringify(race));
+check('M-1 first atomic put commits (ok)', race.resA === 'ok', JSON.stringify(race.resA));
+check('M-1 second atomic put aborts as raced (no overwrite)', race.resB === 'raced', JSON.stringify(race.resB));
+check('M-1 stored record is encrypted after race', race.storedEncrypted === true);
+check('M-1 winner (tab A) ciphertext survived', race.aPwDecrypts === true);
+check('M-1 loser (tab B) password is NOT what is stored', race.bPwRejected === true);
+check('M-1 no plaintext seed left in record after race', race.noPlaintextLeft === true);
+check('M-1 encryptExisting reports already-migrated (false)', race.encryptExistingReturnsFalse === false, JSON.stringify(race.encryptExistingReturnsFalse));
+check('M-1 direct atomic put on already-encrypted returns raced', race.directRaced === 'raced', JSON.stringify(race.directRaced));
+check('M-1 out-of-band winner ciphertext preserved', race.winnerSurvived === true);
+check('M-1 loser password rejected (would-be lockout averted)', race.loserPwRejected === true);
+
+// ---- Scenario 5: L-1 delete requires password (no legacy bypass) ----
+// Encrypted wallet: wrong password must NOT delete; correct password deletes.
+// Legacy unencrypted wallet: delete refuses with WALLET_NEEDS_ENCRYPTION (no
+// password-free destructive path) — the record survives.
+log('scenario 5: L-1 delete-requires-password');
+await page.evaluate(clearStores);
+const del = await page.evaluate(async () => {
+  const out = {}; const crypto = window.DilithiumCrypto;
+
+  // 5a: encrypted wallet — wrong pw rejected, record survives; right pw deletes.
+  const lw = new window.LocalWallet(crypto); await lw.init();
+  await new Promise((res, rej) => { const tx = lw.db.transaction(['wallets','addresses'],'readwrite'); tx.objectStore('wallets').clear(); tx.objectStore('addresses').clear(); tx.oncomplete = () => res(); tx.onerror = () => rej(tx.error); });
+  await lw.createWallet('delete-me-pass-1');
+  out.wrongPwThrows = await lw.deleteWallet('totally-wrong-9').then(() => 'NO-THROW').catch(e => e.message);
+  out.survivesWrongPw = await lw.getWallet().then(w => !!w);
+  out.rightPwDeletes = await lw.deleteWallet('delete-me-pass-1').then(() => true).catch(e => 'THREW:' + e.message);
+  out.goneAfterRightPw = await lw.getWallet().then(w => w === null);
+
+  // 5b: legacy unencrypted wallet — delete must refuse (no password-free bypass).
+  const seed = await crypto.mnemonicToSeed(await crypto.generateMnemonic());
+  await new Promise((res, rej) => { const tx = lw.db.transaction(['wallets','addresses'],'readwrite'); tx.objectStore('wallets').clear(); tx.objectStore('addresses').clear();
+    tx.objectStore('wallets').put({ id:'legacy-del', version:1, encrypted:false, encryptedSeed:new Uint8Array(seed), createdAt:Date.now(), accounts:[{index:0,name:'Main Account',nextAddressIndex:1}] });
+    tx.oncomplete = () => res(); tx.onerror = () => rej(tx.error); });
+  out.legacyNoPwThrows = await lw.deleteWallet().then(() => 'NO-THROW').catch(e => e.message);
+  out.legacyAnyPwThrows = await lw.deleteWallet('anything-9').then(() => 'NO-THROW').catch(e => e.message);
+  out.legacySurvives = await lw.getWallet().then(w => !!w && w.encrypted === false);
+  lw.db.close();
+  return out;
+});
+check('L-1 encrypted delete: wrong password rejected', /Wrong password/.test(del.wrongPwThrows), del.wrongPwThrows);
+check('L-1 encrypted wallet survives wrong-password delete', del.survivesWrongPw === true);
+check('L-1 encrypted delete: correct password deletes', del.rightPwDeletes === true, JSON.stringify(del.rightPwDeletes));
+check('L-1 wallet gone after correct-password delete', del.goneAfterRightPw === true);
+check('L-1 legacy delete (no pw) refused (WALLET_NEEDS_ENCRYPTION)', del.legacyNoPwThrows === 'WALLET_NEEDS_ENCRYPTION', del.legacyNoPwThrows);
+check('L-1 legacy delete (any pw) refused (no plaintext-flag bypass)', del.legacyAnyPwThrows === 'WALLET_NEEDS_ENCRYPTION', del.legacyAnyPwThrows);
+check('L-1 legacy wallet survives refused delete', del.legacySurvives === true);
+
 await browser.close();
 
 const realErrs = pageErrs.filter(e => !/explorer\.dilithion\.org|Failed to fetch|net::ERR|ERR_|getblockchaininfo|seed node|No seed|Connection|favicon/i.test(e));

--- a/website/tests/lp9-at-rest/lp9.test.mjs
+++ b/website/tests/lp9-at-rest/lp9.test.mjs
@@ -313,6 +313,44 @@ const race = await page.evaluate(async () => {
   out.winnerSurvived = await crypto.decrypt(finalRec.encryptedSeed, 'winner-pass-9').then(() => true).catch(() => false);
   out.loserPwRejected = await crypto.decrypt(finalRec.encryptedSeed, 'loser-pass-9').then(() => false).catch(() => true);
   loser.db.close();
+
+  // --- 4c: FULL encryptExisting() race (exercises the 'raced' THROW at ~452-457,
+  // not just the _atomicMigratePut primitive). Two tabs call encryptExisting() on the
+  // SAME wallet with DIFFERENT passwords. Both pass the early encrypted-check (both read
+  // plaintext), both round-trip-encrypt, then both hit the atomic put: IndexedDB
+  // serializes the two readwrite transactions so exactly ONE commits and the OTHER sees
+  // encrypted===true in-transaction → 'raced' → encryptExisting() THROWS. The loser must
+  // NOT unlock from its stale plaintext (isUnlocked stays false), and the persisted record
+  // must be the WINNER's ciphertext (decrypts with winner pw, not loser pw).
+  await seedLegacy();
+  const c1 = new window.LocalWallet(crypto); await c1.init();
+  const c2 = new window.LocalWallet(crypto); await c2.init();
+  // Fire BOTH concurrently on the same walletId with different passwords.
+  const settled = await Promise.allSettled([
+    c1.encryptExisting('tabone-pass-1'),
+    c2.encryptExisting('tabtwo-pass-2'),
+  ]);
+  const fulfilled = settled.filter(s => s.status === 'fulfilled' && s.value === true);
+  const rejected = settled.filter(s => s.status === 'rejected');
+  out.fullRaceExactlyOneWon = fulfilled.length === 1;
+  out.fullRaceExactlyOneRejected = rejected.length === 1;
+  out.fullRaceLoserThrewRaceMsg = rejected.length === 1 && /encrypted in another tab/i.test(rejected[0].reason && rejected[0].reason.message || '');
+  // Identify winner/loser instances by their resulting unlock state.
+  const c1Won = settled[0].status === 'fulfilled' && settled[0].value === true;
+  const winnerInst = c1Won ? c1 : c2;
+  const loserInst = c1Won ? c2 : c1;
+  const winnerPw = c1Won ? 'tabone-pass-1' : 'tabtwo-pass-2';
+  const loserPw = c1Won ? 'tabtwo-pass-2' : 'tabone-pass-1';
+  // Loser must NOT have unlocked from stale plaintext.
+  out.fullRaceLoserNotUnlocked = loserInst.isWalletUnlocked() === false;
+  // Winner DID unlock.
+  out.fullRaceWinnerUnlocked = winnerInst.isWalletUnlocked() === true;
+  // Persisted record is encrypted and is the WINNER's ciphertext (not the loser's).
+  const fullRec = await readRec();
+  out.fullRaceStoredEncrypted = fullRec.encrypted === true;
+  out.fullRaceWinnerPwDecrypts = await crypto.decrypt(fullRec.encryptedSeed, winnerPw).then(s => Array.from(s).join(',') === seedArr.join(',')).catch(() => false);
+  out.fullRaceLoserPwRejected = await crypto.decrypt(fullRec.encryptedSeed, loserPw).then(() => false).catch(() => true);
+  c1.db.close(); c2.db.close();
   return out;
 });
 check('M-1 both tabs read plaintext (true race precondition)', race.bothSawUnencrypted === true, JSON.stringify(race));
@@ -326,6 +364,15 @@ check('M-1 encryptExisting reports already-migrated (false)', race.encryptExisti
 check('M-1 direct atomic put on already-encrypted returns raced', race.directRaced === 'raced', JSON.stringify(race.directRaced));
 check('M-1 out-of-band winner ciphertext preserved', race.winnerSurvived === true);
 check('M-1 loser password rejected (would-be lockout averted)', race.loserPwRejected === true);
+// 4c: full encryptExisting() race — exercises the 'raced' THROW + no-unlock path E2E.
+check('M-1 full encryptExisting race: exactly one tab succeeds', race.fullRaceExactlyOneWon === true, JSON.stringify(race.fullRaceExactlyOneWon));
+check('M-1 full encryptExisting race: exactly one tab rejects', race.fullRaceExactlyOneRejected === true, JSON.stringify(race.fullRaceExactlyOneRejected));
+check('M-1 full encryptExisting race: loser throws "encrypted in another tab"', race.fullRaceLoserThrewRaceMsg === true, JSON.stringify(race.fullRaceLoserThrewRaceMsg));
+check('M-1 full encryptExisting race: loser did NOT unlock from stale plaintext', race.fullRaceLoserNotUnlocked === true, JSON.stringify(race.fullRaceLoserNotUnlocked));
+check('M-1 full encryptExisting race: winner is unlocked', race.fullRaceWinnerUnlocked === true, JSON.stringify(race.fullRaceWinnerUnlocked));
+check('M-1 full encryptExisting race: stored record encrypted', race.fullRaceStoredEncrypted === true);
+check('M-1 full encryptExisting race: WINNER password decrypts stored seed', race.fullRaceWinnerPwDecrypts === true);
+check('M-1 full encryptExisting race: LOSER password rejected', race.fullRaceLoserPwRejected === true);
 
 // ---- Scenario 5: L-1 delete requires password (no legacy bypass) ----
 // Encrypted wallet: wrong password must NOT delete; correct password deletes.

--- a/website/wallet.html
+++ b/website/wallet.html
@@ -5520,7 +5520,15 @@
                     try { await handleModeChange(); } catch (e) { /* connection handled elsewhere */ }
                 }
             } catch (e) {
-                showErr('Could not encrypt wallet: ' + (e && e.message ? e.message : 'unknown error') + ' — your wallet is unchanged. Please try again.');
+                const msg = (e && e.message) ? e.message : 'unknown error';
+                // The "raced" case (another tab encrypted this wallet first) DID change the
+                // stored wallet, so the "your wallet is unchanged" reassurance would be wrong.
+                // That error message already explains the situation; surface it as-is. Only
+                // append "unchanged" for genuine failures where the wallet is truly untouched.
+                const raced = /encrypted in another tab/i.test(msg);
+                showErr(raced
+                    ? ('Could not encrypt wallet: ' + msg)
+                    : ('Could not encrypt wallet: ' + msg + ' — your wallet is unchanged. Please try again.'));
                 if (btn) { btn.disabled = false; btn.textContent = 'Encrypt & Continue'; }
                 return;
             }

--- a/website/wallet.html
+++ b/website/wallet.html
@@ -34,10 +34,17 @@
     <script>!function(t){if("object"==typeof exports&&"undefined"!=typeof module)module.exports=t();else if("function"==typeof define&&define.amd)define([],t);else{var e;e="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:this,e.QRCode=t()}}(function(){return function(){function t(e,r,n){function o(a,u){if(!r[a]){if(!e[a]){var s="function"==typeof require&&require;if(!u&&s)return s(a,!0);if(i)return i(a,!0);var f=new Error("Cannot find module '"+a+"'");throw f.code="MODULE_NOT_FOUND",f}var l=r[a]={exports:{}};e[a][0].call(l.exports,function(t){return o(e[a][1][t]||t)},l,l.exports,t,e,r,n)}return r[a].exports}for(var i="function"==typeof require&&require,a=0;a<n.length;a++)o(n[a]);return o}return t}()({1:[function(t,e,r){var n=t("./utils").getSymbolSize;r.getRowColCoords=function(t){if(1===t)return[];for(var e=Math.floor(t/7)+2,r=n(t),o=145===r?26:2*Math.ceil((r-13)/(2*e-2)),i=[r-7],a=1;a<e-1;a++)i[a]=i[a-1]-o;return i.push(6),i.reverse()},r.getPositions=function(t){for(var e=[],n=r.getRowColCoords(t),o=n.length,i=0;i<o;i++)for(var a=0;a<o;a++)0===i&&0===a||0===i&&a===o-1||i===o-1&&0===a||e.push([n[i],n[a]]);return e}},{"./utils":20}],2:[function(t,e,r){function n(t){this.mode=o.ALPHANUMERIC,this.data=t}var o=t("./mode"),i=["0","1","2","3","4","5","6","7","8","9","A","B","C","D","E","F","G","H","I","J","K","L","M","N","O","P","Q","R","S","T","U","V","W","X","Y","Z"," ","$","%","*","+","-",".","/",":"];n.getBitsLength=function(t){return 11*Math.floor(t/2)+t%2*6},n.prototype.getLength=function(){return this.data.length},n.prototype.getBitsLength=function(){return n.getBitsLength(this.data.length)},n.prototype.write=function(t){var e;for(e=0;e+2<=this.data.length;e+=2){var r=45*i.indexOf(this.data[e]);r+=i.indexOf(this.data[e+1]),t.put(r,11)}this.data.length%2&&t.put(i.indexOf(this.data[e]),6)},e.exports=n},{"./mode":13}],3:[function(t,e,r){function n(){this.buffer=[],this.length=0}n.prototype={get:function(t){var e=Math.floor(t/8);return 1==(this.buffer[e]>>>7-t%8&1)},put:function(t,e){for(var r=0;r<e;r++)this.putBit(1==(t>>>e-r-1&1))},getLengthInBits:function(){return this.length},putBit:function(t){var e=Math.floor(this.length/8);this.buffer.length<=e&&this.buffer.push(0),t&&(this.buffer[e]|=128>>>this.length%8),this.length++}},e.exports=n},{}],4:[function(t,e,r){function n(t){if(!t||t<1)throw new Error("BitMatrix size must be defined and greater than 0");this.size=t,this.data=new o(t*t),this.data.fill(0),this.reservedBit=new o(t*t),this.reservedBit.fill(0)}var o=t("../utils/buffer");n.prototype.set=function(t,e,r,n){var o=t*this.size+e;this.data[o]=r,n&&(this.reservedBit[o]=!0)},n.prototype.get=function(t,e){return this.data[t*this.size+e]},n.prototype.xor=function(t,e,r){this.data[t*this.size+e]^=r},n.prototype.isReserved=function(t,e){return this.reservedBit[t*this.size+e]},e.exports=n},{"../utils/buffer":27}],5:[function(t,e,r){function n(t){this.mode=i.BYTE,this.data=new o(t)}var o=t("../utils/buffer"),i=t("./mode");n.getBitsLength=function(t){return 8*t},n.prototype.getLength=function(){return this.data.length},n.prototype.getBitsLength=function(){return n.getBitsLength(this.data.length)},n.prototype.write=function(t){for(var e=0,r=this.data.length;e<r;e++)t.put(this.data[e],8)},e.exports=n},{"../utils/buffer":27,"./mode":13}],6:[function(t,e,r){var n=t("./error-correction-level"),o=[1,1,1,1,1,1,1,1,1,1,2,2,1,2,2,4,1,2,4,4,2,4,4,4,2,4,6,5,2,4,6,6,2,5,8,8,4,5,8,8,4,5,8,11,4,8,10,11,4,9,12,16,4,9,16,16,6,10,12,18,6,10,17,16,6,11,16,19,6,13,18,21,7,14,21,25,8,16,20,25,8,17,23,25,9,17,23,34,9,18,25,30,10,20,27,32,12,21,29,35,12,23,34,37,12,25,34,40,13,26,35,42,14,28,38,45,15,29,40,48,16,31,43,51,17,33,45,54,18,35,48,57,19,37,51,60,19,38,53,63,20,40,56,66,21,43,59,70,22,45,62,74,24,47,65,77,25,49,68,81],i=[7,10,13,17,10,16,22,28,15,26,36,44,20,36,52,64,26,48,72,88,36,64,96,112,40,72,108,130,48,88,132,156,60,110,160,192,72,130,192,224,80,150,224,264,96,176,260,308,104,198,288,352,120,216,320,384,132,240,360,432,144,280,408,480,168,308,448,532,180,338,504,588,196,364,546,650,224,416,600,700,224,442,644,750,252,476,690,816,270,504,750,900,300,560,810,960,312,588,870,1050,336,644,952,1110,360,700,1020,1200,390,728,1050,1260,420,784,1140,1350,450,812,1200,1440,480,868,1290,1530,510,924,1350,1620,540,980,1440,1710,570,1036,1530,1800,570,1064,1590,1890,600,1120,1680,1980,630,1204,1770,2100,660,1260,1860,2220,720,1316,1950,2310,750,1372,2040,2430];r.getBlocksCount=function(t,e){switch(e){case n.L:return o[4*(t-1)+0];case n.M:return o[4*(t-1)+1];case n.Q:return o[4*(t-1)+2];case n.H:return o[4*(t-1)+3];default:return}},r.getTotalCodewordsCount=function(t,e){switch(e){case n.L:return i[4*(t-1)+0];case n.M:return i[4*(t-1)+1];case n.Q:return i[4*(t-1)+2];case n.H:return i[4*(t-1)+3];default:return}}},{"./error-correction-level":7}],7:[function(t,e,r){function n(t){if("string"!=typeof t)throw new Error("Param is not a string");switch(t.toLowerCase()){case"l":case"low":return r.L;case"m":case"medium":return r.M;case"q":case"quartile":return r.Q;case"h":case"high":return r.H;default:throw new Error("Unknown EC Level: "+t)}}r.L={bit:1},r.M={bit:0},r.Q={bit:3},r.H={bit:2},r.isValid=function(t){return t&&void 0!==t.bit&&t.bit>=0&&t.bit<4},r.from=function(t,e){if(r.isValid(t))return t;try{return n(t)}catch(t){return e}}},{}],8:[function(t,e,r){var n=t("./utils").getSymbolSize;r.getPositions=function(t){var e=n(t);return[[0,0],[e-7,0],[0,e-7]]}},{"./utils":20}],9:[function(t,e,r){var n=t("./utils"),o=n.getBCHDigit(1335);r.getEncodedBits=function(t,e){for(var r=t.bit<<3|e,i=r<<10;n.getBCHDigit(i)-o>=0;)i^=1335<<n.getBCHDigit(i)-o;return 21522^(r<<10|i)}},{"./utils":20}],10:[function(t,e,r){var n=t("../utils/buffer"),o=new n(512),i=new n(256);!function(){for(var t=1,e=0;e<255;e++)o[e]=t,i[t]=e,256&(t<<=1)&&(t^=285);for(e=255;e<512;e++)o[e]=o[e-255]}(),r.log=function(t){if(t<1)throw new Error("log("+t+")");return i[t]},r.exp=function(t){return o[t]},r.mul=function(t,e){return 0===t||0===e?0:o[i[t]+i[e]]}},{"../utils/buffer":27}],11:[function(t,e,r){function n(t){this.mode=o.KANJI,this.data=t}var o=t("./mode"),i=t("./utils");n.getBitsLength=function(t){return 13*t},n.prototype.getLength=function(){return this.data.length},n.prototype.getBitsLength=function(){return n.getBitsLength(this.data.length)},n.prototype.write=function(t){var e;for(e=0;e<this.data.length;e++){var r=i.toSJIS(this.data[e]);if(r>=33088&&r<=40956)r-=33088;else{if(!(r>=57408&&r<=60351))throw new Error("Invalid SJIS character: "+this.data[e]+"\nMake sure your charset is UTF-8");r-=49472}r=192*(r>>>8&255)+(255&r),t.put(r,13)}},e.exports=n},{"./mode":13,"./utils":20}],12:[function(t,e,r){function n(t,e,n){switch(t){case r.Patterns.PATTERN000:return(e+n)%2==0;case r.Patterns.PATTERN001:return e%2==0;case r.Patterns.PATTERN010:return n%3==0;case r.Patterns.PATTERN011:return(e+n)%3==0;case r.Patterns.PATTERN100:return(Math.floor(e/2)+Math.floor(n/3))%2==0;case r.Patterns.PATTERN101:return e*n%2+e*n%3==0;case r.Patterns.PATTERN110:return(e*n%2+e*n%3)%2==0;case r.Patterns.PATTERN111:return(e*n%3+(e+n)%2)%2==0;default:throw new Error("bad maskPattern:"+t)}}r.Patterns={PATTERN000:0,PATTERN001:1,PATTERN010:2,PATTERN011:3,PATTERN100:4,PATTERN101:5,PATTERN110:6,PATTERN111:7};var o={N1:3,N2:3,N3:40,N4:10};r.isValid=function(t){return null!=t&&""!==t&&!isNaN(t)&&t>=0&&t<=7},r.from=function(t){return r.isValid(t)?parseInt(t,10):void 0},r.getPenaltyN1=function(t){for(var e=t.size,r=0,n=0,i=0,a=null,u=null,s=0;s<e;s++){n=i=0,a=u=null;for(var f=0;f<e;f++){var l=t.get(s,f);l===a?n++:(n>=5&&(r+=o.N1+(n-5)),a=l,n=1),l=t.get(f,s),l===u?i++:(i>=5&&(r+=o.N1+(i-5)),u=l,i=1)}n>=5&&(r+=o.N1+(n-5)),i>=5&&(r+=o.N1+(i-5))}return r},r.getPenaltyN2=function(t){for(var e=t.size,r=0,n=0;n<e-1;n++)for(var i=0;i<e-1;i++){var a=t.get(n,i)+t.get(n,i+1)+t.get(n+1,i)+t.get(n+1,i+1);4!==a&&0!==a||r++}return r*o.N2},r.getPenaltyN3=function(t){for(var e=t.size,r=0,n=0,i=0,a=0;a<e;a++){n=i=0;for(var u=0;u<e;u++)n=n<<1&2047|t.get(a,u),u>=10&&(1488===n||93===n)&&r++,i=i<<1&2047|t.get(u,a),u>=10&&(1488===i||93===i)&&r++}return r*o.N3},r.getPenaltyN4=function(t){for(var e=0,r=t.data.length,n=0;n<r;n++)e+=t.data[n];return Math.abs(Math.ceil(100*e/r/5)-10)*o.N4},r.applyMask=function(t,e){for(var r=e.size,o=0;o<r;o++)for(var i=0;i<r;i++)e.isReserved(i,o)||e.xor(i,o,n(t,i,o))},r.getBestMask=function(t,e){for(var n=Object.keys(r.Patterns).length,o=0,i=1/0,a=0;a<n;a++){e(a),r.applyMask(a,t);var u=r.getPenaltyN1(t)+r.getPenaltyN2(t)+r.getPenaltyN3(t)+r.getPenaltyN4(t);r.applyMask(a,t),u<i&&(i=u,o=a)}return o}},{}],13:[function(t,e,r){function n(t){if("string"!=typeof t)throw new Error("Param is not a string");switch(t.toLowerCase()){case"numeric":return r.NUMERIC;case"alphanumeric":return r.ALPHANUMERIC;case"kanji":return r.KANJI;case"byte":return r.BYTE;default:throw new Error("Unknown mode: "+t)}}var o=t("./version-check"),i=t("./regex");r.NUMERIC={id:"Numeric",bit:1,ccBits:[10,12,14]},r.ALPHANUMERIC={id:"Alphanumeric",bit:2,ccBits:[9,11,13]},r.BYTE={id:"Byte",bit:4,ccBits:[8,16,16]},r.KANJI={id:"Kanji",bit:8,ccBits:[8,10,12]},r.MIXED={bit:-1},r.getCharCountIndicator=function(t,e){if(!t.ccBits)throw new Error("Invalid mode: "+t);if(!o.isValid(e))throw new Error("Invalid version: "+e);return e>=1&&e<10?t.ccBits[0]:e<27?t.ccBits[1]:t.ccBits[2]},r.getBestModeForData=function(t){return i.testNumeric(t)?r.NUMERIC:i.testAlphanumeric(t)?r.ALPHANUMERIC:i.testKanji(t)?r.KANJI:r.BYTE},r.toString=function(t){if(t&&t.id)return t.id;throw new Error("Invalid mode")},r.isValid=function(t){return t&&t.bit&&t.ccBits},r.from=function(t,e){if(r.isValid(t))return t;try{return n(t)}catch(t){return e}}},{"./regex":18,"./version-check":21}],14:[function(t,e,r){function n(t){this.mode=o.NUMERIC,this.data=t.toString()}var o=t("./mode");n.getBitsLength=function(t){return 10*Math.floor(t/3)+(t%3?t%3*3+1:0)},n.prototype.getLength=function(){return this.data.length},n.prototype.getBitsLength=function(){return n.getBitsLength(this.data.length)},n.prototype.write=function(t){var e,r,n;for(e=0;e+3<=this.data.length;e+=3)r=this.data.substr(e,3),n=parseInt(r,10),t.put(n,10);var o=this.data.length-e;o>0&&(r=this.data.substr(e),n=parseInt(r,10),t.put(n,3*o+1))},e.exports=n},{"./mode":13}],15:[function(t,e,r){var n=t("../utils/buffer"),o=t("./galois-field");r.mul=function(t,e){var r=new n(t.length+e.length-1);r.fill(0);for(var i=0;i<t.length;i++)for(var a=0;a<e.length;a++)r[i+a]^=o.mul(t[i],e[a]);return r},r.mod=function(t,e){for(var r=new n(t);r.length-e.length>=0;){for(var i=r[0],a=0;a<e.length;a++)r[a]^=o.mul(e[a],i);for(var u=0;u<r.length&&0===r[u];)u++;r=r.slice(u)}return r},r.generateECPolynomial=function(t){for(var e=new n([1]),i=0;i<t;i++)e=r.mul(e,[1,o.exp(i)]);return e}},{"../utils/buffer":27,"./galois-field":10}],16:[function(t,e,r){function n(t,e){for(var r=t.size,n=m.getPositions(e),o=0;o<n.length;o++)for(var i=n[o][0],a=n[o][1],u=-1;u<=7;u++)if(!(i+u<=-1||r<=i+u))for(var s=-1;s<=7;s++)a+s<=-1||r<=a+s||(u>=0&&u<=6&&(0===s||6===s)||s>=0&&s<=6&&(0===u||6===u)||u>=2&&u<=4&&s>=2&&s<=4?t.set(i+u,a+s,!0,!0):t.set(i+u,a+s,!1,!0))}function o(t){for(var e=t.size,r=8;r<e-8;r++){var n=r%2==0;t.set(r,6,n,!0),t.set(6,r,n,!0)}}function i(t,e){for(var r=w.getPositions(e),n=0;n<r.length;n++)for(var o=r[n][0],i=r[n][1],a=-2;a<=2;a++)for(var u=-2;u<=2;u++)-2===a||2===a||-2===u||2===u||0===a&&0===u?t.set(o+a,i+u,!0,!0):t.set(o+a,i+u,!1,!0)}function a(t,e){for(var r,n,o,i=t.size,a=A.getEncodedBits(e),u=0;u<18;u++)r=Math.floor(u/3),n=u%3+i-8-3,o=1==(a>>u&1),t.set(r,n,o,!0),t.set(n,r,o,!0)}function u(t,e,r){var n,o,i=t.size,a=B.getEncodedBits(e,r);for(n=0;n<15;n++)o=1==(a>>n&1),n<6?t.set(n,8,o,!0):n<8?t.set(n+1,8,o,!0):t.set(i-15+n,8,o,!0),n<8?t.set(8,i-n-1,o,!0):n<9?t.set(8,15-n-1+1,o,!0):t.set(8,15-n-1,o,!0);t.set(i-8,8,1,!0)}function s(t,e){for(var r=t.size,n=-1,o=r-1,i=7,a=0,u=r-1;u>0;u-=2)for(6===u&&u--;;){for(var s=0;s<2;s++)if(!t.isReserved(o,u-s)){var f=!1;a<e.length&&(f=1==(e[a]>>>i&1)),t.set(o,u-s,f),i--,-1===i&&(a++,i=7)}if((o+=n)<0||r<=o){o-=n,n=-n;break}}}function f(t,e,r){var n=new p;r.forEach(function(e){n.put(e.mode.bit,4),n.put(e.getLength(),R.getCharCountIndicator(e.mode,t)),e.write(n)});var o=d.getSymbolTotalCodewords(t),i=E.getTotalCodewordsCount(t,e),a=8*(o-i);for(n.getLengthInBits()+4<=a&&n.put(0,4);n.getLengthInBits()%8!=0;)n.putBit(0);for(var u=(a-n.getLengthInBits())/8,s=0;s<u;s++)n.put(s%2?17:236,8);return l(n,t,e)}function l(t,e,r){for(var n=d.getSymbolTotalCodewords(e),o=E.getTotalCodewordsCount(e,r),i=n-o,a=E.getBlocksCount(e,r),u=n%a,s=a-u,f=Math.floor(n/a),l=Math.floor(i/a),c=l+1,g=f-l,p=new b(g),v=0,w=new Array(a),m=new Array(a),y=0,A=new h(t.buffer),B=0;B<a;B++){var R=B<s?l:c;w[B]=A.slice(v,v+R),m[B]=p.encode(w[B]),v+=R,y=Math.max(y,R)}var P,T,C=new h(n),N=0;for(P=0;P<y;P++)for(T=0;T<a;T++)P<w[T].length&&(C[N++]=w[T][P]);for(P=0;P<g;P++)for(T=0;T<a;T++)C[N++]=m[T][P];return C}function c(t,e,r,l){var c;if(T(t))c=P.fromArray(t);else{if("string"!=typeof t)throw new Error("Invalid data");var h=e;if(!h){var g=P.rawSplit(t);h=A.getBestVersionForData(g,r)}c=P.fromString(t,h||40)}var p=A.getBestVersionForData(c,r);if(!p)throw new Error("The amount of data is too big to be stored in a QR Code");if(e){if(e<p)throw new Error("\nThe chosen QR Code version cannot contain this amount of data.\nMinimum version required to store current data is: "+p+".\n")}else e=p;var w=f(e,r,c),m=d.getSymbolSize(e),E=new v(m);return n(E,e),o(E),i(E,e),u(E,r,0),e>=7&&a(E,e),s(E,w),isNaN(l)&&(l=y.getBestMask(E,u.bind(null,E,r))),y.applyMask(l,E),u(E,r,l),{modules:E,version:e,errorCorrectionLevel:r,maskPattern:l,segments:c}}var h=t("../utils/buffer"),d=t("./utils"),g=t("./error-correction-level"),p=t("./bit-buffer"),v=t("./bit-matrix"),w=t("./alignment-pattern"),m=t("./finder-pattern"),y=t("./mask-pattern"),E=t("./error-correction-code"),b=t("./reed-solomon-encoder"),A=t("./version"),B=t("./format-info"),R=t("./mode"),P=t("./segments"),T=t("isarray");r.create=function(t,e){if(void 0===t||""===t)throw new Error("No input text");var r,n,o=g.M;return void 0!==e&&(o=g.from(e.errorCorrectionLevel,g.M),r=A.from(e.version),n=y.from(e.maskPattern),e.toSJISFunc&&d.setToSJISFunction(e.toSJISFunc)),c(t,r,o,n)}},{"../utils/buffer":27,"./alignment-pattern":1,"./bit-buffer":3,"./bit-matrix":4,"./error-correction-code":6,"./error-correction-level":7,"./finder-pattern":8,"./format-info":9,"./mask-pattern":12,"./mode":13,"./reed-solomon-encoder":17,"./segments":19,"./utils":20,"./version":22,isarray:30}],17:[function(t,e,r){function n(t){this.genPoly=void 0,this.degree=t,this.degree&&this.initialize(this.degree)}var o=t("../utils/buffer"),i=t("./polynomial");n.prototype.initialize=function(t){this.degree=t,this.genPoly=i.generateECPolynomial(this.degree)},n.prototype.encode=function(t){if(!this.genPoly)throw new Error("Encoder not initialized");var e=new o(this.degree);e.fill(0);var r=o.concat([t,e],t.length+this.degree),n=i.mod(r,this.genPoly),a=this.degree-n.length;if(a>0){var u=new o(this.degree);return u.fill(0),n.copy(u,a),u}return n},e.exports=n},{"../utils/buffer":27,"./polynomial":15}],18:[function(t,e,r){var n="(?:[u3000-u303F]|[u3040-u309F]|[u30A0-u30FF]|[uFF00-uFFEF]|[u4E00-u9FAF]|[u2605-u2606]|[u2190-u2195]|u203B|[u2010u2015u2018u2019u2025u2026u201Cu201Du2225u2260]|[u0391-u0451]|[u00A7u00A8u00B1u00B4u00D7u00F7])+";n=n.replace(/u/g,"\\u");var o="(?:(?![A-Z0-9 $%*+\\-./:]|"+n+").)+";r.KANJI=new RegExp(n,"g"),r.BYTE_KANJI=new RegExp("[^A-Z0-9 $%*+\\-./:]+","g"),r.BYTE=new RegExp(o,"g"),r.NUMERIC=new RegExp("[0-9]+","g"),r.ALPHANUMERIC=new RegExp("[A-Z $%*+\\-./:]+","g");var i=new RegExp("^"+n+"$"),a=new RegExp("^[0-9]+$"),u=new RegExp("^[A-Z0-9 $%*+\\-./:]+$");r.testKanji=function(t){return i.test(t)},r.testNumeric=function(t){return a.test(t)},r.testAlphanumeric=function(t){return u.test(t)}},{}],19:[function(t,e,r){function n(t){return unescape(encodeURIComponent(t)).length}function o(t,e,r){for(var n,o=[];null!==(n=t.exec(r));)o.push({data:n[0],index:n.index,mode:e,length:n[0].length});return o}function i(t){var e,r,n=o(v.NUMERIC,c.NUMERIC,t),i=o(v.ALPHANUMERIC,c.ALPHANUMERIC,t);return w.isKanjiModeEnabled()?(e=o(v.BYTE,c.BYTE,t),r=o(v.KANJI,c.KANJI,t)):(e=o(v.BYTE_KANJI,c.BYTE,t),r=[]),n.concat(i,e,r).sort(function(t,e){return t.index-e.index}).map(function(t){return{data:t.data,mode:t.mode,length:t.length}})}function a(t,e){switch(e){case c.NUMERIC:return h.getBitsLength(t);case c.ALPHANUMERIC:return d.getBitsLength(t);case c.KANJI:return p.getBitsLength(t);case c.BYTE:return g.getBitsLength(t)}}function u(t){return t.reduce(function(t,e){var r=t.length-1>=0?t[t.length-1]:null;return r&&r.mode===e.mode?(t[t.length-1].data+=e.data,t):(t.push(e),t)},[])}function s(t){for(var e=[],r=0;r<t.length;r++){var o=t[r];switch(o.mode){case c.NUMERIC:e.push([o,{data:o.data,mode:c.ALPHANUMERIC,length:o.length},{data:o.data,mode:c.BYTE,length:o.length}]);break;case c.ALPHANUMERIC:e.push([o,{data:o.data,mode:c.BYTE,length:o.length}]);break;case c.KANJI:e.push([o,{data:o.data,mode:c.BYTE,length:n(o.data)}]);break;case c.BYTE:e.push([{data:o.data,mode:c.BYTE,length:n(o.data)}])}}return e}function f(t,e){for(var r={},n={start:{}},o=["start"],i=0;i<t.length;i++){for(var u=t[i],s=[],f=0;f<u.length;f++){var l=u[f],h=""+i+f;s.push(h),r[h]={node:l,lastCount:0},n[h]={};for(var d=0;d<o.length;d++){var g=o[d];r[g]&&r[g].node.mode===l.mode?(n[g][h]=a(r[g].lastCount+l.length,l.mode)-a(r[g].lastCount,l.mode),r[g].lastCount+=l.length):(r[g]&&(r[g].lastCount=l.length),n[g][h]=a(l.length,l.mode)+4+c.getCharCountIndicator(l.mode,e))}}o=s}for(d=0;d<o.length;d++)n[o[d]].end=0;return{map:n,table:r}}function l(t,e){var r,n=c.getBestModeForData(t);if((r=c.from(e,n))!==c.BYTE&&r.bit<n.bit)throw new Error('"'+t+'" cannot be encoded with mode '+c.toString(r)+".\n Suggested mode is: "+c.toString(n));switch(r!==c.KANJI||w.isKanjiModeEnabled()||(r=c.BYTE),r){case c.NUMERIC:return new h(t);case c.ALPHANUMERIC:return new d(t);case c.KANJI:return new p(t);case c.BYTE:return new g(t)}}var c=t("./mode"),h=t("./numeric-data"),d=t("./alphanumeric-data"),g=t("./byte-data"),p=t("./kanji-data"),v=t("./regex"),w=t("./utils"),m=t("dijkstrajs");r.fromArray=function(t){return t.reduce(function(t,e){return"string"==typeof e?t.push(l(e,null)):e.data&&t.push(l(e.data,e.mode)),t},[])},r.fromString=function(t,e){for(var n=i(t,w.isKanjiModeEnabled()),o=s(n),a=f(o,e),l=m.find_path(a.map,"start","end"),c=[],h=1;h<l.length-1;h++)c.push(a.table[l[h]].node);return r.fromArray(u(c))},r.rawSplit=function(t){return r.fromArray(i(t,w.isKanjiModeEnabled()))}},{"./alphanumeric-data":2,"./byte-data":5,"./kanji-data":11,"./mode":13,"./numeric-data":14,"./regex":18,"./utils":20,dijkstrajs:29}],20:[function(t,e,r){var n,o=[0,26,44,70,100,134,172,196,242,292,346,404,466,532,581,655,733,815,901,991,1085,1156,1258,1364,1474,1588,1706,1828,1921,2051,2185,2323,2465,2611,2761,2876,3034,3196,3362,3532,3706];r.getSymbolSize=function(t){if(!t)throw new Error('"version" cannot be null or undefined');if(t<1||t>40)throw new Error('"version" should be in range from 1 to 40');return 4*t+17},r.getSymbolTotalCodewords=function(t){return o[t]},r.getBCHDigit=function(t){for(var e=0;0!==t;)e++,t>>>=1;return e},r.setToSJISFunction=function(t){if("function"!=typeof t)throw new Error('"toSJISFunc" is not a valid function.');n=t},r.isKanjiModeEnabled=function(){return void 0!==n},r.toSJIS=function(t){return n(t)}},{}],21:[function(t,e,r){r.isValid=function(t){return!isNaN(t)&&t>=1&&t<=40}},{}],22:[function(t,e,r){function n(t,e,n){for(var o=1;o<=40;o++)if(e<=r.getCapacity(o,n,t))return o}function o(t,e){return l.getCharCountIndicator(t,e)+4}function i(t,e){var r=0;return t.forEach(function(t){var n=o(t.mode,e);r+=n+t.getBitsLength()}),r}function a(t,e){for(var n=1;n<=40;n++){if(i(t,n)<=r.getCapacity(n,e,l.MIXED))return n}}var u=t("./utils"),s=t("./error-correction-code"),f=t("./error-correction-level"),l=t("./mode"),c=t("./version-check"),h=t("isarray"),d=u.getBCHDigit(7973);r.from=function(t,e){return c.isValid(t)?parseInt(t,10):e},r.getCapacity=function(t,e,r){if(!c.isValid(t))throw new Error("Invalid QR Code version");void 0===r&&(r=l.BYTE);var n=u.getSymbolTotalCodewords(t),i=s.getTotalCodewordsCount(t,e),a=8*(n-i);if(r===l.MIXED)return a;var f=a-o(r,t);switch(r){case l.NUMERIC:return Math.floor(f/10*3);case l.ALPHANUMERIC:return Math.floor(f/11*2);case l.KANJI:return Math.floor(f/13);case l.BYTE:default:return Math.floor(f/8)}},r.getBestVersionForData=function(t,e){var r,o=f.from(e,f.M);if(h(t)){if(t.length>1)return a(t,o);if(0===t.length)return 1;r=t[0]}else r=t;return n(r.mode,r.getLength(),o)},r.getEncodedBits=function(t){if(!c.isValid(t)||t<7)throw new Error("Invalid QR Code version");for(var e=t<<12;u.getBCHDigit(e)-d>=0;)e^=7973<<u.getBCHDigit(e)-d;return t<<12|e}},{"./error-correction-code":6,"./error-correction-level":7,"./mode":13,"./utils":20,"./version-check":21,isarray:30}],23:[function(t,e,r){function n(t,e,r,n,a){var u=[].slice.call(arguments,1),s=u.length,f="function"==typeof u[s-1];if(!f&&!o())throw new Error("Callback required as last argument");if(!f){if(s<1)throw new Error("Too few arguments provided");return 1===s?(r=e,e=n=void 0):2!==s||e.getContext||(n=r,r=e,e=void 0),new Promise(function(o,a){try{var u=i.create(r,n);o(t(u,e,n))}catch(t){a(t)}})}if(s<2)throw new Error("Too few arguments provided");2===s?(a=r,r=e,e=n=void 0):3===s&&(e.getContext&&void 0===a?(a=n,n=void 0):(a=n,n=r,r=e,e=void 0));try{var l=i.create(r,n);a(null,t(l,e,n))}catch(t){a(t)}}var o=t("can-promise"),i=t("./core/qrcode"),a=t("./renderer/canvas"),u=t("./renderer/svg-tag.js");r.create=i.create,r.toCanvas=n.bind(null,a.render),r.toDataURL=n.bind(null,a.renderToDataURL),r.toString=n.bind(null,function(t,e,r){return u.render(t,r)})},{"./core/qrcode":16,"./renderer/canvas":24,"./renderer/svg-tag.js":25,"can-promise":28}],24:[function(t,e,r){function n(t,e,r){t.clearRect(0,0,e.width,e.height),e.style||(e.style={}),e.height=r,e.width=r,e.style.height=r+"px",e.style.width=r+"px"}function o(){try{return document.createElement("canvas")}catch(t){throw new Error("You need to specify a canvas element")}}var i=t("./utils");r.render=function(t,e,r){var a=r,u=e;void 0!==a||e&&e.getContext||(a=e,e=void 0),e||(u=o()),a=i.getOptions(a);var s=i.getImageWidth(t.modules.size,a),f=u.getContext("2d"),l=f.createImageData(s,s);return i.qrToImageData(l.data,t,a),n(f,u,s),f.putImageData(l,0,0),u},r.renderToDataURL=function(t,e,n){var o=n;void 0!==o||e&&e.getContext||(o=e,e=void 0),o||(o={});var i=r.render(t,e,o),a=o.type||"image/png",u=o.rendererOpts||{};return i.toDataURL(a,u.quality)}},{"./utils":26}],25:[function(t,e,r){function n(t,e){var r=t.a/255,n=e+'="'+t.hex+'"';return r<1?n+" "+e+'-opacity="'+r.toFixed(2).slice(1)+'"':n}function o(t,e,r){var n=t+e;return void 0!==r&&(n+=" "+r),n}function i(t,e,r){for(var n="",i=0,a=!1,u=0,s=0;s<t.length;s++){var f=Math.floor(s%e),l=Math.floor(s/e);f||a||(a=!0),t[s]?(u++,s>0&&f>0&&t[s-1]||(n+=a?o("M",f+r,.5+l+r):o("m",i,0),i=0,a=!1),f+1<e&&t[s+1]||(n+=o("h",u),u=0)):i++}return n}var a=t("./utils");r.render=function(t,e,r){var o=a.getOptions(e),u=t.modules.size,s=t.modules.data,f=u+2*o.margin,l=o.color.light.a?"<path "+n(o.color.light,"fill")+' d="M0 0h'+f+"v"+f+'H0z"/>':"",c="<path "+n(o.color.dark,"stroke")+' d="'+i(s,u,o.margin)+'"/>',h='viewBox="0 0 '+f+" "+f+'"',d=o.width?'width="'+o.width+'" height="'+o.width+'" ':"",g='<svg xmlns="http://www.w3.org/2000/svg" '+d+h+' shape-rendering="crispEdges">'+l+c+"</svg>";return"function"==typeof r&&r(null,g),g}},{"./utils":26}],26:[function(t,e,r){function n(t){if("string"!=typeof t)throw new Error("Color should be defined as hex string");var e=t.slice().replace("#","").split("");if(e.length<3||5===e.length||e.length>8)throw new Error("Invalid hex color: "+t);3!==e.length&&4!==e.length||(e=Array.prototype.concat.apply([],e.map(function(t){return[t,t]}))),6===e.length&&e.push("F","F");var r=parseInt(e.join(""),16);return{r:r>>24&255,g:r>>16&255,b:r>>8&255,a:255&r,hex:"#"+e.slice(0,6).join("")}}r.getOptions=function(t){t||(t={}),t.color||(t.color={});var e=void 0===t.margin||null===t.margin||t.margin<0?4:t.margin,r=t.width&&t.width>=21?t.width:void 0,o=t.scale||4;return{width:r,scale:r?4:o,margin:e,color:{dark:n(t.color.dark||"#000000ff"),light:n(t.color.light||"#ffffffff")},type:t.type,rendererOpts:t.rendererOpts||{}}},r.getScale=function(t,e){return e.width&&e.width>=t+2*e.margin?e.width/(t+2*e.margin):e.scale},r.getImageWidth=function(t,e){var n=r.getScale(t,e);return Math.floor((t+2*e.margin)*n)},r.qrToImageData=function(t,e,n){for(var o=e.modules.size,i=e.modules.data,a=r.getScale(o,n),u=Math.floor((o+2*n.margin)*a),s=n.margin*a,f=[n.color.light,n.color.dark],l=0;l<u;l++)for(var c=0;c<u;c++){var h=4*(l*u+c),d=n.color.light;if(l>=s&&c>=s&&l<u-s&&c<u-s){var g=Math.floor((l-s)/a),p=Math.floor((c-s)/a);d=f[i[g*o+p]?1:0]}t[h++]=d.r,t[h++]=d.g,t[h++]=d.b,t[h]=d.a}}},{}],27:[function(t,e,r){"use strict";function n(t,e,r){return n.TYPED_ARRAY_SUPPORT||this instanceof n?"number"==typeof t?u(this,t):v(this,t,e,r):new n(t,e,r)}function o(t){if(t>=m)throw new RangeError("Attempt to allocate Buffer larger than maximum size: 0x"+m.toString(16)+" bytes");return 0|t}function i(t){return t!==t}function a(t,e){var r;return n.TYPED_ARRAY_SUPPORT?(r=new Uint8Array(e),r.__proto__=n.prototype):(r=t,null===r&&(r=new n(e)),r.length=e),r}function u(t,e){var r=a(t,e<0?0:0|o(e));if(!n.TYPED_ARRAY_SUPPORT)for(var i=0;i<e;++i)r[i]=0;return r}function s(t,e){var r=0|d(e),n=a(t,r),o=n.write(e);return o!==r&&(n=n.slice(0,o)),n}function f(t,e){for(var r=e.length<0?0:0|o(e.length),n=a(t,r),i=0;i<r;i+=1)n[i]=255&e[i];return n}function l(t,e,r,o){if(r<0||e.byteLength<r)throw new RangeError("'offset' is out of bounds");if(e.byteLength<r+(o||0))throw new RangeError("'length' is out of bounds");var i;return i=void 0===r&&void 0===o?new Uint8Array(e):void 0===o?new Uint8Array(e,r):new Uint8Array(e,r,o),n.TYPED_ARRAY_SUPPORT?i.__proto__=n.prototype:i=f(t,i),i}function c(t,e){if(n.isBuffer(e)){var r=0|o(e.length),u=a(t,r);return 0===u.length?u:(e.copy(u,0,0,r),u)}if(e){if("undefined"!=typeof ArrayBuffer&&e.buffer instanceof ArrayBuffer||"length"in e)return"number"!=typeof e.length||i(e.length)?a(t,0):f(t,e);if("Buffer"===e.type&&Array.isArray(e.data))return f(t,e.data)}throw new TypeError("First argument must be a string, Buffer, ArrayBuffer, Array, or array-like object.")}function h(t,e){e=e||1/0;for(var r,n=t.length,o=null,i=[],a=0;a<n;++a){if((r=t.charCodeAt(a))>55295&&r<57344){if(!o){if(r>56319){(e-=3)>-1&&i.push(239,191,189);continue}if(a+1===n){(e-=3)>-1&&i.push(239,191,189);continue}o=r;continue}if(r<56320){(e-=3)>-1&&i.push(239,191,189),o=r;continue}r=65536+(o-55296<<10|r-56320)}else o&&(e-=3)>-1&&i.push(239,191,189);if(o=null,r<128){if((e-=1)<0)break;i.push(r)}else if(r<2048){if((e-=2)<0)break;i.push(r>>6|192,63&r|128)}else if(r<65536){if((e-=3)<0)break;i.push(r>>12|224,r>>6&63|128,63&r|128)}else{if(!(r<1114112))throw new Error("Invalid code point");if((e-=4)<0)break;i.push(r>>18|240,r>>12&63|128,r>>6&63|128,63&r|128)}}return i}function d(t){return n.isBuffer(t)?t.length:"undefined"!=typeof ArrayBuffer&&"function"==typeof ArrayBuffer.isView&&(ArrayBuffer.isView(t)||t instanceof ArrayBuffer)?t.byteLength:("string"!=typeof t&&(t=""+t),0===t.length?0:h(t).length)}function g(t,e,r,n){for(var o=0;o<n&&!(o+r>=e.length||o>=t.length);++o)e[o+r]=t[o];return o}function p(t,e,r,n){return g(h(e,t.length-r),t,r,n)}function v(t,e,r,n){if("number"==typeof e)throw new TypeError('"value" argument must not be a number');return"undefined"!=typeof ArrayBuffer&&e instanceof ArrayBuffer?l(t,e,r,n):"string"==typeof e?s(t,e,r):c(t,e)}var w=t("isarray");n.TYPED_ARRAY_SUPPORT=function(){try{var t=new Uint8Array(1);return t.__proto__={__proto__:Uint8Array.prototype,foo:function(){return 42}},42===t.foo()}catch(t){return!1}}();var m=n.TYPED_ARRAY_SUPPORT?2147483647:1073741823;n.TYPED_ARRAY_SUPPORT&&(n.prototype.__proto__=Uint8Array.prototype,n.__proto__=Uint8Array,"undefined"!=typeof Symbol&&Symbol.species&&n[Symbol.species]===n&&Object.defineProperty(n,Symbol.species,{value:null,configurable:!0,enumerable:!1,writable:!1})),n.prototype.write=function(t,e,r){void 0===e?(r=this.length,e=0):void 0===r&&"string"==typeof e?(r=this.length,e=0):isFinite(e)&&(e|=0,isFinite(r)?r|=0:r=void 0);var n=this.length-e;if((void 0===r||r>n)&&(r=n),t.length>0&&(r<0||e<0)||e>this.length)throw new RangeError("Attempt to write outside buffer bounds");return p(this,t,e,r)},n.prototype.slice=function(t,e){var r=this.length;t=~~t,e=void 0===e?r:~~e,t<0?(t+=r)<0&&(t=0):t>r&&(t=r),e<0?(e+=r)<0&&(e=0):e>r&&(e=r),e<t&&(e=t);var o;if(n.TYPED_ARRAY_SUPPORT)o=this.subarray(t,e),o.__proto__=n.prototype;else{var i=e-t;o=new n(i,void 0);for(var a=0;a<i;++a)o[a]=this[a+t]}return o},n.prototype.copy=function(t,e,r,o){if(r||(r=0),o||0===o||(o=this.length),e>=t.length&&(e=t.length),e||(e=0),o>0&&o<r&&(o=r),o===r)return 0;if(0===t.length||0===this.length)return 0;if(e<0)throw new RangeError("targetStart out of bounds");if(r<0||r>=this.length)throw new RangeError("sourceStart out of bounds");if(o<0)throw new RangeError("sourceEnd out of bounds");o>this.length&&(o=this.length),t.length-e<o-r&&(o=t.length-e+r);var i,a=o-r;if(this===t&&r<e&&e<o)for(i=a-1;i>=0;--i)t[i+e]=this[i+r];else if(a<1e3||!n.TYPED_ARRAY_SUPPORT)for(i=0;i<a;++i)t[i+e]=this[i+r];else Uint8Array.prototype.set.call(t,this.subarray(r,r+a),e);return a},n.prototype.fill=function(t,e,r){if("string"==typeof t){if("string"==typeof e?(e=0,r=this.length):"string"==typeof r&&(r=this.length),1===t.length){var o=t.charCodeAt(0);o<256&&(t=o)}}else"number"==typeof t&&(t&=255);if(e<0||this.length<e||this.length<r)throw new RangeError("Out of range index");if(r<=e)return this;e>>>=0,r=void 0===r?this.length:r>>>0,t||(t=0);var i;if("number"==typeof t)for(i=e;i<r;++i)this[i]=t;else{var a=n.isBuffer(t)?t:new n(t),u=a.length;for(i=0;i<r-e;++i)this[i+e]=a[i%u]}return this},n.concat=function(t,e){if(!w(t))throw new TypeError('"list" argument must be an Array of Buffers');if(0===t.length)return a(null,0);var r;if(void 0===e)for(e=0,r=0;r<t.length;++r)e+=t[r].length;var o=u(null,e),i=0;for(r=0;r<t.length;++r){var s=t[r];if(!n.isBuffer(s))throw new TypeError('"list" argument must be an Array of Buffers');s.copy(o,i),i+=s.length}return o},n.byteLength=d,n.prototype._isBuffer=!0,n.isBuffer=function(t){return!(null==t||!t._isBuffer)},e.exports=n},{isarray:30}],28:[function(t,e,r){"use strict";var n=t("window-or-global");e.exports=function(){return"function"==typeof n.Promise&&"function"==typeof n.Promise.prototype.then}},{"window-or-global":31}],29:[function(t,e,r){"use strict";var n={single_source_shortest_paths:function(t,e,r){var o={},i={};i[e]=0;var a=n.PriorityQueue.make();a.push(e,0);for(var u,s,f,l,c,h,d,g;!a.empty();){u=a.pop(),s=u.value,l=u.cost,c=t[s]||{};for(f in c)c.hasOwnProperty(f)&&(h=c[f],d=l+h,g=i[f],(void 0===i[f]||g>d)&&(i[f]=d,a.push(f,d),o[f]=s))}if(void 0!==r&&void 0===i[r]){var p=["Could not find a path from ",e," to ",r,"."].join("");throw new Error(p)}return o},extract_shortest_path_from_predecessor_list:function(t,e){for(var r=[],n=e;n;)r.push(n),t[n],n=t[n];return r.reverse(),r},find_path:function(t,e,r){var o=n.single_source_shortest_paths(t,e,r);return n.extract_shortest_path_from_predecessor_list(o,r)},PriorityQueue:{make:function(t){var e,r=n.PriorityQueue,o={};t=t||{};for(e in r)r.hasOwnProperty(e)&&(o[e]=r[e]);return o.queue=[],o.sorter=t.sorter||r.default_sorter,o},default_sorter:function(t,e){return t.cost-e.cost},push:function(t,e){var r={value:t,cost:e};this.queue.push(r),this.queue.sort(this.sorter)},pop:function(){return this.queue.shift()},empty:function(){return 0===this.queue.length}}};void 0!==e&&(e.exports=n)},{}],30:[function(t,e,r){var n={}.toString;e.exports=Array.isArray||function(t){return"[object Array]"==n.call(t)}},{}],31:[function(t,e,r){
 (function(t){"use strict";e.exports="object"==typeof self&&self.self===self&&self||"object"==typeof t&&t.global===t&&t||this}).call(this,"undefined"!=typeof global?global:"undefined"!=typeof self?self:"undefined"!=typeof window?window:{})},{}]},{},[23])(23)});
 //# sourceMappingURL=qrcode.min.js.map</script>
-    <!-- SHA3 library for Light Wallet -->
-    <script src="https://cdn.jsdelivr.net/npm/js-sha3@0.9.3/src/sha3.min.js"></script>
-    <!-- Ethers.js for MetaMask / Base bridge integration -->
-    <script src="https://cdn.jsdelivr.net/npm/ethers@5.7.2/dist/ethers.umd.min.js"></script>
+    <!-- SHA3 library for Light Wallet.
+         NOTE: pinned to the package's pre-built /build/ asset (NOT /src/, which jsDelivr
+         minifies on-the-fly and explicitly marks "Do NOT use SRI"). SRI hash is over the
+         exact pinned bytes of js-sha3@0.9.3/build/sha3.min.js. -->
+    <script src="https://cdn.jsdelivr.net/npm/js-sha3@0.9.3/build/sha3.min.js"
+            integrity="sha384-+JAeTqUiH9WuByObPHouP4rQKYUTLQ9AQW4HHJZ4uNmkA2+nkDpbssQNGsVXnJpe"
+            crossorigin="anonymous"></script>
+    <!-- Ethers.js for MetaMask / Base bridge integration (pre-built /dist/ → SRI-safe) -->
+    <script src="https://cdn.jsdelivr.net/npm/ethers@5.7.2/dist/ethers.umd.min.js"
+            integrity="sha384-Htz1SE4Sl5aitpvFgr2j0sfsGUIuSXI6t8hEyrlQ93zflEF3a29bH2AvkUROUw7J"
+            crossorigin="anonymous"></script>
     <!-- Dilithium WASM Module (must load before dilithium-crypto.js) -->
     <script src="js/dilithium.js"></script>
     <!-- Light Wallet Modules -->
@@ -1848,8 +1855,8 @@
                                       placeholder="Enter your 24 words separated by spaces"></textarea>
                         </div>
                         <div class="form-group">
-                            <label class="form-label">Password <span style="color: var(--text-muted); font-weight: normal;">(optional)</span></label>
-                            <input type="password" class="form-input" id="restoreLightPassword" placeholder="Leave blank to restore without encryption">
+                            <label class="form-label">Password</label>
+                            <input type="password" class="form-input" id="restoreLightPassword" placeholder="Minimum 8 characters — encrypts your wallet">
                         </div>
                         <div style="display: flex; gap: 12px;">
                             <button class="btn btn-primary" onclick="restoreLightWallet()">Restore Wallet</button>
@@ -1873,6 +1880,33 @@
                         </div>
                         <button class="btn btn-primary" onclick="confirmMnemonicBackup()">I've Written Them Down</button>
                     </div>
+                </div>
+            </div>
+
+            <!-- LP-9: Blocking "Secure your wallet" migration modal.
+                 Shown when a legacy UNENCRYPTED browser wallet is detected at load.
+                 Has NO cancel/close button: the wallet cannot be used until the seed
+                 is encrypted at rest. Dismissing (Escape/click-out is disabled) just
+                 re-presents it on the next load. -->
+            <div id="walletMigrationModal" style="display: none; position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0,0,0,0.92); z-index: 2000; align-items: center; justify-content: center;">
+                <div style="background: var(--bg-card); padding: 32px; border-radius: 16px; max-width: 480px; width: 90%; max-height: 90vh; overflow-y: auto;">
+                    <h3 style="margin-bottom: 8px;">🔒 Secure your wallet</h3>
+                    <p style="color: var(--text-secondary); margin-bottom: 16px; font-size: 0.9rem;">
+                        Your wallet is currently stored <strong style="color: var(--error, #ef4444);">unencrypted</strong> in this browser, which means anyone with access to this device could read your recovery seed. Set a password now to encrypt it. This uses the <em>same wallet and the same addresses</em> — you do not need to re-enter your recovery phrase.
+                    </p>
+                    <div class="form-group">
+                        <label class="form-label">New Password</label>
+                        <input type="password" class="form-input" id="migrationPassword" placeholder="Minimum 8 characters">
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label">Confirm Password</label>
+                        <input type="password" class="form-input" id="migrationPasswordConfirm" placeholder="Re-enter password">
+                    </div>
+                    <div id="migrationError" style="display:none; color: var(--error, #ef4444); font-size: 0.85rem; margin-bottom: 12px;"></div>
+                    <button class="btn btn-primary" id="migrationSubmitBtn" onclick="submitWalletMigration()" style="width: 100%;">Encrypt &amp; Continue</button>
+                    <p style="color: var(--text-muted); font-size: 0.75rem; margin-top: 12px; text-align: center;">
+                        You must encrypt your wallet to continue.
+                    </p>
                 </div>
             </div>
 
@@ -2170,6 +2204,10 @@
                 updateLightWalletUI();
                 refreshAll();
             } catch (e) {
+                if (e && e.message === 'WALLET_NEEDS_ENCRYPTION') {
+                    presentWalletMigration();
+                    return;
+                }
                 showNotification('Wrong password', 'error');
             }
         }
@@ -5289,13 +5327,15 @@
                 unlockSection.style.display = 'none';
                 unlockedSection.style.display = 'none';
             } else if (!localWallet.isWalletUnlocked()) {
-                // Wallet exists but locked — auto-unlock if unencrypted
+                // Wallet exists but locked.
                 const isEncrypted = await localWallet.isWalletEncrypted();
                 if (!isEncrypted) {
-                    await localWallet.unlock(null);
+                    // LP-9: legacy unencrypted (plaintext-at-rest) wallet — do NOT
+                    // silently unlock. Present the BLOCKING "secure your wallet" step.
                     createSection.style.display = 'none';
                     unlockSection.style.display = 'none';
-                    unlockedSection.style.display = 'block';
+                    unlockedSection.style.display = 'none';
+                    presentWalletMigration();
                 } else {
                     createSection.style.display = 'none';
                     unlockSection.style.display = 'block';
@@ -5386,8 +5426,9 @@
                 return;
             }
 
-            // If password provided, validate minimum length
-            if (password && password.length > 0 && password.length < 8) {
+            // LP-9: a password is mandatory — a blank/short password is rejected,
+            // never silently coerced to an unencrypted (plaintext-at-rest) wallet.
+            if (!password || password.length < 8) {
                 showNotification('Password must be at least 8 characters', 'error');
                 return;
             }
@@ -5400,21 +5441,89 @@
 
             try {
                 showNotification('Restoring wallet...', 'info');
-                const usePassword = password && password.length >= 8 ? password : null;
-                await localWallet.importWallet(usePassword, mnemonic);
+                await localWallet.importWallet(password, mnemonic);
 
                 closeLightWalletModal();
                 updateLightWalletUI();
 
-                if (usePassword) {
-                    showNotification('Wallet restored and encrypted successfully!', 'success');
-                } else {
-                    showNotification('Wallet restored! Consider encrypting your wallet for added security.', 'warning');
-                }
+                showNotification('Wallet restored and encrypted successfully!', 'success');
 
             } catch (e) {
                 showNotification('Failed to restore wallet: ' + e.message, 'error');
             }
+        }
+
+        // LP-9: present the blocking "secure your wallet" migration step for a legacy
+        // unencrypted wallet. Idempotent — safe to call from multiple chokepoints.
+        function presentWalletMigration() {
+            const modal = document.getElementById('walletMigrationModal');
+            if (!modal) return;
+            // Hide any welcome screen so the migration is the only visible surface.
+            const welcome = document.getElementById('page-welcome');
+            if (welcome) welcome.style.display = 'none';
+            const errEl = document.getElementById('migrationError');
+            if (errEl) { errEl.style.display = 'none'; errEl.textContent = ''; }
+            modal.style.display = 'flex';
+            const pw = document.getElementById('migrationPassword');
+            if (pw) pw.focus();
+        }
+
+        // LP-9: perform the in-place encryption migration. Hard-blocks until success.
+        async function submitWalletMigration() {
+            const btn = document.getElementById('migrationSubmitBtn');
+            const errEl = document.getElementById('migrationError');
+            const showErr = (msg) => {
+                if (errEl) { errEl.textContent = msg; errEl.style.display = 'block'; }
+            };
+
+            const pw = document.getElementById('migrationPassword').value;
+            const pw2 = document.getElementById('migrationPasswordConfirm').value;
+
+            if (!pw || pw.length < 8) { showErr('Password must be at least 8 characters'); return; }
+            if (pw !== pw2) { showErr('Passwords do not match'); return; }
+
+            if (btn) { btn.disabled = true; btn.textContent = 'Encrypting…'; }
+            try {
+                // Race-tolerant: if another tab already encrypted, encryptExisting returns
+                // false — fall back to unlocking with the supplied password.
+                const migrated = await localWallet.encryptExisting(pw);
+                if (!migrated) {
+                    // Already encrypted elsewhere; try to unlock with this password.
+                    try {
+                        await localWallet.unlock(pw);
+                    } catch (e) {
+                        showErr('This wallet was already secured in another tab. Please reload and enter your password.');
+                        if (btn) { btn.disabled = false; btn.textContent = 'Encrypt & Continue'; }
+                        return;
+                    }
+                }
+
+                // Clear the password fields from the DOM.
+                document.getElementById('migrationPassword').value = '';
+                document.getElementById('migrationPasswordConfirm').value = '';
+
+                // Close the modal and proceed into the wallet.
+                document.getElementById('walletMigrationModal').style.display = 'none';
+                showNotification('Wallet encrypted successfully. Your addresses are unchanged.', 'success');
+
+                // Show sidebar + dashboard, mirror the welcomeFinish() entry path.
+                const welcome = document.getElementById('page-welcome');
+                if (welcome) welcome.style.display = 'none';
+                document.querySelectorAll('.nav-item').forEach(i => i.style.display = '');
+                await updateLightWalletUI();
+                navigateTo('dashboard');
+
+                // Establish connection if needed.
+                const savedMode = localStorage.getItem('dilithionWalletMode');
+                if (savedMode === 'light') {
+                    try { await handleModeChange(); } catch (e) { /* connection handled elsewhere */ }
+                }
+            } catch (e) {
+                showErr('Could not encrypt wallet: ' + (e && e.message ? e.message : 'unknown error') + ' — your wallet is unchanged. Please try again.');
+                if (btn) { btn.disabled = false; btn.textContent = 'Encrypt & Continue'; }
+                return;
+            }
+            if (btn) { btn.disabled = false; btn.textContent = 'Encrypt & Continue'; }
         }
 
         // Unlock light wallet
@@ -5447,6 +5556,11 @@
                 }
 
             } catch (e) {
+                if (e && e.message === 'WALLET_NEEDS_ENCRYPTION') {
+                    // LP-9: legacy unencrypted wallet — route to the blocking migration.
+                    presentWalletMigration();
+                    return;
+                }
                 showNotification('Failed to unlock: ' + e.message, 'error');
             }
         }
@@ -5789,6 +5903,10 @@
                 showNotification('Wallet unlocked', 'success');
                 welcomeFinish();
             } catch (e) {
+                if (e && e.message === 'WALLET_NEEDS_ENCRYPTION') {
+                    presentWalletMigration();
+                    return;
+                }
                 showNotification('Wrong password', 'error');
             }
         }
@@ -5929,7 +6047,15 @@
                         const hasBrowserWallet = await localWallet.hasWallet();
                         if (hasBrowserWallet && localWallet.isWalletUnlocked()) return false;
                         if (hasBrowserWallet) {
-                            // Wallet exists but locked — show welcome with unlock option
+                            // LP-9: a legacy UNENCRYPTED wallet must be migrated before
+                            // anything else — present the blocking encrypt step instead
+                            // of the welcome/unlock screen, and do not show welcome.
+                            const isEncrypted = await localWallet.isWalletEncrypted();
+                            if (isEncrypted === false) {
+                                presentWalletMigration();
+                                return false;
+                            }
+                            // Encrypted wallet, locked — show welcome with unlock option
                             document.getElementById('welcomeUnlockCard').style.display = 'block';
                         }
                     } catch (e) {

--- a/website/wallet.html
+++ b/website/wallet.html
@@ -1885,9 +1885,10 @@
 
             <!-- LP-9: Blocking "Secure your wallet" migration modal.
                  Shown when a legacy UNENCRYPTED browser wallet is detected at load.
-                 Has NO cancel/close button: the wallet cannot be used until the seed
-                 is encrypted at rest. Dismissing (Escape/click-out is disabled) just
-                 re-presents it on the next load. -->
+                 Has NO cancel/close button and no close-wiring (no Escape/backdrop-click
+                 handler exists), so it cannot be dismissed; the wallet cannot be used until
+                 the seed is encrypted at rest. Even if the element were hidden, the next
+                 load re-presents it because the stored record is still encrypted:false. -->
             <div id="walletMigrationModal" style="display: none; position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0,0,0,0.92); z-index: 2000; align-items: center; justify-content: center;">
                 <div style="background: var(--bg-card); padding: 32px; border-radius: 16px; max-width: 480px; width: 90%; max-height: 90vh; overflow-y: auto;">
                     <h3 style="margin-bottom: 8px;">🔒 Secure your wallet</h3>


### PR DESCRIPTION
**LP-9 — the browser wallet stored the HD seed PLAINTEXT in IndexedDB when the user chose 'no encryption'. HIGH.**

Fix (ratified migrate-then-require, per the architecture analysis): remove the unencrypted create/import path (blank password rejected); add `encryptExisting()` to re-encrypt an already-stored plaintext seed in place; **blocking migrate-on-load** modal for legacy unencrypted wallets (no silent auto-unlock); SRI hashes on the CDN scripts; drop `'unsafe-eval'` from the website CSP; regenerate `src/api/wallet_html.h`.

**Reviews:** red-team-validator **GO — no LP-9-introduced defects**; the migration is **interruption-safe** (encrypt → round-trip-verify → single atomic IndexedDB put → zeroize; no half-encrypted/seedless window); 27/27 Playwright tests; `/evaluate` PASS.

**⚠️ Separate pre-existing follow-up (NOT this PR):** the *node-served* wallet has a stricter CSP (`server.cpp:1320`) that blocks the CDN scripts + WASM + external connect, and the node serves no `js/*` route — so the node-served surface needs CSP convergence + a static-asset route. Boarding it; LP-9 closes the website surface + the migration. Fable to review the result (3 design forks flagged in the mission dir).

DRAFT. Contract in `.claude/missions/hosted-wallet-at-rest/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)