### PR TITLE
fix(dilv): eliminate per-block-connect 440KB DNA deep-copy — DilV OOM root cause

### DIFF
--- a/src/digital_dna/digital_dna.cpp
+++ b/src/digital_dna/digital_dna.cpp
@@ -504,6 +504,15 @@ std::optional<DigitalDNA> DigitalDNACollector::get_dna() const {
     return dna;
 }
 
+std::optional<std::array<uint8_t, 20>> DigitalDNACollector::get_address_if_ready() const {
+    // Mirror get_dna()'s readiness guard, but return ONLY the cheap 20-byte address
+    // — no full-DNA build/deep-copy (see header: hot-path allocator-churn / OOM fix).
+    if (!latency_result_ || !timing_result_) {
+        return std::nullopt;
+    }
+    return address_;
+}
+
 void DigitalDNACollector::on_peer_connected(const std::array<uint8_t, 20>& peer_id) {
     perspective_collector_.on_peer_connected(peer_id);
 }

--- a/src/digital_dna/digital_dna.h
+++ b/src/digital_dna/digital_dna.h
@@ -252,6 +252,14 @@ public:
     // Get collected DNA (only valid after latency + timing complete)
     std::optional<DigitalDNA> get_dna() const;
 
+    // Cheap accessor: the own 20-byte address + readiness, WITHOUT building/copying
+    // the full DigitalDNA. get_dna() deep-copies ~440KB (clock-drift sample vector,
+    // perspective snapshots, bandwidth, behavioral); callers that need only the
+    // address — e.g. the per-block-connect block-relay-credit check — MUST use this.
+    // Calling get_dna() on the hot connect path churned the allocator at DilV's
+    // block rate and fragmented the glibc arenas → OOM after 1–2 days (fix 2026-06-15).
+    std::optional<std::array<uint8_t, 20>> get_address_if_ready() const;
+
     // Peer hooks (call from peer manager)
     void on_peer_connected(const std::array<uint8_t, 20>& peer_id);
     void on_peer_disconnected(const std::array<uint8_t, 20>& peer_id);

--- a/src/node/dilithion-node.cpp
+++ b/src/node/dilithion-node.cpp
@@ -1968,12 +1968,10 @@ int main(int argc, char* argv[]) {
     SetUnhandledExceptionFilter(CrashHandler);
 #endif
 
-    // Limit glibc malloc arenas to reduce memory fragmentation.
-    // Default is 8*ncpus which causes RSS to grow unboundedly on long-running
-    // multi-threaded nodes (OOM after ~4 days on 4GB servers).
-#ifdef __linux__
-    mallopt(M_ARENA_MAX, 4);
-#endif
+    // (The glibc M_ARENA_MAX cap is set once at the top of main() above — a single
+    //  __GLIBC__-guarded mallopt(M_ARENA_MAX, 2). The prior duplicate `=4` cap here was
+    //  removed (mallopt is last-write-wins; it overrode the =2). DIL churns slower than
+    //  DilV so it didn't OOM, but the consolidation keeps both nodes identical.)
 
     // Quick Start Mode: If no arguments provided, use beginner-friendly defaults
     bool quick_start_mode = (argc == 1);

--- a/src/node/dilithion-node.cpp
+++ b/src/node/dilithion-node.cpp
@@ -1957,21 +1957,17 @@ std::optional<CBlockTemplate> BuildMiningTemplate(CBlockchainDB& blockchain, CWa
 }
 
 int main(int argc, char* argv[]) {
-#if defined(__linux__) && defined(__GLIBC__)
-    // Parity with dilv-node (2026-06-15): bound the glibc allocator arenas to cap
-    // fragmentation from high-frequency alloc/free churn. DIL churns slower than DilV
-    // so it doesn't OOM, but the mitigation is cheap and identical.
-    mallopt(M_ARENA_MAX, 2);
-#endif
 #ifdef _WIN32
     // Register crash handler to log crash info before terminating
     SetUnhandledExceptionFilter(CrashHandler);
 #endif
 
-    // (The glibc M_ARENA_MAX cap is set once at the top of main() above — a single
-    //  __GLIBC__-guarded mallopt(M_ARENA_MAX, 2). The prior duplicate `=4` cap here was
-    //  removed (mallopt is last-write-wins; it overrode the =2). DIL churns slower than
-    //  DilV so it didn't OOM, but the consolidation keeps both nodes identical.)
+    // Limit glibc malloc arenas to reduce memory fragmentation.
+    // Default is 8*ncpus which causes RSS to grow unboundedly on long-running
+    // multi-threaded nodes (OOM after ~4 days on 4GB servers).
+#ifdef __linux__
+    mallopt(M_ARENA_MAX, 4);
+#endif
 
     // Quick Start Mode: If no arguments provided, use beginner-friendly defaults
     bool quick_start_mode = (argc == 1);

--- a/src/node/dilithion-node.cpp
+++ b/src/node/dilithion-node.cpp
@@ -1957,6 +1957,12 @@ std::optional<CBlockTemplate> BuildMiningTemplate(CBlockchainDB& blockchain, CWa
 }
 
 int main(int argc, char* argv[]) {
+#if defined(__linux__) && defined(__GLIBC__)
+    // Parity with dilv-node (2026-06-15): bound the glibc allocator arenas to cap
+    // fragmentation from high-frequency alloc/free churn. DIL churns slower than DilV
+    // so it doesn't OOM, but the mitigation is cheap and identical.
+    mallopt(M_ARENA_MAX, 2);
+#endif
 #ifdef _WIN32
     // Register crash handler to log crash info before terminating
     SetUnhandledExceptionFilter(CrashHandler);
@@ -5896,12 +5902,15 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                         minerAddr, static_cast<uint32_t>(height));
                 }
 
-                // Block relay credit for our own registered identity
+                // Block relay credit for our own registered identity.
+                // Cheap address-only accessor — NOT the full get_dna() (~440KB deep-copy).
+                // Same hot-path allocator-churn fix as dilv-node (DIL churns slower, but
+                // the waste — copying 440KB to read a 20-byte address — is identical).
                 if (collector) {
-                    auto my_dna = collector->get_dna();
-                    if (my_dna && g_node_context.dna_registry->is_registered(my_dna->address)) {
+                    auto my_addr = collector->get_address_if_ready();
+                    if (my_addr && g_node_context.dna_registry->is_registered(*my_addr)) {
                         g_node_context.trust_manager->on_block_relayed(
-                            my_dna->address, static_cast<uint32_t>(height));
+                            *my_addr, static_cast<uint32_t>(height));
                     }
                 }
             }

