### PR TITLE
fix(api): LP-12 public-API path-gate bypass + x402 query preservation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -300,6 +300,7 @@ RPC_SOURCES := src/rpc/server.cpp \
                src/rpc/host_validator.cpp
 
 API_SOURCES := src/api/http_server.cpp \
+               src/api/http_path_gate.cpp \
                src/api/cached_stats.cpp
 
 X402_SOURCES := src/x402/x402_types.cpp \
@@ -526,7 +527,7 @@ rpc_host_header_tests: $(OBJ_DIR)/rpc/host_validator.o $(OBJ_DIR)/test/rpc_host_
 # LP-12: CHttpServer wallet-HTML serving-gate unit tests. Self-contained — links
 # ONLY host_validator.o (the IsLoopbackIP SSoT predicate), so it builds and runs
 # WITHOUT the node's depends/ (libzmq/randomx/chiavdf). No CORE_OBJECTS dependency.
-http_server_wallet_gate_tests: $(OBJ_DIR)/rpc/host_validator.o $(OBJ_DIR)/test/http_server_wallet_gate_tests.o
+http_server_wallet_gate_tests: $(OBJ_DIR)/rpc/host_validator.o $(OBJ_DIR)/api/http_path_gate.o $(OBJ_DIR)/test/http_server_wallet_gate_tests.o
 	@echo "$(COLOR_BLUE)[LINK]$(COLOR_RESET) $@"
 	@$(CXX) $(CXXFLAGS) -o $@ $^
 

--- a/src/api/http_path_gate.cpp
+++ b/src/api/http_path_gate.cpp
@@ -129,6 +129,24 @@ NormalizedPath NormalizeRequestPath(const std::string& rawPath) {
     return result;
 }
 
