### PR TITLE
fix(node): integrity-monitor self-heal on transient faults (DIL overnight-shutdown root cause) — v4.5.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -765,7 +765,31 @@ auto_rebuild_marker_mode_symmetry_tests: $(CORE_OBJECTS) $(OBJ_DIR)/test/auto_re
 # block in [highest_checkpoint+1 .. tip] has a present, SHA3-checksummed undo
 # record. Detects the missing/corrupt undo-data corruption mode that crash-looped
 # NYC + LDN on 2026-04-25. See src/test/chainstate_integrity_tests.cpp.
-chainstate_integrity_tests: $(CORE_OBJECTS) $(OBJ_DIR)/test/chainstate_integrity_tests.o $(DILITHIUM_OBJECTS) $(CHIAVDF_OBJECTS)
+# extreview PR #120 (HIGH): the undo-fetch fault injector must NOT exist in any
+# shipped binary. It is guarded by DILITHION_ENABLE_FAULT_INJECTION, defined ONLY
+# for this private test recompile of utxo_set.cpp. The production CORE utxo_set.o
+# (linked by dilithion-node / dilv-node) is built WITHOUT the macro, so the
+# injectable seam is compiled out entirely. We substitute the fault-injection
+# object for the CORE one in this test's link line so there is exactly one
+# utxo_set definition (no duplicate-symbol clash).
+INTEGRITY_TEST_FAULT_OBJ := $(OBJ_DIR)/test/utxo_set_faultinject.o
+$(INTEGRITY_TEST_FAULT_OBJ): src/node/utxo_set.cpp | $(OBJ_DIR)/test
+	@echo "$(COLOR_BLUE)[CXX]$(COLOR_RESET)  $< (fault-injection enabled, test-only)"
+	@$(CXX) $(CXXFLAGS) -DDILITHION_ENABLE_FAULT_INJECTION $(INCLUDES) -c $< -o $@
+
+# The test driver references g_undo_fetch_fault_injector, so its own object must
+# also see DILITHION_ENABLE_FAULT_INJECTION. Built via a target-specific recompile
+# (distinct .o name) so it doesn't collide with the generic src/%.o rule.
+INTEGRITY_TEST_DRIVER_OBJ := $(OBJ_DIR)/test/chainstate_integrity_tests_faultinject.o
+$(INTEGRITY_TEST_DRIVER_OBJ): src/test/chainstate_integrity_tests.cpp | $(OBJ_DIR)/test
+	@echo "$(COLOR_BLUE)[CXX]$(COLOR_RESET)  $< (fault-injection enabled, test-only)"
+	@$(CXX) $(CXXFLAGS) -DDILITHION_ENABLE_FAULT_INJECTION $(INCLUDES) -c $< -o $@
+
+CHAINSTATE_INTEGRITY_CORE_OBJECTS := \
+	$(filter-out $(OBJ_DIR)/node/utxo_set.o,$(CORE_OBJECTS)) \
+	$(INTEGRITY_TEST_FAULT_OBJ)
+
+chainstate_integrity_tests: $(CHAINSTATE_INTEGRITY_CORE_OBJECTS) $(INTEGRITY_TEST_DRIVER_OBJ) $(DILITHIUM_OBJECTS) $(CHIAVDF_OBJECTS)
 	@echo "$(COLOR_BLUE)[LINK]$(COLOR_RESET) $@"
 	@$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LIBS)
 	@echo "$(COLOR_GREEN)✓ chainstate_integrity_tests built successfully$(COLOR_RESET)"