--- a/src/node/dilv-node.cpp
+++ b/src/node/dilv-node.cpp
@@ -1911,6 +1911,14 @@ std::optional<CBlockTemplate> BuildMiningTemplate(CBlockchainDB& blockchain, CWa
 }
 
 int main(int argc, char* argv[]) {
+#if defined(__linux__) && defined(__GLIBC__)
+    // DilV OOM fix (2026-06-15): bound the glibc allocator arenas. High-frequency
+    // alloc/free churn (the per-block DNA path, mining) fragments the default
+    // per-thread arenas → RSS climbs to OOM over 1–2 days. M_ARENA_MAX=2 caps that
+    // fragmentation (belt-and-braces alongside the get_dna() hot-path fix); trades a
+    // little multi-thread malloc contention for bounded RSS — a standard mitigation.
+    mallopt(M_ARENA_MAX, 2);
+#endif
 #ifdef _WIN32
     // Register crash handler to log crash info before terminating
     SetUnhandledExceptionFilter(CrashHandler);
@@ -6006,12 +6014,15 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                         minerAddr, static_cast<uint32_t>(height));
                 }
 
-                // Block relay credit for our own registered identity
+                // Block relay credit for our own registered identity.
+                // Use the cheap address-only accessor — NOT the full get_dna(), which
+                // deep-copies ~440KB. This runs on EVERY block-connect; at DilV's block
+                // rate the full copy churned + fragmented the allocator → OOM (fix 2026-06-15).
                 if (collector) {
-                    auto my_dna = collector->get_dna();
-                    if (my_dna && g_node_context.dna_registry->is_registered(my_dna->address)) {
+                    auto my_addr = collector->get_address_if_ready();
+                    if (my_addr && g_node_context.dna_registry->is_registered(*my_addr)) {
                         g_node_context.trust_manager->on_block_relayed(
-                            my_dna->address, static_cast<uint32_t>(height));
+                            *my_addr, static_cast<uint32_t>(height));
                     }
                 }
             }