+std::string ExtractRawQuery(const std::string& rawPath) {
+    // Mirror NormalizeRequestPath step 1's split EXACTLY: find the first raw
+    // '?' or '#'. If the first such char is '?', the query is everything after
+    // it up to (but not including) any later '#'. If a '#' comes first (or there
+    // is no '?'), there is no query.
+    size_t cut = rawPath.find_first_of("?#");
+    if (cut == std::string::npos || rawPath[cut] != '?') {
+        return std::string();
+    }
+    std::string afterQ = rawPath.substr(cut + 1);
+    // Drop a fragment if present (everything from the first '#').
+    size_t frag = afterQ.find('#');
+    if (frag != std::string::npos) {
+        afterQ = afterQ.substr(0, frag);
+    }
+    return afterQ;
+}
+
 bool IsSensitiveSurface(const std::string& normalizedPath) {
     // Case-fold for the comparison. Gating a superset of what the live handler
     // routes (which is case-sensitive) is safe: a gated-but-unrouted path 404s

--- a/src/api/http_path_gate.cpp
+++ b/src/api/http_path_gate.cpp
@@ -1,0 +1,154 @@
+// Copyright (c) 2026 The Dilithion Core developers
+// Distributed under the MIT software license
+
+#include <api/http_path_gate.h>
+
+#include <cctype>
+#include <vector>
+
+namespace api {
+
+namespace {
+
+// Lowercase ASCII only (paths are ASCII; we never case-fold above 0x7f).
+char LowerAscii(char c) {
+    return static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+}
+
+// Decode a single hex nibble; -1 on non-hex.
+int HexVal(char c) {
+    if (c >= '0' && c <= '9') return c - '0';
+    if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+    if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+    return -1;
+}
+
+// Percent-decode `in` into `out`. Returns false on a malformed escape (a '%'
+// not followed by two hex digits) — fail-closed: the caller treats this as a
+// non-normalizable (therefore sensitive) path.
+//
+// We decode %XX into its raw byte UNCONDITIONALLY (including an encoded '/',
+// %2f, and an encoded '.', %2e). That is the whole point: an attacker who hides
+// a slash or a dot-segment behind percent-encoding (e.g. /api/v1/%2e%2e/x402/)
+// must be normalized into the same canonical form as the literal spelling so
+// the gate sees through the disguise. Re-encoding ambiguity does not apply here
+// because the normalized path is used only for the gate decision and for the
+// server's own case-sensitive routing, never re-emitted to another parser.
+bool PercentDecode(const std::string& in, std::string& out) {
+    out.clear();
+    out.reserve(in.size());
+    for (size_t i = 0; i < in.size(); ++i) {
+        char c = in[i];
+        if (c == '%') {
+            if (i + 2 >= in.size()) return false;       // truncated escape
+            int hi = HexVal(in[i + 1]);
+            int lo = HexVal(in[i + 2]);
+            if (hi < 0 || lo < 0) return false;          // non-hex escape
+            out.push_back(static_cast<char>((hi << 4) | lo));
+            i += 2;
+        } else {
+            out.push_back(c);
+        }
+    }
+    return true;
+}
+
+} // namespace
+
+NormalizedPath NormalizeRequestPath(const std::string& rawPath) {
+    NormalizedPath result;
+
+    // 1. Strip query string and fragment. The gate is about the path only; a
+    //    `?`/`#` must never let a sensitive path slip through (the original bug:
+    //    `/wallet?x` != `/wallet`).
+    std::string p = rawPath;
+    size_t cut = p.find_first_of("?#");
+    if (cut != std::string::npos) p = p.substr(0, cut);
+
+    // 2. Percent-decode (fail-closed on a malformed escape).
+    std::string decoded;
+    if (!PercentDecode(p, decoded)) {
+        result.ok = false;
+        return result;
+    }
+    p = decoded;
+
+    // 3. A reject for a NUL byte injected via %00 — a normalized path must not
+    //    contain one (truncation / smuggling defense). Fail-closed.
+    if (p.find('\0') != std::string::npos) {
+        result.ok = false;
+        return result;
+    }
+
+    // 4. Treat an empty or non-absolute target conservatively. A request target
+    //    that does not begin with '/' (e.g. "*", or an absolute-form URI) is not
+    //    a path we route; normalize to "/" is wrong (would look like root, a
+    //    sensitive surface) — but returning ok with a leading '/' added keeps it
+    //    classifiable. Prepend '/' so segment logic below is uniform; the gate
+    //    will then evaluate it like any other path.
+    if (p.empty() || p.front() != '/') {
+        p.insert(p.begin(), '/');
+    }
+
+    // 5. Split on '/', collapsing duplicate slashes, and resolve '.'/'..'.
+    //    A '..' that would pop above root is a traversal attempt -> fail-closed.
+    std::vector<std::string> segs;
+    size_t i = 0;
+    const size_t n = p.size();
+    while (i < n) {
+        // p[i] is '/' at the start of each iteration boundary; skip run of '/'.
+        while (i < n && p[i] == '/') ++i;
+        if (i >= n) break;
+        size_t start = i;
+        while (i < n && p[i] != '/') ++i;
+        std::string seg = p.substr(start, i - start);
+        if (seg == ".") {
+            // current-dir: drop.
+        } else if (seg == "..") {
+            if (segs.empty()) {
+                // Traversal above root — reject (fail-closed).
+                result.ok = false;
+                return result;
+            }
+            segs.pop_back();
+        } else {
+            segs.push_back(seg);
+        }
+    }
+
+    // 6. Rebuild canonical path. No trailing slash (except bare root). Leading
+    //    slash always present.
+    std::string canon = "/";
+    for (size_t s = 0; s < segs.size(); ++s) {
+        canon += segs[s];
+        if (s + 1 < segs.size()) canon += "/";
+    }
+
+    result.path = canon;
+    result.ok = true;
+    return result;
+}
+
+bool IsSensitiveSurface(const std::string& normalizedPath) {
+    // Case-fold for the comparison. Gating a superset of what the live handler
+    // routes (which is case-sensitive) is safe: a gated-but-unrouted path 404s
+    // AFTER passing the Host check, leaking nothing. Never the inverse.
+    std::string lp;
+    lp.reserve(normalizedPath.size());
+    for (char c : normalizedPath) lp.push_back(LowerAscii(c));
+
+    // Prefix surfaces (REST + x402 facilitator). Normalized => no duplicate
+    // slashes, no dot-segments, no query; a literal "/api/v1/" prefix (or the
+    // exact bare "/api/v1") now matches every disguised spelling.
+    if (lp == "/api/v1" || lp.rfind("/api/v1/", 0) == 0) return true;
+    if (lp == "/x402" || lp.rfind("/x402/", 0) == 0) return true;
+
+    // Exact node-touching surfaces.
+    if (lp == "/wallet" || lp == "/wallet.html" || lp == "/") return true;
+    if (lp == "/api/stats") return true;
+    if (lp == "/metrics") return true;
+
+    return false;
+}
+
+} // namespace api

--- a/src/api/http_path_gate.h
+++ b/src/api/http_path_gate.h
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 The Dilithion Core developers
+// Distributed under the MIT software license
+//
+// LP-12 (gate-bypass fold) — request-path normalization + sensitive-surface
+// classification for the standalone CHttpServer's anti-DNS-rebinding Host gate.
+//
+// Why this is its own dependency-free translation unit:
+//   The external-consensus review (PR #112) found that the gate decided
+//   `sensitive_surface` on the RAW, un-normalized request path using exact `==`
+//   and raw `rfind(...,0)==0`. That let every alternate spelling of a sensitive
+//   path — query string (`/wallet?x`), trailing slash (`/wallet/`), case
+//   (`/API/v1/`), percent-encoding (`/%61pi/v1/`), dot-segment traversal
+//   (`/api/v1/../x402/`), duplicate slashes (`//api//v1//`) — evade the gate.
+//   It ALSO found the gate test re-modelled the logic instead of exercising the
+//   real code. Extracting the decision into pure functions kills both findings
+//   at once: CHttpServer::HandleRequest calls them (real path), and the unit
+//   test calls the SAME functions (no re-model), with no node depends/ needed.
+//
+// Fail-closed contract: NormalizeRequestPath reports `ok=false` for any path it
+// cannot safely canonicalize (bad percent-encoding, a `..` that would escape
+// above root). Callers MUST treat a non-ok result as SENSITIVE (gate it), never
+// as public.
+
+#ifndef DILITHION_API_HTTP_PATH_GATE_H
+#define DILITHION_API_HTTP_PATH_GATE_H
+
+#include <string>
+
+namespace api {
+
+struct NormalizedPath {
+    // The canonical path used for BOTH the gate decision and (in the live
+    // server) handler dispatch. Always begins with '/'. Query string and
+    // fragment are stripped. Percent-escapes are decoded. Duplicate slashes are
+    // collapsed. '.' and '..' segments are resolved. A trailing slash is removed
+    // (except for the bare root "/").
+    std::string path;
+
+    // false => the raw path could not be safely normalized (malformed percent
+    // escape, or a '..' that traverses above root). The gate MUST treat this as
+    // sensitive / reject — fail-closed.
+    bool ok = false;
+};
+
+// Normalize a raw HTTP request-target path (the second token of the request
+// line, e.g. "/api/v1/../x402/foo?bar"). See NormalizedPath for the contract.
+// Pure; no I/O; depends only on <string>.
+NormalizedPath NormalizeRequestPath(const std::string& rawPath);
+
+// Decide whether a NORMALIZED path is a node-touching "sensitive surface" that
+// the anti-DNS-rebinding Host gate must protect. Case-folded so that, e.g.,
+// "/API/V1/x" is gated even though the live handler routes case-sensitively —
+// gating a superset of routed paths is safe (fail-closed); never the reverse.
+//
+// Pass the .path from a NormalizeRequestPath result. If that result had
+// ok==false, callers must gate regardless (do not even call this) — a path that
+// would not normalize is sensitive by definition.
+bool IsSensitiveSurface(const std::string& normalizedPath);
+
+} // namespace api
+
+#endif // DILITHION_API_HTTP_PATH_GATE_H

--- a/src/api/http_path_gate.h
+++ b/src/api/http_path_gate.h
@@ -57,6 +57,24 @@ NormalizedPath NormalizeRequestPath(const std::string& rawPath);
 // would not normalize is sensitive by definition.
 bool IsSensitiveSurface(const std::string& normalizedPath);
 
+// Extract the RAW query string from a raw request-target path: the bytes after
+// the FIRST raw '?' and before any '#' fragment. Returns "" if there is no raw
+// '?'. This is the EXACT delimiter NormalizeRequestPath strips in its step 1, so
+// the query carved out here is precisely the part the gate path dropped — no
+// more, no less.
+//
+// Why raw, not decoded: a percent-encoded '?' (%3f) is a LITERAL path byte, not
+// a query delimiter (e.g. "/wallet%3fx" is the single path segment "wallet?x",
+// never the path "/wallet" with query "x"). Keying on the raw '?' keeps this
+// query-extraction in lockstep with the gate's query-strip, so the same byte
+// the gate treats as a query delimiter is the byte that begins the query here —
+// a percent-encoded '?' is never mistaken for a delimiter on either side.
+//
+// SECURITY: this value is used ONLY to reconstruct a handler's input AFTER the
+// gate and dispatch decision have already been made on the normalized, query-
+// stripped path. It can never influence the sensitivity classification.
+std::string ExtractRawQuery(const std::string& rawPath);
+
 } // namespace api
 
 #endif // DILITHION_API_HTTP_PATH_GATE_H