--- a/src/node/chainstate_integrity_monitor.cpp
+++ b/src/node/chainstate_integrity_monitor.cpp
@@ -14,6 +14,7 @@
 namespace Dilithion {
 
 std::atomic<bool> ChainstateIntegrityMonitor::s_instance_alive{false};
+std::atomic<bool> ChainstateIntegrityMonitor::s_health_degraded{false};
 
 ChainstateIntegrityMonitor::ChainstateIntegrityMonitor(
     CChainState& chainstate,
@@ -35,6 +36,9 @@ ChainstateIntegrityMonitor::ChainstateIntegrityMonitor(
         throw std::runtime_error(
             "ChainstateIntegrityMonitor: another instance is already alive in this process");
     }
+    // Fresh monitor starts from a clean health slate — defends against a stale
+    // s_health_degraded surviving a destroy/reconstruct within one process.
+    s_health_degraded.store(false, std::memory_order_seq_cst);
 }
 
 ChainstateIntegrityMonitor::~ChainstateIntegrityMonitor() {
@@ -92,6 +96,11 @@ bool ChainstateIntegrityMonitor::InterruptibleWait(std::chrono::milliseconds dur
     return !stopped;  // true => full duration elapsed without a stop.
 }
 
+void ChainstateIntegrityMonitor::MarkCycleHealthy() {
+    m_consecutive_transient_cycles = 0;
+    s_health_degraded.store(false, std::memory_order_seq_cst);
+}
+
 bool ChainstateIntegrityMonitor::RunSingleWalk(UndoIntegrityFailure& failure_out) {
     // Phase 1 — snapshot under cs_main (briefly).
     auto snapshot = m_chainstate.SnapshotIntegrityWindow(kWindowBlocks);
@@ -134,6 +143,8 @@ bool ChainstateIntegrityMonitor::ExecuteSingleCycle() {
                           << " — earlier failure was transient (node healthy)."
                           << std::endl;
             }
+            // Healthy cycle — clear any persistent-transient escalation state.
+            MarkCycleHealthy();
             return true;  // Healthy (possibly after a transient fault cleared).
         }
 
@@ -163,23 +174,57 @@ bool ChainstateIntegrityMonitor::ExecuteSingleCycle() {
     if (failure.transient) {
         // Still a transient-class storage fault after kRevalidateAttempts. This
         // is NOT confirmed corruption — bricking here would wipe a healthy chain
-        // because of a flaky disk. Log loudly + persistently and keep running.
+        // because of a flaky disk, and an auto-rebuild can't fix a dying disk.
+        // We NEVER write the marker or shut down for a transient/IsIOError fault.
+        //
+        // extreview PR #120 B1 (Will's decision): keep tolerating, but escalate
+        // a PERSISTENT fault from a per-cycle warning to a sustained, louder
+        // signal so it can't scroll past an operator unnoticed. Count consecutive
+        // cycles that end here; at kEscalateAfterCycles, promote to a sustained
+        // ERROR + raise the operator/RPC-observable degraded-health flag.
+        ++m_consecutive_transient_cycles;
+        const bool escalated =
+            m_consecutive_transient_cycles >= kEscalateAfterCycles;
+
         std::cerr << "\n=========================================================="
                   << std::endl;
-        std::cerr << "[WARNING] ChainstateIntegrityMonitor: persistent TRANSIENT "
+        std::cerr << (escalated ? "[ERROR] " : "[WARNING] ")
+                  << "ChainstateIntegrityMonitor: persistent TRANSIENT "
                   << "read fault (cause=" << failure.cause << ") at height "
                   << failure.height << " hash="
                   << failure.blockHash.GetHex() << " after "
-                  << kRevalidateAttempts << " attempts." << std::endl;
+                  << kRevalidateAttempts << " attempts (consecutive cycle "
+                  << m_consecutive_transient_cycles << ")." << std::endl;
         std::cerr << "This indicates a storage-layer problem (failing disk, "
                   << "fsync lag, or a file lock — e.g. antivirus on Windows), "
                   << "NOT chainstate corruption." << std::endl;
-        std::cerr << "Node will KEEP RUNNING and re-check next cycle. If this "
-                  << "recurs, inspect the disk / move the data directory off the "
-                  << "failing volume." << std::endl;
+        if (escalated) {
+            // Raise the durable, observable degraded-health signal. Sustained
+            // ERROR (re-emitted every cycle while the fault persists) + a flag
+            // the operator / an RPC (getblockchaininfo) can poll.
+            s_health_degraded.store(true, std::memory_order_seq_cst);
+            std::cerr << "[ERROR] This storage fault has now persisted across "
+                      << m_consecutive_transient_cycles << " consecutive monitor "
+                      << "cycles (~" << (kCycleInterval.count()
+                                         * m_consecutive_transient_cycles)
+                      << "h). The node is STILL RUNNING and will NOT auto-rebuild "
+                      << "(a rebuild cannot fix failing hardware), but the "
+                      << "chainstate-integrity monitor is now in a DEGRADED state "
+                      << "and requires operator attention." << std::endl;
+            std::cerr << "[ERROR] ACTION REQUIRED: inspect the disk (SMART), move "
+                      << "the data directory off the failing volume, or restore "
+                      << "from a known-good backup. integrity_health=degraded is "
+                      << "now visible via getblockchaininfo." << std::endl;
+        } else {
+            std::cerr << "Node will KEEP RUNNING and re-check next cycle. If this "
+                      << "recurs across " << kEscalateAfterCycles << " cycles it "
+                      << "will escalate to a sustained ERROR + degraded-health "
+                      << "flag. Inspect the disk / move the data directory off "
+                      << "the failing volume." << std::endl;
+        }
         std::cerr << "=========================================================="
                   << std::endl;
-        return true;  // Do NOT brick on a transient fault.
+        return true;  // Do NOT brick on a transient fault (ever).
     }
 
     // Phase 3 — revalidation gate (Inverse Adversarial traps 2A + 2B).
@@ -228,6 +273,8 @@ bool ChainstateIntegrityMonitor::ExecuteSingleCycle() {
                   << failure.blockHash.GetHex().substr(0, 16)
                   << "... was reorged out of active chain (no corruption)"
                   << std::endl;
+        // Not a storage fault — the chain is healthy. Clear escalation state.
+        MarkCycleHealthy();
         return true;
     }
 

--- a/src/node/chainstate_integrity_monitor.cpp
+++ b/src/node/chainstate_integrity_monitor.cpp
@@ -80,7 +80,19 @@ bool ChainstateIntegrityMonitor::RunOneCycleForTesting() {
     return ExecuteSingleCycle();
 }
 
-bool ChainstateIntegrityMonitor::ExecuteSingleCycle() {
+bool ChainstateIntegrityMonitor::InterruptibleWait(std::chrono::milliseconds dur) {
+    if (dur <= std::chrono::milliseconds::zero()) {
+        return !m_stop_requested.load(std::memory_order_seq_cst);
+    }
+    std::unique_lock<std::mutex> lk(m_cv_mutex);
+    // Returns true if the predicate (stop requested) became true => interrupted.
+    const bool stopped = m_cv.wait_for(
+        lk, dur,
+        [this] { return m_stop_requested.load(std::memory_order_seq_cst); });
+    return !stopped;  // true => full duration elapsed without a stop.
+}
+
+bool ChainstateIntegrityMonitor::RunSingleWalk(UndoIntegrityFailure& failure_out) {
     // Phase 1 — snapshot under cs_main (briefly).
     auto snapshot = m_chainstate.SnapshotIntegrityWindow(kWindowBlocks);
     if (snapshot.empty()) {
@@ -89,14 +101,85 @@ bool ChainstateIntegrityMonitor::ExecuteSingleCycle() {
     }
 
     // Phase 2 — walk lock-free w.r.t. cs_main; uses cs_utxo internally.
-    UndoIntegrityFailure failure;
-    const bool walkPass = m_utxo_set.VerifyUndoDataFromSnapshot(
-        snapshot, failure, &m_stop_requested);
-    if (walkPass) return true;  // Healthy.
+    return m_utxo_set.VerifyUndoDataFromSnapshot(
+        snapshot, failure_out, &m_stop_requested);
+}
 
-    if (failure.cause == "aborted_for_shutdown") {
-        // Mid-walk shutdown — bail without any state change.
-        return true;
+bool ChainstateIntegrityMonitor::ExecuteSingleCycle() {
+    // ---------------------------------------------------------------------
+    // Self-heal retry loop (fix/integrity-monitor-self-heal).
+    //
+    // A single failed walk is NEVER sufficient to brick the node. We re-verify
+    // up to kRevalidateAttempts times with backoff. Rationale:
+    //   * A transient storage-layer fault (flaky disk, fsync lag, AV file lock
+    //     on Windows, a momentary LevelDB IsIOError) clears across retries — the
+    //     re-walk passes and we return healthy.
+    //   * Genuine corruption (a clean missing key on an active-chain block, or a
+    //     checksum/size mismatch) is reproducible — it fails every attempt.
+    // Only a reproducible failure that ALSO survives the cs_main revalidation
+    // gate (not a reorg orphan-skip) is allowed to write the marker + shut down.
+    // A failure that remains transient-class after all retries is logged loudly
+    // and TOLERATED — the node keeps running; next cycle re-checks. We must not
+    // wipe-and-resync a node whose disk is merely throwing transient IOErrors.
+    // ---------------------------------------------------------------------
+    UndoIntegrityFailure failure;
+    bool walkPass = false;
+    for (int attempt = 1; attempt <= kRevalidateAttempts; ++attempt) {
+        failure = UndoIntegrityFailure{};  // reset between attempts
+        walkPass = RunSingleWalk(failure);
+        if (walkPass) {
+            if (attempt > 1) {
+                std::cerr << "[IntegrityMonitor] walk passed on retry attempt "
+                          << attempt << "/" << kRevalidateAttempts
+                          << " — earlier failure was transient (node healthy)."
+                          << std::endl;
+            }
+            return true;  // Healthy (possibly after a transient fault cleared).
+        }
+
+        if (failure.cause == "aborted_for_shutdown") {
+            // Mid-walk shutdown — bail without any state change.
+            return true;
+        }
+
+        // Failed this attempt. If more attempts remain, back off and retry so a
+        // transient fault has time to clear. The wait is interruptible by Stop()
+        // so shutdown latency is not extended by the retry backoff.
+        if (attempt < kRevalidateAttempts) {
+            std::cerr << "[IntegrityMonitor] walk attempt " << attempt << "/"
+                      << kRevalidateAttempts << " failed (cause=" << failure.cause
+                      << ", transient=" << (failure.transient ? "yes" : "no")
+                      << ") at height " << failure.height
+                      << " — re-verifying after backoff before acting."
+                      << std::endl;
+            if (!InterruptibleWait(m_revalidate_backoff)) {
+                // Stop requested during backoff — bail without state change.
+                return true;
+            }
+        }
+    }
+
+    // All retries exhausted and every attempt failed.
+    if (failure.transient) {
+        // Still a transient-class storage fault after kRevalidateAttempts. This
+        // is NOT confirmed corruption — bricking here would wipe a healthy chain
+        // because of a flaky disk. Log loudly + persistently and keep running.
+        std::cerr << "\n=========================================================="
+                  << std::endl;
+        std::cerr << "[WARNING] ChainstateIntegrityMonitor: persistent TRANSIENT "
+                  << "read fault (cause=" << failure.cause << ") at height "
+                  << failure.height << " hash="
+                  << failure.blockHash.GetHex() << " after "
+                  << kRevalidateAttempts << " attempts." << std::endl;
+        std::cerr << "This indicates a storage-layer problem (failing disk, "
+                  << "fsync lag, or a file lock — e.g. antivirus on Windows), "
+                  << "NOT chainstate corruption." << std::endl;
+        std::cerr << "Node will KEEP RUNNING and re-check next cycle. If this "
+                  << "recurs, inspect the disk / move the data directory off the "
+                  << "failing volume." << std::endl;
+        std::cerr << "=========================================================="
+                  << std::endl;
+        return true;  // Do NOT brick on a transient fault.
     }
 
     // Phase 3 — revalidation gate (Inverse Adversarial traps 2A + 2B).

--- a/src/node/chainstate_integrity_monitor.h
+++ b/src/node/chainstate_integrity_monitor.h
@@ -13,6 +13,7 @@
 
 class CChainState;
 class CUTXOSet;
+struct UndoIntegrityFailure;
 
 namespace Dilithion {
 
@@ -53,6 +54,17 @@ public:
     // Hardcoded operational constants (resolved decision (g)).
     static constexpr int kWindowBlocks = 500;
     static constexpr std::chrono::hours kCycleInterval{6};
+
+    // Self-heal / anti-false-positive (fix/integrity-monitor-self-heal).
+    // A first failed walk is re-verified up to kRevalidateAttempts-1 more times
+    // with backoff before the node is allowed to act. A transient storage-layer
+    // fault (flaky disk / fsync lag / AV file lock) clears across retries; only
+    // a reproducible, data-level failure on a still-active-chain block survives
+    // all attempts AND the cs_main revalidation gate, and only THAT writes the
+    // auto_rebuild marker + shuts down. A failure that is still transient-class
+    // after all retries is logged loudly + tolerated (node keeps running).
+    static constexpr int kRevalidateAttempts = 3;
+    static constexpr std::chrono::seconds kRevalidateBackoff{30};
 
     /**
      * @param chainstate     Shared chainstate; the monitor calls
@@ -100,14 +112,32 @@ public:
     /// Test hook: true iff the worker thread is alive.
     bool IsRunningForTesting() const { return m_worker.joinable(); }
 
+    /// Test-only: override the inter-retry backoff so retry-loop tests don't
+    /// stall for kRevalidateBackoff * (kRevalidateAttempts-1). Production never
+    /// calls this; the worker uses kRevalidateBackoff.
+    void SetRevalidateBackoffForTesting(std::chrono::milliseconds backoff) {
+        m_revalidate_backoff = backoff;
+    }
+
 private:
     void WorkerLoop();
     bool ExecuteSingleCycle();
+
+    /// Run one snapshot→walk attempt. Returns true on a clean/healthy walk;
+    /// false on failure (populating failure_out) or shutdown abort. Shared by
+    /// the retry loop inside ExecuteSingleCycle.
+    bool RunSingleWalk(UndoIntegrityFailure& failure_out);
+
+    /// Interruptible sleep used between retries. Returns immediately (false) if
+    /// stop was requested during the wait; true if the full duration elapsed.
+    bool InterruptibleWait(std::chrono::milliseconds dur);
 
     CChainState& m_chainstate;
     CUTXOSet& m_utxo_set;
     std::string m_datadir;
     std::atomic<bool>* m_running_flag;  // External; not owned. nullable for tests.
+    std::chrono::milliseconds m_revalidate_backoff{
+        std::chrono::duration_cast<std::chrono::milliseconds>(kRevalidateBackoff)};
 
     std::thread m_worker;
     std::mutex m_cv_mutex;

--- a/src/node/chainstate_integrity_monitor.h
+++ b/src/node/chainstate_integrity_monitor.h
@@ -66,6 +66,27 @@ public:
     static constexpr int kRevalidateAttempts = 3;
     static constexpr std::chrono::seconds kRevalidateBackoff{30};
 
+    // Persistent-IsIOError escalation (extreview PR #120 B1 — Will's decision).
+    // A persistent storage IsIOError (a dying disk, a stuck file lock) survives
+    // the intra-cycle retry loop above and is TOLERATED every cycle — we never
+    // brick or auto-rebuild on a hardware fault (an auto-rebuild can't fix a
+    // failing disk). But silent per-cycle warnings can scroll past an operator
+    // forever. So we count CONSECUTIVE cycles that end in a persistent
+    // transient-class fault; once the count reaches kEscalateAfterCycles we
+    // promote the per-cycle warning to a sustained ERROR and raise an
+    // operator/RPC-observable degraded-health flag (IsIntegrityHealthDegraded()).
+    // The counter resets to zero the moment any cycle comes back healthy.
+    //
+    // N = 4 at the 6h cycle cadence ≈ 24h of *uninterrupted* reproducible
+    // IsIOError before escalation. A genuinely transient blip clears inside a
+    // single cycle's 3-attempt retry loop, so it never even increments this
+    // counter; reaching 4 consecutive whole-cycle persistent faults means the
+    // fault has reproduced across ~24h and ~12 underlying read attempts — well
+    // past any plausible momentary disk/AV hiccup, yet still surfaced within a
+    // day rather than buried in scrollback. Tolerate forever, but make a
+    // sustained hardware fault impossible to miss.
+    static constexpr int kEscalateAfterCycles = 4;
+
     /**
      * @param chainstate     Shared chainstate; the monitor calls
      *                       SnapshotIntegrityWindow + RevalidateUnderCsMain.
@@ -112,6 +133,30 @@ public:
     /// Test hook: true iff the worker thread is alive.
     bool IsRunningForTesting() const { return m_worker.joinable(); }
 
+    /**
+     * Operator/RPC-observable health signal (extreview PR #120 B1).
+     *
+     * Returns true once the monitor has tolerated kEscalateAfterCycles
+     * CONSECUTIVE cycles of a persistent transient-class (IsIOError) read fault
+     * — i.e. a sustained storage-layer problem (a failing disk, a stuck file
+     * lock) that is NOT chainstate corruption and will NOT trigger an
+     * auto-rebuild. The node keeps running; this flag lets an operator (or an
+     * RPC such as getblockchaininfo) observe that the chainstate-integrity
+     * monitor is in a degraded, attention-required state. Cleared automatically
+     * the next time a cycle completes healthy.
+     *
+     * Static (process-wide, the monitor is a singleton) so it is reachable from
+     * the RPC layer without threading a monitor handle through. Lock-free atomic.
+     */
+    static bool IsIntegrityHealthDegraded() {
+        return s_health_degraded.load(std::memory_order_seq_cst);
+    }
+
+    /// Test-only: read the current consecutive-persistent-transient cycle count.
+    int GetConsecutiveTransientCyclesForTesting() const {
+        return m_consecutive_transient_cycles;
+    }
+
     /// Test-only: override the inter-retry backoff so retry-loop tests don't
     /// stall for kRevalidateBackoff * (kRevalidateAttempts-1). Production never
     /// calls this; the worker uses kRevalidateBackoff.
@@ -132,6 +177,11 @@ private:
     /// stop was requested during the wait; true if the full duration elapsed.
     bool InterruptibleWait(std::chrono::milliseconds dur);
 
+    /// Reset persistent-transient escalation state after a genuinely-healthy
+    /// cycle (clean walk or orphan-skip): zero the consecutive-cycle counter and
+    /// clear the observable degraded-health flag.
+    void MarkCycleHealthy();
+
     CChainState& m_chainstate;
     CUTXOSet& m_utxo_set;
     std::string m_datadir;
@@ -144,7 +194,16 @@ private:
     std::condition_variable m_cv;
     std::atomic<bool> m_stop_requested{false};
 
+    // Count of CONSECUTIVE cycles ending in a persistent transient-class fault.
+    // Only ExecuteSingleCycle (the worker thread, or RunOneCycleForTesting on a
+    // single thread) touches it, so a plain int suffices — no cross-thread races.
+    int m_consecutive_transient_cycles{0};
+
     static std::atomic<bool> s_instance_alive;
+    // Process-wide degraded-health flag (extreview PR #120 B1). Set when the
+    // consecutive-persistent-transient count reaches kEscalateAfterCycles;
+    // cleared when a cycle completes healthy. Read by IsIntegrityHealthDegraded().
+    static std::atomic<bool> s_health_degraded;
 };
 
 }  // namespace Dilithion

--- a/src/node/utxo_set.cpp
+++ b/src/node/utxo_set.cpp
@@ -57,7 +57,20 @@ bool FetchAndVerifyUndo(leveldb::DB* db,
     if (!st.ok()) {
         failure_out.height = height;
         failure_out.blockHash = blockHash;
-        failure_out.cause = "missing";
+        // Distinguish a TRANSIENT storage-layer fault (IsIOError / IsCorruption
+        // — flaky disk, fsync lag, AV file lock on Windows) from a clean
+        // IsNotFound() (key genuinely absent). Only the latter is real
+        // "missing undo data" corruption. The periodic monitor uses the
+        // transient flag to avoid self-bricking a healthy node on a recoverable
+        // read fault. A genuinely-missing key on an active-chain block is real
+        // corruption and still confirms after the monitor's retry loop.
+        if (st.IsIOError() || st.IsCorruption()) {
+            failure_out.cause = "io_error";
+            failure_out.transient = true;
+        } else {
+            failure_out.cause = "missing";
+            failure_out.transient = false;
+        }
         return false;
     }
     switch (VerifyUndoChecksum(undoValue)) {

--- a/src/node/utxo_set.cpp
+++ b/src/node/utxo_set.cpp
@@ -41,10 +41,31 @@
 //     non-transient. A genuinely-absent key on an active-chain block is real
 //     corruption; anything unexpected fails safe toward the corruption gate
 //     (shutdown) rather than tolerate.
-// v4.4 test-only fault-injection hook (see utxo_set.h). Production leaves null.
+// v4.4 test-only fault-injection hook (see utxo_set.h). Compiled OUT of
+// production builds — exists only when DILITHION_ENABLE_FAULT_INJECTION is
+// defined (the chainstate_integrity_tests object). extreview PR #120 HIGH.
+#ifdef DILITHION_ENABLE_FAULT_INJECTION
 std::function<leveldb::Status()> g_undo_fetch_fault_injector = nullptr;
+#endif
 
 void ClassifyUndoFetchStatus(const leveldb::Status& st, UndoIntegrityFailure& failure_out) {
+    // ORDERING IS SAFETY-CRITICAL (extreview PR #120, two models flagged this as
+    // non-obvious). IsCorruption() is checked FIRST, BEFORE IsIOError(). A
+    // leveldb::Status can in principle satisfy both predicates; checking
+    // corruption first guarantees any such overlapping status is hard-failed
+    // (transient=false -> corruption gate -> marker + shutdown), never
+    // mislabelled transient and tolerated. Do NOT reorder these branches: putting
+    // IsIOError() first would route a corruption-AND-ioerror status into the
+    // tolerate branch and mask real on-disk damage forever. The both-predicate
+    // case is locked by a regression test (chainstate_integrity_tests.cpp).
+    //
+    // The trailing else is the FAIL-CLOSED bucket: IsNotFound and EVERY other
+    // unmapped/unexpected non-ok status (NotSupported / InvalidArgument / Busy /
+    // future LevelDB statuses) fall here -> cause="missing", transient=false
+    // (hard-fail). We deliberately do NOT enumerate them: anything we did not
+    // explicitly classify as a recoverable IOError blip is treated as real
+    // corruption and routed to the shutdown/rebuild gate, never silently
+    // tolerated. New status classes are safe-by-default.
     if (st.IsCorruption()) {
         failure_out.cause = "io_corruption";
         failure_out.transient = false;
@@ -98,12 +119,18 @@ bool FetchAndVerifyUndo(leveldb::DB* db,
     undoKey.append(reinterpret_cast<const char*>(blockHash.data), 32);
 
     std::string undoValue;
-    // v4.4 test-only fault injection (g_undo_fetch_fault_injector is null in
-    // production). A non-ok injected Status simulates a storage-layer fault
-    // (IsCorruption / IsIOError) that real on-disk data can't easily produce, so
-    // the monitor's retry/tolerate/confirm routing is exercised end-to-end.
-    leveldb::Status st = g_undo_fetch_fault_injector ? g_undo_fetch_fault_injector()
-                                                     : leveldb::Status::OK();
+    leveldb::Status st = leveldb::Status::OK();
+#ifdef DILITHION_ENABLE_FAULT_INJECTION
+    // TEST-ONLY fault injection (extreview PR #120: the whole seam is compiled
+    // out of production via DILITHION_ENABLE_FAULT_INJECTION). A non-ok injected
+    // Status simulates a storage-layer fault (IsCorruption / IsIOError) that real
+    // on-disk data can't easily produce, so the monitor's retry/tolerate/confirm
+    // routing is exercised end-to-end. In a shipped binary this block, the global,
+    // and its declaration do not exist — there is no injectable seam.
+    if (g_undo_fetch_fault_injector) {
+        st = g_undo_fetch_fault_injector();
+    }
+#endif
     if (st.ok()) {
         st = db->Get(leveldb::ReadOptions(), undoKey, &undoValue);
     }

--- a/src/node/utxo_set.cpp
+++ b/src/node/utxo_set.cpp
@@ -12,6 +12,51 @@
 #include <iostream>
 #include <atomic>
 
+// v4.4 (fix/integrity-monitor-self-heal): classify a non-ok leveldb::Status
+// from an undo-record Get() into the (cause, transient) taxonomy the periodic
+// ChainstateIntegrityMonitor routes on. The monitor uses the transient flag to
+// decide whether to TOLERATE (keep running, re-check next cycle) or to
+// confirm-and-rebuild (marker + shutdown). Extracted to namespace scope and
+// declared in the header so the safety-critical mapping is unit-testable with
+// synthetic leveldb::Status values (see chainstate_integrity_tests.cpp Test 9b).
+//
+//   * IsCorruption() -> transient=false. LevelDB's signal for REAL on-disk data
+//     damage: a failed SST block CRC32C checksum, a malformed block handle, or a
+//     corrupt manifest/log. It REPRODUCES on every read (that is the whole point
+//     of the checksum), so it survives the monitor's retry loop. Classifying it
+//     transient would route a genuinely-corrupt node into the tolerate branch
+//     and mask real corruption FOREVER (the inverse, more-dangerous failure
+//     mode). It must go through the cs_main revalidation gate -> marker ->
+//     shutdown -> rebuild, exactly like the application-level checksum_mismatch
+//     / size_invalid cases.
+//
+//   * IsIOError() -> transient=true. A recoverable storage-layer blip
+//     (open-file-handle exhaustion, an EIO hiccup, a momentary AV file lock on
+//     Windows). May clear across the retry loop; we must not wipe-and-resync a
+//     healthy chain because of a flaky disk. (A *persistent* IsIOError that
+//     never clears is still tolerated with a loud stderr warning — a known,
+//     accepted residual: limp-with-warning beats bricking on a transient blip.)
+//
+//   * else (IsNotFound and any other unexpected non-ok status) -> "missing" /
+//     non-transient. A genuinely-absent key on an active-chain block is real
+//     corruption; anything unexpected fails safe toward the corruption gate
+//     (shutdown) rather than tolerate.
+// v4.4 test-only fault-injection hook (see utxo_set.h). Production leaves null.
+std::function<leveldb::Status()> g_undo_fetch_fault_injector = nullptr;
+
+void ClassifyUndoFetchStatus(const leveldb::Status& st, UndoIntegrityFailure& failure_out) {
+    if (st.IsCorruption()) {
+        failure_out.cause = "io_corruption";
+        failure_out.transient = false;
+    } else if (st.IsIOError()) {
+        failure_out.cause = "io_error";
+        failure_out.transient = true;
+    } else {
+        failure_out.cause = "missing";
+        failure_out.transient = false;
+    }
+}
+
 namespace {
 
 // v4.4 trap-7 (storage-of-record) fix: single canonical undo-checksum verifier.
@@ -53,24 +98,19 @@ bool FetchAndVerifyUndo(leveldb::DB* db,
     undoKey.append(reinterpret_cast<const char*>(blockHash.data), 32);
 
     std::string undoValue;
-    leveldb::Status st = db->Get(leveldb::ReadOptions(), undoKey, &undoValue);
+    // v4.4 test-only fault injection (g_undo_fetch_fault_injector is null in
+    // production). A non-ok injected Status simulates a storage-layer fault
+    // (IsCorruption / IsIOError) that real on-disk data can't easily produce, so
+    // the monitor's retry/tolerate/confirm routing is exercised end-to-end.
+    leveldb::Status st = g_undo_fetch_fault_injector ? g_undo_fetch_fault_injector()
+                                                     : leveldb::Status::OK();
+    if (st.ok()) {
+        st = db->Get(leveldb::ReadOptions(), undoKey, &undoValue);
+    }
     if (!st.ok()) {
         failure_out.height = height;
         failure_out.blockHash = blockHash;
-        // Distinguish a TRANSIENT storage-layer fault (IsIOError / IsCorruption
-        // — flaky disk, fsync lag, AV file lock on Windows) from a clean
-        // IsNotFound() (key genuinely absent). Only the latter is real
-        // "missing undo data" corruption. The periodic monitor uses the
-        // transient flag to avoid self-bricking a healthy node on a recoverable
-        // read fault. A genuinely-missing key on an active-chain block is real
-        // corruption and still confirms after the monitor's retry loop.
-        if (st.IsIOError() || st.IsCorruption()) {
-            failure_out.cause = "io_error";
-            failure_out.transient = true;
-        } else {
-            failure_out.cause = "missing";
-            failure_out.transient = false;
-        }
+        ClassifyUndoFetchStatus(st, failure_out);
         return false;
     }
     switch (VerifyUndoChecksum(undoValue)) {

--- a/src/node/utxo_set.h
+++ b/src/node/utxo_set.h
@@ -77,10 +77,23 @@ void ClassifyUndoFetchStatus(const leveldb::Status& st, UndoIntegrityFailure& fa
  * tests drive the full ChainstateIntegrityMonitor retry/tolerate/confirm
  * routing through a synthetic persistent-Corruption or transient-IOError fault.
  *
- * Production code MUST leave this null. It is a std::function so a test can
- * decrement a counter per call (persistent vs clears-on-retry).
+ * COMPILED OUT OF PRODUCTION (extreview PR #120 HIGH, unanimous 3/3 providers).
+ * The whole symbol — declaration, definition, and the FetchAndVerifyUndo call
+ * site — lives inside `#ifdef DILITHION_ENABLE_FAULT_INJECTION`. That macro is
+ * defined ONLY for the dedicated test object built by the Makefile's
+ * `chainstate_integrity_tests` target (a private recompile of utxo_set.cpp);
+ * the production `dilithion-node` / `dilv-node` link the normal CORE
+ * `utxo_set.o`, where this mutable `extern std::function` seam does not exist at
+ * all and therefore cannot be reassigned to steer the monitor's corruption
+ * routing. There is intentionally no runtime path that touches the injector in a
+ * shipped binary.
+ *
+ * It is a std::function so a test can decrement a counter per call (persistent
+ * vs clears-on-retry).
  */
+#ifdef DILITHION_ENABLE_FAULT_INJECTION
 extern std::function<leveldb::Status()> g_undo_fetch_fault_injector;
+#endif
 
 /**
  * UTXO (Unspent Transaction Output) entry

--- a/src/node/utxo_set.h
+++ b/src/node/utxo_set.h
@@ -17,6 +17,7 @@
 #include <cstdint>
 #include <atomic>
 #include <utility>
+#include <functional>
 
 // Forward declaration — VerifyUndoDataInRange takes CBlockIndex* without needing the full type.
 class CBlockIndex;
@@ -27,20 +28,59 @@ class CBlockIndex;
  * or corrupt undo record. The cause field distinguishes failure modes for
  * operator diagnostics + auto-rebuild marker reason text.
  *
- * `transient`: true when the underlying LevelDB read failed with an
- * IsIOError()/IsCorruption() status (a recoverable storage-layer fault — flaky
- * disk, fsync lag, AV file lock on Windows) rather than a clean IsNotFound()
- * (key genuinely absent) or a data-level checksum/size mismatch. The periodic
- * ChainstateIntegrityMonitor uses this flag to AVOID self-bricking a healthy
- * node on a transient fault: a transient failure that does not clear across
- * retries is logged + tolerated, never marker-written.
+ * `transient`: true ONLY when the underlying LevelDB read failed with an
+ * IsIOError() status (a recoverable storage-layer fault — open-file-handle
+ * exhaustion, an EIO blip, an AV file lock on Windows) that may clear across
+ * the monitor's retry loop. The periodic ChainstateIntegrityMonitor uses this
+ * flag to AVOID self-bricking a healthy node on a transient fault: a transient
+ * failure that does not clear across retries is logged + tolerated, never
+ * marker-written.
+ *
+ * IsCorruption() is deliberately NOT transient. It is LevelDB's signal for REAL
+ * on-disk data damage (a failed SST CRC32C checksum, a bad block handle, a
+ * corrupt manifest); it reproduces on every read, so it survives the retry loop
+ * and must route through the corruption gate -> marker + shutdown + rebuild.
+ * Treating it as transient would mask genuine corruption forever (the inverse,
+ * more-dangerous failure mode). It is hard-fail, like checksum_mismatch /
+ * size_invalid.
  */
 struct UndoIntegrityFailure {
     int height = -1;
     uint256 blockHash;
-    std::string cause;  // "missing" | "checksum_mismatch" | "size_invalid" | "io_error" | "db_not_open" | "block_index_missing"
-    bool transient = false;  // true => recoverable storage-layer read fault (do NOT brick on it)
+    std::string cause;  // "missing" | "checksum_mismatch" | "size_invalid" | "io_error" | "io_corruption" | "db_not_open" | "block_index_missing"
+    bool transient = false;  // true => recoverable IsIOError storage blip (do NOT brick); false => hard-fail
 };
+
+/**
+ * v4.4: Classify a non-ok leveldb::Status from an undo-record Get() into the
+ * (cause, transient) taxonomy. Extracted as a free, side-effect-free function so
+ * the safety-critical mapping can be unit-tested directly with synthetic
+ * leveldb::Status values (a real on-disk IsCorruption is otherwise impractical
+ * to inject). Sets failure_out.cause and failure_out.transient; callers fill in
+ * height/blockHash. MUST be called only when st is NOT ok.
+ *
+ * Mapping (see definition for full rationale):
+ *   IsCorruption() -> cause="io_corruption", transient=false  (real on-disk damage; hard-fail)
+ *   IsIOError()    -> cause="io_error",      transient=true   (recoverable storage blip)
+ *   else           -> cause="missing",       transient=false  (absent key / fail-safe default)
+ */
+void ClassifyUndoFetchStatus(const leveldb::Status& st, UndoIntegrityFailure& failure_out);
+
+/**
+ * v4.4 test-only fault injection for the undo-fetch seam.
+ *
+ * When g_undo_fetch_fault_injector is non-null, FetchAndVerifyUndo consults it
+ * BEFORE the real db->Get(): the hook may return a non-ok leveldb::Status to
+ * simulate a storage-layer fault (IsCorruption / IsIOError) that is otherwise
+ * impractical to produce on real on-disk data. Returning an ok() Status means
+ * "no injected fault — proceed with the real read". This lets the integrity
+ * tests drive the full ChainstateIntegrityMonitor retry/tolerate/confirm
+ * routing through a synthetic persistent-Corruption or transient-IOError fault.
+ *
+ * Production code MUST leave this null. It is a std::function so a test can
+ * decrement a counter per call (persistent vs clears-on-retry).
+ */
+extern std::function<leveldb::Status()> g_undo_fetch_fault_injector;
 
 /**
  * UTXO (Unspent Transaction Output) entry

--- a/src/node/utxo_set.h
+++ b/src/node/utxo_set.h
@@ -26,11 +26,20 @@ class CBlockIndex;
  * Populated by CUTXOSet::VerifyUndoDataInRange when the walk detects a missing
  * or corrupt undo record. The cause field distinguishes failure modes for
  * operator diagnostics + auto-rebuild marker reason text.
+ *
+ * `transient`: true when the underlying LevelDB read failed with an
+ * IsIOError()/IsCorruption() status (a recoverable storage-layer fault — flaky
+ * disk, fsync lag, AV file lock on Windows) rather than a clean IsNotFound()
+ * (key genuinely absent) or a data-level checksum/size mismatch. The periodic
+ * ChainstateIntegrityMonitor uses this flag to AVOID self-bricking a healthy
+ * node on a transient fault: a transient failure that does not clear across
+ * retries is logged + tolerated, never marker-written.
  */
 struct UndoIntegrityFailure {
     int height = -1;
     uint256 blockHash;
-    std::string cause;  // "missing" | "checksum_mismatch" | "size_invalid" | "db_not_open" | "block_index_missing"
+    std::string cause;  // "missing" | "checksum_mismatch" | "size_invalid" | "io_error" | "db_not_open" | "block_index_missing"
+    bool transient = false;  // true => recoverable storage-layer read fault (do NOT brick on it)
 };
 
 /**

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -21,6 +21,7 @@
 #include <node/mempool.h>
 #include <node/blockchain_storage.h>
 #include <node/utxo_set.h>
+#include <node/chainstate_integrity_monitor.h>  // extreview PR #120 B1: integrity_health field
 #include <x402/facilitator.h>  // x402 payment facilitator
 #include <consensus/params.h>
 #include <consensus/chain.h>
@@ -3728,7 +3729,17 @@ std::string CRPCServer::RPC_GetBlockchainInfo(const std::string& params) {
     oss << "\"bestblockhash\":\"" << bestBlockHash.GetHex() << "\",";
     oss << "\"difficulty\":" << std::fixed << std::setprecision(8) << difficulty << ",";
     oss << "\"mediantime\":" << mediantime << ",";
-    oss << "\"chainwork\":\"" << m_chainstate->GetChainWork().GetHex() << "\"";
+    oss << "\"chainwork\":\"" << m_chainstate->GetChainWork().GetHex() << "\",";
+    // extreview PR #120 B1: operator-observable chainstate-integrity health.
+    // "degraded" once a persistent storage IsIOError has been tolerated across
+    // kEscalateAfterCycles consecutive monitor cycles (a sustained disk/file-lock
+    // fault that the node keeps limping through and will NOT auto-rebuild).
+    // "ok" otherwise. Lets operators / monitoring poll for a silent hardware
+    // fault without scraping stderr.
+    oss << "\"integrity_health\":\""
+        << (Dilithion::ChainstateIntegrityMonitor::IsIntegrityHealthDegraded()
+                ? "degraded" : "ok")
+        << "\"";
     oss << "}";
     return oss.str();
 }

--- a/src/test/chainstate_integrity_tests.cpp
+++ b/src/test/chainstate_integrity_tests.cpp
@@ -666,6 +666,87 @@ void test_retry_loop_confirms_reproducible_corruption() {
     std::cout << " OK\n";
 }
 
+// =============================================================================
+// Test 11 (extreview PR #120 B1 — Will's decision): a PERSISTENT IsIOError that
+// never clears is tolerated forever — NEVER writes the marker, NEVER shuts the
+// node down — but after kEscalateAfterCycles consecutive cycles it escalates the
+// observable degraded-health flag. And a healthy cycle clears that flag.
+// =============================================================================
+void test_persistent_ioerror_escalates_but_never_bricks() {
+    std::cout << "  test_persistent_ioerror_escalates_but_never_bricks..."
+              << std::flush;
+
+    namespace D = Dilithion;
+    constexpr int kN = D::ChainstateIntegrityMonitor::kEscalateAfterCycles;
+
+    TempDir td("persistent-ioerror");
+    CUTXOSet utxo;
+    assert(utxo.Open(td.str(), true));
+    std::vector<std::unique_ptr<CBlockIndex>> chain;
+    CBlockIndex* tip = BuildSyntheticChain(50, chain);
+    WriteValidUndoForChain(utxo, chain);  // chain is CLEAN on disk
+    CChainState cs;
+    cs.SetUTXOSet(&utxo);
+    cs.SetTipForTest(tip);
+
+    std::atomic<bool> running{true};
+    D::ChainstateIntegrityMonitor monitor(cs, utxo, td.str(), &running);
+    monitor.SetRevalidateBackoffForTesting(std::chrono::milliseconds::zero());
+    auto markerPath = std::filesystem::path(td.str()) / "auto_rebuild";
+
+    // Persistent (every-call) IsIOError at the fetch seam — never clears.
+    g_undo_fetch_fault_injector = []() {
+        return leveldb::Status::IOError("persistent EIO (failing disk)");
+    };
+
+    // Cycles 1..N-1: tolerated, NOT yet escalated, flag stays clean.
+    for (int cycle = 1; cycle < kN; ++cycle) {
+        bool cyclePass = monitor.RunOneCycleForTesting();
+        assert(cyclePass &&
+               "persistent IsIOError must be TOLERATED every cycle (cyclePass)");
+        assert(running.load() &&
+               "persistent IsIOError must NEVER flip running=false (no shutdown)");
+        assert(!std::filesystem::exists(markerPath) &&
+               "persistent IsIOError must NEVER write the auto_rebuild marker");
+        assert(!D::ChainstateIntegrityMonitor::IsIntegrityHealthDegraded() &&
+               "must NOT escalate before kEscalateAfterCycles consecutive cycles");
+        assert(monitor.GetConsecutiveTransientCyclesForTesting() == cycle &&
+               "consecutive-transient counter must increment each cycle");
+    }
+
+    // Cycle N: still tolerated + still running + still no marker, but NOW the
+    // observable degraded-health flag is raised.
+    {
+        bool cyclePass = monitor.RunOneCycleForTesting();
+        assert(cyclePass && "Nth persistent IsIOError still TOLERATED (no brick)");
+        assert(running.load() &&
+               "Nth persistent IsIOError must still NOT shut down");
+        assert(!std::filesystem::exists(markerPath) &&
+               "Nth persistent IsIOError must still NOT write the marker");
+        assert(D::ChainstateIntegrityMonitor::IsIntegrityHealthDegraded() &&
+               "after kEscalateAfterCycles consecutive cycles, health = degraded");
+        assert(monitor.GetConsecutiveTransientCyclesForTesting() == kN &&
+               "counter must equal kEscalateAfterCycles at escalation");
+    }
+
+    // Now let the fault clear: a healthy cycle must reset the counter AND clear
+    // the degraded-health flag.
+    g_undo_fetch_fault_injector = nullptr;  // reads now hit clean on-disk data
+    {
+        bool cyclePass = monitor.RunOneCycleForTesting();
+        assert(cyclePass && "healthy cycle passes");
+        assert(running.load() && "healthy cycle keeps running");
+        assert(!D::ChainstateIntegrityMonitor::IsIntegrityHealthDegraded() &&
+               "a healthy cycle MUST clear the degraded-health flag");
+        assert(monitor.GetConsecutiveTransientCyclesForTesting() == 0 &&
+               "a healthy cycle MUST reset the consecutive-transient counter");
+    }
+
+    g_undo_fetch_fault_injector = nullptr;  // belt-and-braces before destructors
+    (void)tip;
+    std::cout << " OK\n";
+}
+
 }  // namespace
 
 int main() {
@@ -691,8 +772,9 @@ int main() {
         test_classify_undo_fetch_status_mapping();
         test_monitor_routes_injected_faults();
         test_retry_loop_confirms_reproducible_corruption();
+        test_persistent_ioerror_escalates_but_never_bricks();
 
-        std::cout << "\n=== All 12 tests passed ===\n" << std::endl;
+        std::cout << "\n=== All 13 tests passed ===\n" << std::endl;
         return 0;
     } catch (const std::exception& e) {
         std::cerr << "Test failed: " << e.what() << std::endl;

--- a/src/test/chainstate_integrity_tests.cpp
+++ b/src/test/chainstate_integrity_tests.cpp
@@ -480,6 +480,141 @@ void test_transient_classification_never_masks_real_corruption() {
 }
 
 // =============================================================================
+// Test 9b: classifier unit — the (cause, transient) mapping at the LevelDB-
+// status seam. This is the EXACT line that shipped the BLOCKER: IsCorruption()
+// was bucketed transient=true, so real on-disk corruption would be tolerated
+// forever. A no-op classifier (or one that buckets IsCorruption with IsIOError)
+// MUST fail these asserts. Drives synthetic leveldb::Status values directly —
+// the dangerous direction (IsCorruption) that Test 9 admitted it couldn't reach.
+// =============================================================================
+void test_classify_undo_fetch_status_mapping() {
+    std::cout << "  test_classify_undo_fetch_status_mapping..." << std::flush;
+
+    // IsCorruption() => HARD FAIL. Real on-disk damage reproduces on every read;
+    // it must route to the corruption gate (marker + shutdown), NOT tolerate.
+    {
+        UndoIntegrityFailure f;
+        ClassifyUndoFetchStatus(leveldb::Status::Corruption("bad SST CRC32C"), f);
+        assert(f.transient == false &&
+               "IsCorruption MUST be non-transient (real on-disk corruption, not a blip)");
+        assert(f.cause == "io_corruption" && "IsCorruption => cause 'io_corruption'");
+    }
+
+    // IsIOError() => transient. A recoverable storage blip may clear on retry.
+    {
+        UndoIntegrityFailure f;
+        ClassifyUndoFetchStatus(leveldb::Status::IOError("EIO blip"), f);
+        assert(f.transient == true &&
+               "IsIOError MUST be transient (recoverable storage-layer blip)");
+        assert(f.cause == "io_error" && "IsIOError => cause 'io_error'");
+    }
+
+    // NotFound / any other non-ok status => fail-safe non-transient "missing".
+    {
+        UndoIntegrityFailure f;
+        ClassifyUndoFetchStatus(leveldb::Status::NotFound("absent key"), f);
+        assert(f.transient == false &&
+               "a genuinely-absent key must be non-transient ('missing')");
+        assert(f.cause == "missing" && "IsNotFound => cause 'missing'");
+    }
+
+    std::cout << " OK\n";
+}
+
+// =============================================================================
+// Test 9c: end-to-end monitor routing through the undo-fetch fault injector.
+// Proves the DANGEROUS direction the BLOCKER was about — a persistent
+// IsCorruption is NEVER tolerated; it confirms across retries -> marker +
+// shutdown. And the SAFE-but-tolerant direction — a transient IsIOError that
+// clears on retry IS tolerated (node keeps running, no marker). A no-op
+// classifier (IsCorruption mislabelled transient) fails the persistent-
+// corruption case: it would take the tolerate branch, leave running=true, and
+// write no marker.
+// =============================================================================
+void test_monitor_routes_injected_faults() {
+    std::cout << "  test_monitor_routes_injected_faults..." << std::flush;
+
+    // --- Case A: persistent IsCorruption -> shut down WITH marker (NOT tolerated).
+    {
+        TempDir td("inject-corruption");
+        CUTXOSet utxo;
+        assert(utxo.Open(td.str(), true));
+        std::vector<std::unique_ptr<CBlockIndex>> chain;
+        CBlockIndex* tip = BuildSyntheticChain(50, chain);
+        WriteValidUndoForChain(utxo, chain);  // chain is otherwise CLEAN on disk
+        CChainState cs;
+        cs.SetUTXOSet(&utxo);
+        cs.SetTipForTest(tip);
+
+        // Inject a persistent (every-call) IsCorruption at the fetch seam.
+        int corruptionCalls = 0;
+        g_undo_fetch_fault_injector = [&corruptionCalls]() {
+            ++corruptionCalls;
+            return leveldb::Status::Corruption("persistent SST CRC failure");
+        };
+
+        std::atomic<bool> running{true};
+        Dilithion::ChainstateIntegrityMonitor monitor(cs, utxo, td.str(), &running);
+        monitor.SetRevalidateBackoffForTesting(std::chrono::milliseconds::zero());
+        bool cyclePass = monitor.RunOneCycleForTesting();
+        g_undo_fetch_fault_injector = nullptr;  // clear before asserts/destructors
+
+        assert(!cyclePass &&
+               "persistent IsCorruption must NOT pass the cycle (real corruption)");
+        assert(!running.load() &&
+               "persistent IsCorruption MUST flip running=false (shutdown), NOT tolerate");
+        auto markerPath = std::filesystem::path(td.str()) / "auto_rebuild";
+        assert(std::filesystem::exists(markerPath) &&
+               "persistent IsCorruption MUST write the auto_rebuild marker");
+        assert(corruptionCalls >= 1 && "injector must have been consulted");
+    }
+
+    // --- Case B: transient IsIOError that CLEARS on retry -> tolerated (running).
+    {
+        TempDir td("inject-ioerror-clears");
+        CUTXOSet utxo;
+        assert(utxo.Open(td.str(), true));
+        std::vector<std::unique_ptr<CBlockIndex>> chain;
+        CBlockIndex* tip = BuildSyntheticChain(50, chain);
+        WriteValidUndoForChain(utxo, chain);  // clean on disk
+        CChainState cs;
+        cs.SetUTXOSet(&utxo);
+        cs.SetTipForTest(tip);
+
+        // Deterministic one-shot: fail the very FIRST fetch with IsIOError, then
+        // clear. The walk short-circuits on first failure, so attempt 1 fails
+        // (transient IOError); the post-backoff (zero) retry walk reads the
+        // healthy on-disk data and passes -> the fault is tolerated, no marker.
+        std::atomic<int> calls{0};
+        g_undo_fetch_fault_injector = [&calls]() {
+            if (calls.fetch_add(1) == 0) {
+                return leveldb::Status::IOError("transient EIO (one-shot)");
+            }
+            return leveldb::Status::OK();
+        };
+
+        std::atomic<bool> running{true};
+        Dilithion::ChainstateIntegrityMonitor monitor(cs, utxo, td.str(), &running);
+        monitor.SetRevalidateBackoffForTesting(std::chrono::milliseconds::zero());
+        bool cyclePass = monitor.RunOneCycleForTesting();
+        g_undo_fetch_fault_injector = nullptr;
+
+        assert(calls.load() >= 2 &&
+               "injector must have been consulted on attempt 1 (fail) and a retry");
+        assert(cyclePass &&
+               "transient IsIOError that clears on retry MUST pass (tolerated)");
+        assert(running.load() &&
+               "transient IsIOError that clears MUST keep running (no shutdown)");
+        auto markerPath = std::filesystem::path(td.str()) / "auto_rebuild";
+        assert(!std::filesystem::exists(markerPath) &&
+               "no marker for a transient fault that cleared on retry");
+        (void)tip;
+    }
+
+    std::cout << " OK\n";
+}
+
+// =============================================================================
 // Test 10: retry loop confirms reproducible corruption only after exhausting
 // all attempts (with zeroed backoff) — and a clean chain still passes through
 // the multi-attempt loop with no false positive.
@@ -553,9 +688,11 @@ int main() {
 
         std::cout << "[self-heal / transient tolerance]" << std::endl;
         test_transient_classification_never_masks_real_corruption();
+        test_classify_undo_fetch_status_mapping();
+        test_monitor_routes_injected_faults();
         test_retry_loop_confirms_reproducible_corruption();
 
-        std::cout << "\n=== All 10 tests passed ===\n" << std::endl;
+        std::cout << "\n=== All 12 tests passed ===\n" << std::endl;
         return 0;
     } catch (const std::exception& e) {
         std::cerr << "Test failed: " << e.what() << std::endl;

--- a/src/test/chainstate_integrity_tests.cpp
+++ b/src/test/chainstate_integrity_tests.cpp
@@ -277,6 +277,10 @@ void test_periodic_monitor_fails_on_runtime_corruption() {
 
     std::atomic<bool> running{true};
     Dilithion::ChainstateIntegrityMonitor monitor(cs, utxo, td.str(), &running);
+    // Zero the retry backoff so the 3-attempt self-heal loop doesn't add 60s.
+    // A checksum mismatch is reproducible, so it still fails all 3 attempts and
+    // confirms corruption exactly as before the self-heal change.
+    monitor.SetRevalidateBackoffForTesting(std::chrono::milliseconds::zero());
 
     bool result = monitor.RunOneCycleForTesting();
     assert(!result && "corrupted chain cycle must return false");
@@ -422,6 +426,111 @@ void test_periodic_monitor_skips_orphan_on_reorg() {
     std::cout << " OK\n";
 }
 
+// =============================================================================
+// Test 9: transient-classification — genuine corruption modes (missing key,
+// checksum mismatch) must be classified transient=false so the self-heal loop
+// NEVER tolerates real corruption. (The inverse direction — a true IsIOError
+// being classified transient=true — cannot be exercised without LevelDB fault
+// injection; this test locks in the safety-critical direction: real corruption
+// is never mislabelled transient.)
+// =============================================================================
+void test_transient_classification_never_masks_real_corruption() {
+    std::cout << "  test_transient_classification_never_masks_real_corruption..."
+              << std::flush;
+    TempDir td("transient-class");
+    CUTXOSet utxo;
+    assert(utxo.Open(td.str(), true));
+
+    std::vector<std::unique_ptr<CBlockIndex>> chain;
+    CBlockIndex* tip = BuildSyntheticChain(20, chain);
+    WriteValidUndoForChain(utxo, chain);
+
+    // Case A: clean missing key (IsNotFound) — transient must be false.
+    {
+        const uint256 victim = chain[9]->phashBlock;
+        assert(utxo.DeleteUndoForTesting(victim));
+        std::vector<std::pair<int, uint256>> snapshot;
+        snapshot.emplace_back(chain[9]->nHeight, victim);
+        UndoIntegrityFailure failure;
+        bool ok = utxo.VerifyUndoDataFromSnapshot(snapshot, failure);
+        assert(!ok && "missing key must fail the walk");
+        assert(failure.cause == "missing" && "clean absent key => 'missing'");
+        assert(failure.transient == false &&
+               "a genuinely-missing key must NEVER be classified transient");
+        // restore for next case
+        WriteValidUndoForChain(utxo, chain);
+    }
+
+    // Case B: checksum mismatch — transient must be false.
+    {
+        const uint256 victim = chain[9]->phashBlock;
+        assert(utxo.CorruptUndoForTesting(victim));
+        std::vector<std::pair<int, uint256>> snapshot;
+        snapshot.emplace_back(chain[9]->nHeight, victim);
+        UndoIntegrityFailure failure;
+        bool ok = utxo.VerifyUndoDataFromSnapshot(snapshot, failure);
+        assert(!ok && "checksum mismatch must fail the walk");
+        assert(failure.cause == "checksum_mismatch");
+        assert(failure.transient == false &&
+               "a checksum mismatch must NEVER be classified transient");
+    }
+
+    (void)tip;
+    std::cout << " OK\n";
+}
+
+// =============================================================================
+// Test 10: retry loop confirms reproducible corruption only after exhausting
+// all attempts (with zeroed backoff) — and a clean chain still passes through
+// the multi-attempt loop with no false positive.
+// =============================================================================
+void test_retry_loop_confirms_reproducible_corruption() {
+    std::cout << "  test_retry_loop_confirms_reproducible_corruption..."
+              << std::flush;
+
+    // Clean chain: must pass even though the loop now runs up to 3 attempts.
+    {
+        TempDir td("retry-clean");
+        CUTXOSet utxo;
+        assert(utxo.Open(td.str(), true));
+        std::vector<std::unique_ptr<CBlockIndex>> chain;
+        CBlockIndex* tip = BuildSyntheticChain(50, chain);
+        WriteValidUndoForChain(utxo, chain);
+        CChainState cs;
+        cs.SetUTXOSet(&utxo);
+        cs.SetTipForTest(tip);
+        std::atomic<bool> running{true};
+        Dilithion::ChainstateIntegrityMonitor monitor(cs, utxo, td.str(), &running);
+        monitor.SetRevalidateBackoffForTesting(std::chrono::milliseconds::zero());
+        assert(monitor.RunOneCycleForTesting() && "clean chain must pass loop");
+        assert(running.load() && "running flag preserved on clean chain");
+    }
+
+    // Reproducible corruption: fails all attempts, confirms, writes marker.
+    {
+        TempDir td("retry-corrupt");
+        CUTXOSet utxo;
+        assert(utxo.Open(td.str(), true));
+        std::vector<std::unique_ptr<CBlockIndex>> chain;
+        CBlockIndex* tip = BuildSyntheticChain(50, chain);
+        WriteValidUndoForChain(utxo, chain);
+        assert(utxo.CorruptUndoForTesting(chain[24]->phashBlock));
+        CChainState cs;
+        cs.SetUTXOSet(&utxo);
+        cs.SetTipForTest(tip);
+        std::atomic<bool> running{true};
+        Dilithion::ChainstateIntegrityMonitor monitor(cs, utxo, td.str(), &running);
+        monitor.SetRevalidateBackoffForTesting(std::chrono::milliseconds::zero());
+        assert(!monitor.RunOneCycleForTesting() &&
+               "reproducible corruption must confirm after retries");
+        assert(!running.load() && "running flag flipped on confirmed corruption");
+        auto markerPath = std::filesystem::path(td.str()) / "auto_rebuild";
+        assert(std::filesystem::exists(markerPath) && "marker written");
+    }
+
+    std::cout << " OK\n";
+}
+
 }  // namespace
 
 int main() {
@@ -442,7 +551,11 @@ int main() {
         test_periodic_monitor_clean_shutdown();
         test_periodic_monitor_skips_orphan_on_reorg();
 
-        std::cout << "\n=== All 8 tests passed ===\n" << std::endl;
+        std::cout << "[self-heal / transient tolerance]" << std::endl;
+        test_transient_classification_never_masks_real_corruption();
+        test_retry_loop_confirms_reproducible_corruption();
+
+        std::cout << "\n=== All 10 tests passed ===\n" << std::endl;
         return 0;
     } catch (const std::exception& e) {
         std::cerr << "Test failed: " << e.what() << std::endl;


### PR DESCRIPTION
The ChainstateIntegrityMonitor (every shipped release, both chains) could self-shutdown a HEALTHY node on a single TRANSIENT storage fault (flaky disk / fsync lag / Windows AV lock) and stay down → multi-hour resync. Credible root cause for 'DIL nodes shut down overnight' (seeds dodge it on clean SSDs). Fix: classify transient (IsIOError) vs real (IsCorruption→hard-fail) faults, retry-with-backoff, tolerate only persistent-transient. Red-team found + folded a BLOCKER (IsCorruption was wrongly transient → masked real corruption); the masked-corruption hole is **mutation-proven closed**, re-review clean (0 blocker/high). v4.5.1 candidate. Needs your Cursor pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)