--- a/src/node/dilv-node.cpp
+++ b/src/node/dilv-node.cpp
@@ -1911,24 +1911,17 @@ std::optional<CBlockTemplate> BuildMiningTemplate(CBlockchainDB& blockchain, CWa
 }
 
 int main(int argc, char* argv[]) {
-#if defined(__linux__) && defined(__GLIBC__)
-    // DilV OOM fix (2026-06-15): bound the glibc allocator arenas. High-frequency
-    // alloc/free churn (the per-block DNA path, mining) fragments the default
-    // per-thread arenas → RSS climbs to OOM over 1–2 days. M_ARENA_MAX=2 caps that
-    // fragmentation (belt-and-braces alongside the get_dna() hot-path fix); trades a
-    // little multi-thread malloc contention for bounded RSS — a standard mitigation.
-    mallopt(M_ARENA_MAX, 2);
-#endif
 #ifdef _WIN32
     // Register crash handler to log crash info before terminating
     SetUnhandledExceptionFilter(CrashHandler);
 #endif
 
-    // (The glibc M_ARENA_MAX cap is set once at the top of main() above — a single
-    //  __GLIBC__-guarded mallopt(M_ARENA_MAX, 2). A prior duplicate `=4` cap here was
-    //  removed: mallopt is last-write-wins so it overrode the =2, AND =4 did not hold
-    //  once the per-block-connect 440KB get_dna() churn overwhelmed it — that churn is
-    //  the real fix, eliminated via get_address_if_ready().)
+    // Limit glibc malloc arenas to reduce memory fragmentation.
+    // Default is 8*ncpus which causes RSS to grow unboundedly on long-running
+    // multi-threaded nodes (OOM after ~4 days on 4GB servers).
+#ifdef __linux__
+    mallopt(M_ARENA_MAX, 4);
+#endif
 
     // Quick Start Mode: If no arguments provided, use beginner-friendly defaults
     bool quick_start_mode = (argc == 1);

--- a/src/node/dilv-node.cpp
+++ b/src/node/dilv-node.cpp
@@ -1924,12 +1924,11 @@ int main(int argc, char* argv[]) {
     SetUnhandledExceptionFilter(CrashHandler);
 #endif
 
-    // Limit glibc malloc arenas to reduce memory fragmentation.
-    // Default is 8*ncpus which causes RSS to grow unboundedly on long-running
-    // multi-threaded nodes (OOM after ~4 days on 4GB servers).
-#ifdef __linux__
-    mallopt(M_ARENA_MAX, 4);
-#endif
+    // (The glibc M_ARENA_MAX cap is set once at the top of main() above — a single
+    //  __GLIBC__-guarded mallopt(M_ARENA_MAX, 2). A prior duplicate `=4` cap here was
+    //  removed: mallopt is last-write-wins so it overrode the =2, AND =4 did not hold
+    //  once the per-block-connect 440KB get_dna() churn overwhelmed it — that churn is
+    //  the real fix, eliminated via get_address_if_ready().)
 
     // Quick Start Mode: If no arguments provided, use beginner-friendly defaults
     bool quick_start_mode = (argc == 1);


### PR DESCRIPTION
**Fixes the DilV miner OOM-after-1–2-days** (release-gating for v4.5.0).

## Root cause (mining-path memory analysis)
The block-connect callback called `collector->get_dna()` on **every block-connect** just to read the **20-byte own-address** for the block-relay-credit check — but `get_dna()` deep-copies the full **~440KB** DigitalDNA (clock-drift 10K-sample vector + perspective snapshots + bandwidth + behavioral). At DilV's ~5× block rate, the high-frequency 440KB alloc/free churn **fragmented the glibc allocator arenas** → RSS climbed to ~3GB OOM over 1–2 days, with **no single large live object** (which is why hunting for an unbounded container found nothing). Gated on `has_mik_` → **miner-only**, so relay-only seeds were unaffected.

## Fix
- New `DigitalDNACollector::get_address_if_ready()` — same readiness guard as `get_dna()`, returns only the cheap 20-byte `address_` (no full-DNA build/copy).
- Both hot block-connect paths use it (`dilv-node.cpp` + `dilithion-node.cpp`; DIL churns slower but the waste is identical).
- Belt-and-braces: `mallopt(M_ARENA_MAX, 2)` at startup (Linux/glibc) to bound arena fragmentation from any residual churn (mining / DNA-receive paths).

## Verification
- Self-evidently correct (same guard, returns the same address the old path read).
- CI builds the batch+fix integration (clang/gcc/TSAN).
- Correctness + RSS-effect test to follow on this branch.
- Field-confirmable via `MALLOC_ARENA_MAX=2` on a miner (independent mitigation that should also stabilize RSS).

Branched off pre-batch main (batch-independent change) → merges clean into current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)