--- a/src/api/http_server.cpp
+++ b/src/api/http_server.cpp
@@ -372,7 +372,25 @@ void CHttpServer::HandleRequest(SOCKET client_socket) {
     // embedded NUL) is treated as sensitive AND not routed — fail-closed.
     // ========================================================================
     const api::NormalizedPath norm = api::NormalizeRequestPath(rawPath);
-    const std::string& path = norm.path;  // canonical; dispatch uses this below
+    const std::string& path = norm.path;  // canonical; gate + dispatch DECISION use this
+
+    // LP-12 (x402 query-preservation, MEDIUM functional regression fix).
+    // NormalizeRequestPath STRIPS the `?...` query — correct for the gate and for
+    // choosing WHICH handler runs, but the x402 endpoint
+    // `GET /x402/dna-attest?address=ADDR` parses `address=` from that query
+    // (CFacilitator::HandleDnaAttest). Carving the query off the gate path made
+    // every such request fail with "Missing address parameter". We therefore
+    // carry the ORIGINAL raw query forward and hand the handlers a query-
+    // preserving path — WITHOUT ever feeding the query back into the gate.
+    //
+    // INVARIANT (do NOT weaken): the query is extracted from the RAW path and is
+    // used ONLY to rebuild a handler's input. The sensitivity classification and
+    // the which-handler dispatch decision below both key on the normalized,
+    // query-stripped `path`. A query string can never reach IsSensitiveSurface
+    // and so can never smuggle a sensitive path past the gate, nor un-gate one.
+    // It is also reconstructed ONLY on the norm.ok path: a non-normalizable
+    // request is rejected (403/404) before this value is ever consulted.
+    const std::string rawQuery = api::ExtractRawQuery(rawPath);
 
     // STRESS TEST FIX: Handle GET /api/health - simple health check that NEVER
     // blocks. Stays ABOVE the Host gate as an intentional load-balancer probe;
@@ -446,7 +464,10 @@ void CHttpServer::HandleRequest(SOCKET client_socket) {
         }
     }
 
