### PR TITLE
fix(attestation): consolidated seed-key hardening — M-1/M-2 + corrected H-3 (4-way decision table)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -933,6 +933,7 @@ BOOST_TEST_OBJECTS := $(OBJ_DIR)/test/test_dilithion.o \
 	$(OBJ_DIR)/test/fee_persist_tests.o \
 	$(OBJ_DIR)/test/fee_wiring_tests.o \
 	$(OBJ_DIR)/test/zmq_tests.o \
+	$(OBJ_DIR)/test/seed_attestation_glue_tests.o \
 	$(CRYPTO_PROPERTY_OBJECTS)
 
 # Link test objects + full library (CORE_OBJECTS) to avoid hand-picked object drift

--- a/src/attestation/seed_attestation.cpp
+++ b/src/attestation/seed_attestation.cpp
@@ -112,6 +112,109 @@ bool SeedKeyFilePresent(const std::string& dataDir) {
     return present;
 }
 
+// ============================================================================
+// LP-13 M-1/M-2 SEED-IDENTITY RESOLUTION (HIGH-1 / HIGH-2 fold)
+// ============================================================================
+
+std::string NormalizeExternalIpForSeedMatch(const std::string& externalIp) {
+    // 1) Trim surrounding whitespace (HIGH-2: quoting/templating artifacts).
+    size_t b = externalIp.find_first_not_of(" \t\r\n");
+    if (b == std::string::npos) return std::string();
+    size_t e = externalIp.find_last_not_of(" \t\r\n");
+    std::string s = externalIp.substr(b, e - b + 1);
+
+    // 2) IPv6 handling — do NOT strip on a raw IPv6 literal (it contains
+    //    colons legitimately). Bracketed form "[addr]" or "[addr]:port" keeps
+    //    the address inside the brackets; a bare value with >1 colon is treated
+    //    as IPv6 and returned trimmed-only. The configured seed set is IPv4-only,
+    //    so an IPv6 externalip simply fails to match -> SKIP_NOT_A_SEED, never a
+    //    false FATAL.
+    if (!s.empty() && s.front() == '[') {
+        size_t rb = s.find(']');
+        if (rb != std::string::npos) {
+            return s.substr(1, rb - 1);  // inside brackets, drop any ":port"
+        }
+        return s;  // malformed; leave as-is (won't match IPv4 set)
+    }
+    if (std::count(s.begin(), s.end(), ':') > 1) {
+        return s;  // bare IPv6 literal; trimmed only, no port strip
+    }
+
+    // 3) IPv4 / hostname: strip a single trailing ":port" suffix
+    //    (HIGH-2: --externalip=138.197.68.128:8444 must resolve).
+    size_t colon = s.find(':');
+    if (colon != std::string::npos) {
+        s = s.substr(0, colon);
+    }
+    return s;
+}
+
+SeedIdentityResult ResolveSeedIdentity(
+    const std::vector<std::string>& seedIPs,
+    const std::vector<std::vector<uint8_t>>& seedPubkeys,
+    const std::string& externalIp,
+    const std::vector<uint8_t>& loadedPubkey) {
+    SeedIdentityResult r;
+
+    // Resolve seedId by matching our normalized --externalip against the known
+    // seed IPs. seedAttestationIPs[i] and seedAttestationPubkeys[i] are
+    // index-aligned (same NYC/London/Singapore/Sydney order), so the resolved
+    // index is also the index into the consensus pubkey set.
+    int seedId = -1;
+    if (!externalIp.empty()) {
+        std::string normIp = NormalizeExternalIpForSeedMatch(externalIp);
+        if (!normIp.empty()) {
+            for (size_t i = 0; i < seedIPs.size(); i++) {
+                if (seedIPs[i] == normIp) {
+                    seedId = static_cast<int>(i);
+                    break;
+                }
+            }
+        }
+    }
+
+    if (seedPubkeys.empty()) {
+        // Testnet: no consensus pubkey to enforce. Preserve the prior lenient
+        // behavior — register under the resolved index, or default 0 with a
+        // WARN when unresolved.
+        r.decision = SeedIdentityDecision::REGISTER;
+        if (seedId < 0) {
+            r.seedId = 0;
+            r.usedTestnetDefault = true;
+        } else {
+            r.seedId = seedId;
+        }
+        return r;
+    }
+
+    // Mainnet (configured seed set present).
+    if (seedId < 0) {
+        // HIGH-1 fix: externalip matches no configured seed slot. This node is
+        // NOT one of the seeds (even if a key file is on disk). Skip
+        // registration rather than abort: consensus rejects a non-seed's
+        // attestations anyway, so aborting is a pure availability regression
+        // with zero security gain. This still fixes the original M-2 bug — a
+        // non-seed never silently registers under wrong-index-0.
+        r.decision = SeedIdentityDecision::SKIP_NOT_A_SEED;
+        r.seedId = -1;
+        return r;
+    }
+
+    // seedId resolved to a real seed slot: the key MUST match that slot's
+    // consensus pubkey (M-1). A mismatch (or out-of-range index) is a genuine
+    // misconfig — fail loud.
+    if (static_cast<size_t>(seedId) >= seedPubkeys.size() ||
+        loadedPubkey != seedPubkeys[seedId]) {
+        r.decision = SeedIdentityDecision::FATAL_MISMATCH;
+        r.seedId = seedId;
+        return r;
+    }
+
+    r.decision = SeedIdentityDecision::REGISTER;
+    r.seedId = seedId;
+    return r;
+}
+
 // LP-13 H-2 atomic-save test seam (see header). nullptr in production.
 bool (*g_seedKeySaveFailpoint)() = nullptr;
 // LP-13 B-1 fsync-failure test seam (see header). nullptr in production.

--- a/src/attestation/seed_attestation.cpp
+++ b/src/attestation/seed_attestation.cpp
@@ -153,7 +153,8 @@ SeedIdentityResult ResolveSeedIdentity(
     const std::vector<std::string>& seedIPs,
     const std::vector<std::vector<uint8_t>>& seedPubkeys,
     const std::string& externalIp,
-    const std::vector<uint8_t>& loadedPubkey) {
+    const std::vector<uint8_t>& loadedPubkey,
+    bool asnLoaded) {
     SeedIdentityResult r;
 
     // Resolve seedId by matching our normalized --externalip against the known
@@ -177,13 +178,17 @@ SeedIdentityResult ResolveSeedIdentity(
         // Testnet: no consensus pubkey to enforce. Preserve the prior lenient
         // behavior — register under the resolved index, or default 0 with a
         // WARN when unresolved.
-        r.decision = SeedIdentityDecision::REGISTER;
         if (seedId < 0) {
             r.seedId = 0;
             r.usedTestnetDefault = true;
         } else {
             r.seedId = seedId;
         }
+        // H-3: a valid (testnet) identity that would register, but with the ASN
+        // DB down, has zero attestation capacity -> DEGRADED (stay online, don't
+        // register, make the state loud + diagnosable). Otherwise REGISTER.
+        r.decision = asnLoaded ? SeedIdentityDecision::REGISTER
+                               : SeedIdentityDecision::DEGRADED_NO_ASN;
         return r;
     }
 
@@ -210,8 +215,14 @@ SeedIdentityResult ResolveSeedIdentity(
         return r;
     }
 
-    r.decision = SeedIdentityDecision::REGISTER;
+    // Identity is valid for this seed slot. H-3: fold in ASN-DB state LAST — a
+    // valid identity with the ASN DB down has zero attestation capacity, so it
+    // DEGRADES (stay online, don't register, loud + diagnosable) rather than
+    // registering. A trust failure (FATAL_MISMATCH above) is never reached here,
+    // so ASN state can only ever soften a would-be REGISTER, never a FATAL.
     r.seedId = seedId;
+    r.decision = asnLoaded ? SeedIdentityDecision::REGISTER
+                           : SeedIdentityDecision::DEGRADED_NO_ASN;
     return r;
 }
 

--- a/src/attestation/seed_attestation.cpp
+++ b/src/attestation/seed_attestation.cpp
@@ -182,8 +182,26 @@ SeedIdentityResult ResolveSeedIdentity(
     const std::vector<std::vector<uint8_t>>& seedPubkeys,
     const std::string& externalIp,
     const std::vector<uint8_t>& loadedPubkey,
-    bool asnLoaded) {
+    bool asnLoaded,
+    bool datacenterBanChain,
+    bool datacenterListLoaded) {
     SeedIdentityResult r;
+
+    // Final disposition for a would-be REGISTER (valid identity). Folds the
+    // availability dependencies LAST and in the documented order: a down ASN DB
+    // degrades first (DEGRADED_NO_ASN — no attestation capacity at all), then a
+    // ban-chain-with-empty-datacenter-list degrades
+    // (DEGRADED_NO_DATACENTER_LIST — IsDatacenterIP() would fail open and let
+    // datacenter miners through the Sybil ban). On a non-ban chain (DIL) the
+    // datacenter condition is inert, so the result is REGISTER unchanged. Each can
+    // only SOFTEN a REGISTER; this helper is only ever reached after
+    // FATAL_MISMATCH / SKIP_NOT_A_SEED have already been ruled out.
+    auto registerOrDegrade = [&]() -> SeedIdentityDecision {
+        if (!asnLoaded) return SeedIdentityDecision::DEGRADED_NO_ASN;
+        if (datacenterBanChain && !datacenterListLoaded)
+            return SeedIdentityDecision::DEGRADED_NO_DATACENTER_LIST;
+        return SeedIdentityDecision::REGISTER;
+    };
 
     // Resolve seedId by matching our normalized --externalip against the known
     // seed IPs. seedAttestationIPs[i] and seedAttestationPubkeys[i] are
@@ -212,11 +230,11 @@ SeedIdentityResult ResolveSeedIdentity(
         } else {
             r.seedId = seedId;
         }
-        // H-3: a valid (testnet) identity that would register, but with the ASN
-        // DB down, has zero attestation capacity -> DEGRADED (stay online, don't
-        // register, make the state loud + diagnosable). Otherwise REGISTER.
-        r.decision = asnLoaded ? SeedIdentityDecision::REGISTER
-                               : SeedIdentityDecision::DEGRADED_NO_ASN;
+        // H-3 + Fix 1: a valid (testnet) identity that would register degrades if
+        // the ASN DB is down, or (on a ban chain) if the datacenter list is empty.
+        // Otherwise REGISTER. (Testnet typically runs DIL-shaped non-ban params, so
+        // the datacenter condition is normally inert here.)
+        r.decision = registerOrDegrade();
         return r;
     }
 
@@ -243,14 +261,14 @@ SeedIdentityResult ResolveSeedIdentity(
         return r;
     }
 
-    // Identity is valid for this seed slot. H-3: fold in ASN-DB state LAST — a
-    // valid identity with the ASN DB down has zero attestation capacity, so it
-    // DEGRADES (stay online, don't register, loud + diagnosable) rather than
-    // registering. A trust failure (FATAL_MISMATCH above) is never reached here,
-    // so ASN state can only ever soften a would-be REGISTER, never a FATAL.
+    // Identity is valid for this seed slot. H-3 + Fix 1: fold the availability
+    // dependencies in LAST — a valid identity with the ASN DB down, or (on a ban
+    // chain) with an empty datacenter list, DEGRADES (stay online, don't register,
+    // loud + diagnosable) rather than registering. A trust failure (FATAL_MISMATCH
+    // above) is never reached here, so these can only ever soften a would-be
+    // REGISTER, never a FATAL.
     r.seedId = seedId;
-    r.decision = asnLoaded ? SeedIdentityDecision::REGISTER
-                           : SeedIdentityDecision::DEGRADED_NO_ASN;
+    r.decision = registerOrDegrade();
     return r;
 }
 

--- a/src/attestation/seed_attestation.cpp
+++ b/src/attestation/seed_attestation.cpp
@@ -7,6 +7,7 @@
 #include <wallet/crypter.h>  // For memory_cleanse() + CCrypter/DeriveKey (LP-13 encrypt-at-rest)
 
 #include <algorithm>
+#include <cctype>  // Finding C: std::tolower for IPv6 case canonicalization
 #include <cerrno>
 #include <cstdlib>
 #include <cstring>
