### PR TITLE
fix(dilv): lower nMapBlockIndexCap 5M→500K (attack-memory + eviction-DoS footgun)

### DIFF
--- a/src/core/chainparams.cpp
+++ b/src/core/chainparams.cpp
@@ -497,12 +497,27 @@ ChainParams ChainParams::DilV() {
     // room for the new header.
     //
     // Why 500K (lowered from a prior 5M): at ~420 B/CBlockIndex entry, 500K
-    // caps pre-saturation attacker header-headroom at ~210 MB (vs ~2.1 GB at
-    // 5M) — the memory blast-radius that matters most in the early-launch
-    // window before the honest chain has grown. It also keeps the O(cap)
-    // per-header eviction scan (a linear walk of the std::map / red-black
-    // tree, chain.cpp:210) ~10x cheaper than 5M under a sustained header
-    // flood.
+    // caps pre-saturation mapBlockIndex growth at ~210 MB (vs ~2.1 GB at 5M)
+    // — the memory blast-radius that matters most in the early-launch window
+    // before the honest chain has grown. It also keeps the O(cap) per-header
+    // eviction scan (a linear walk of the std::map / red-black tree,
+    // chain.cpp:210) ~10x cheaper than 5M under a sustained header flood.
+    //
+    // SCOPE OF THIS BOUND (do not overstate): this cap bounds ONLY the
+    // consensus mapBlockIndex (consensus/chain.cpp). It does NOT bound the
+    // P2P header-sync store CHeadersManager::mapHeaders
+    // (net/headers_manager.cpp), which is UNBOUNDED — it is only ever shrunk
+    // by reset/ClearAboveHeight/InvalidateHeader, never lowest-work-evicted.
+    // So the TOTAL header-memory blast radius under a sustained header flood
+    // is larger than the ~210 MB above (mapHeaders grows separately). That is
+    // a DoS / availability surface, NOT a consensus divergence: an unbounded
+    // mapHeaders does not change any node's best-chain decision, and in fact
+    // it is what makes this cap consensus-safe — an evicted mapBlockIndex
+    // entry's header survives in mapHeaders and is re-fetchable as a block,
+    // which rebuilds the evicted CBlockIndex via the direct block-arrival
+    // path (block_validation_queue.cpp AddBlockIndex), independent of the
+    // header-dedup short-circuit. Bounding mapHeaders is tracked as a
+    // separate availability/DoS hardening item, not gated on this cap.
     //
     // Honest-path cost (stated honestly): at DilV's 45s block time, 500K
     // entries is reached after ~8.7 MONTHS of honest operation (500K * 45s
@@ -510,7 +525,9 @@ ChainParams ChainParams::DilV() {
     // past saturation the node runs the O(cap) eviction scan once per
     // connected block as steady state. A ~500K-node red-black-tree walk is
     // negligible against a 45s block interval, so this is an accepted cost,
-    // not a regression.
+    // not a regression. PERF WATCH-ITEM: confirm the post-saturation
+    // per-block eviction-scan wall-time against a live chain near the cap
+    // before relying on this in the >8mo steady-state regime.
     //
     // NOTE: not justified by "matching DIL's 500K". DIL has 240s blocks, so
     // its identical 500K cap saturates in ~3.8 years — same number, very

--- a/src/core/chainparams.cpp
+++ b/src/core/chainparams.cpp
@@ -487,9 +487,36 @@ ChainParams ChainParams::DilV() {
     params.nOutboundFullRelayTarget = 8;
     params.nOutboundBlockRelayTarget = 4;
 
-    // Phase 6 PR6.1: mapBlockIndex cap — DilV is 5M (10× DIL) because
-    // its 60s blocks produce headers ~4× faster than DIL's 240s.
-    params.nMapBlockIndexCap = 5000000;
+    // Phase 6 PR6.1: mapBlockIndex cap. This is a local memory-bound policy
+    // (NOT a consensus rule — no divergence; nodes with different caps still
+    // accept the same best chain). The cap bounds non-active (fork/attack)
+    // header headroom: when mapBlockIndex.size() >= cap, ProcessNewHeader
+    // (consensus/port/chain_selector_impl.cpp:261) calls
+    // EvictLowestWorkNotOnBestChain (consensus/chain.cpp:191), which removes
+    // the GLOBAL lowest-work entry that is NOT on the active chain to make
+    // room for the new header.
+    //
+    // Why 500K (lowered from a prior 5M): at ~420 B/CBlockIndex entry, 500K
+    // caps pre-saturation attacker header-headroom at ~210 MB (vs ~2.1 GB at
+    // 5M) — the memory blast-radius that matters most in the early-launch
+    // window before the honest chain has grown. It also keeps the O(cap)
+    // per-header eviction scan (a linear walk of the std::map / red-black
+    // tree, chain.cpp:210) ~10x cheaper than 5M under a sustained header
+    // flood.
+    //
+    // Honest-path cost (stated honestly): at DilV's 45s block time, 500K
+    // entries is reached after ~8.7 MONTHS of honest operation (500K * 45s
+    // ~= 260 days). This cap is NOT "inert for years" the way 5M would be —
+    // past saturation the node runs the O(cap) eviction scan once per
+    // connected block as steady state. A ~500K-node red-black-tree walk is
+    // negligible against a 45s block interval, so this is an accepted cost,
+    // not a regression.
+    //
+    // NOTE: not justified by "matching DIL's 500K". DIL has 240s blocks, so
+    // its identical 500K cap saturates in ~3.8 years — same number, very
+    // different honest-path behavior. The justification here is the
+    // attack-headroom (~210 MB) and eviction-scan-cost grounds above.
+    params.nMapBlockIndexCap = 500000;
 
     // VDF: active from genesis — DilV is a VDF-only chain
     params.vdfActivationHeight = 0;

--- a/src/test/chain_selector_tests.cpp
+++ b/src/test/chain_selector_tests.cpp
@@ -1187,6 +1187,133 @@ void test_v4_3_1_chainwork_gate_blocks_strictly_lesser_candidate()
     std::cout << " OK\n";
 }
 
+// ============================================================================
+// PR6.1 cap-fold (2026-06-15): verify-the-verifier on the consensus surface.
+//
+// CONSENSUS_REFETCH_FINDINGS.md adjudicated the 5M->500K nMapBlockIndexCap
+// lowering as (A) CONSENSUS-SAFE by code-trace: an evicted low-work FORK
+// header is recoverable because (1) eviction only ever removes a non-active,
+// lowest-work entry (never an active ancestor), and (2) the evicted entry is
+// rebuilt in mapBlockIndex via the DIRECT block-arrival path
+// (block_validation_queue.cpp AddBlockIndex), independent of the header-dedup
+// short-circuit — after which a higher-work branch building on it wins
+// FindMostWorkChainImpl (the reorg-target decision).
+//
+// This test converts that code-traced recovery into an EXECUTED proof. It
+// drives the recovery sequence through the real CChainState consensus API
+// (EvictLowestWorkNotOnBestChain -> AddBlockIndex rebuild -> extend ->
+// FindMostWorkChainImpl), asserting the evicted fork is recovered AND becomes
+// the selected reorg target.
+//
+// SCOPE / what this covers vs. does not:
+//   * COVERS: the eviction policy (lowest-work-not-on-active), the block-path
+//     rebuild of an evicted CBlockIndex via AddBlockIndex (the exact call the
+//     block-arrival code makes), and that the rebuilt+extended branch is
+//     selected as the most-work chain (the reorg DECISION point). This is the
+//     load-bearing evict->recover->reorg-target chain.
+//   * DOES NOT cover (deliberately, too heavy for a unit test): a full P2P
+//     E2E with real header/block wire delivery and a real ConnectTip reorg via
+//     ActivateBestChainStep (which needs block data on disk / a wired pdb and
+//     the DILITHION_USE_NEW_CHAIN_SELECTOR=1 path). The selection decision
+//     (FindMostWorkChainImpl) is the deterministic point that DETERMINES the
+//     reorg target; asserting it picks the recovered branch is the tightest
+//     proof of "the node would reorg to the evicted-then-recovered fork".
+//
+// Cap is exercised via the public EvictLowestWorkNotOnBestChain() directly
+// (rather than saturating to 500K through ProcessNewHeader) so the test is a
+// fast, deterministic O(few-entries) unit test while exercising the IDENTICAL
+// eviction + rebuild + selection code the production cap-trigger invokes.
+void test_pr61_cap_evicted_fork_recovers_and_becomes_reorg_target()
+{
+    std::cout << "  test_pr61_cap_evicted_fork_recovers_and_becomes_reorg_target..."
+              << std::flush;
+
+    CChainState chainstate;
+
+    // Active chain: A(genesis, work=5) -> M(work=20). M is the active tip.
+    auto pA = MakePreValidationLeaf(0x40, nullptr, 0,
+                                    CBlockIndex::BLOCK_VALID_TRANSACTIONS, 5, 1);
+    uint256 hA = pA->GetBlockHash();
+    assert(chainstate.AddBlockIndex(hA, std::move(pA)));
+    CBlockIndex* A = chainstate.GetBlockIndex(hA);
+
+    auto pM = MakePreValidationLeaf(0x41, A, 1,
+                                    CBlockIndex::BLOCK_VALID_TRANSACTIONS, 20, 2);
+    uint256 hM = pM->GetBlockHash();
+    assert(chainstate.AddBlockIndex(hM, std::move(pM)));
+    CBlockIndex* M = chainstate.GetBlockIndex(hM);
+    chainstate.SetTip(M);  // active tip = M (work=20)
+
+    // Low-work FORK header F off genesis A (work=3 < active tip work=20),
+    // NOT on the active chain. This is the eviction victim.
+    auto pF = MakePreValidationLeaf(0x42, A, 1,
+                                    CBlockIndex::BLOCK_VALID_TRANSACTIONS, 3, 3);
+    uint256 hF = pF->GetBlockHash();
+    assert(chainstate.AddBlockIndex(hF, std::move(pF)));
+    assert(chainstate.GetBlockIndex(hF) != nullptr &&
+           "fork header F must be present before eviction");
+
+    // --- (1) EVICT: the cap-trigger's eviction must pick the lowest-work
+    //         NON-active entry. With A(5) and M(20) on the active chain and
+    //         F(3) off-chain, F is the unique lowest-work-not-on-active entry.
+    size_t size_before = chainstate.GetBlockIndexSize();
+    bool evicted = chainstate.EvictLowestWorkNotOnBestChain();
+    assert(evicted && "eviction must succeed when a non-active entry exists");
+    assert(chainstate.GetBlockIndex(hF) == nullptr &&
+           "the low-work FORK header F must be the evicted entry (gone from mapBlockIndex)");
+    // Active-chain ancestors must survive eviction (never evict an ancestor).
+    assert(chainstate.GetBlockIndex(hA) != nullptr &&
+           "genesis A (active ancestor) must NOT be evicted");
+    assert(chainstate.GetBlockIndex(hM) != nullptr &&
+           "active tip M must NOT be evicted");
+    assert(chainstate.GetBlockIndexSize() == size_before - 1);
+
+    // --- (2) RECOVER via the DIRECT block-arrival path. This is exactly what
+    //         block_validation_queue.cpp does when the re-requested fork BLOCK
+    //         arrives: build a fresh CBlockIndex linked to its (un-evicted)
+    //         parent and call AddBlockIndex — NOT ProcessNewHeader, so the
+    //         header-dedup short-circuit is bypassed. AddBlockIndex's
+    //         first-time-add branch re-creates the evicted entry from scratch.
+    //         (Reuse the same synthetic hash-seed 0x42 so the rebuilt entry is
+    //         byte-identical to the evicted one — proving recovery of THAT
+    //         hash, not a different fork.)
+    auto pF_rebuilt = MakePreValidationLeaf(0x42, A, 1,
+                                            CBlockIndex::BLOCK_VALID_TRANSACTIONS, 3, 3);
+    uint256 hF_rebuilt = pF_rebuilt->GetBlockHash();
+    assert(std::memcmp(hF.data, hF_rebuilt.data, 32) == 0 &&
+           "rebuilt entry must have the SAME hash as the evicted fork header");
+    assert(chainstate.AddBlockIndex(hF_rebuilt, std::move(pF_rebuilt)) &&
+           "block-path AddBlockIndex must re-create the evicted CBlockIndex");
+    CBlockIndex* F = chainstate.GetBlockIndex(hF);
+    assert(F != nullptr && "evicted fork entry must be back in mapBlockIndex after block-path rebuild");
+
+    // --- (3) The competing chain builds a HIGHER-work block G on the recovered
+    //         fork F. Cumulative work: A(5)->F(3 leaf) then G with work=99,
+    //         exceeding the active tip M (work=20). G is a fully-validated leaf
+    //         (BLOCK_HAVE_DATA auto-set), so it is reorg-eligible.
+    auto pG = MakePreValidationLeaf(0x43, F, 2,
+                                    CBlockIndex::BLOCK_VALID_TRANSACTIONS, 99, 4);
+    uint256 hG = pG->GetBlockHash();
+    assert(chainstate.AddBlockIndex(hG, std::move(pG)));
+    CBlockIndex* G = chainstate.GetBlockIndex(hG);
+
+    // --- (4) REORG-TARGET DECISION: seed the candidate set and assert
+    //         FindMostWorkChainImpl selects G (the recovered branch's leaf) over
+    //         the current tip M. This is the deterministic decision that DRIVES
+    //         the reorg in ActivateBestChain's connect-loop (chain.cpp:521) —
+    //         proving the node would reorg ONTO the evicted-then-recovered fork.
+    chainstate.RecomputeCandidates();
+    CBlockIndex* picked = chainstate.FindMostWorkChainImpl();
+    assert(picked == G &&
+           "EVICT->RECOVER->REORG: the node must select the higher-work branch "
+           "built on the recovered (previously-evicted) fork as its reorg target");
+    // Sanity: G genuinely outweighs the active tip M (a real reorg, not a no-op).
+    assert(ChainWorkGreaterThan(G->nChainWork, M->nChainWork) &&
+           "recovered-branch leaf G must have strictly greater work than active tip M");
+
+    std::cout << " OK\n";
+}
+
 int main()
 {
     std::cout << "\n=== Phase 5 PR5.1 + 5.3-prereq + 5.3 Day 3 AM: ChainSelector Tests ===\n"
@@ -1237,7 +1364,11 @@ int main()
         test_blocker2_mark_block_as_valid_independent_failure_is_barrier();
         test_blocker3_checkpoint_violation_in_ancestry_rejects_candidate();
 
-        std::cout << "\n=== All chain_selector_tests passed (24 tests: 4 + 5 + 5 + 2 + 2 + 3 + 3) ==="
+        std::cout << "\n--- PR6.1 cap-fold: evicted-fork recovery -> reorg target ---"
+                  << std::endl;
+        test_pr61_cap_evicted_fork_recovers_and_becomes_reorg_target();
+
+        std::cout << "\n=== All chain_selector_tests passed (25 tests: 4 + 5 + 5 + 2 + 2 + 3 + 3 + 1) ==="
                   << std::endl;
         return 0;
     } catch (const std::exception& e) {


### PR DESCRIPTION
Lowers DilV's block-index cap from 5,000,000 to 500,000 (matches DIL). 5M permitted ~2GB index memory + an O(N) eviction scan per flooded header; the justifying comment was factually wrong ("60s blocks" — DilV is 45s). Consensus-safety red-team: it's local memory policy, NOT a consensus rule — no divergence; 500K over-covers MAX_REORG_DEPTH=100 by ~5000x. **Merge prerequisites: your Cursor pass + Zach sign-off (DilV is co-owned, consensus-adjacent) + a quick eviction-scan wall-time spot-check.** Not blocking v4.5.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)