-    // Handle REST API requests for light wallet (/api/v1/*) and x402 facilitator (/x402/*)
+    // Handle REST API requests for light wallet (/api/v1/*) and x402 facilitator
+    // (/x402/*). The which-handler DISPATCH DECISION keys on the normalized,
+    // query-stripped `path` (so the gate's normalize-once-drives-both invariant
+    // holds); only the handler's INPUT regains the original query, below.
     if (path.rfind("/api/v1/", 0) == 0 || path.rfind("/x402/", 0) == 0) {
         if (m_rest_api_handler) {
             try {
@@ -460,12 +481,21 @@ void CHttpServer::HandleRequest(SOCKET client_socket) {
                     }
                 }
 
+                // LP-12 query-preservation: hand the handler the canonical path
+                // with the ORIGINAL query re-attached, so query-parsing endpoints
+                // (x402 /dna-attest reads `address=` from the query) work again.
+                // The dispatch decision above already used the query-stripped
+                // `path`; this only restores the handler's own input. Downstream
+                // handlers (CFacilitator / CRestAPI) strip the query themselves.
+                const std::string dispatchPath =
+                    rawQuery.empty() ? path : (path + "?" + rawQuery);
+
                 // Call REST API handler (returns full HTTP response).
                 // LP-12: pass the REAL peer IP (was hardcoded "0.0.0.0", which
                 // collapsed every client onto one rate-limit bucket and erased
                 // attribution). Per-IP limiting on the REST broadcast path now
                 // keys on the actual connection.
-                std::string response = m_rest_api_handler(method, path, body, clientIP);
+                std::string response = m_rest_api_handler(method, dispatchPath, body, clientIP);
 
                 // Send raw response (handler builds complete HTTP response)
 #ifdef _WIN32

--- a/src/api/http_server.cpp
+++ b/src/api/http_server.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license
 
 #include <api/http_server.h>
+#include <api/http_path_gate.h>
 #include <api/wallet_html.h>
 #include <net/sock.h>
 #include <rpc/host_validator.h>
@@ -339,16 +340,46 @@ void CHttpServer::HandleRequest(SOCKET client_socket) {
     buffer[bytes_read] = '\0';
     std::string request(buffer);
 
+    // LP-12 (gate-bypass fold, MEDIUM) — TRUNCATION FAIL-CLOSED. We read at most
+    // one 4095-byte chunk. If it came back completely full, the request may be
+    // truncated mid-header, and a Host value cut at the buffer boundary
+    // ("Host: 127.0.0.1<cut>.evil.com" -> "127.0.0.1") could spuriously match
+    // the allowlist while the FULL header would not. We cannot see the complete
+    // headers, so treat the request as untrusted: it is gated like any sensitive
+    // path below and rejected unless the (possibly partial) Host still passes.
+    // Rather than rely on that, force the gate's fail-closed branch.
+    const bool requestMaybeTruncated =
+        (static_cast<size_t>(bytes_read) >= sizeof(buffer) - 1);
+
     // Parse request
-    std::string method, path;
-    if (!ParseRequest(request, method, path)) {
+    std::string method, rawPath;
+    if (!ParseRequest(request, method, rawPath)) {
         Send500(client_socket);
         return;
     }
 
-    // STRESS TEST FIX: Handle GET /api/health - simple health check that NEVER blocks
-    // This endpoint is always available, even during high load
-    if (method == "GET" && path == "/api/health") {
+    // ========================================================================
+    // LP-12 (gate-bypass fold) — NORMALIZE THE PATH BEFORE ANY DECISION.
+    //
+    // The external-consensus review found the H-01 gate decided on the RAW
+    // request path, so every alternate spelling of a sensitive path evaded it
+    // (`/wallet?x`, `/wallet/`, `/API/v1/`, `/%61pi/v1/`, `/api/v1/../x402/`,
+    // `//api//v1//`). We now canonicalize ONCE here — strip query/fragment,
+    // percent-decode, collapse `//`, resolve `.`/`..`, drop the trailing slash —
+    // and drive BOTH the gate AND handler dispatch off the SAME normalized path,
+    // so a spelling can never reach a node-touching handler while skipping the
+    // gate. A path that will not normalize (bad %-escape, `..` above root, an
+    // embedded NUL) is treated as sensitive AND not routed — fail-closed.
+    // ========================================================================
+    const api::NormalizedPath norm = api::NormalizeRequestPath(rawPath);
+    const std::string& path = norm.path;  // canonical; dispatch uses this below
+
+    // STRESS TEST FIX: Handle GET /api/health - simple health check that NEVER
+    // blocks. Stays ABOVE the Host gate as an intentional load-balancer probe;
+    // it returns a STATIC liveness string only (no node/identity data). Matched
+    // on the normalized path so a disguised spelling cannot smuggle something
+    // else through this pre-gate branch. A non-normalizable path never matches.
+    if (norm.ok && method == "GET" && path == "/api/health") {
         SendResponse(client_socket, 200, "application/json", R"({"status":"ok"})");
         return;
     }
@@ -391,16 +422,26 @@ void CHttpServer::HandleRequest(SOCKET client_socket) {
     // production ConfigureHostAllowlist() runs before Start() spawns workers.
     // ========================================================================
     {
+        // Fail-closed: a path that would not normalize (bad %-escape, traversal
+        // above root, embedded NUL) is treated as sensitive — it must NOT slip
+        // past the Host gate. Otherwise classify the canonical path.
         const bool sensitive_surface =
-            path.rfind("/api/v1/", 0) == 0 ||
-            path.rfind("/x402/", 0) == 0 ||
-            path == "/wallet" || path == "/wallet.html" || path == "/" ||
-            path == "/api/stats" || path == "/metrics";
+            !norm.ok || api::IsSensitiveSurface(path);
         if (sensitive_surface &&
-            (!m_host_validator_ready.load() ||
+            (requestMaybeTruncated ||
+             !m_host_validator_ready.load() ||
              !m_host_validator.IsRequestHostAllowed(request))) {
             SendResponse(client_socket, 403, "application/json",
                 R"({"error":"Forbidden: Host header not allowed (DNS-rebinding protection). Connect via 127.0.0.1/localhost or configure --rpcallowhost.","code":-32600})");
+            return;
+        }
+        // A non-normalizable path that somehow passed the Host check (e.g. a
+        // loopback operator hitting a malformed URL) is still never routed to a
+        // node-touching handler: every dispatch branch below keys on the
+        // canonical `path`, which is empty/garbage when !norm.ok, so it falls
+        // through to 404. Make that explicit and fail-closed.
+        if (!norm.ok) {
+            Send404(client_socket);
             return;
         }
     }
@@ -465,6 +506,18 @@ void CHttpServer::HandleRequest(SOCKET client_socket) {
                 R"({"error":"Forbidden: the wallet UI is disabled on a public-API node. SSH-tunnel to a loopback RPC to use the wallet.","code":-32600})");
             return;
         }
+        // LP-12 (gate-bypass fold, finding #3) — IPv4-mapped-IPv6 loopback spoof
+        // is NOT exploitable here. clientIP is GetPeerIP(), which calls
+        // getpeername() (kernel-reported peer, not attacker-supplied) and then
+        // CSock::ExtractAddress(), which UNWRAPS any IPv4-mapped v6 source
+        // (IN6_IS_ADDR_V4MAPPED -> dotted IPv4) BEFORE it reaches IsLoopbackIP.
+        // So a REMOTE peer can never present "::ffff:127.0.0.1" to this check:
+        // the kernel reports the peer's real address, and a real remote address
+        // unwraps to its real (non-127) IPv4. A 127.x source on a remote socket
+        // would be a martian packet rejected by the OS network stack. Belt-and-
+        // suspenders: on --public-api nodes the wallet UI is already disabled
+        // entirely above (the public-node branch), so this loopback gate is only
+        // reached on a localhost-bound server in the first place.
         if (!rpc::HostValidator::IsLoopbackIP(clientIP)) {
             SendResponse(client_socket, 403, "application/json",
                 R"({"error":"Forbidden: the wallet UI is served to loopback connections only. Use an SSH tunnel for remote access.","code":-32600})");
@@ -478,7 +531,8 @@ void CHttpServer::HandleRequest(SOCKET client_socket) {
         // belt-and-suspenders anti-rebinding layer. Fail-closed if the validator
         // is not ready. Either failing rejects the token-minting page.
         // ====================================================================
-        if (!m_host_validator_ready.load() ||
+        if (requestMaybeTruncated ||
+            !m_host_validator_ready.load() ||
             !m_host_validator.IsRequestLoopbackHost(request)) {
             SendResponse(client_socket, 403, "application/json",
                 R"({"error":"Forbidden: the wallet UI is served on loopback only (127.0.0.1/localhost). Use an SSH tunnel for remote access.","code":-32600})");

--- a/src/rpc/rest_api.cpp
+++ b/src/rpc/rest_api.cpp
@@ -61,6 +61,17 @@ std::string CRestAPI::HandleRequest(const std::string& method,
     // Remove /api/v1/ prefix
     std::string subpath = path.substr(8);  // Skip "/api/v1/"
 
+    // Strip any query string. REST endpoints take their argument as a PATH
+    // segment (e.g. /api/v1/balance/{address}), not as a query, so a trailing
+    // `?...` must not bleed into the path param. The standalone CHttpServer now
+    // hands this handler a query-preserving path (to keep x402's /dna-attest
+    // query intact); strip it here so /api/v1/balance/ADDR?foo parses ADDR, not
+    // "ADDR?foo". (The RPC server passes the raw target through too — same fix.)
+    size_t qmark = subpath.find('?');
+    if (qmark != std::string::npos) {
+        subpath = subpath.substr(0, qmark);
+    }
+
     // Find first slash to separate endpoint from parameter
     size_t slash = subpath.find('/');
     if (slash != std::string::npos) {

--- a/src/test/http_server_wallet_gate_tests.cpp
+++ b/src/test/http_server_wallet_gate_tests.cpp
@@ -20,6 +20,7 @@
 // http_server.cpp calls the same predicate in the same order.
 
 #include <rpc/host_validator.h>
+#include <api/http_path_gate.h>
 
 #include <cstdint>
 #include <iostream>
@@ -300,6 +301,130 @@ static void TestRateLimiterRecordsStayBounded() {
     CHECK(recs.empty());
 }
 
+// ==========================================================================
+// 7. GATE-BYPASS FOLD (PR #112 extreview, finding #1) — the H-01 gate's
+//    sensitive-surface decision, exercised through the REAL production
+//    functions api::NormalizeRequestPath + api::IsSensitiveSurface (NOT a
+//    re-model). CHttpServer::HandleRequest computes exactly:
+//
+//        const api::NormalizedPath norm = api::NormalizeRequestPath(rawPath);
+//        const bool sensitive = !norm.ok || api::IsSensitiveSurface(norm.path);
+//
+//    GateSensitive() below calls those SAME functions, so if the normalization
+//    is deleted or weakened the must-gate assertions here FAIL — this is the
+//    mutation-resistance the review demanded (it caught that the OLD test
+//    re-implemented the gate and was blind to every bypass vector).
+// ==========================================================================
+
+// The live gate decision, verbatim from http_server.cpp's gate block.
+static bool GateSensitive(const std::string& rawPath) {
+    const api::NormalizedPath norm = api::NormalizeRequestPath(rawPath);
+    return !norm.ok || api::IsSensitiveSurface(norm.path);
+}
+
+static void TestPathNormalizationGateBypassMatrix() {
+    std::cout << "LP-12 fold: every spelling of a sensitive path is gated..." << std::endl;
+
+    // ---- Canonical sensitive surfaces are gated. ----
+    CHECK(GateSensitive("/wallet"));
+    CHECK(GateSensitive("/wallet.html"));
+    CHECK(GateSensitive("/"));
+    CHECK(GateSensitive("/api/stats"));
+    CHECK(GateSensitive("/metrics"));
+    CHECK(GateSensitive("/api/v1/broadcast"));
+    CHECK(GateSensitive("/api/v1/info"));
+    CHECK(GateSensitive("/x402/pay"));
+
+    // ---- Finding #1 bypass vectors — ALL must now be gated. ----
+    // Query string on an exact-match path (the original headline bypass).
+    CHECK(GateSensitive("/wallet?x"));
+    CHECK(GateSensitive("/wallet?a=b&c=d"));
+    CHECK(GateSensitive("/api/stats?x"));
+    CHECK(GateSensitive("/metrics?format=prom"));
+    // Fragment.
+    CHECK(GateSensitive("/wallet#frag"));
+    CHECK(GateSensitive("/api/stats#x"));
+    // Trailing slash.
+    CHECK(GateSensitive("/wallet/"));
+    CHECK(GateSensitive("/api/stats/"));
+    CHECK(GateSensitive("/metrics/"));
+    CHECK(GateSensitive("/api/v1/"));
+    CHECK(GateSensitive("/x402/"));
+    // Mixed / upper case.
+    CHECK(GateSensitive("/API/v1/broadcast"));
+    CHECK(GateSensitive("/Api/V1/Broadcast"));
+    CHECK(GateSensitive("/X402/pay"));
+    CHECK(GateSensitive("/WALLET"));
+    CHECK(GateSensitive("/Metrics"));
+    CHECK(GateSensitive("/API/STATS"));
+    // Percent-encoding (/%61pi/ == /api/, %2f == '/', %2e == '.').
+    CHECK(GateSensitive("/%61pi/v1/broadcast"));     // %61 = 'a'
+    CHECK(GateSensitive("/api/v1%2fbroadcast"));     // encoded slash -> /api/v1/broadcast
+    CHECK(GateSensitive("/%77allet"));               // %77 = 'w'
+    // Dot-segment traversal that resolves ONTO a sensitive surface IS gated.
+    // (NOTE: /api/v1/../x402/pay canonicalizes to /api/x402/pay — the '..' pops
+    //  the v1 segment, NOT 'api' — so it is NOT sensitive and 404s; covered in
+    //  the negative cases below. The protection is gate/dispatch agreement on
+    //  the SAME canonical path, whatever that path is.)
+    CHECK(GateSensitive("/x402/../wallet"));         // -> /wallet
+    CHECK(GateSensitive("/api/v1/../../wallet"));    // -> /wallet
+    CHECK(GateSensitive("/foo/../wallet"));          // -> /wallet
+    CHECK(GateSensitive("/api/v1/%2e%2e/v1/broadcast")); // -> /api/v1/broadcast
+    CHECK(GateSensitive("/api/v1/./broadcast"));     // -> /api/v1/broadcast
+    CHECK(GateSensitive("/./wallet"));               // -> /wallet
+    // Duplicate slashes.
+    CHECK(GateSensitive("//api//v1//broadcast"));
+    CHECK(GateSensitive("///wallet"));
+    CHECK(GateSensitive("//metrics"));
+    CHECK(GateSensitive("/api//stats"));
+
+    // ---- Fail-closed: non-normalizable paths are gated (treated sensitive). ----
+    CHECK(GateSensitive("/api/v1/%zz"));   // malformed %-escape
+    CHECK(GateSensitive("/wallet%2"));     // truncated %-escape
+    CHECK(GateSensitive("/%2e%2e/etc"));   // '..' traversing above root
+    CHECK(GateSensitive("/../etc/passwd"));
+    CHECK(GateSensitive("/wallet%00.html")); // embedded NUL via %00
+
+    // ---- Genuinely public paths are NOT gated (gate must not over-block to
+    //      the point of breaking the LB health probe handling order). These are
+    //      paths the server would 404 or treat as health; none are sensitive. ----
+    CHECK(!GateSensitive("/favicon.ico"));
+    CHECK(!GateSensitive("/robots.txt"));
+    CHECK(!GateSensitive("/api/health"));   // health is matched ABOVE the gate
+    CHECK(!GateSensitive("/api/v2/info"));  // not a known sensitive prefix
+    CHECK(!GateSensitive("/walletx"));      // not /wallet (no false prefix)
+    CHECK(!GateSensitive("/metricsx"));
+    CHECK(!GateSensitive("/api/statsx"));
+    CHECK(!GateSensitive("/x402x/pay"));
+    CHECK(!GateSensitive("/nope"));
+    // /api/v1/../x402/pay -> /api/x402/pay ('..' cancels v1): NOT sensitive.
+    // The gate and the live REST dispatch agree it is unrouted -> 404.
+    CHECK(!GateSensitive("/api/v1/../x402/pay"));
+    CHECK(!GateSensitive("/api/v1/%2e%2e/x402/pay"));  // same, percent-encoded
+}
+
+// Direct assertions on the normalizer's canonical output (pins the contract
+// the gate relies on — also mutation-resistant: weakening any step shows here).
+static void TestNormalizerCanonicalForm() {
+    std::cout << "LP-12 fold: NormalizeRequestPath canonical-form contract..." << std::endl;
+    auto norm = [](const std::string& p) { return api::NormalizeRequestPath(p); };
+
+    CHECK(norm("/wallet?x").ok && norm("/wallet?x").path == "/wallet");
+    CHECK(norm("/wallet/").path == "/wallet");
+    CHECK(norm("//api//v1//broadcast").path == "/api/v1/broadcast");
+    CHECK(norm("/api/v1/../x402/pay").path == "/api/x402/pay"); // '..' pops v1
+    CHECK(norm("/x402/../wallet").path == "/wallet");           // '..' pops x402
+    CHECK(norm("/%61pi/v1/info").path == "/api/v1/info");
+    CHECK(norm("/").ok && norm("/").path == "/");
+    CHECK(norm("/foo/./bar").path == "/foo/bar");
+    // Fail-closed cases report ok == false.
+    CHECK(!norm("/%zz").ok);
+    CHECK(!norm("/wallet%2").ok);
+    CHECK(!norm("/../escape").ok);
+    CHECK(!norm("/a/../../escape").ok);
+    CHECK(!norm("/x%00y").ok);
+}
+
 int main() {
     std::cout << "=== LP-12 CHttpServer wallet-HTML gate tests ===" << std::endl;
     TestPublicApiDisablesWalletEntirely();
@@ -308,6 +433,8 @@ int main() {
     TestRestHostAllowlistGate();             // H-01
     TestWalletGateSecondaryHostCheck();      // M-03
     TestRateLimiterRecordsStayBounded();     // M-01
+    TestPathNormalizationGateBypassMatrix(); // gate-bypass fold (finding #1+#2)
+    TestNormalizerCanonicalForm();           // gate-bypass fold (normalizer contract)
     std::cout << "All " << g_checks << " checks passed." << std::endl;
     return 0;
 }

--- a/src/test/http_server_wallet_gate_tests.cpp
+++ b/src/test/http_server_wallet_gate_tests.cpp
@@ -425,6 +425,163 @@ static void TestNormalizerCanonicalForm() {
     CHECK(!norm("/x%00y").ok);
 }
 
+// ==========================================================================
+// 9. QUERY-PRESERVATION (x402 functional-regression fix) — the gate strips the
+//    query for CLASSIFICATION, but the handler must still RECEIVE it. This
+//    models CHttpServer::HandleRequest's dispatch exactly:
+//
+//        const NormalizedPath norm = NormalizeRequestPath(rawPath);   // gate path
+//        const std::string rawQuery = ExtractRawQuery(rawPath);       // carried query
+//        dispatchPath = rawQuery.empty() ? norm.path
+//                                        : norm.path + "?" + rawQuery; // handler input
+//
+//    using the REAL production functions (NormalizeRequestPath + ExtractRawQuery),
+//    so a regression in either shows up here. We then run the facilitator's OWN
+//    query-extraction (subpath.find('?'), verbatim from facilitator.cpp:73) and
+//    the REST handler's OWN query-strip on the dispatch path to prove the handler
+//    recovers `address=ADDR`.
+// ==========================================================================
+
+// Build the dispatch path EXACTLY as the live server does (only on norm.ok).
+static std::string DispatchPathForRoutedRequest(const std::string& rawPath) {
+    const api::NormalizedPath norm = api::NormalizeRequestPath(rawPath);
+    // The live server only reaches handler dispatch when norm.ok; a non-ok path
+    // is rejected before this point. Mirror that: callers below use only ok paths.
+    const std::string rawQuery = api::ExtractRawQuery(rawPath);
+    return rawQuery.empty() ? norm.path : (norm.path + "?" + rawQuery);
+}
+
+// Verbatim model of CFacilitator::HandleRequest's query carve-out
+// (facilitator.cpp:64-78): strip "/x402/", then split the FIRST '?' into
+// pathPart + query. Returns the `query` the handler would parse `address=` from.
+static std::string FacilitatorQueryFor(const std::string& dispatchPath) {
+    std::string subpath = dispatchPath.substr(6);  // Skip "/x402/"
+    size_t qmark = subpath.find('?');
+    if (qmark != std::string::npos) return subpath.substr(qmark + 1);
+    return std::string();
+}
+
+// Verbatim model of CFacilitator::HandleDnaAttest's address parse
+// (facilitator.cpp:243-257): pull `address=` out of the query, trim at '&'.
+static std::string ParsedAddressFor(const std::string& query) {
+    size_t pos = query.find("address=");
+    if (pos == std::string::npos) return std::string();
+    std::string address = query.substr(pos + 8);
+    size_t amp = address.find('&');
+    if (amp != std::string::npos) address = address.substr(0, amp);
+    return address;
+}
+
+// Verbatim model of CRestAPI::HandleRequest's subpath/param parse INCLUDING the
+// new query-strip: skip "/api/v1/", drop a trailing '?...', split first '/'.
+// Returns the `param` the REST handler would treat as e.g. the address/txid.
+static std::string RestParamFor(const std::string& dispatchPath) {
+    std::string subpath = dispatchPath.substr(8);  // Skip "/api/v1/"
+    size_t qmark = subpath.find('?');
+    if (qmark != std::string::npos) subpath = subpath.substr(0, qmark);
+    size_t slash = subpath.find('/');
+    if (slash != std::string::npos) return subpath.substr(slash + 1);
+    return std::string();  // no param segment
+}
+
+static void TestQueryPreservationForHandlers() {
+    std::cout << "LP-12 fix: handlers receive the query (x402 dna-attest regression)..." << std::endl;
+
+    // ---- THE REGRESSION: /x402/dna-attest?address=ADDR must reach the handler
+    //      with the query (and thus address=ADDR) intact. ----
+    {
+        const std::string dp = DispatchPathForRoutedRequest("/x402/dna-attest?address=DvWxyzADDR123");
+        // The gate path used for dispatch is canonical /x402/dna-attest...
+        CHECK(dp.rfind("/x402/dna-attest", 0) == 0);
+        // ...but the query rode along for the handler.
+        const std::string q = FacilitatorQueryFor(dp);
+        CHECK(q == "address=DvWxyzADDR123");
+        CHECK(ParsedAddressFor(q) == "DvWxyzADDR123");
+    }
+    // Multi-param query: address= still parsed, trimmed at '&'.
+    {
+        const std::string dp = DispatchPathForRoutedRequest("/x402/dna-attest?address=ADDR42&foo=bar");
+        const std::string q = FacilitatorQueryFor(dp);
+        CHECK(q == "address=ADDR42&foo=bar");
+        CHECK(ParsedAddressFor(q) == "ADDR42");
+    }
+    // address= not first in the query is still found (find, not prefix).
+    {
+        const std::string dp = DispatchPathForRoutedRequest("/x402/dna-attest?foo=1&address=ADDR9");
+        CHECK(ParsedAddressFor(FacilitatorQueryFor(dp)) == "ADDR9");
+    }
+    // A duplicate-slash / case spelling normalizes for dispatch but STILL carries
+    // the query (gate path canonical, handler input query-preserved).
+    {
+        const std::string dp = DispatchPathForRoutedRequest("//x402//dna-attest?address=ADDRdup");
+        CHECK(dp.rfind("/x402/dna-attest", 0) == 0);
+        CHECK(ParsedAddressFor(FacilitatorQueryFor(dp)) == "ADDRdup");
+    }
+    // No-query x402 request: dispatch path is just the canonical path (no stray '?').
+    {
+        const std::string dp = DispatchPathForRoutedRequest("/x402/supported");
+        CHECK(dp == "/x402/supported");
+        CHECK(FacilitatorQueryFor(dp).empty());
+    }
+
+    // ---- REST path-param handlers are UNAFFECTED: their argument is a path
+    //      segment, and the new query-strip means a stray query never corrupts it. ----
+    {
+        // Pure path-segment param (the normal case) — no query.
+        const std::string dp = DispatchPathForRoutedRequest("/api/v1/balance/SomeAddress");
+        CHECK(dp == "/api/v1/balance/SomeAddress");
+        CHECK(RestParamFor(dp) == "SomeAddress");
+    }
+    {
+        // A query tacked onto a REST path must NOT bleed into the param.
+        const std::string dp = DispatchPathForRoutedRequest("/api/v1/balance/SomeAddress?foo=bar");
+        CHECK(RestParamFor(dp) == "SomeAddress");   // NOT "SomeAddress?foo=bar"
+    }
+
+    // ---- SECURITY: query-preservation must NOT open a gate bypass. The query is
+    //      carried for the HANDLER only; the gate/dispatch keys on the query-
+    //      stripped canonical path. A query can neither un-gate a sensitive path
+    //      nor smuggle a sensitive path past the gate. ----
+    {
+        // /wallet?x is STILL sensitive (gate sees /wallet); the query is irrelevant
+        // to classification. (Re-assert against the live gate predicate.)
+        CHECK(GateSensitive("/wallet?x"));
+        // ExtractRawQuery pulls "x" off /wallet?x, but that value never feeds the gate.
+        CHECK(api::ExtractRawQuery("/wallet?x") == "x");
+        // The classification depends ONLY on the normalized path, never the query:
+        // identical normalized path => identical verdict regardless of query.
+        CHECK(GateSensitive("/wallet") == GateSensitive("/wallet?anything=here"));
+        CHECK(GateSensitive("/x402/dna-attest") == GateSensitive("/x402/dna-attest?address=ADDR"));
+        CHECK(GateSensitive("/nope") == GateSensitive("/nope?address=ADDR"));
+    }
+    {
+        // A query cannot carry a '/' that smuggles a NEW path: ExtractRawQuery
+        // returns only the post-'?' bytes; the dispatch path's ROUTING prefix is
+        // the canonical pre-'?' path. The handler's own '?' split discards it.
+        const std::string dp = DispatchPathForRoutedRequest("/x402/dna-attest?address=ADDR&next=/wallet");
+        // Dispatch still routes as /x402/... (the canonical gate path), and the
+        // facilitator's pathPart is "dna-attest" — the "/wallet" in the query is
+        // inert query data, never a route.
+        CHECK(dp.rfind("/x402/", 0) == 0);
+        CHECK(FacilitatorQueryFor(dp) == "address=ADDR&next=/wallet");
+        CHECK(ParsedAddressFor(FacilitatorQueryFor(dp)) == "ADDR");
+    }
+
+    // ---- ExtractRawQuery contract: raw '?' only; %3f is NOT a delimiter;
+    //      fragment dropped; first '#' before '?' => no query. ----
+    CHECK(api::ExtractRawQuery("/x402/dna-attest?address=A") == "address=A");
+    CHECK(api::ExtractRawQuery("/wallet").empty());                 // no query
+    CHECK(api::ExtractRawQuery("/wallet#frag").empty());            // fragment, no query
+    CHECK(api::ExtractRawQuery("/p?a=b#frag") == "a=b");            // fragment trimmed off query
+    CHECK(api::ExtractRawQuery("/p#x?a=b").empty());                // '#' before '?' => no query
+    // %3f is a literal byte, NOT a query delimiter — unchanged prior behavior.
+    // /wallet%3fx normalizes to a single segment "wallet?x" (NOT /wallet) and has
+    // NO raw '?', so ExtractRawQuery returns "" and it is NOT classified sensitive.
+    CHECK(api::ExtractRawQuery("/wallet%3fx").empty());
+    CHECK(!GateSensitive("/wallet%3fx"));   // prior %3f behavior unchanged
+    CHECK(api::NormalizeRequestPath("/wallet%3fx").path == "/wallet?x");
+}
+
 int main() {
     std::cout << "=== LP-12 CHttpServer wallet-HTML gate tests ===" << std::endl;
     TestPublicApiDisablesWalletEntirely();
@@ -435,6 +592,7 @@ int main() {
     TestRateLimiterRecordsStayBounded();     // M-01
     TestPathNormalizationGateBypassMatrix(); // gate-bypass fold (finding #1+#2)
     TestNormalizerCanonicalForm();           // gate-bypass fold (normalizer contract)
+    TestQueryPreservationForHandlers();      // x402 dna-attest query-preservation fix
     std::cout << "All " << g_checks << " checks passed." << std::endl;
     return 0;
 }


### PR DESCRIPTION
Closes PR #112 finding #1 (sensitive-surface gate bypassable by alternate path spellings) via a fail-closed normalize-once design (NormalizeRequestPath + IsSensitiveSurface), and fixes the x402 /dna-attest query-stripping regression (dispatchPath preserves the raw query for handlers while the gate keys on the normalized path).

Convergence: red-team + extreview (adjudicated) + Cursor close-readiness = ready-to-merge, no blocking findings. Part of the v4.5.0 bundle.

Follow-ups (non-blocking, tracked on the security track): CRPCServer path-normalization parity (RPC port shares the same alternate-spelling class); truncation-flag unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)