@@ -116,28 +117,49 @@ bool SeedKeyFilePresent(const std::string& dataDir) {
 // LP-13 M-1/M-2 SEED-IDENTITY RESOLUTION (HIGH-1 / HIGH-2 fold)
 // ============================================================================
 
+// Finding C (extreview PR#121): lowercase an IPv6 literal so case-variant input
+// (e.g. "2001:DB8::1") canonicalizes to the configured form. Hex digits and the
+// ':' separator are the only characters in a textual IPv6 literal; lowercasing
+// is safe and idempotent. The configured seed set is IPv4-only today, so this is
+// forward-compat for when an IPv6 seed is added — it never affects IPv4 matching.
+static std::string LowercaseIPv6(std::string s) {
+    std::transform(s.begin(), s.end(), s.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    return s;
+}
+
 std::string NormalizeExternalIpForSeedMatch(const std::string& externalIp) {
     // 1) Trim surrounding whitespace (HIGH-2: quoting/templating artifacts).
+    //    Finding C: also collapse/strip any INTERIOR whitespace — a textual IP
+    //    literal (v4 or v6) never legitimately contains spaces/tabs, so removing
+    //    them lets "138.197. 68.128" or "[ 2001:db8::1 ]" style artifacts resolve
+    //    rather than silently SKIP. (Trailing-dot and case are handled below.)
     size_t b = externalIp.find_first_not_of(" \t\r\n");
     if (b == std::string::npos) return std::string();
     size_t e = externalIp.find_last_not_of(" \t\r\n");
     std::string s = externalIp.substr(b, e - b + 1);
+    s.erase(std::remove_if(s.begin(), s.end(),
+                           [](unsigned char c) { return c == ' ' || c == '\t' ||
+                                                        c == '\r' || c == '\n'; }),
+            s.end());
+    if (s.empty()) return std::string();
 
     // 2) IPv6 handling — do NOT strip on a raw IPv6 literal (it contains
     //    colons legitimately). Bracketed form "[addr]" or "[addr]:port" keeps
     //    the address inside the brackets; a bare value with >1 colon is treated
     //    as IPv6 and returned trimmed-only. The configured seed set is IPv4-only,
     //    so an IPv6 externalip simply fails to match -> SKIP_NOT_A_SEED, never a
-    //    false FATAL.
+    //    false FATAL. Finding C: lowercase the IPv6 result for case-insensitive
+    //    match (IPv6 hex digits are case-insensitive per RFC 5952).
     if (!s.empty() && s.front() == '[') {
         size_t rb = s.find(']');
         if (rb != std::string::npos) {
-            return s.substr(1, rb - 1);  // inside brackets, drop any ":port"
+            return LowercaseIPv6(s.substr(1, rb - 1));  // inside brackets, drop any ":port"
         }
-        return s;  // malformed; leave as-is (won't match IPv4 set)
+        return LowercaseIPv6(s);  // malformed; leave as-is (won't match IPv4 set)
     }
     if (std::count(s.begin(), s.end(), ':') > 1) {
-        return s;  // bare IPv6 literal; trimmed only, no port strip
+        return LowercaseIPv6(s);  // bare IPv6 literal; lowercased, no port strip
     }
 
     // 3) IPv4 / hostname: strip a single trailing ":port" suffix
@@ -145,6 +167,12 @@ std::string NormalizeExternalIpForSeedMatch(const std::string& externalIp) {
     size_t colon = s.find(':');
     if (colon != std::string::npos) {
         s = s.substr(0, colon);
+    }
+    // Finding C: strip a single trailing dot (a fully-qualified DNS name like
+    // "seed.example.com." or a dotted-quad written "138.197.68.128." is valid but
+    // would not string-equal the configured form). One trailing dot only.
+    if (!s.empty() && s.back() == '.') {
+        s.pop_back();
     }
     return s;
 }

--- a/src/attestation/seed_attestation.h
+++ b/src/attestation/seed_attestation.h
@@ -95,6 +95,73 @@ void CleanseSeedKeyBuffer(std::vector<uint8_t>& buf);
  *  startup. Both node binaries call this to classify a LoadOrGenerate failure. */
 bool SeedKeyFilePresent(const std::string& dataDir);
 
+// ============================================================================
+// LP-13 M-1/M-2 SEED-IDENTITY RESOLUTION (fail-loud, pure helper)
+// ============================================================================
+
+/**
+ * Disposition of the startup seed-identity check. The node glue (both
+ * dilithion-node and dilv-node) factors its resolve+validate decision into
+ * ResolveSeedIdentity() so the load-bearing FATAL/SKIP/REGISTER glue is unit
+ * testable independently of process startup (the prior test exercised only the
+ * pubkey-equality PRIMITIVE, not this decision).
+ */
+enum class SeedIdentityDecision {
+    // Proceed: register as an attestation seed under .seedId.
+    //  - mainnet: externalip resolved to a configured seed AND the loaded key's
+    //    pubkey matches seedAttestationPubkeys[seedId].
+    //  - testnet (empty pubkey set): no consensus pubkey to enforce; seedId is
+    //    the resolved index, or the lenient default 0 when unresolved
+    //    (.usedTestnetDefault is set so the caller can emit the legacy WARN).
+    REGISTER,
+    // HIGH-1 fix: a configured seed set IS present but this node's externalip
+    // matches NO configured seed slot. This is NOT a seed (e.g. a third-party
+    // --public-api explorer/exchange/former-seed that merely carries a key
+    // file). Do NOT abort and do NOT register: a non-seed's attestations are
+    // rejected by consensus anyway, so skipping is the correct, available
+    // behavior (zero security loss). Caller logs a clear WARN and continues.
+    SKIP_NOT_A_SEED,
+    // Genuine misconfiguration: a configured seed set is present AND externalip
+    // resolved to a real seed slot, but the loaded/minted key's pubkey does NOT
+    // match seedAttestationPubkeys[seedId] (or the index is out of range). This
+    // key cannot produce consensus-accepted attestations for this seed_id —
+    // fail loud (caller returns 1).
+    FATAL_MISMATCH,
+};
+
+struct SeedIdentityResult {
+    SeedIdentityDecision decision;
+    int seedId = -1;            // resolved index (REGISTER), or -1 (SKIP)
+    bool usedTestnetDefault = false;  // testnet, unresolved -> defaulted to 0
+};
+
+/**
+ * Normalize a user-supplied --externalip value for comparison against the bare
+ * dotted-quad strings in chainparams (HIGH-2 fix). Strips surrounding
+ * whitespace and a trailing ":port" suffix for IPv4 / hostnames. IPv6 literals
+ * (which legitimately contain colons) are left intact: a bracketed "[..]:port"
+ * form keeps the address inside the brackets, and a bare "::"-containing value
+ * is returned trimmed-only (port stripping on raw IPv6 is ambiguous and the
+ * configured seed set is IPv4-only, so an IPv6 externalip simply won't match —
+ * which correctly routes to SKIP_NOT_A_SEED, never a false FATAL).
+ */
+std::string NormalizeExternalIpForSeedMatch(const std::string& externalIp);
+
+/**
+ * Pure resolve+validate decision for the seed-attestation startup glue.
+ *
+ * @param seedIPs       chainparams seedAttestationIPs (index-aligned w/ pubkeys)
+ * @param seedPubkeys   chainparams seedAttestationPubkeys (empty => testnet)
+ * @param externalIp    raw --externalip value (normalized internally)
+ * @param loadedPubkey  the loaded/minted key's GetPubKey()
+ * @return decision + resolved seedId; see SeedIdentityDecision.
+ */
+SeedIdentityResult ResolveSeedIdentity(
+    const std::vector<std::string>& seedIPs,
+    const std::vector<std::vector<uint8_t>>& seedPubkeys,
+    const std::string& externalIp,
+    const std::vector<uint8_t>& loadedPubkey);
+
 /** LP-13 H-2 (atomic-save) TEST SEAM. When set to a non-null function, Save()
  *  invokes it immediately after the temp file has been fully written + fsynced
  *  but BEFORE the atomic rename over the target. If the hook returns true, Save

--- a/src/attestation/seed_attestation.h
+++ b/src/attestation/seed_attestation.h
@@ -145,6 +145,24 @@ enum class SeedIdentityDecision {
     // Net: relay stays up, attestation stays UNregistered, the degraded state is
     // loud at startup AND queryable at the RPC.
     DEGRADED_NO_ASN,
+    // Datacenter-over-attestation gate (extreview PR#121 Fix 1): on a chain whose
+    // consensus BANS datacenter miners (DilV: attestationDatacenterBan==true), the
+    // datacenter-IP refusal is enforced by IsDatacenterIP(), which consults the
+    // datacenter-ASN set. If that set is EMPTY (DatacenterASNCount()==0) — e.g. a
+    // missing/unparseable datacenter-asns.txt after a data-dir rotation —
+    // IsDatacenterIP() fails OPEN (always false), so the seed would REGISTER and
+    // then sign attestations for datacenter miners it is required to reject. That
+    // silently defeats the datacenter Sybil ban while the seed looks healthy.
+    // Like DEGRADED_NO_ASN, this is NEITHER fatal NOR a silent skip: the node
+    // stays ONLINE for relay/P2P but does NOT register attestation (so it never
+    // hands out an under-defended attestation), and the state is loud at startup
+    // and queryable at getmikattestation. Folded LAST, exactly where asnLoaded is:
+    // it can only soften a would-be REGISTER, never override FATAL_MISMATCH (trust
+    // failure stays fatal) or SKIP_NOT_A_SEED (a non-seed has nothing to register).
+    // INERT on a non-ban chain (DIL: attestationDatacenterBan==false) — there the
+    // datacenter list is not a consensus input, so a missing list never demotes a
+    // would-be REGISTER.
+    DEGRADED_NO_DATACENTER_LIST,
 };
 
 struct SeedIdentityResult {
@@ -181,14 +199,27 @@ std::string NormalizeExternalIpForSeedMatch(const std::string& externalIp);
  * @param externalIp    raw --externalip value (normalized internally)
  * @param loadedPubkey  the loaded/minted key's GetPubKey()
  * @param asnLoaded     whether the ASN database loaded (asnDatabase.IsLoaded())
+ * @param datacenterBanChain   this chain bans datacenter miners
+ *        (g_chainParams->attestationDatacenterBan; DilV true, DIL false)
+ * @param datacenterListLoaded the datacenter-ASN set is non-empty
+ *        (asnDatabase.DatacenterASNCount() > 0)
  * @return decision + resolved seedId; see SeedIdentityDecision.
+ *
+ * Fold order for a would-be REGISTER (each can only SOFTEN, never override a
+ * FATAL_MISMATCH or SKIP_NOT_A_SEED): asnLoaded first (DEGRADED_NO_ASN), then
+ * datacenterBanChain && !datacenterListLoaded (DEGRADED_NO_DATACENTER_LIST). A
+ * down ASN DB is reported before a missing datacenter list because the ASN DB is
+ * the harder dependency (no attestation at all without it), but either alone is
+ * enough to withhold registration on a ban chain.
  */
 SeedIdentityResult ResolveSeedIdentity(
     const std::vector<std::string>& seedIPs,
     const std::vector<std::vector<uint8_t>>& seedPubkeys,
     const std::string& externalIp,
     const std::vector<uint8_t>& loadedPubkey,
-    bool asnLoaded);
+    bool asnLoaded,
+    bool datacenterBanChain,
+    bool datacenterListLoaded);
 
 /** LP-13 H-2 (atomic-save) TEST SEAM. When set to a non-null function, Save()
  *  invokes it immediately after the temp file has been fully written + fsynced

--- a/src/attestation/seed_attestation.h
+++ b/src/attestation/seed_attestation.h
@@ -127,6 +127,24 @@ enum class SeedIdentityDecision {
     // key cannot produce consensus-accepted attestations for this seed_id —
     // fail loud (caller returns 1).
     FATAL_MISMATCH,
+    // H-3 (consolidated): this node WOULD register (identity is valid — either a
+    // mainnet seed whose key matches its slot, or a testnet seed), but the ASN
+    // database failed to load, so RegisterSeedAttestation cannot run and the seed
+    // has ZERO attestation capacity. This is NEITHER fatal NOR a silent skip:
+    //  - NOT fatal (the rejected H-3 over-correction): an ASN failure only
+    //    disables ATTESTATION; aborting would also take relay/P2P/--public-api
+    //    offline. On the known ASN-file-lost-on-rotation incident, with a
+    //    3-of-4 zero-spare quorum, that bricks a live seed for an attestation-only
+    //    fault. So the node stays ONLINE.
+    //  - NOT a silent skip (the original H-3 target bug): the seed would start
+    //    "healthy" with a loaded key yet serve zero attestation capacity, and
+    //    getmikattestation would return only the generic "only available on seed
+    //    nodes". So the caller logs a LOUD persistent ERROR and registers a
+    //    DEGRADED marker that makes getmikattestation return a DISTINCT,
+    //    diagnosable "ASN database not loaded" error.
+    // Net: relay stays up, attestation stays UNregistered, the degraded state is
+    // loud at startup AND queryable at the RPC.
+    DEGRADED_NO_ASN,
 };
 
 struct SeedIdentityResult {
@@ -150,17 +168,27 @@ std::string NormalizeExternalIpForSeedMatch(const std::string& externalIp);
 /**
  * Pure resolve+validate decision for the seed-attestation startup glue.
  *
+ * The decision is the FINAL 4-way disposition the node-startup glue dispatches
+ * on (REGISTER / SKIP_NOT_A_SEED / FATAL_MISMATCH / DEGRADED_NO_ASN), so the
+ * whole decision — including the ASN-DB-failure degradation — is unit-testable
+ * in one place. asnLoaded folds in last: it can only turn a would-be REGISTER
+ * into DEGRADED_NO_ASN; it never overrides FATAL_MISMATCH (a trust failure
+ * stays fatal regardless of ASN state) or SKIP_NOT_A_SEED (a non-seed has
+ * nothing to register, ASN-loaded or not).
+ *
  * @param seedIPs       chainparams seedAttestationIPs (index-aligned w/ pubkeys)
  * @param seedPubkeys   chainparams seedAttestationPubkeys (empty => testnet)
  * @param externalIp    raw --externalip value (normalized internally)
  * @param loadedPubkey  the loaded/minted key's GetPubKey()
+ * @param asnLoaded     whether the ASN database loaded (asnDatabase.IsLoaded())
  * @return decision + resolved seedId; see SeedIdentityDecision.
  */
 SeedIdentityResult ResolveSeedIdentity(
     const std::vector<std::string>& seedIPs,
     const std::vector<std::vector<uint8_t>>& seedPubkeys,
     const std::string& externalIp,
-    const std::vector<uint8_t>& loadedPubkey);
+    const std::vector<uint8_t>& loadedPubkey,
+    bool asnLoaded);
 
 /** LP-13 H-2 (atomic-save) TEST SEAM. When set to a non-null function, Save()
  *  invokes it immediately after the temp file has been fully written + fsynced

--- a/src/node/dilithion-node.cpp
+++ b/src/node/dilithion-node.cpp
@@ -7084,61 +7084,59 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                 std::cerr << "[Attestation] No seed attestation key and minting not requested; "
                              "this relay will not serve attestations." << std::endl;
             } else {
-                // Determine seed ID by matching our --externalip against the known
-                // seed IPs. seedAttestationIPs[i] and seedAttestationPubkeys[i] are
-                // index-aligned (same NYC/London/Singapore/Sydney order), so the
-                // resolved seedId is also the index into the consensus pubkey set.
-                int seedId = -1;
+                // M-1/M-2 (seed key-identity validation, fail-LOUD) + HIGH-1/HIGH-2
+                // fold. Resolve our --externalip to a seed_id and decide the
+                // disposition. seedAttestationIPs[i] and seedAttestationPubkeys[i]
+                // are index-aligned (NYC/London/Singapore/Sydney), so a resolved
+                // index is also the index into the consensus pubkey set. The
+                // resolve+validate decision is a pure, unit-tested helper
+                // (ResolveSeedIdentity) so the FATAL/SKIP/REGISTER glue is covered
+                // by tests, not only the pubkey-equality primitive.
                 const auto& seedIPs = Dilithion::g_chainParams->seedAttestationIPs;
                 const auto& seedPubkeys = Dilithion::g_chainParams->seedAttestationPubkeys;
-                if (!config.external_ip.empty()) {
-                    for (size_t i = 0; i < seedIPs.size(); i++) {
-                        if (seedIPs[i] == config.external_ip) {
-                            seedId = static_cast<int>(i);
-                            break;
-                        }
-                    }
-                }
+                Attestation::SeedIdentityResult ident = Attestation::ResolveSeedIdentity(
+                    seedIPs, seedPubkeys, config.external_ip, seedAttestKey.GetPubKey());
 
-                // M-1/M-2 (seed key-identity validation, fail-LOUD): only enforced
-                // when a known seed set is configured (seedAttestationPubkeys
-                // non-empty — i.e. mainnet/DIL, not the empty-set testnet config).
-                // For a configured seed set we MUST NOT silently default seedId to 0
-                // (M-2) and MUST NOT register a key whose pubkey does not match the
-                // consensus pubkey for the resolved seedId (M-1) — either case makes
-                // the seed sign attestations that consensus rejects while the node
-                // looks healthy. Abort startup, matching the FATAL idiom the
-                // key-init failure above already uses (return 1).
-                if (!seedPubkeys.empty()) {
-                    if (seedId < 0) {
-                        std::cerr << "[Attestation] FATAL: could not resolve this seed's seed_id "
-                                     "from --externalip against the known seed set. Refusing to "
-                                     "act as a seed with an unknown/defaulted index (would sign "
-                                     "attestations consensus rejects). Set --externalip=<IP> to "
-                                     "this seed's configured public IP. Aborting startup." << std::endl;
-                        return 1;
-                    }
-                    if (static_cast<size_t>(seedId) >= seedPubkeys.size() ||
-                        seedAttestKey.GetPubKey() != seedPubkeys[seedId]) {
+                bool registerSeed = false;
+                switch (ident.decision) {
+                    case Attestation::SeedIdentityDecision::FATAL_MISMATCH:
+                        // Genuine misconfig: externalip resolved to a real seed slot
+                        // but the loaded/minted key's pubkey does NOT match
+                        // seedAttestationPubkeys[seed_id]. This key cannot produce
+                        // attestations consensus accepts for this seed_id. Fail loud.
                         std::cerr << "[Attestation] FATAL: loaded/minted seed key pubkey does NOT "
-                                     "match seedAttestationPubkeys[" << seedId << "] for the resolved "
-                                     "seed_id. This key cannot produce attestations consensus accepts "
-                                     "for this seed_id (wrong key file, wrong seed_id, or a minted key "
-                                     "not registered in chainparams). Aborting startup." << std::endl;
+                                     "match seedAttestationPubkeys[" << ident.seedId << "] for the "
+                                     "resolved seed_id. This key cannot produce attestations consensus "
+                                     "accepts for this seed_id (wrong key file, wrong seed_id, or a "
+                                     "minted key not registered in chainparams). Aborting startup."
+                                  << std::endl;
                         return 1;
-                    }
-                } else if (seedId < 0) {
-                    // No configured seed set (testnet): no consensus pubkey to match
-                    // against. Preserve the prior lenient behavior — default index 0,
-                    // warn only. There is no attestation correctness to enforce here.
-                    seedId = 0;
-                    std::cerr << "[Attestation] WARNING: Could not determine seed ID "
-                                 "(no configured seed set). Defaulting to seed_id=0" << std::endl;
+                    case Attestation::SeedIdentityDecision::SKIP_NOT_A_SEED:
+                        // HIGH-1 fix: a configured seed set is present but this node's
+                        // --externalip matches no configured seed slot. This node is
+                        // NOT one of the seeds (e.g. a third-party --public-api
+                        // explorer/exchange/former-seed that merely carries a key
+                        // file). Do NOT register and do NOT abort — a non-seed's
+                        // attestations are rejected by consensus anyway, so skipping
+                        // is correct and keeps the node available (zero security loss).
+                        std::cerr << "[Attestation] WARNING: this node's --externalip does not match a "
+                                     "configured seed; not registering as an attestation seed "
+                                     "(continuing to run normally). Set --externalip=<this seed's "
+                                     "configured public IP> only if this node IS one of the seeds."
+                                  << std::endl;
+                        break;
+                    case Attestation::SeedIdentityDecision::REGISTER:
+                        if (ident.usedTestnetDefault) {
+                            std::cerr << "[Attestation] WARNING: Could not determine seed ID "
+                                         "(no configured seed set). Defaulting to seed_id=0" << std::endl;
+                        }
+                        registerSeed = true;
+                        break;
                 }
 
-                if (asnDatabase.IsLoaded()) {
-                    rpc_server.RegisterSeedAttestation(&seedAttestKey, &asnDatabase, seedId);
-                    std::cout << "  [OK] Seed attestation ready (seed_id=" << seedId
+                if (registerSeed && asnDatabase.IsLoaded()) {
+                    rpc_server.RegisterSeedAttestation(&seedAttestKey, &asnDatabase, ident.seedId);
+                    std::cout << "  [OK] Seed attestation ready (seed_id=" << ident.seedId
                               << ", key=" << seedAttestKey.GetPubKeyHex().substr(0, 16) << "...)"
                               << std::endl;
                 }

--- a/src/node/dilithion-node.cpp
+++ b/src/node/dilithion-node.cpp
@@ -7039,29 +7039,20 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
             }
 
             if (asnDatabase.IsLoaded()) {
-                // Finding B (extreview PR#121): the datacenter ASN list is a
+                // Finding B + Fix 1 (extreview PR#121): the datacenter ASN list is a
                 // SEPARATE defense from attestation capacity — it powers the
-                // datacenter-IP Sybil ban, not MIK signing. A load failure here
-                // must NOT be silently swallowed: an empty datacenter set makes
-                // IsDatacenterIP() fail-open (always false), so the Sybil ban is
-                // silently OFF while the seed still REGISTERs healthy. Judgment
-                // (documented): this does NOT gate DEGRADED — datacenter-ban !=
-                // attestation capacity, so we keep attesting — but the failure is
-                // surfaced as a LOUD persistent ERROR with operator guidance so an
-                // operator notices the dropped defense (mirrors the ip2asn-v4.tsv
-                // loud treatment this PR added for the attestation side).
+                // datacenter-IP Sybil ban via IsDatacenterIP(). An EMPTY datacenter
+                // set makes IsDatacenterIP() fail OPEN (always false). On a
+                // datacenter-ban chain a seed would then sign attestations for
+                // datacenter miners it must reject; the gate folded into
+                // ResolveSeedIdentity below DEGRADES that case instead. DIL is a
+                // NON-ban chain (attestationDatacenterBan==false), so the datacenter
+                // list is not a consensus input here and a missing list is inert —
+                // the gate never demotes a DIL seed. We load the list (no-op effect
+                // on DIL) and let ResolveSeedIdentity decide.
                 std::string dcPath = dataDir + "/datacenter-asns.txt";
                 if (!asnDatabase.LoadDatacenterList(dcPath)) {
                     asnDatabase.LoadDatacenterList("datacenter-asns.txt");
-                }
-                if (asnDatabase.DatacenterASNCount() == 0) {
-                    std::cerr << "[Attestation] ERROR: datacenter ASN list FAILED to load or is empty "
-                                 "(missing/unparseable " << dataDir << "/datacenter-asns.txt or "
-                                 "./datacenter-asns.txt). The datacenter-IP Sybil ban is DISABLED "
-                                 "(IsDatacenterIP fails open) — datacenter-hosted miners will NOT be "
-                                 "refused MIK attestation. Attestation itself continues normally. "
-                                 "Restore datacenter-asns.txt (e.g. after a data-dir rotation) and "
-                                 "restart to re-enable the datacenter Sybil ban." << std::endl;
                 }
                 std::cout << "  [OK] ASN database loaded (" << asnDatabase.RangeCount()
                           << " ranges, " << asnDatabase.DatacenterASNCount()
@@ -7114,9 +7105,15 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                 // by tests, not only the pubkey-equality primitive.
                 const auto& seedIPs = Dilithion::g_chainParams->seedAttestationIPs;
                 const auto& seedPubkeys = Dilithion::g_chainParams->seedAttestationPubkeys;
+                // Fix 1: pass the datacenter-ban chain flag and whether the
+                // datacenter ASN list actually loaded. On DIL (non-ban) the flag is
+                // false, so this is inert and a DIL seed REGISTERs on identity match
+                // exactly as before.
                 Attestation::SeedIdentityResult ident = Attestation::ResolveSeedIdentity(
                     seedIPs, seedPubkeys, config.external_ip, seedAttestKey.GetPubKey(),
-                    asnDatabase.IsLoaded());
+                    asnDatabase.IsLoaded(),
+                    Dilithion::g_chainParams->attestationDatacenterBan,
+                    asnDatabase.DatacenterASNCount() > 0);
 
                 bool registerSeed = false;
                 switch (ident.decision) {
@@ -7165,7 +7162,31 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                                      "\"ASN database not loaded\". The node continues to run for "
                                      "relay/P2P. Fix ip2asn-v4.tsv (e.g. restore after a data-dir "
                                      "rotation) and restart to restore attestation." << std::endl;
-                        rpc_server.RegisterSeedAttestationDegraded(ident.seedId);
+                        rpc_server.RegisterSeedAttestationDegraded(
+                            ident.seedId, CRPCServer::SeedDegradedReason::NO_ASN);
+                        break;
+                    case Attestation::SeedIdentityDecision::DEGRADED_NO_DATACENTER_LIST:
+                        // Fix 1 (extreview PR#121): valid identity, ASN DB loaded,
+                        // but a datacenter-ban chain with an EMPTY datacenter ASN list
+                        // (IsDatacenterIP would fail OPEN). Mirror DEGRADED_NO_ASN: do
+                        // NOT abort, do NOT register attestation, loud ERROR, distinct
+                        // diagnosable marker. INERT on DIL (non-ban) — this case is
+                        // unreachable there because ResolveSeedIdentity never returns
+                        // it when attestationDatacenterBan==false; present for parity
+                        // with dilv-node so the two glues stay identical.
+                        std::cerr << "[Attestation] ERROR: seed identity is valid (seed_id="
+                                  << ident.seedId << ") and ip2asn loaded, but the datacenter "
+                                     "ASN list is EMPTY on a datacenter-ban chain "
+                                     "(missing/unparseable " << dataDir << "/datacenter-asns.txt "
+                                     "or ./datacenter-asns.txt). IsDatacenterIP() would fail OPEN, "
+                                     "so attestation is DISABLED rather than sign attestations for "
+                                     "datacenter miners that the datacenter Sybil ban must reject. "
+                                     "getmikattestation will report \"datacenter ASN list not "
+                                     "loaded\". The node continues to run for relay/P2P. Restore "
+                                     "datacenter-asns.txt (e.g. after a data-dir rotation) and "
+                                     "restart to restore attestation." << std::endl;
+                        rpc_server.RegisterSeedAttestationDegraded(
+                            ident.seedId, CRPCServer::SeedDegradedReason::NO_DATACENTER_LIST);
                         break;
                     case Attestation::SeedIdentityDecision::REGISTER:
                         if (ident.usedTestnetDefault) {

--- a/src/node/dilithion-node.cpp
+++ b/src/node/dilithion-node.cpp
@@ -7084,8 +7084,13 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                 std::cerr << "[Attestation] No seed attestation key and minting not requested; "
                              "this relay will not serve attestations." << std::endl;
             } else {
+                // Determine seed ID by matching our --externalip against the known
+                // seed IPs. seedAttestationIPs[i] and seedAttestationPubkeys[i] are
+                // index-aligned (same NYC/London/Singapore/Sydney order), so the
+                // resolved seedId is also the index into the consensus pubkey set.
                 int seedId = -1;
                 const auto& seedIPs = Dilithion::g_chainParams->seedAttestationIPs;
+                const auto& seedPubkeys = Dilithion::g_chainParams->seedAttestationPubkeys;
                 if (!config.external_ip.empty()) {
                     for (size_t i = 0; i < seedIPs.size(); i++) {
                         if (seedIPs[i] == config.external_ip) {
@@ -7094,10 +7099,41 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                         }
                     }
                 }
-                if (seedId < 0) {
+
+                // M-1/M-2 (seed key-identity validation, fail-LOUD): only enforced
+                // when a known seed set is configured (seedAttestationPubkeys
+                // non-empty — i.e. mainnet/DIL, not the empty-set testnet config).
+                // For a configured seed set we MUST NOT silently default seedId to 0
+                // (M-2) and MUST NOT register a key whose pubkey does not match the
+                // consensus pubkey for the resolved seedId (M-1) — either case makes
+                // the seed sign attestations that consensus rejects while the node
+                // looks healthy. Abort startup, matching the FATAL idiom the
+                // key-init failure above already uses (return 1).
+                if (!seedPubkeys.empty()) {
+                    if (seedId < 0) {
+                        std::cerr << "[Attestation] FATAL: could not resolve this seed's seed_id "
+                                     "from --externalip against the known seed set. Refusing to "
+                                     "act as a seed with an unknown/defaulted index (would sign "
+                                     "attestations consensus rejects). Set --externalip=<IP> to "
+                                     "this seed's configured public IP. Aborting startup." << std::endl;
+                        return 1;
+                    }
+                    if (static_cast<size_t>(seedId) >= seedPubkeys.size() ||
+                        seedAttestKey.GetPubKey() != seedPubkeys[seedId]) {
+                        std::cerr << "[Attestation] FATAL: loaded/minted seed key pubkey does NOT "
+                                     "match seedAttestationPubkeys[" << seedId << "] for the resolved "
+                                     "seed_id. This key cannot produce attestations consensus accepts "
+                                     "for this seed_id (wrong key file, wrong seed_id, or a minted key "
+                                     "not registered in chainparams). Aborting startup." << std::endl;
+                        return 1;
+                    }
+                } else if (seedId < 0) {
+                    // No configured seed set (testnet): no consensus pubkey to match
+                    // against. Preserve the prior lenient behavior — default index 0,
+                    // warn only. There is no attestation correctness to enforce here.
                     seedId = 0;
-                    std::cerr << "[Attestation] WARNING: Could not determine seed ID. "
-                              << "Use --externalip=<IP> to set. Defaulting to seed_id=0" << std::endl;
+                    std::cerr << "[Attestation] WARNING: Could not determine seed ID "
+                                 "(no configured seed set). Defaulting to seed_id=0" << std::endl;
                 }
 
                 if (asnDatabase.IsLoaded()) {

--- a/src/node/dilithion-node.cpp
+++ b/src/node/dilithion-node.cpp
@@ -7039,9 +7039,29 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
             }
 
             if (asnDatabase.IsLoaded()) {
+                // Finding B (extreview PR#121): the datacenter ASN list is a
+                // SEPARATE defense from attestation capacity — it powers the
+                // datacenter-IP Sybil ban, not MIK signing. A load failure here
+                // must NOT be silently swallowed: an empty datacenter set makes
+                // IsDatacenterIP() fail-open (always false), so the Sybil ban is
+                // silently OFF while the seed still REGISTERs healthy. Judgment
+                // (documented): this does NOT gate DEGRADED — datacenter-ban !=
+                // attestation capacity, so we keep attesting — but the failure is
+                // surfaced as a LOUD persistent ERROR with operator guidance so an
+                // operator notices the dropped defense (mirrors the ip2asn-v4.tsv
+                // loud treatment this PR added for the attestation side).
                 std::string dcPath = dataDir + "/datacenter-asns.txt";
                 if (!asnDatabase.LoadDatacenterList(dcPath)) {
                     asnDatabase.LoadDatacenterList("datacenter-asns.txt");
+                }
+                if (asnDatabase.DatacenterASNCount() == 0) {
+                    std::cerr << "[Attestation] ERROR: datacenter ASN list FAILED to load or is empty "
+                                 "(missing/unparseable " << dataDir << "/datacenter-asns.txt or "
+                                 "./datacenter-asns.txt). The datacenter-IP Sybil ban is DISABLED "
+                                 "(IsDatacenterIP fails open) — datacenter-hosted miners will NOT be "
+                                 "refused MIK attestation. Attestation itself continues normally. "
+                                 "Restore datacenter-asns.txt (e.g. after a data-dir rotation) and "
+                                 "restart to re-enable the datacenter Sybil ban." << std::endl;
                 }
                 std::cout << "  [OK] ASN database loaded (" << asnDatabase.RangeCount()
                           << " ranges, " << asnDatabase.DatacenterASNCount()

--- a/src/node/dilithion-node.cpp
+++ b/src/node/dilithion-node.cpp
@@ -7095,7 +7095,8 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                 const auto& seedIPs = Dilithion::g_chainParams->seedAttestationIPs;
                 const auto& seedPubkeys = Dilithion::g_chainParams->seedAttestationPubkeys;
                 Attestation::SeedIdentityResult ident = Attestation::ResolveSeedIdentity(
-                    seedIPs, seedPubkeys, config.external_ip, seedAttestKey.GetPubKey());
+                    seedIPs, seedPubkeys, config.external_ip, seedAttestKey.GetPubKey(),
+                    asnDatabase.IsLoaded());
 
                 bool registerSeed = false;
                 switch (ident.decision) {
@@ -7125,6 +7126,27 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                                      "configured public IP> only if this node IS one of the seeds."
                                   << std::endl;
                         break;
+                    case Attestation::SeedIdentityDecision::DEGRADED_NO_ASN:
+                        // H-3 (consolidated): identity is VALID for this seed, but the
+                        // ASN database failed to load -> zero attestation capacity.
+                        // Do NOT abort (that would take relay/P2P/--public-api offline
+                        // for an attestation-only fault — the rejected over-correction,
+                        // fatal on the known ASN-file-lost-on-rotation incident). Do NOT
+                        // silently skip (the original H-3 bug — a "healthy"-looking seed
+                        // with zero capacity). Instead: log a LOUD persistent ERROR with
+                        // operator guidance, keep the node ONLINE, leave attestation
+                        // UNregistered, and register a degraded marker so
+                        // getmikattestation returns a DISTINCT diagnosable error.
+                        std::cerr << "[Attestation] ERROR: seed identity is valid (seed_id="
+                                  << ident.seedId << ") but the ASN database FAILED to load "
+                                     "(missing/unparseable " << dataDir << "/ip2asn-v4.tsv or "
+                                     "./ip2asn-v4.tsv). Attestation is DISABLED — this seed has zero "
+                                     "attestation capacity and getmikattestation will report "
+                                     "\"ASN database not loaded\". The node continues to run for "
+                                     "relay/P2P. Fix ip2asn-v4.tsv (e.g. restore after a data-dir "
+                                     "rotation) and restart to restore attestation." << std::endl;
+                        rpc_server.RegisterSeedAttestationDegraded(ident.seedId);
+                        break;
                     case Attestation::SeedIdentityDecision::REGISTER:
                         if (ident.usedTestnetDefault) {
                             std::cerr << "[Attestation] WARNING: Could not determine seed ID "
@@ -7134,7 +7156,10 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                         break;
                 }
 
-                if (registerSeed && asnDatabase.IsLoaded()) {
+                // REGISTER already implies asnDatabase.IsLoaded() — the helper folds
+                // the ASN-DB state into the decision, routing a valid identity with a
+                // failed ASN DB to DEGRADED_NO_ASN above. So no extra IsLoaded() guard.
+                if (registerSeed) {
                     rpc_server.RegisterSeedAttestation(&seedAttestKey, &asnDatabase, ident.seedId);
                     std::cout << "  [OK] Seed attestation ready (seed_id=" << ident.seedId
                               << ", key=" << seedAttestKey.GetPubKeyHex().substr(0, 16) << "...)"

--- a/src/node/dilv-node.cpp
+++ b/src/node/dilv-node.cpp
@@ -6889,9 +6889,29 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
             }
 
             if (asnDatabase.IsLoaded()) {
+                // Finding B (extreview PR#121): the datacenter ASN list is a
+                // SEPARATE defense from attestation capacity — it powers the
+                // datacenter-IP Sybil ban, not MIK signing. A load failure here
+                // must NOT be silently swallowed: an empty datacenter set makes
+                // IsDatacenterIP() fail-open (always false), so the Sybil ban is
+                // silently OFF while the seed still REGISTERs healthy. Judgment
+                // (documented): this does NOT gate DEGRADED — datacenter-ban !=
+                // attestation capacity, so we keep attesting — but the failure is
+                // surfaced as a LOUD persistent ERROR with operator guidance so an
+                // operator notices the dropped defense (mirrors the ip2asn-v4.tsv
+                // loud treatment this PR added for the attestation side).
                 std::string dcPath = dataDir + "/datacenter-asns.txt";
                 if (!asnDatabase.LoadDatacenterList(dcPath)) {
                     asnDatabase.LoadDatacenterList("datacenter-asns.txt");
+                }
+                if (asnDatabase.DatacenterASNCount() == 0) {
+                    std::cerr << "[Attestation] ERROR: datacenter ASN list FAILED to load or is empty "
+                                 "(missing/unparseable " << dataDir << "/datacenter-asns.txt or "
+                                 "./datacenter-asns.txt). The datacenter-IP Sybil ban is DISABLED "
+                                 "(IsDatacenterIP fails open) — datacenter-hosted miners will NOT be "
+                                 "refused MIK attestation. Attestation itself continues normally. "
+                                 "Restore datacenter-asns.txt (e.g. after a data-dir rotation) and "
+                                 "restart to re-enable the datacenter Sybil ban." << std::endl;
                 }
                 std::cout << "  [OK] ASN database loaded (" << asnDatabase.RangeCount()
                           << " ranges, " << asnDatabase.DatacenterASNCount()

--- a/src/node/dilv-node.cpp
+++ b/src/node/dilv-node.cpp
@@ -6933,61 +6933,59 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                 std::cerr << "[Attestation] No seed attestation key and minting not requested; "
                              "this relay will not serve attestations." << std::endl;
             } else {
-                // Determine seed ID by matching our --externalip against the known
-                // seed IPs. seedAttestationIPs[i] and seedAttestationPubkeys[i] are
-                // index-aligned (same NYC/London/Singapore/Sydney order), so the
-                // resolved seedId is also the index into the consensus pubkey set.
-                int seedId = -1;
+                // M-1/M-2 (seed key-identity validation, fail-LOUD) + HIGH-1/HIGH-2
+                // fold. Resolve our --externalip to a seed_id and decide the
+                // disposition. seedAttestationIPs[i] and seedAttestationPubkeys[i]
+                // are index-aligned (NYC/London/Singapore/Sydney), so a resolved
+                // index is also the index into the consensus pubkey set. The
+                // resolve+validate decision is a pure, unit-tested helper
+                // (ResolveSeedIdentity) so the FATAL/SKIP/REGISTER glue is covered
+                // by tests, not only the pubkey-equality primitive.
                 const auto& seedIPs = Dilithion::g_chainParams->seedAttestationIPs;
                 const auto& seedPubkeys = Dilithion::g_chainParams->seedAttestationPubkeys;
-                if (!config.external_ip.empty()) {
-                    for (size_t i = 0; i < seedIPs.size(); i++) {
-                        if (seedIPs[i] == config.external_ip) {
-                            seedId = static_cast<int>(i);
-                            break;
-                        }
-                    }
-                }
+                Attestation::SeedIdentityResult ident = Attestation::ResolveSeedIdentity(
+                    seedIPs, seedPubkeys, config.external_ip, seedAttestKey.GetPubKey());
 
-                // M-1/M-2 (seed key-identity validation, fail-LOUD): only enforced
-                // when a known seed set is configured (seedAttestationPubkeys
-                // non-empty — i.e. mainnet/DIL, not the empty-set testnet config).
-                // For a configured seed set we MUST NOT silently default seedId to 0
-                // (M-2) and MUST NOT register a key whose pubkey does not match the
-                // consensus pubkey for the resolved seedId (M-1) — either case makes
-                // the seed sign attestations that consensus rejects while the node
-                // looks healthy. Abort startup, matching the FATAL idiom the
-                // key-init failure above already uses (return 1).
-                if (!seedPubkeys.empty()) {
-                    if (seedId < 0) {
-                        std::cerr << "[Attestation] FATAL: could not resolve this seed's seed_id "
-                                     "from --externalip against the known seed set. Refusing to "
-                                     "act as a seed with an unknown/defaulted index (would sign "
-                                     "attestations consensus rejects). Set --externalip=<IP> to "
-                                     "this seed's configured public IP. Aborting startup." << std::endl;
-                        return 1;
-                    }
-                    if (static_cast<size_t>(seedId) >= seedPubkeys.size() ||
-                        seedAttestKey.GetPubKey() != seedPubkeys[seedId]) {
+                bool registerSeed = false;
+                switch (ident.decision) {
+                    case Attestation::SeedIdentityDecision::FATAL_MISMATCH:
+                        // Genuine misconfig: externalip resolved to a real seed slot
+                        // but the loaded/minted key's pubkey does NOT match
+                        // seedAttestationPubkeys[seed_id]. This key cannot produce
+                        // attestations consensus accepts for this seed_id. Fail loud.
                         std::cerr << "[Attestation] FATAL: loaded/minted seed key pubkey does NOT "
-                                     "match seedAttestationPubkeys[" << seedId << "] for the resolved "
-                                     "seed_id. This key cannot produce attestations consensus accepts "
-                                     "for this seed_id (wrong key file, wrong seed_id, or a minted key "
-                                     "not registered in chainparams). Aborting startup." << std::endl;
+                                     "match seedAttestationPubkeys[" << ident.seedId << "] for the "
+                                     "resolved seed_id. This key cannot produce attestations consensus "
+                                     "accepts for this seed_id (wrong key file, wrong seed_id, or a "
+                                     "minted key not registered in chainparams). Aborting startup."
+                                  << std::endl;
                         return 1;
-                    }
-                } else if (seedId < 0) {
-                    // No configured seed set (testnet): no consensus pubkey to match
-                    // against. Preserve the prior lenient behavior — default index 0,
-                    // warn only. There is no attestation correctness to enforce here.
-                    seedId = 0;
-                    std::cerr << "[Attestation] WARNING: Could not determine seed ID "
-                                 "(no configured seed set). Defaulting to seed_id=0" << std::endl;
+                    case Attestation::SeedIdentityDecision::SKIP_NOT_A_SEED:
+                        // HIGH-1 fix: a configured seed set is present but this node's
+                        // --externalip matches no configured seed slot. This node is
+                        // NOT one of the seeds (e.g. a third-party --public-api
+                        // explorer/exchange/former-seed that merely carries a key
+                        // file). Do NOT register and do NOT abort — a non-seed's
+                        // attestations are rejected by consensus anyway, so skipping
+                        // is correct and keeps the node available (zero security loss).
+                        std::cerr << "[Attestation] WARNING: this node's --externalip does not match a "
+                                     "configured seed; not registering as an attestation seed "
+                                     "(continuing to run normally). Set --externalip=<this seed's "
+                                     "configured public IP> only if this node IS one of the seeds."
+                                  << std::endl;
+                        break;
+                    case Attestation::SeedIdentityDecision::REGISTER:
+                        if (ident.usedTestnetDefault) {
+                            std::cerr << "[Attestation] WARNING: Could not determine seed ID "
+                                         "(no configured seed set). Defaulting to seed_id=0" << std::endl;
+                        }
+                        registerSeed = true;
+                        break;
                 }
 
-                if (asnDatabase.IsLoaded()) {
-                    rpc_server.RegisterSeedAttestation(&seedAttestKey, &asnDatabase, seedId);
-                    std::cout << "  [OK] Seed attestation ready (seed_id=" << seedId
+                if (registerSeed && asnDatabase.IsLoaded()) {
+                    rpc_server.RegisterSeedAttestation(&seedAttestKey, &asnDatabase, ident.seedId);
+                    std::cout << "  [OK] Seed attestation ready (seed_id=" << ident.seedId
                               << ", key=" << seedAttestKey.GetPubKeyHex().substr(0, 16) << "...)"
                               << std::endl;
                 }

--- a/src/node/dilv-node.cpp
+++ b/src/node/dilv-node.cpp
@@ -6944,7 +6944,8 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                 const auto& seedIPs = Dilithion::g_chainParams->seedAttestationIPs;
                 const auto& seedPubkeys = Dilithion::g_chainParams->seedAttestationPubkeys;
                 Attestation::SeedIdentityResult ident = Attestation::ResolveSeedIdentity(
-                    seedIPs, seedPubkeys, config.external_ip, seedAttestKey.GetPubKey());
+                    seedIPs, seedPubkeys, config.external_ip, seedAttestKey.GetPubKey(),
+                    asnDatabase.IsLoaded());
 
                 bool registerSeed = false;
                 switch (ident.decision) {
@@ -6974,6 +6975,27 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                                      "configured public IP> only if this node IS one of the seeds."
                                   << std::endl;
                         break;
+                    case Attestation::SeedIdentityDecision::DEGRADED_NO_ASN:
+                        // H-3 (consolidated): identity is VALID for this seed, but the
+                        // ASN database failed to load -> zero attestation capacity.
+                        // Do NOT abort (that would take relay/P2P/--public-api offline
+                        // for an attestation-only fault — the rejected over-correction,
+                        // fatal on the known ASN-file-lost-on-rotation incident). Do NOT
+                        // silently skip (the original H-3 bug — a "healthy"-looking seed
+                        // with zero capacity). Instead: log a LOUD persistent ERROR with
+                        // operator guidance, keep the node ONLINE, leave attestation
+                        // UNregistered, and register a degraded marker so
+                        // getmikattestation returns a DISTINCT diagnosable error.
+                        std::cerr << "[Attestation] ERROR: seed identity is valid (seed_id="
+                                  << ident.seedId << ") but the ASN database FAILED to load "
+                                     "(missing/unparseable " << dataDir << "/ip2asn-v4.tsv or "
+                                     "./ip2asn-v4.tsv). Attestation is DISABLED — this seed has zero "
+                                     "attestation capacity and getmikattestation will report "
+                                     "\"ASN database not loaded\". The node continues to run for "
+                                     "relay/P2P. Fix ip2asn-v4.tsv (e.g. restore after a data-dir "
+                                     "rotation) and restart to restore attestation." << std::endl;
+                        rpc_server.RegisterSeedAttestationDegraded(ident.seedId);
+                        break;
                     case Attestation::SeedIdentityDecision::REGISTER:
                         if (ident.usedTestnetDefault) {
                             std::cerr << "[Attestation] WARNING: Could not determine seed ID "
@@ -6983,7 +7005,10 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                         break;
                 }
 
-                if (registerSeed && asnDatabase.IsLoaded()) {
+                // REGISTER already implies asnDatabase.IsLoaded() — the helper folds
+                // the ASN-DB state into the decision, routing a valid identity with a
+                // failed ASN DB to DEGRADED_NO_ASN above. So no extra IsLoaded() guard.
+                if (registerSeed) {
                     rpc_server.RegisterSeedAttestation(&seedAttestKey, &asnDatabase, ident.seedId);
                     std::cout << "  [OK] Seed attestation ready (seed_id=" << ident.seedId
                               << ", key=" << seedAttestKey.GetPubKeyHex().substr(0, 16) << "...)"

--- a/src/node/dilv-node.cpp
+++ b/src/node/dilv-node.cpp
@@ -6933,10 +6933,13 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                 std::cerr << "[Attestation] No seed attestation key and minting not requested; "
                              "this relay will not serve attestations." << std::endl;
             } else {
-                // Determine seed ID by matching our IP against known seed IPs
-                // For now, use a simple index. In production, compare external IP.
+                // Determine seed ID by matching our --externalip against the known
+                // seed IPs. seedAttestationIPs[i] and seedAttestationPubkeys[i] are
+                // index-aligned (same NYC/London/Singapore/Sydney order), so the
+                // resolved seedId is also the index into the consensus pubkey set.
                 int seedId = -1;
                 const auto& seedIPs = Dilithion::g_chainParams->seedAttestationIPs;
+                const auto& seedPubkeys = Dilithion::g_chainParams->seedAttestationPubkeys;
                 if (!config.external_ip.empty()) {
                     for (size_t i = 0; i < seedIPs.size(); i++) {
                         if (seedIPs[i] == config.external_ip) {
@@ -6945,14 +6948,41 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                         }
                     }
                 }
-                // Fallback: use --seed-id flag or auto-detect
-                // For testnet, just assign based on order of known IPs
-                if (seedId < 0) {
-                    // Try to auto-detect from the port number or IP binding
-                    // For now, default to 0 if not specified
+
+                // M-1/M-2 (seed key-identity validation, fail-LOUD): only enforced
+                // when a known seed set is configured (seedAttestationPubkeys
+                // non-empty — i.e. mainnet/DIL, not the empty-set testnet config).
+                // For a configured seed set we MUST NOT silently default seedId to 0
+                // (M-2) and MUST NOT register a key whose pubkey does not match the
+                // consensus pubkey for the resolved seedId (M-1) — either case makes
+                // the seed sign attestations that consensus rejects while the node
+                // looks healthy. Abort startup, matching the FATAL idiom the
+                // key-init failure above already uses (return 1).
+                if (!seedPubkeys.empty()) {
+                    if (seedId < 0) {
+                        std::cerr << "[Attestation] FATAL: could not resolve this seed's seed_id "
+                                     "from --externalip against the known seed set. Refusing to "
+                                     "act as a seed with an unknown/defaulted index (would sign "
+                                     "attestations consensus rejects). Set --externalip=<IP> to "
+                                     "this seed's configured public IP. Aborting startup." << std::endl;
+                        return 1;
+                    }
+                    if (static_cast<size_t>(seedId) >= seedPubkeys.size() ||
+                        seedAttestKey.GetPubKey() != seedPubkeys[seedId]) {
+                        std::cerr << "[Attestation] FATAL: loaded/minted seed key pubkey does NOT "
+                                     "match seedAttestationPubkeys[" << seedId << "] for the resolved "
+                                     "seed_id. This key cannot produce attestations consensus accepts "
+                                     "for this seed_id (wrong key file, wrong seed_id, or a minted key "
+                                     "not registered in chainparams). Aborting startup." << std::endl;
+                        return 1;
+                    }
+                } else if (seedId < 0) {
+                    // No configured seed set (testnet): no consensus pubkey to match
+                    // against. Preserve the prior lenient behavior — default index 0,
+                    // warn only. There is no attestation correctness to enforce here.
                     seedId = 0;
-                    std::cerr << "[Attestation] WARNING: Could not determine seed ID. "
-                              << "Use --externalip=<IP> to set. Defaulting to seed_id=0" << std::endl;
+                    std::cerr << "[Attestation] WARNING: Could not determine seed ID "
+                                 "(no configured seed set). Defaulting to seed_id=0" << std::endl;
                 }
 
                 if (asnDatabase.IsLoaded()) {

--- a/src/node/dilv-node.cpp
+++ b/src/node/dilv-node.cpp
@@ -6889,29 +6889,21 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
             }
 
             if (asnDatabase.IsLoaded()) {
-                // Finding B (extreview PR#121): the datacenter ASN list is a
+                // Finding B + Fix 1 (extreview PR#121): the datacenter ASN list is a
                 // SEPARATE defense from attestation capacity — it powers the
-                // datacenter-IP Sybil ban, not MIK signing. A load failure here
-                // must NOT be silently swallowed: an empty datacenter set makes
-                // IsDatacenterIP() fail-open (always false), so the Sybil ban is
-                // silently OFF while the seed still REGISTERs healthy. Judgment
-                // (documented): this does NOT gate DEGRADED — datacenter-ban !=
-                // attestation capacity, so we keep attesting — but the failure is
-                // surfaced as a LOUD persistent ERROR with operator guidance so an
-                // operator notices the dropped defense (mirrors the ip2asn-v4.tsv
-                // loud treatment this PR added for the attestation side).
+                // datacenter-IP Sybil ban via IsDatacenterIP(). An EMPTY datacenter
+                // set makes IsDatacenterIP() fail OPEN (always false), so on a
+                // datacenter-ban chain (DilV) a seed would REGISTER and then sign
+                // attestations for datacenter miners it is required to reject —
+                // silently defeating the ban while looking healthy. The earlier
+                // PR#121 residual only LOGGED this ("continues normally") and did
+                // NOT gate. We now load the list here, then fold
+                // (DatacenterASNCount() > 0) into ResolveSeedIdentity below so a
+                // missing list on a ban chain DEGRADES (stay online for relay, do
+                // NOT register attestation) instead of attesting under-defended.
                 std::string dcPath = dataDir + "/datacenter-asns.txt";
                 if (!asnDatabase.LoadDatacenterList(dcPath)) {
                     asnDatabase.LoadDatacenterList("datacenter-asns.txt");
-                }
-                if (asnDatabase.DatacenterASNCount() == 0) {
-                    std::cerr << "[Attestation] ERROR: datacenter ASN list FAILED to load or is empty "
-                                 "(missing/unparseable " << dataDir << "/datacenter-asns.txt or "
-                                 "./datacenter-asns.txt). The datacenter-IP Sybil ban is DISABLED "
-                                 "(IsDatacenterIP fails open) — datacenter-hosted miners will NOT be "
-                                 "refused MIK attestation. Attestation itself continues normally. "
-                                 "Restore datacenter-asns.txt (e.g. after a data-dir rotation) and "
-                                 "restart to re-enable the datacenter Sybil ban." << std::endl;
                 }
                 std::cout << "  [OK] ASN database loaded (" << asnDatabase.RangeCount()
                           << " ranges, " << asnDatabase.DatacenterASNCount()
@@ -6963,9 +6955,14 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                 // by tests, not only the pubkey-equality primitive.
                 const auto& seedIPs = Dilithion::g_chainParams->seedAttestationIPs;
                 const auto& seedPubkeys = Dilithion::g_chainParams->seedAttestationPubkeys;
+                // Fix 1: pass the datacenter-ban chain flag and whether the
+                // datacenter ASN list actually loaded, so a ban chain with an empty
+                // datacenter set degrades rather than attesting under-defended.
                 Attestation::SeedIdentityResult ident = Attestation::ResolveSeedIdentity(
                     seedIPs, seedPubkeys, config.external_ip, seedAttestKey.GetPubKey(),
-                    asnDatabase.IsLoaded());
+                    asnDatabase.IsLoaded(),
+                    Dilithion::g_chainParams->attestationDatacenterBan,
+                    asnDatabase.DatacenterASNCount() > 0);
 
                 bool registerSeed = false;
                 switch (ident.decision) {
@@ -7014,7 +7011,34 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
                                      "\"ASN database not loaded\". The node continues to run for "
                                      "relay/P2P. Fix ip2asn-v4.tsv (e.g. restore after a data-dir "
                                      "rotation) and restart to restore attestation." << std::endl;
-                        rpc_server.RegisterSeedAttestationDegraded(ident.seedId);
+                        rpc_server.RegisterSeedAttestationDegraded(
+                            ident.seedId, CRPCServer::SeedDegradedReason::NO_ASN);
+                        break;
+                    case Attestation::SeedIdentityDecision::DEGRADED_NO_DATACENTER_LIST:
+                        // Fix 1 (extreview PR#121): identity is VALID and the ASN DB
+                        // loaded, but this is a datacenter-ban chain (DilV) and the
+                        // datacenter ASN list is EMPTY (missing/unparseable
+                        // datacenter-asns.txt). IsDatacenterIP() would fail OPEN, so a
+                        // registered seed would sign attestations for datacenter
+                        // miners it must reject — silently defeating the Sybil ban.
+                        // Mirror DEGRADED_NO_ASN: do NOT abort (relay/P2P stay up),
+                        // do NOT register attestation (never hand out an
+                        // under-defended attestation), log a LOUD persistent ERROR,
+                        // and register a degraded marker so getmikattestation returns
+                        // a DISTINCT diagnosable error.
+                        std::cerr << "[Attestation] ERROR: seed identity is valid (seed_id="
+                                  << ident.seedId << ") and ip2asn loaded, but the datacenter "
+                                     "ASN list is EMPTY on a datacenter-ban chain "
+                                     "(missing/unparseable " << dataDir << "/datacenter-asns.txt "
+                                     "or ./datacenter-asns.txt). IsDatacenterIP() would fail OPEN, "
+                                     "so attestation is DISABLED rather than sign attestations for "
+                                     "datacenter miners that the datacenter Sybil ban must reject. "
+                                     "getmikattestation will report \"datacenter ASN list not "
+                                     "loaded\". The node continues to run for relay/P2P. Restore "
+                                     "datacenter-asns.txt (e.g. after a data-dir rotation) and "
+                                     "restart to restore attestation." << std::endl;
+                        rpc_server.RegisterSeedAttestationDegraded(
+                            ident.seedId, CRPCServer::SeedDegradedReason::NO_DATACENTER_LIST);
                         break;
                     case Attestation::SeedIdentityDecision::REGISTER:
                         if (ident.usedTestnetDefault) {

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -9190,9 +9190,21 @@ std::string CRPCServer::RPC_GetMIKAttestation(const std::string& params) {
         // so the operator can see the ASN-DB cause instead of the generic
         // "only available on seed nodes" (which would hide the degraded state).
         if (m_seedAttestationAsnDegraded) {
+            // Fix 2: surface the resolved seed_id (m_seedAttestationDegradedSeedId,
+            // previously written-but-never-read) so the degraded state is fully
+            // diagnosable. Fix 1: distinct string per degraded reason.
+            std::string seedIdStr = std::to_string(m_seedAttestationDegradedSeedId);
+            if (m_seedAttestationDegradedReason == SeedDegradedReason::NO_DATACENTER_LIST) {
+                throw std::runtime_error(
+                    "attestation unavailable: datacenter ASN list not loaded on a "
+                    "datacenter-ban chain (seed_id=" + seedIdStr + " running degraded "
+                    "for relay only; restore datacenter-asns.txt and restart)");
+            }
+            // Default / NO_ASN: ip2asn-v4.tsv missing -> zero attestation capacity.
             throw std::runtime_error(
                 "attestation unavailable: ASN database not loaded "
-                "(seed running degraded for relay only; fix ip2asn-v4.tsv and restart)");
+                "(seed_id=" + seedIdStr + " running degraded for relay only; "
+                "fix ip2asn-v4.tsv and restart)");
         }
         throw std::runtime_error("getmikattestation is only available on seed nodes");
     }

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -9182,8 +9182,18 @@ std::string CRPCServer::RPC_ListSwaps(const std::string& params) {
 // ============================================================================
 
 std::string CRPCServer::RPC_GetMIKAttestation(const std::string& params) {
-    // This RPC is only available on seed nodes with attestation key loaded
+    // This RPC is only available on seed nodes with attestation key loaded.
     if (!m_seedAttestationKey || m_seedId < 0) {
+        // H-3 (consolidated): distinguish a DEGRADED seed (valid identity, but the
+        // ASN DB failed to load so attestation was never registered) from a plain
+        // non-seed. A degraded seed returns a DISTINCT, diagnosable error string
+        // so the operator can see the ASN-DB cause instead of the generic
+        // "only available on seed nodes" (which would hide the degraded state).
+        if (m_seedAttestationAsnDegraded) {
+            throw std::runtime_error(
+                "attestation unavailable: ASN database not loaded "
+                "(seed running degraded for relay only; fix ip2asn-v4.tsv and restart)");
+        }
         throw std::runtime_error("getmikattestation is only available on seed nodes");
     }
 

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -217,6 +217,13 @@ private:
     Attestation::CSeedAttestationKey* m_seedAttestationKey{nullptr};
     CASNDatabase* m_asnDatabase{nullptr};
     int m_seedId{-1};  // This seed's index (0-3), or -1 if not a seed
+    // H-3 (consolidated): set on a valid seed whose ASN database failed to load.
+    // The node stays online for relay/P2P but attestation is NOT registered
+    // (m_seedAttestationKey stays null). This flag lets getmikattestation return
+    // a DISTINCT "ASN database not loaded" diagnostic instead of the generic
+    // "only available on seed nodes", so the degraded state is queryable.
+    bool m_seedAttestationAsnDegraded{false};
+    int m_seedAttestationDegradedSeedId{-1};  // resolved seed_id for the degraded diagnostic
 
     // Attestation rate limiting (Sybil defense Phase 0)
     // Rate limits NEW MIK registrations per /24 subnet per day.
@@ -626,6 +633,20 @@ public:
         m_seedAttestationKey = key;
         m_asnDatabase = asnDb;
         m_seedId = seedId;
+        m_seedAttestationAsnDegraded = false;
+    }
+
+    /**
+     * H-3 (consolidated): mark this seed as ATTESTATION-DEGRADED because its ASN
+     * database failed to load. Does NOT register a signing key — the node stays
+     * online for relay/P2P, attestation stays unavailable — but flips
+     * getmikattestation's error from the generic "only available on seed nodes"
+     * to a distinct, diagnosable "ASN database not loaded" so an operator can
+     * tell a degraded seed apart from a plain non-seed.
+     */
+    void RegisterSeedAttestationDegraded(int seedId) {
+        m_seedAttestationAsnDegraded = true;
+        m_seedAttestationDegradedSeedId = seedId;
     }
 
     /**

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -224,6 +224,18 @@ private:
     // "only available on seed nodes", so the degraded state is queryable.
     bool m_seedAttestationAsnDegraded{false};
     int m_seedAttestationDegradedSeedId{-1};  // resolved seed_id for the degraded diagnostic
+public:
+    // Fix 1 (extreview PR#121): WHY a valid seed is running attestation-degraded.
+    // Surfaced by getmikattestation so an operator can tell the two distinct
+    // degraded causes apart (and from a plain non-seed).
+    enum class SeedDegradedReason {
+        NONE,             // not degraded
+        NO_ASN,           // ip2asn-v4.tsv failed to load (zero attestation capacity)
+        NO_DATACENTER_LIST,  // datacenter-asns.txt empty on a datacenter-ban chain
+                             // (IsDatacenterIP would fail open -> datacenter Sybil ban off)
+    };
+private:
+    SeedDegradedReason m_seedAttestationDegradedReason{SeedDegradedReason::NONE};
 
     // Attestation rate limiting (Sybil defense Phase 0)
     // Rate limits NEW MIK registrations per /24 subnet per day.
@@ -634,19 +646,23 @@ public:
         m_asnDatabase = asnDb;
         m_seedId = seedId;
         m_seedAttestationAsnDegraded = false;
+        m_seedAttestationDegradedReason = SeedDegradedReason::NONE;
     }
 
     /**
-     * H-3 (consolidated): mark this seed as ATTESTATION-DEGRADED because its ASN
-     * database failed to load. Does NOT register a signing key — the node stays
-     * online for relay/P2P, attestation stays unavailable — but flips
-     * getmikattestation's error from the generic "only available on seed nodes"
-     * to a distinct, diagnosable "ASN database not loaded" so an operator can
-     * tell a degraded seed apart from a plain non-seed.
+     * H-3 (consolidated) + Fix 1: mark this seed as ATTESTATION-DEGRADED. Does NOT
+     * register a signing key — the node stays online for relay/P2P, attestation
+     * stays unavailable — but flips getmikattestation's error from the generic
+     * "only available on seed nodes" to a distinct, diagnosable error keyed on
+     * `reason`, so an operator can tell a degraded seed apart from a plain
+     * non-seed AND tell the two degraded causes apart. Defaults to NO_ASN to keep
+     * existing callers/tests that pass only a seed_id unchanged.
      */
-    void RegisterSeedAttestationDegraded(int seedId) {
+    void RegisterSeedAttestationDegraded(
+        int seedId, SeedDegradedReason reason = SeedDegradedReason::NO_ASN) {
         m_seedAttestationAsnDegraded = true;
         m_seedAttestationDegradedSeedId = seedId;
+        m_seedAttestationDegradedReason = reason;
     }
 
     /**

--- a/src/test/seed_attestation_glue_tests.cpp
+++ b/src/test/seed_attestation_glue_tests.cpp
@@ -1,0 +1,229 @@
+// Copyright (c) 2026 The Dilithion Core developers
+// Distributed under the MIT software license
+//
+// Fix 3 (extreview PR#121): the seed-attestation glue tests previously lived ONLY
+// in the standalone seed_attestation_key_tests.cpp (its own main()), wired only
+// into the Makefile `tests` target. CI runs ONLY the Boost test_dilithion binary,
+// so those load-bearing decision/gate assertions never gated CI. This file folds
+// the security-critical cases into the Boost suite so CI actually enforces them:
+//   - ResolveSeedIdentity REGISTER / SKIP / FATAL / DEGRADED dispositions
+//   - the Fix 1 datacenter-over-attestation gate (ban chain + empty datacenter
+//     list -> DEGRADED_NO_DATACENTER_LIST; DIL/non-ban never demoted)
+//   - the consensus-equivalence assertion the FATAL_MISMATCH design rests on
+//   - the distinct degraded getmikattestation error strings (Fix 1/Fix 2)
+//
+// The standalone binary is kept too (it carries the at-rest key-format tests).
+
+#include <boost/test/unit_test.hpp>
+
+#include <attestation/seed_attestation.h>
+#include <attestation/seed_pubkeys_mainnet.h>
+#include <dfmp/dfmp.h>
+#include <rpc/server.h>
+
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+using namespace Attestation;
+
+namespace {
+
+// Build a 4-seed mainnet-shaped configuration with REAL Dilithium3 keys per slot
+// so the byte-compare mirrors production.
+struct SeedFixture {
+    std::vector<std::string> seedIPs{"10.0.0.1", "10.0.0.2", "10.0.0.3", "10.0.0.4"};
+    std::vector<CSeedAttestationKey> keys{4};
+    std::vector<std::vector<uint8_t>> seedPubkeys;
+    SeedFixture() {
+        for (int i = 0; i < 4; i++) {
+            BOOST_REQUIRE(keys[i].Generate());
+            seedPubkeys.push_back(keys[i].GetPubKey());
+        }
+    }
+};
+
+} // namespace
+
+BOOST_AUTO_TEST_SUITE(seed_attestation_glue_tests)
+
+// --- Core dispositions: REGISTER / FATAL_MISMATCH / SKIP / testnet -----------
+BOOST_AUTO_TEST_CASE(resolve_core_dispositions)
+{
+    SeedFixture f;
+
+    // REGISTER: resolved slot + matching key + ASN ok + inert datacenter inputs.
+    {
+        SeedIdentityResult r = ResolveSeedIdentity(
+            f.seedIPs, f.seedPubkeys, "10.0.0.3", f.keys[2].GetPubKey(),
+            /*asnLoaded=*/true, /*datacenterBanChain=*/false, /*datacenterListLoaded=*/true);
+        BOOST_CHECK(r.decision == SeedIdentityDecision::REGISTER);
+        BOOST_CHECK_EQUAL(r.seedId, 2);
+        BOOST_CHECK(!r.usedTestnetDefault);
+    }
+
+    // FATAL_MISMATCH: resolved slot, WRONG key.
+    {
+        SeedIdentityResult r = ResolveSeedIdentity(
+            f.seedIPs, f.seedPubkeys, "10.0.0.1", f.keys[3].GetPubKey(),
+            /*asnLoaded=*/true, /*datacenterBanChain=*/false, /*datacenterListLoaded=*/true);
+        BOOST_CHECK(r.decision == SeedIdentityDecision::FATAL_MISMATCH);
+        BOOST_CHECK_EQUAL(r.seedId, 0);
+    }
+
+    // SKIP_NOT_A_SEED: externalip matches no slot (even with a usable key).
+    {
+        SeedIdentityResult r = ResolveSeedIdentity(
+            f.seedIPs, f.seedPubkeys, "203.0.113.7", f.keys[0].GetPubKey(),
+            /*asnLoaded=*/true, /*datacenterBanChain=*/false, /*datacenterListLoaded=*/true);
+        BOOST_CHECK(r.decision == SeedIdentityDecision::SKIP_NOT_A_SEED);
+        BOOST_CHECK_EQUAL(r.seedId, -1);
+    }
+
+    // Testnet (empty pubkey set): lenient default-0 register.
+    {
+        std::vector<std::vector<uint8_t>> emptyPubkeys;
+        SeedIdentityResult r = ResolveSeedIdentity(
+            f.seedIPs, emptyPubkeys, "203.0.113.7", f.keys[0].GetPubKey(),
+            /*asnLoaded=*/true, /*datacenterBanChain=*/false, /*datacenterListLoaded=*/true);
+        BOOST_CHECK(r.decision == SeedIdentityDecision::REGISTER);
+        BOOST_CHECK_EQUAL(r.seedId, 0);
+        BOOST_CHECK(r.usedTestnetDefault);
+    }
+}
+
+// --- DEGRADED_NO_ASN: valid identity, ASN DB down ----------------------------
+BOOST_AUTO_TEST_CASE(resolve_degraded_no_asn)
+{
+    SeedFixture f;
+    SeedIdentityResult r = ResolveSeedIdentity(
+        f.seedIPs, f.seedPubkeys, "10.0.0.3", f.keys[2].GetPubKey(),
+        /*asnLoaded=*/false, /*datacenterBanChain=*/true, /*datacenterListLoaded=*/true);
+    BOOST_CHECK(r.decision == SeedIdentityDecision::DEGRADED_NO_ASN);
+    BOOST_CHECK(r.decision != SeedIdentityDecision::REGISTER);
+    BOOST_CHECK(r.decision != SeedIdentityDecision::FATAL_MISMATCH);
+    BOOST_CHECK_EQUAL(r.seedId, 2);
+}
+
+// --- Fix 1: datacenter-over-attestation gate ---------------------------------
+// Mutation self-check: disabling the gate (registerOrDegrade always REGISTER on
+// the ban+no-list case) makes case (a) FAIL.
+BOOST_AUTO_TEST_CASE(resolve_datacenter_gate)
+{
+    SeedFixture f;
+
+    // (a) ban chain + datacenter list NOT loaded + valid id + ASN loaded
+    //     -> DEGRADED_NO_DATACENTER_LIST (NOT register, NOT fatal).
+    {
+        SeedIdentityResult r = ResolveSeedIdentity(
+            f.seedIPs, f.seedPubkeys, "10.0.0.3", f.keys[2].GetPubKey(),
+            /*asnLoaded=*/true, /*datacenterBanChain=*/true, /*datacenterListLoaded=*/false);
+        BOOST_CHECK(r.decision == SeedIdentityDecision::DEGRADED_NO_DATACENTER_LIST);
+        BOOST_CHECK(r.decision != SeedIdentityDecision::REGISTER);
+        BOOST_CHECK(r.decision != SeedIdentityDecision::FATAL_MISMATCH);
+        BOOST_CHECK_EQUAL(r.seedId, 2);
+    }
+
+    // (b) ban chain + datacenter list LOADED -> REGISTER (provisioned DilV seed
+    //     not demoted).
+    {
+        SeedIdentityResult r = ResolveSeedIdentity(
+            f.seedIPs, f.seedPubkeys, "10.0.0.3", f.keys[2].GetPubKey(),
+            /*asnLoaded=*/true, /*datacenterBanChain=*/true, /*datacenterListLoaded=*/true);
+        BOOST_CHECK(r.decision == SeedIdentityDecision::REGISTER);
+        BOOST_CHECK_EQUAL(r.seedId, 2);
+    }
+
+    // (c) NON-ban chain (DIL) + datacenter list NOT loaded -> REGISTER. DIL is
+    //     never demoted by a missing datacenter list.
+    {
+        SeedIdentityResult r = ResolveSeedIdentity(
+            f.seedIPs, f.seedPubkeys, "10.0.0.3", f.keys[2].GetPubKey(),
+            /*asnLoaded=*/true, /*datacenterBanChain=*/false, /*datacenterListLoaded=*/false);
+        BOOST_CHECK(r.decision == SeedIdentityDecision::REGISTER);
+        BOOST_CHECK_EQUAL(r.seedId, 2);
+    }
+
+    // (d) FATAL_MISMATCH on ban chain + empty list is STILL fatal (trust > datacenter).
+    {
+        SeedIdentityResult r = ResolveSeedIdentity(
+            f.seedIPs, f.seedPubkeys, "10.0.0.1", f.keys[3].GetPubKey(),
+            /*asnLoaded=*/true, /*datacenterBanChain=*/true, /*datacenterListLoaded=*/false);
+        BOOST_CHECK(r.decision == SeedIdentityDecision::FATAL_MISMATCH);
+    }
+
+    // Fold order: ASN-down reported before datacenter-list.
+    {
+        SeedIdentityResult r = ResolveSeedIdentity(
+            f.seedIPs, f.seedPubkeys, "10.0.0.3", f.keys[2].GetPubKey(),
+            /*asnLoaded=*/false, /*datacenterBanChain=*/true, /*datacenterListLoaded=*/false);
+        BOOST_CHECK(r.decision == SeedIdentityDecision::DEGRADED_NO_ASN);
+    }
+
+    // A non-seed stays SKIP even on a ban chain with empty list.
+    {
+        SeedIdentityResult r = ResolveSeedIdentity(
+            f.seedIPs, f.seedPubkeys, "203.0.113.7", f.keys[0].GetPubKey(),
+            /*asnLoaded=*/true, /*datacenterBanChain=*/true, /*datacenterListLoaded=*/false);
+        BOOST_CHECK(r.decision == SeedIdentityDecision::SKIP_NOT_A_SEED);
+    }
+}
+
+// --- Fix 3: consensus-equivalence of the baked-in mainnet seed pubkeys --------
+BOOST_AUTO_TEST_CASE(mainnet_seed_pubkey_consensus_equivalence)
+{
+    std::vector<std::vector<uint8_t>> pubs = GetMainnetSeedPubkeys();
+    BOOST_REQUIRE_EQUAL(pubs.size(), (size_t)NUM_SEEDS);
+    for (size_t i = 0; i < pubs.size(); i++) {
+        BOOST_CHECK_EQUAL(pubs[i].size(), (size_t)DFMP::MIK_PUBKEY_SIZE);
+        // The exact comparison the node's FATAL_MISMATCH gate performs
+        // (loadedPubkey != seedPubkeys[seedId]); pin the accessor's stability.
+        BOOST_CHECK(GetMainnetSeedPubkeys()[i] == pubs[i]);
+    }
+    // Pairwise-distinct: a duplicate would collapse the 3-of-4 Byzantine model.
+    for (size_t i = 0; i < pubs.size(); i++)
+        for (size_t j = i + 1; j < pubs.size(); j++)
+            BOOST_CHECK(pubs[i] != pubs[j]);
+}
+
+// --- Fix 1/Fix 2: distinct degraded getmikattestation error strings ----------
+BOOST_AUTO_TEST_CASE(degraded_getmikattestation_error_strings)
+{
+    // Plain (un-registered) server -> generic non-seed error.
+    {
+        CRPCServer rpc;
+        std::string err;
+        try { rpc.InvokeRPCForTest("getmikattestation", "{}"); err = "<no throw>"; }
+        catch (const std::exception& e) { err = e.what(); }
+        BOOST_CHECK(err.find("only available on seed nodes") != std::string::npos);
+        BOOST_CHECK(err.find("ASN database not loaded") == std::string::npos);
+    }
+
+    // NO_ASN degraded -> distinct ASN-DB string + seed_id surfaced (Fix 2).
+    {
+        CRPCServer rpc;
+        rpc.RegisterSeedAttestationDegraded(/*seedId=*/2,
+            CRPCServer::SeedDegradedReason::NO_ASN);
+        std::string err;
+        try { rpc.InvokeRPCForTest("getmikattestation", "{}"); err = "<no throw>"; }
+        catch (const std::exception& e) { err = e.what(); }
+        BOOST_CHECK(err.find("ASN database not loaded") != std::string::npos);
+        BOOST_CHECK(err.find("only available on seed nodes") == std::string::npos);
+        BOOST_CHECK(err.find("seed_id=2") != std::string::npos);
+    }
+
+    // NO_DATACENTER_LIST degraded -> distinct datacenter string (NOT the ASN one).
+    {
+        CRPCServer rpc;
+        rpc.RegisterSeedAttestationDegraded(/*seedId=*/1,
+            CRPCServer::SeedDegradedReason::NO_DATACENTER_LIST);
+        std::string err;
+        try { rpc.InvokeRPCForTest("getmikattestation", "{}"); err = "<no throw>"; }
+        catch (const std::exception& e) { err = e.what(); }
+        BOOST_CHECK(err.find("datacenter ASN list not loaded") != std::string::npos);
+        BOOST_CHECK(err.find("ASN database not loaded") == std::string::npos);
+        BOOST_CHECK(err.find("seed_id=1") != std::string::npos);
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/seed_attestation_key_tests.cpp
+++ b/src/test/seed_attestation_key_tests.cpp
@@ -14,6 +14,9 @@
 
 #include <attestation/seed_attestation.h>
 #include <dfmp/dfmp.h>
+#include <rpc/server.h>  // Finding E: end-to-end degraded getmikattestation error string
+
+#include <stdexcept>
 
 #include <cstdio>
 #include <cstdlib>
@@ -734,6 +737,27 @@ static void TestSeedIdentityResolutionGlue() {
     CHECK(NormalizeExternalIpForSeedMatch("[2001:db8::1]:8444") == "2001:db8::1",
           "normalize extracts address from bracketed IPv6:port");
 
+    // --- Finding C (extreview PR#121): normalization edge cases. -------------
+    // Trailing dot (FQDN form, or dotted-quad with a stray trailing dot) must be
+    // stripped so it string-equals the configured form.
+    CHECK(NormalizeExternalIpForSeedMatch("1.2.3.4.") == "1.2.3.4",
+          "Finding C: strip single trailing dot on dotted-quad");
+    CHECK(NormalizeExternalIpForSeedMatch("seed.example.com.") == "seed.example.com",
+          "Finding C: strip single trailing dot on FQDN form");
+    CHECK(NormalizeExternalIpForSeedMatch("1.2.3.4.:8444") == "1.2.3.4",
+          "Finding C: trailing dot stripped after :port removal");
+    // Uppercase IPv6 must canonicalize to lowercase (RFC 5952 case-insensitive).
+    CHECK(NormalizeExternalIpForSeedMatch("2001:DB8::1") == "2001:db8::1",
+          "Finding C: lowercase bare uppercase IPv6");
+    CHECK(NormalizeExternalIpForSeedMatch("[2001:DB8::1]:8444") == "2001:db8::1",
+          "Finding C: lowercase bracketed uppercase IPv6:port");
+    // Embedded whitespace (quoting/templating artifact) inside the literal must
+    // be stripped, not left to silently fail the match.
+    CHECK(NormalizeExternalIpForSeedMatch("138.197. 68.128") == "138.197.68.128",
+          "Finding C: strip interior whitespace in IPv4 literal");
+    CHECK(NormalizeExternalIpForSeedMatch("\t1.2.3.4\t") == "1.2.3.4",
+          "Finding C: tab-padded externalip trims");
+
     // --- Testnet (empty pubkey set): lenient default-0 register, with flag. --
     {
         std::vector<std::vector<uint8_t>> emptyPubkeys;
@@ -799,6 +823,52 @@ static void TestSeedIdentityResolutionGlue() {
     }
 }
 
+// Finding E (extreview PR#121): end-to-end RPC glue for the DEGRADED state.
+// TestSeedIdentityResolutionGlue covers the decision helper; this asserts the
+// other half — that a CRPCServer marked degraded returns the DISTINCT
+// "ASN database not loaded" error from getmikattestation (and NOT the generic
+// "only available on seed nodes"), so an operator can tell a degraded seed from
+// a plain non-seed. CRPCServer links into this test binary via CORE_OBJECTS and
+// default-constructs with null node deps, so no chainstate is needed.
+static void TestDegradedGetMikAttestationErrorString() {
+    std::cout << "[Test] Finding E: degraded getmikattestation error string (RPC glue)"
+              << std::endl;
+
+    // 1) A plain (un-registered, non-degraded) server: generic non-seed error.
+    {
+        CRPCServer rpc;  // default port; no node wired
+        std::string err;
+        try {
+            rpc.InvokeRPCForTest("getmikattestation", "{}");
+            err = "<no throw>";
+        } catch (const std::exception& e) {
+            err = e.what();
+        }
+        CHECK(err.find("only available on seed nodes") != std::string::npos,
+              "non-seed getmikattestation -> generic 'only available on seed nodes'");
+        CHECK(err.find("ASN database not loaded") == std::string::npos,
+              "non-seed error does NOT claim ASN-degraded");
+    }
+
+    // 2) A DEGRADED server (valid identity, ASN DB failed to load): distinct,
+    //    diagnosable ASN-DB error string.
+    {
+        CRPCServer rpc;
+        rpc.RegisterSeedAttestationDegraded(/*seedId=*/2);
+        std::string err;
+        try {
+            rpc.InvokeRPCForTest("getmikattestation", "{}");
+            err = "<no throw>";
+        } catch (const std::exception& e) {
+            err = e.what();
+        }
+        CHECK(err.find("ASN database not loaded") != std::string::npos,
+              "degraded getmikattestation -> distinct 'ASN database not loaded'");
+        CHECK(err.find("only available on seed nodes") == std::string::npos,
+              "degraded error is NOT the generic non-seed string (diagnosable apart)");
+    }
+}
+
 int main() {
     std::cout << "=== LP-13 seed_attestation_key_tests ===" << std::endl;
 
@@ -817,6 +887,7 @@ int main() {
     TestSeedKeyFilePresentDetectsUnreadable(); // extreview HIGH (presence vs readability)
     TestKeyIdentityComparison();             // M-1 (key-identity pubkey comparison)
     TestSeedIdentityResolutionGlue();        // HIGH-1/HIGH-2 (resolve+decide glue)
+    TestDegradedGetMikAttestationErrorString(); // Finding E (degraded RPC error string)
 #ifndef _WIN32
     TestLoadRepairsPerms();                  // M-3
     TestFailClosedPerms();                   // M-4 (best-effort/informational)

--- a/src/test/seed_attestation_key_tests.cpp
+++ b/src/test/seed_attestation_key_tests.cpp
@@ -604,6 +604,40 @@ static void TestSeedKeyFilePresentDetectsUnreadable() {
 #endif
 }
 
+// M-1 (seed key-identity validation): the node's startup check compares the
+// loaded/minted key's GetPubKey() against the consensus pubkey for the resolved
+// seedId, aborting on mismatch. This test exercises that exact comparison
+// primitive: a key matches the pubkey it was generated/saved/loaded with (the
+// "accept" leg), and two independently-generated keys have DIFFERENT pubkeys, so
+// a wrong key bound to a seedId is detected (the "reject"/fail-loud leg).
+static void TestKeyIdentityComparison() {
+    std::cout << "[Test] M-1 seed key-identity pubkey comparison" << std::endl;
+    std::string dir = MakeTempDir();
+    SetPass(nullptr);  // v1 plaintext path is fine for a pubkey-equality test
+
+    CSeedAttestationKey kReal;
+    CHECK(kReal.Generate(), "generate the 'correct' seed key");
+    std::vector<uint8_t> realPub = kReal.GetPubKey();
+    CHECK(realPub.size() == DFMP::MIK_PUBKEY_SIZE, "pubkey is full Dilithium3 size");
+
+    // Accept leg: the same key (and a save/load round-trip of it) matches the
+    // consensus pubkey it would be registered under.
+    CHECK(kReal.GetPubKey() == realPub, "same key: GetPubKey() == consensus pubkey (ACCEPT)");
+    CHECK(kReal.Save(dir), "save the correct key");
+    CSeedAttestationKey kReloaded;
+    CHECK(kReloaded.Load(dir), "reload the correct key");
+    CHECK(kReloaded.GetPubKey() == realPub,
+          "reloaded key still matches consensus pubkey (ACCEPT survives persist)");
+
+    // Reject leg: a DIFFERENT key (what a misconfigured seed would load/mint —
+    // any Dilithium3 key, but not THIS seedId's consensus key) does NOT match,
+    // so the node's GetPubKey() != seedPubkeys[seedId] check fires (fail-loud).
+    CSeedAttestationKey kWrong;
+    CHECK(kWrong.Generate(), "generate a 'wrong' (mismatched) seed key");
+    CHECK(kWrong.GetPubKey() != realPub,
+          "different key: GetPubKey() != consensus pubkey (REJECT -> fail-loud)");
+}
+
 int main() {
     std::cout << "=== LP-13 seed_attestation_key_tests ===" << std::endl;
 
@@ -620,6 +654,7 @@ int main() {
     TestSaveFailMakesLoadOrGenerateFail();   // M-2
     TestRequireEncryptionPolicy();           // H-1
     TestSeedKeyFilePresentDetectsUnreadable(); // extreview HIGH (presence vs readability)
+    TestKeyIdentityComparison();             // M-1 (key-identity pubkey comparison)
 #ifndef _WIN32
     TestLoadRepairsPerms();                  // M-3
     TestFailClosedPerms();                   // M-4 (best-effort/informational)

--- a/src/test/seed_attestation_key_tests.cpp
+++ b/src/test/seed_attestation_key_tests.cpp
@@ -13,6 +13,7 @@
 //   - (POSIX) saved key file is chmod 0600
 
 #include <attestation/seed_attestation.h>
+#include <attestation/seed_pubkeys_mainnet.h>  // Fix 3: consensus-equivalence assertion
 #include <dfmp/dfmp.h>
 #include <rpc/server.h>  // Finding E: end-to-end degraded getmikattestation error string
 
@@ -35,6 +36,22 @@
 #endif
 
 using namespace Attestation;
+
+// Test-only thin wrapper: most legacy cases predate the Fix 1 datacenter-gate
+// params and exercise non-ban / inert behavior. Default datacenterBanChain=false
+// (DIL-shaped) + datacenterListLoaded=true so the gate is INERT, preserving the
+// prior REGISTER/DEGRADE outcomes for those cases. Cases that exercise the new
+// gate call the full Attestation::ResolveSeedIdentity directly.
+static SeedIdentityResult ResolveSeedIdentity(
+    const std::vector<std::string>& seedIPs,
+    const std::vector<std::vector<uint8_t>>& seedPubkeys,
+    const std::string& externalIp,
+    const std::vector<uint8_t>& loadedPubkey,
+    bool asnLoaded) {
+    return Attestation::ResolveSeedIdentity(
+        seedIPs, seedPubkeys, externalIp, loadedPubkey, asnLoaded,
+        /*datacenterBanChain=*/false, /*datacenterListLoaded=*/true);
+}
 
 // Dilithium3 verify (same extern the production .cpp uses) — lets us prove the
 // private key round-tripped by checking a signature it produced verifies under
@@ -821,6 +838,108 @@ static void TestSeedIdentityResolutionGlue() {
               "testnet would-be REGISTER + ASN DB down -> DEGRADED_NO_ASN");
         CHECK(r.seedId == 1, "testnet DEGRADED keeps the resolved seed_id");
     }
+
+    // --- Fix 1 (extreview PR#121): datacenter-over-attestation gate. ----------
+    // Calls the FULL Attestation::ResolveSeedIdentity (the wrapper above forces
+    // the inert defaults). Mutation self-check: disabling the gate (always
+    // returning REGISTER from registerOrDegrade for the ban+no-list case) makes
+    // case (a) FAIL.
+    {
+        // (a) ban chain + datacenter list NOT loaded + valid identity ->
+        //     DEGRADED_NO_DATACENTER_LIST (NOT register, NOT fatal). ASN DB IS
+        //     loaded, so this isolates the datacenter condition from DEGRADED_NO_ASN.
+        SeedIdentityResult r = Attestation::ResolveSeedIdentity(
+            seedIPs, seedPubkeys, "10.0.0.3", keys[2].GetPubKey(),
+            /*asnLoaded=*/true, /*datacenterBanChain=*/true,
+            /*datacenterListLoaded=*/false);
+        CHECK(r.decision == SeedIdentityDecision::DEGRADED_NO_DATACENTER_LIST,
+              "(a) ban chain + empty datacenter list + valid id -> DEGRADED_NO_DATACENTER_LIST");
+        CHECK(r.decision != SeedIdentityDecision::REGISTER,
+              "(a) ban chain + empty datacenter list must NOT REGISTER (the security gate)");
+        CHECK(r.decision != SeedIdentityDecision::FATAL_MISMATCH,
+              "(a) datacenter-list gate must NOT abort (stay online for relay)");
+        CHECK(r.seedId == 2, "(a) DEGRADED_NO_DATACENTER_LIST keeps the resolved seed_id");
+    }
+    {
+        // (b) ban chain + datacenter list LOADED -> REGISTER (correctly-provisioned
+        //     DilV seed is NOT demoted).
+        SeedIdentityResult r = Attestation::ResolveSeedIdentity(
+            seedIPs, seedPubkeys, "10.0.0.3", keys[2].GetPubKey(),
+            /*asnLoaded=*/true, /*datacenterBanChain=*/true,
+            /*datacenterListLoaded=*/true);
+        CHECK(r.decision == SeedIdentityDecision::REGISTER,
+              "(b) ban chain + datacenter list loaded -> REGISTER (provisioned seed not demoted)");
+        CHECK(r.seedId == 2, "(b) REGISTER resolves to seed_id=2");
+    }
+    {
+        // (c) NON-ban chain (DIL) + datacenter list NOT loaded -> REGISTER.
+        //     Proves DIL is never demoted by a missing datacenter list.
+        SeedIdentityResult r = Attestation::ResolveSeedIdentity(
+            seedIPs, seedPubkeys, "10.0.0.3", keys[2].GetPubKey(),
+            /*asnLoaded=*/true, /*datacenterBanChain=*/false,
+            /*datacenterListLoaded=*/false);
+        CHECK(r.decision == SeedIdentityDecision::REGISTER,
+              "(c) NON-ban chain (DIL) + empty datacenter list -> REGISTER (DIL not demoted)");
+        CHECK(r.seedId == 2, "(c) DIL REGISTER resolves to seed_id=2");
+    }
+    {
+        // (d) FATAL_MISMATCH on a ban chain with empty datacenter list is STILL
+        //     fatal (trust > datacenter — the gate can only soften a REGISTER).
+        SeedIdentityResult r = Attestation::ResolveSeedIdentity(
+            seedIPs, seedPubkeys, "10.0.0.1", keys[3].GetPubKey(),
+            /*asnLoaded=*/true, /*datacenterBanChain=*/true,
+            /*datacenterListLoaded=*/false);
+        CHECK(r.decision == SeedIdentityDecision::FATAL_MISMATCH,
+              "(d) wrong key stays FATAL_MISMATCH on ban chain + empty list (trust > datacenter)");
+    }
+    {
+        // ASN-down takes precedence over the datacenter list (documented fold
+        // order): ban chain + ASN DB down + empty datacenter list -> DEGRADED_NO_ASN.
+        SeedIdentityResult r = Attestation::ResolveSeedIdentity(
+            seedIPs, seedPubkeys, "10.0.0.3", keys[2].GetPubKey(),
+            /*asnLoaded=*/false, /*datacenterBanChain=*/true,
+            /*datacenterListLoaded=*/false);
+        CHECK(r.decision == SeedIdentityDecision::DEGRADED_NO_ASN,
+              "ASN-down reported before datacenter-list (documented fold order)");
+    }
+    {
+        // A non-seed externalip stays SKIP even on a ban chain with empty list
+        // (the gate never promotes a non-seed into a degraded seed).
+        SeedIdentityResult r = Attestation::ResolveSeedIdentity(
+            seedIPs, seedPubkeys, "203.0.113.7", keys[0].GetPubKey(),
+            /*asnLoaded=*/true, /*datacenterBanChain=*/true,
+            /*datacenterListLoaded=*/false);
+        CHECK(r.decision == SeedIdentityDecision::SKIP_NOT_A_SEED,
+              "non-seed stays SKIP_NOT_A_SEED even on ban chain + empty datacenter list");
+    }
+}
+
+// Fix 3 (extreview PR#121): consensus-equivalence assertion. The other identity
+// tests build their OWN local keys and check only self-consistency + size — they
+// never assert the loaded key equals the REAL consensus set. The FATAL_MISMATCH
+// design (a seed whose key != seedAttestationPubkeys[seedId] aborts) rests on the
+// baked-in mainnet pubkeys being well-formed and stable, so pin them here.
+static void TestMainnetSeedPubkeyConsensusEquivalence() {
+    std::cout << "[Test] Fix 3: mainnet seed pubkeys are consensus-shaped + stable"
+              << std::endl;
+    std::vector<std::vector<uint8_t>> pubs = Attestation::GetMainnetSeedPubkeys();
+    CHECK(pubs.size() == (size_t)Attestation::NUM_SEEDS,
+          "mainnet seed pubkey set has NUM_SEEDS entries");
+    for (size_t i = 0; i < pubs.size(); i++) {
+        CHECK(pubs[i].size() == DFMP::MIK_PUBKEY_SIZE,
+              "seed pubkey is full Dilithium3 size");
+        // Self-consistency of the accessor: GetMainnetSeedPubkeys()[i] equals
+        // itself on a fresh call (the value consensus verification reads). This is
+        // the exact comparison the node's FATAL_MISMATCH gate performs against the
+        // loaded key (loadedPubkey != seedPubkeys[seedId]).
+        CHECK(Attestation::GetMainnetSeedPubkeys()[i] == pubs[i],
+              "GetMainnetSeedPubkeys()[i] is stable across calls (consensus value)");
+    }
+    // All four seed pubkeys must be DISTINCT — a duplicate would let one seed's
+    // key satisfy two slots and collapse the 3-of-4 Byzantine assumption.
+    for (size_t i = 0; i < pubs.size(); i++)
+        for (size_t j = i + 1; j < pubs.size(); j++)
+            CHECK(pubs[i] != pubs[j], "seed pubkeys are pairwise distinct");
 }
 
 // Finding E (extreview PR#121): end-to-end RPC glue for the DEGRADED state.
@@ -866,6 +985,30 @@ static void TestDegradedGetMikAttestationErrorString() {
               "degraded getmikattestation -> distinct 'ASN database not loaded'");
         CHECK(err.find("only available on seed nodes") == std::string::npos,
               "degraded error is NOT the generic non-seed string (diagnosable apart)");
+        // Fix 2: the resolved seed_id is surfaced in the degraded string.
+        CHECK(err.find("seed_id=2") != std::string::npos,
+              "Fix 2: degraded string surfaces the resolved seed_id");
+    }
+
+    // 3) Fix 1/Fix 3(e): a server degraded for the NO_DATACENTER_LIST reason
+    //    returns a DISTINCT datacenter-specific string, NOT the ASN-DB one.
+    {
+        CRPCServer rpc;
+        rpc.RegisterSeedAttestationDegraded(
+            /*seedId=*/1, CRPCServer::SeedDegradedReason::NO_DATACENTER_LIST);
+        std::string err;
+        try {
+            rpc.InvokeRPCForTest("getmikattestation", "{}");
+            err = "<no throw>";
+        } catch (const std::exception& e) {
+            err = e.what();
+        }
+        CHECK(err.find("datacenter ASN list not loaded") != std::string::npos,
+              "NO_DATACENTER_LIST degraded -> distinct 'datacenter ASN list not loaded'");
+        CHECK(err.find("ASN database not loaded") == std::string::npos,
+              "datacenter-list degraded is NOT the ip2asn 'ASN database not loaded' string");
+        CHECK(err.find("seed_id=1") != std::string::npos,
+              "Fix 2: datacenter-list degraded string surfaces the resolved seed_id");
     }
 }
 
@@ -886,8 +1029,9 @@ int main() {
     TestRequireEncryptionPolicy();           // H-1
     TestSeedKeyFilePresentDetectsUnreadable(); // extreview HIGH (presence vs readability)
     TestKeyIdentityComparison();             // M-1 (key-identity pubkey comparison)
-    TestSeedIdentityResolutionGlue();        // HIGH-1/HIGH-2 (resolve+decide glue)
-    TestDegradedGetMikAttestationErrorString(); // Finding E (degraded RPC error string)
+    TestSeedIdentityResolutionGlue();        // HIGH-1/HIGH-2 + Fix 1 datacenter gate
+    TestMainnetSeedPubkeyConsensusEquivalence(); // Fix 3 (consensus-equivalence)
+    TestDegradedGetMikAttestationErrorString(); // Finding E + Fix 1/2 (degraded RPC strings)
 #ifndef _WIN32
     TestLoadRepairsPerms();                  // M-3
     TestFailClosedPerms();                   // M-4 (best-effort/informational)

--- a/src/test/seed_attestation_key_tests.cpp
+++ b/src/test/seed_attestation_key_tests.cpp
@@ -638,6 +638,123 @@ static void TestKeyIdentityComparison() {
           "different key: GetPubKey() != consensus pubkey (REJECT -> fail-loud)");
 }
 
+// HIGH-1 / HIGH-2 fold: the production seed-identity GLUE (resolve --externalip
+// -> seed_id, then decide FATAL / SKIP / REGISTER) is factored into the pure
+// helper ResolveSeedIdentity so it is unit-testable. The prior test exercised
+// only the pubkey-equality PRIMITIVE; these tests drive the actual decision the
+// node startup makes, and would FAIL if that decision logic were a no-op.
+static void TestSeedIdentityResolutionGlue() {
+    std::cout << "[Test] HIGH-1/HIGH-2 seed-identity resolution glue (ResolveSeedIdentity)"
+              << std::endl;
+
+    // A 4-seed mainnet-shaped configuration. Pubkeys must be full Dilithium3
+    // size so the byte-compare mirrors production; build a real key per slot.
+    const std::vector<std::string> seedIPs = {
+        "10.0.0.1", "10.0.0.2", "10.0.0.3", "10.0.0.4"};
+
+    std::vector<CSeedAttestationKey> keys(4);
+    std::vector<std::vector<uint8_t>> seedPubkeys;
+    for (int i = 0; i < 4; i++) {
+        CHECK(keys[i].Generate(), "generate seed-slot key");
+        seedPubkeys.push_back(keys[i].GetPubKey());
+    }
+
+    // --- REGISTER: externalip resolves to a slot AND key matches that slot. ---
+    {
+        SeedIdentityResult r = ResolveSeedIdentity(
+            seedIPs, seedPubkeys, "10.0.0.3", keys[2].GetPubKey());
+        CHECK(r.decision == SeedIdentityDecision::REGISTER,
+              "matching key at resolved slot -> REGISTER");
+        CHECK(r.seedId == 2, "REGISTER resolves to seed_id=2");
+        CHECK(!r.usedTestnetDefault, "REGISTER on mainnet is not a testnet default");
+    }
+
+    // --- FATAL_MISMATCH: externalip resolves to a real slot, WRONG key. ------
+    // (Drives the abort path; a no-op decision helper would NOT return this.)
+    {
+        SeedIdentityResult r = ResolveSeedIdentity(
+            seedIPs, seedPubkeys, "10.0.0.1", keys[3].GetPubKey());
+        CHECK(r.decision == SeedIdentityDecision::FATAL_MISMATCH,
+              "resolved slot + mismatched pubkey -> FATAL_MISMATCH (abort path)");
+        CHECK(r.seedId == 0, "FATAL_MISMATCH reports the resolved seed_id");
+    }
+
+    // --- SKIP_NOT_A_SEED: externalip matches NO configured slot. ------------
+    // HIGH-1: must NOT abort even though a usable key is present.
+    {
+        SeedIdentityResult r = ResolveSeedIdentity(
+            seedIPs, seedPubkeys, "203.0.113.7", keys[0].GetPubKey());
+        CHECK(r.decision == SeedIdentityDecision::SKIP_NOT_A_SEED,
+              "non-seed externalip + key present -> SKIP_NOT_A_SEED (NOT abort, HIGH-1)");
+        CHECK(r.seedId == -1, "SKIP leaves seed_id unresolved");
+    }
+    // Empty externalip is also "not a seed" -> SKIP, not FATAL.
+    {
+        SeedIdentityResult r = ResolveSeedIdentity(
+            seedIPs, seedPubkeys, "", keys[0].GetPubKey());
+        CHECK(r.decision == SeedIdentityDecision::SKIP_NOT_A_SEED,
+              "empty externalip on mainnet -> SKIP_NOT_A_SEED (HIGH-1)");
+    }
+
+    // --- HIGH-2: :port suffix and whitespace must still resolve. -------------
+    {
+        SeedIdentityResult r = ResolveSeedIdentity(
+            seedIPs, seedPubkeys, "10.0.0.4:8444", keys[3].GetPubKey());
+        CHECK(r.decision == SeedIdentityDecision::REGISTER,
+              "externalip with :port resolves -> REGISTER (HIGH-2)");
+        CHECK(r.seedId == 3, ":port-stripped externalip resolves to correct seed_id");
+    }
+    {
+        SeedIdentityResult r = ResolveSeedIdentity(
+            seedIPs, seedPubkeys, "  10.0.0.2  ", keys[1].GetPubKey());
+        CHECK(r.decision == SeedIdentityDecision::REGISTER,
+              "whitespace-padded externalip resolves -> REGISTER (HIGH-2)");
+        CHECK(r.seedId == 1, "trimmed externalip resolves to correct seed_id");
+    }
+    // :port + whitespace combined, but with a WRONG key -> still FATAL at the
+    // resolved slot (normalization must not mask a genuine key mismatch).
+    {
+        SeedIdentityResult r = ResolveSeedIdentity(
+            seedIPs, seedPubkeys, " 10.0.0.1:8444 ", keys[2].GetPubKey());
+        CHECK(r.decision == SeedIdentityDecision::FATAL_MISMATCH,
+              "normalized resolve still enforces pubkey match -> FATAL_MISMATCH");
+        CHECK(r.seedId == 0, "normalized externalip resolved to seed_id=0");
+    }
+
+    // --- NormalizeExternalIpForSeedMatch direct cases. ----------------------
+    CHECK(NormalizeExternalIpForSeedMatch("1.2.3.4:8444") == "1.2.3.4",
+          "normalize strips :port");
+    CHECK(NormalizeExternalIpForSeedMatch("  1.2.3.4 ") == "1.2.3.4",
+          "normalize trims whitespace");
+    CHECK(NormalizeExternalIpForSeedMatch("1.2.3.4") == "1.2.3.4",
+          "normalize leaves bare IPv4 intact");
+    // IPv6 must NOT be port-stripped at the colons (would corrupt the address).
+    CHECK(NormalizeExternalIpForSeedMatch("2001:db8::1") == "2001:db8::1",
+          "normalize leaves bare IPv6 literal intact (no false :port strip)");
+    CHECK(NormalizeExternalIpForSeedMatch("[2001:db8::1]:8444") == "2001:db8::1",
+          "normalize extracts address from bracketed IPv6:port");
+
+    // --- Testnet (empty pubkey set): lenient default-0 register, with flag. --
+    {
+        std::vector<std::vector<uint8_t>> emptyPubkeys;
+        SeedIdentityResult r = ResolveSeedIdentity(
+            seedIPs, emptyPubkeys, "203.0.113.7", keys[0].GetPubKey());
+        CHECK(r.decision == SeedIdentityDecision::REGISTER,
+              "testnet empty set + unresolved ip -> REGISTER (lenient)");
+        CHECK(r.seedId == 0, "testnet unresolved defaults to seed_id=0");
+        CHECK(r.usedTestnetDefault, "testnet default flagged for legacy WARN");
+    }
+    {
+        std::vector<std::vector<uint8_t>> emptyPubkeys;
+        SeedIdentityResult r = ResolveSeedIdentity(
+            seedIPs, emptyPubkeys, "10.0.0.2", keys[0].GetPubKey());
+        CHECK(r.decision == SeedIdentityDecision::REGISTER,
+              "testnet empty set + resolved ip -> REGISTER at resolved index");
+        CHECK(r.seedId == 1, "testnet resolved ip keeps its index");
+        CHECK(!r.usedTestnetDefault, "testnet resolved ip is not a default");
+    }
+}
+
 int main() {
     std::cout << "=== LP-13 seed_attestation_key_tests ===" << std::endl;
 
@@ -655,6 +772,7 @@ int main() {
     TestRequireEncryptionPolicy();           // H-1
     TestSeedKeyFilePresentDetectsUnreadable(); // extreview HIGH (presence vs readability)
     TestKeyIdentityComparison();             // M-1 (key-identity pubkey comparison)
+    TestSeedIdentityResolutionGlue();        // HIGH-1/HIGH-2 (resolve+decide glue)
 #ifndef _WIN32
     TestLoadRepairsPerms();                  // M-3
     TestFailClosedPerms();                   // M-4 (best-effort/informational)

--- a/src/test/seed_attestation_key_tests.cpp
+++ b/src/test/seed_attestation_key_tests.cpp
@@ -662,9 +662,9 @@ static void TestSeedIdentityResolutionGlue() {
     // --- REGISTER: externalip resolves to a slot AND key matches that slot. ---
     {
         SeedIdentityResult r = ResolveSeedIdentity(
-            seedIPs, seedPubkeys, "10.0.0.3", keys[2].GetPubKey());
+            seedIPs, seedPubkeys, "10.0.0.3", keys[2].GetPubKey(), /*asnLoaded=*/true);
         CHECK(r.decision == SeedIdentityDecision::REGISTER,
-              "matching key at resolved slot -> REGISTER");
+              "matching key at resolved slot + ASN ok -> REGISTER");
         CHECK(r.seedId == 2, "REGISTER resolves to seed_id=2");
         CHECK(!r.usedTestnetDefault, "REGISTER on mainnet is not a testnet default");
     }
@@ -673,7 +673,7 @@ static void TestSeedIdentityResolutionGlue() {
     // (Drives the abort path; a no-op decision helper would NOT return this.)
     {
         SeedIdentityResult r = ResolveSeedIdentity(
-            seedIPs, seedPubkeys, "10.0.0.1", keys[3].GetPubKey());
+            seedIPs, seedPubkeys, "10.0.0.1", keys[3].GetPubKey(), /*asnLoaded=*/true);
         CHECK(r.decision == SeedIdentityDecision::FATAL_MISMATCH,
               "resolved slot + mismatched pubkey -> FATAL_MISMATCH (abort path)");
         CHECK(r.seedId == 0, "FATAL_MISMATCH reports the resolved seed_id");
@@ -683,7 +683,7 @@ static void TestSeedIdentityResolutionGlue() {
     // HIGH-1: must NOT abort even though a usable key is present.
     {
         SeedIdentityResult r = ResolveSeedIdentity(
-            seedIPs, seedPubkeys, "203.0.113.7", keys[0].GetPubKey());
+            seedIPs, seedPubkeys, "203.0.113.7", keys[0].GetPubKey(), /*asnLoaded=*/true);
         CHECK(r.decision == SeedIdentityDecision::SKIP_NOT_A_SEED,
               "non-seed externalip + key present -> SKIP_NOT_A_SEED (NOT abort, HIGH-1)");
         CHECK(r.seedId == -1, "SKIP leaves seed_id unresolved");
@@ -691,7 +691,7 @@ static void TestSeedIdentityResolutionGlue() {
     // Empty externalip is also "not a seed" -> SKIP, not FATAL.
     {
         SeedIdentityResult r = ResolveSeedIdentity(
-            seedIPs, seedPubkeys, "", keys[0].GetPubKey());
+            seedIPs, seedPubkeys, "", keys[0].GetPubKey(), /*asnLoaded=*/true);
         CHECK(r.decision == SeedIdentityDecision::SKIP_NOT_A_SEED,
               "empty externalip on mainnet -> SKIP_NOT_A_SEED (HIGH-1)");
     }
@@ -699,14 +699,14 @@ static void TestSeedIdentityResolutionGlue() {
     // --- HIGH-2: :port suffix and whitespace must still resolve. -------------
     {
         SeedIdentityResult r = ResolveSeedIdentity(
-            seedIPs, seedPubkeys, "10.0.0.4:8444", keys[3].GetPubKey());
+            seedIPs, seedPubkeys, "10.0.0.4:8444", keys[3].GetPubKey(), /*asnLoaded=*/true);
         CHECK(r.decision == SeedIdentityDecision::REGISTER,
               "externalip with :port resolves -> REGISTER (HIGH-2)");
         CHECK(r.seedId == 3, ":port-stripped externalip resolves to correct seed_id");
     }
     {
         SeedIdentityResult r = ResolveSeedIdentity(
-            seedIPs, seedPubkeys, "  10.0.0.2  ", keys[1].GetPubKey());
+            seedIPs, seedPubkeys, "  10.0.0.2  ", keys[1].GetPubKey(), /*asnLoaded=*/true);
         CHECK(r.decision == SeedIdentityDecision::REGISTER,
               "whitespace-padded externalip resolves -> REGISTER (HIGH-2)");
         CHECK(r.seedId == 1, "trimmed externalip resolves to correct seed_id");
@@ -715,7 +715,7 @@ static void TestSeedIdentityResolutionGlue() {
     // resolved slot (normalization must not mask a genuine key mismatch).
     {
         SeedIdentityResult r = ResolveSeedIdentity(
-            seedIPs, seedPubkeys, " 10.0.0.1:8444 ", keys[2].GetPubKey());
+            seedIPs, seedPubkeys, " 10.0.0.1:8444 ", keys[2].GetPubKey(), /*asnLoaded=*/true);
         CHECK(r.decision == SeedIdentityDecision::FATAL_MISMATCH,
               "normalized resolve still enforces pubkey match -> FATAL_MISMATCH");
         CHECK(r.seedId == 0, "normalized externalip resolved to seed_id=0");
@@ -738,20 +738,64 @@ static void TestSeedIdentityResolutionGlue() {
     {
         std::vector<std::vector<uint8_t>> emptyPubkeys;
         SeedIdentityResult r = ResolveSeedIdentity(
-            seedIPs, emptyPubkeys, "203.0.113.7", keys[0].GetPubKey());
+            seedIPs, emptyPubkeys, "203.0.113.7", keys[0].GetPubKey(), /*asnLoaded=*/true);
         CHECK(r.decision == SeedIdentityDecision::REGISTER,
-              "testnet empty set + unresolved ip -> REGISTER (lenient)");
+              "testnet empty set + unresolved ip + ASN ok -> REGISTER (lenient)");
         CHECK(r.seedId == 0, "testnet unresolved defaults to seed_id=0");
         CHECK(r.usedTestnetDefault, "testnet default flagged for legacy WARN");
     }
     {
         std::vector<std::vector<uint8_t>> emptyPubkeys;
         SeedIdentityResult r = ResolveSeedIdentity(
-            seedIPs, emptyPubkeys, "10.0.0.2", keys[0].GetPubKey());
+            seedIPs, emptyPubkeys, "10.0.0.2", keys[0].GetPubKey(), /*asnLoaded=*/true);
         CHECK(r.decision == SeedIdentityDecision::REGISTER,
               "testnet empty set + resolved ip -> REGISTER at resolved index");
         CHECK(r.seedId == 1, "testnet resolved ip keeps its index");
         CHECK(!r.usedTestnetDefault, "testnet resolved ip is not a default");
+    }
+
+    // --- H-3 (consolidated): DEGRADED_NO_ASN — valid identity, ASN DB down. ---
+    // The load-bearing new case. A no-op DEGRADED helper (one that still returns
+    // REGISTER when asnLoaded=false) would FAIL all four of these.
+    {
+        // Mainnet seed, key MATCHES its slot, but ASN failed to load -> DEGRADED,
+        // NOT REGISTER (stay online, don't register) and NOT FATAL (don't abort).
+        SeedIdentityResult r = ResolveSeedIdentity(
+            seedIPs, seedPubkeys, "10.0.0.3", keys[2].GetPubKey(), /*asnLoaded=*/false);
+        CHECK(r.decision == SeedIdentityDecision::DEGRADED_NO_ASN,
+              "valid mainnet seed + ASN DB FAILED -> DEGRADED_NO_ASN (online, unregistered)");
+        CHECK(r.decision != SeedIdentityDecision::REGISTER,
+              "DEGRADED must NOT register (kills original silent-zero-capacity bug)");
+        CHECK(r.decision != SeedIdentityDecision::FATAL_MISMATCH,
+              "DEGRADED must NOT abort (kills the brick over-correction)");
+        CHECK(r.seedId == 2, "DEGRADED still reports the resolved seed_id (for diagnostics)");
+    }
+    {
+        // ASN state must NOT override a TRUST failure: resolved slot + WRONG key
+        // is still FATAL_MISMATCH even with the ASN DB down. A wrong-key signer
+        // must never run, regardless of ASN state.
+        SeedIdentityResult r = ResolveSeedIdentity(
+            seedIPs, seedPubkeys, "10.0.0.1", keys[3].GetPubKey(), /*asnLoaded=*/false);
+        CHECK(r.decision == SeedIdentityDecision::FATAL_MISMATCH,
+              "mismatched pubkey stays FATAL_MISMATCH even with ASN DB down (trust > ASN)");
+    }
+    {
+        // ASN state must NOT turn a non-seed into a degraded seed: a non-matching
+        // externalip is SKIP_NOT_A_SEED whether or not the ASN DB loaded.
+        SeedIdentityResult r = ResolveSeedIdentity(
+            seedIPs, seedPubkeys, "203.0.113.7", keys[0].GetPubKey(), /*asnLoaded=*/false);
+        CHECK(r.decision == SeedIdentityDecision::SKIP_NOT_A_SEED,
+              "non-seed externalip stays SKIP_NOT_A_SEED even with ASN DB down (no false degrade)");
+    }
+    {
+        // Testnet (empty pubkey set): a would-be lenient REGISTER also degrades
+        // when the ASN DB is down — same online-but-unregistered semantics.
+        std::vector<std::vector<uint8_t>> emptyPubkeys;
+        SeedIdentityResult r = ResolveSeedIdentity(
+            seedIPs, emptyPubkeys, "10.0.0.2", keys[0].GetPubKey(), /*asnLoaded=*/false);
+        CHECK(r.decision == SeedIdentityDecision::DEGRADED_NO_ASN,
+              "testnet would-be REGISTER + ASN DB down -> DEGRADED_NO_ASN");
+        CHECK(r.seedId == 1, "testnet DEGRADED keeps the resolved seed_id");
     }
 }
 


### PR DESCRIPTION
Consolidates M-1 (pubkey-match), M-2 (seedId-resolution + --externalip normalization), and the red-team-corrected H-3 into one coherent change with a single decision table: SKIP_NOT_A_SEED (not a seed → run normally) / FATAL_MISMATCH (wrong key → abort) / DEGRADED_NO_ASN (ASN load fail → loud+online, attestation off, distinct RPC string) / REGISTER. Red-team clean (0 blocker/high; 1 MED: datacenter-asns.txt deserves the same DEGRADED treatment — fold or accept). **Supersedes fix/seed-key-identity-fold + fix/seed-key-security-followups** (close those). Needs your Cursor pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)