### PR TITLE
refactor(wallet): extract LegacyRecordKeying() helper — dedup v7-MAC keying predicate (sweep INFO-1)

### DIFF
--- a/src/test/wallet_encryption_at_rest_tests.cpp
+++ b/src/test/wallet_encryption_at_rest_tests.cpp
@@ -3274,6 +3274,88 @@ static void Test_V7PerAddressKeyMACRoundTrip() {
         }
         std::remove(path.c_str());
     }
+
+    // --- (E) IMPORTKEY on a LOADED LEGACY v6 wallet (LOW-1 fold):
+    //         same property as (D) for the ImportKey store site. A non-HD v6
+    //         wallet never migrates, so ImportKey must write a LEGACY-keyed MAC
+    //         (matching VerifyRecordMAC for v<7). With v7-only keying the imported
+    //         key loads but is silently UNSPENDABLE after reload (MAC mismatch). ---
+    {
+        const std::string path = "lp7_reg_v6import_wallet.dat";
+        std::remove(path.c_str());
+        LegacyV6NonHDResult v6;
+        bool built = BuildLegacyV6NonHDWalletWithKey(path, pass, v6);
+        CHECK(built, "(v6-import) built legacy v6 non-HD wallet");
+        if (built) {
+            CKey imported;
+            CHECK(WalletCrypto::GenerateKeyPair(imported), "(v6-import) generated a keypair to import");
+            CDilithiumAddress impAddr(imported.vchPubKey);
+            {
+                CWallet w;
+                w.SetWalletFile(path);            // autosave on
+                CHECK(w.Load(path), "(v6-import) loaded legacy v6 wallet");
+                CHECK(w.Unlock(pass), "(v6-import) unlocked (non-HD v6 -> NO migration)");
+                CHECK(FileVersion(path) == WALLET_FILE_VERSION_6,
+                      "(v6-import) wallet stays v6 after unlock (no migration)");
+                CHECK(w.ImportKey(imported, impAddr), "(v6-import) imported a key into the v6 wallet");
+                CHECK(FileVersion(path) == WALLET_FILE_VERSION_6,
+                      "(v6-import) file STILL v6 after import (no v7 promotion)");
+            }
+            CWallet w2;
+            w2.SetWalletFile(path);
+            bool loaded = w2.Load(path);
+            CHECK(loaded, "(v6-import) wallet reloads after importing on a v6 wallet");
+            CKey rec;
+            bool spendable = loaded && w2.Unlock(pass) && w2.GetKey(impAddr, rec);
+            CHECK(spendable &&
+                  std::vector<uint8_t>(rec.vchPrivKey.begin(), rec.vchPrivKey.end()) ==
+                  std::vector<uint8_t>(imported.vchPrivKey.begin(), imported.vchPrivKey.end()),
+                  "(v6-import) LOAD-BEARING (LOW-1): imported private key round-trips/SPENDABLE after reload (keying matches verify side)");
+        }
+        std::remove(path.c_str());
+    }
+
+    // --- (F) GetNewHDAddress / DeriveAndCacheHDAddress on a LOADED LEGACY v6
+    //         NON-HD wallet (LOW-1 fold): HD derivation genuinely CANNOT run on a
+    //         non-HD wallet — GetNewHDAddress() is guarded by `if (!fIsHDWallet)
+    //         return CDilithiumAddress();` (wallet.cpp ~L5372), so it never reaches
+    //         the DeriveAndCacheHDAddress store site and never writes a v7 MAC. We
+    //         therefore assert the GUARDED no-brick outcome rather than forcing an
+    //         invalid HD path: GetNewHDAddress returns EMPTY, the file stays v6 and
+    //         un-promoted, the wallet reloads, and the original v6 key stays
+    //         SPENDABLE. (Were the guard removed and the v7 store site reached on a
+    //         v6 wallet, the minted key would silently unspend — the same property
+    //         (D) pins — but the guard makes that path unreachable here.) ---
+    {
+        const std::string path = "lp7_reg_v6hd_wallet.dat";
+        std::remove(path.c_str());
+        LegacyV6NonHDResult v6;
+        bool built = BuildLegacyV6NonHDWalletWithKey(path, pass, v6);
+        CHECK(built, "(v6-hd) built legacy v6 non-HD wallet");
+        if (built) {
+            {
+                CWallet w;
+                w.SetWalletFile(path);            // autosave on
+                CHECK(w.Load(path), "(v6-hd) loaded legacy v6 wallet");
+                CHECK(w.Unlock(pass), "(v6-hd) unlocked (non-HD v6 -> NO migration)");
+                CHECK(!w.IsHDWallet(), "(v6-hd) loaded wallet is correctly NON-HD");
+                CDilithiumAddress hdAddr = w.GetNewHDAddress();   // guarded: returns empty on non-HD
+                CHECK(hdAddr.GetData().empty(),
+                      "(v6-hd) LOAD-BEARING: GetNewHDAddress is GUARDED on a non-HD v6 wallet (returns empty, no v7 store site reached)");
+                CHECK(FileVersion(path) == WALLET_FILE_VERSION_6,
+                      "(v6-hd) file STILL v6 after guarded GetNewHDAddress (no v7 promotion)");
+            }
+            CWallet w2;
+            w2.SetWalletFile(path);
+            bool loaded = w2.Load(path);
+            CHECK(loaded, "(v6-hd) wallet reloads after the guarded HD-derivation attempt (NOT bricked)");
+            CKey rec;
+            bool spendable = loaded && w2.Unlock(pass) && w2.GetKey(v6.perAddr, rec);
+            CHECK(spendable,
+                  "(v6-hd) original v6 key STILL SPENDABLE after the guarded HD attempt (no brick, no keying drift)");
+        }
+        std::remove(path.c_str());
+    }
 }
 
 int main() {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -244,8 +244,7 @@ bool CWallet::GenerateNewKey() {
         // non-HD v6 wallet never migrates — so a v7-keyed MAC written here would
         // make the freshly-minted key UNSPENDABLE on the next load. Select keying
         // by the loaded file version, exactly as EncryptWallet/ChangePassphrase do.
-        const bool legacyKeying =
-            (m_loadedFileVersion != 0 && m_loadedFileVersion < WALLET_FILE_VERSION_7);
+        const bool legacyKeying = LegacyRecordKeying();
         if (!ComputeRecordMAC(crypter, encKey.vchCryptedKey, encKey.vchMAC, legacyKeying)) {
             memory_cleanse(masterKeyVec.data(), masterKeyVec.size());
             return false;
@@ -375,8 +374,7 @@ bool CWallet::VerifyRecordMAC(CCrypter& crypter,
     // matches the on-disk version: legacy AES-keyed HMAC for v3-v6, separated
     // MAC key for v7. (m_loadedFileVersion == 0 means a freshly-created in-memory
     // wallet whose records this build wrote with the default separated keying.)
-    const bool legacyKeying =
-        (m_loadedFileVersion != 0 && m_loadedFileVersion < WALLET_FILE_VERSION_7);
+    const bool legacyKeying = LegacyRecordKeying();
     return crypter.VerifyMAC(ciphertext, mac, legacyKeying);
 }
 
@@ -508,8 +506,7 @@ bool CWallet::ImportKey(const CKey& key, const CDilithiumAddress& address) {
         // non-HD v6 wallet never migrates — so a v7-keyed MAC written here would
         // make the freshly-minted key UNSPENDABLE on the next load. Select keying
         // by the loaded file version, exactly as EncryptWallet/ChangePassphrase do.
-        const bool legacyKeying =
-            (m_loadedFileVersion != 0 && m_loadedFileVersion < WALLET_FILE_VERSION_7);
+        const bool legacyKeying = LegacyRecordKeying();
         if (!ComputeRecordMAC(crypter, encKey.vchCryptedKey, encKey.vchMAC, legacyKeying)) {
             memory_cleanse(masterKeyVec.data(), masterKeyVec.size());
             return false;
@@ -1914,8 +1911,7 @@ bool CWallet::ChangePassphrase(const std::string& passphraseOld,
     //   - loaded v7 / 0 -> separated v7 keying (file is/stays v7)
     // (The single v6->v7 migration — which DOES recompute every MAC to separated
     // keying — still happens exactly once, on the next Unlock, never here.)
-    const bool legacyMasterKeying =
-        (m_loadedFileVersion != 0 && m_loadedFileVersion < WALLET_FILE_VERSION_7);
+    const bool legacyMasterKeying = LegacyRecordKeying();
     std::vector<uint8_t> newMAC;
     if (!ComputeRecordMAC(crypterNew, newCryptedKey, newMAC, legacyMasterKeying)) {
         memory_cleanse(derivedKeyOld.data(), derivedKeyOld.size());
@@ -3059,8 +3055,7 @@ bool CWallet::SaveUnlocked(const std::string& filename) const {
     // m_loadedFileVersion to v7, so this writer then emits v7 from then on. A freshly
     // created in-memory wallet (m_loadedFileVersion == 0) and an already-v7 wallet
     // both write v7.
-    const bool writeLegacyV6 =
-        (m_loadedFileVersion != 0 && m_loadedFileVersion < WALLET_FILE_VERSION_7);
+    const bool writeLegacyV6 = LegacyRecordKeying();
 
     if (writeLegacyV6) {
         file.write(WALLET_FILE_MAGIC_V6, 8);  // "DILWLT06" — keep the loaded version
@@ -5738,8 +5733,7 @@ bool CWallet::DeriveAndCacheHDAddress(const CHDKeyPath& path) {
         // non-HD v6 wallet never migrates — so a v7-keyed MAC written here would
         // make the freshly-minted key UNSPENDABLE on the next load. Select keying
         // by the loaded file version, exactly as EncryptWallet/ChangePassphrase do.
-        const bool legacyKeying =
-            (m_loadedFileVersion != 0 && m_loadedFileVersion < WALLET_FILE_VERSION_7);
+        const bool legacyKeying = LegacyRecordKeying();
         if (!ComputeRecordMAC(crypter, encKey.vchCryptedKey, encKey.vchMAC, legacyKeying)) {
             memory_cleanse(masterKeyVec.data(), masterKeyVec.size());
             key.Clear();

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -302,6 +302,14 @@ private:
     // HD seed. Used to (a) verify legacy MACs with the correct keying, and (b)
     // detect a legacy plaintext-seed encrypted wallet that needs migration on unlock.
     uint32_t m_loadedFileVersion{0};
+    // LP-7 / ecosystem-sweep C-1: a per-record MAC must be keyed to MATCH the
+    // verify side. A wallet loaded from a pre-v7 file (and a non-HD v6 wallet that
+    // never migrates) uses legacy AES-keyed HMAC; a freshly-created in-memory
+    // wallet (m_loadedFileVersion==0) and a loaded v7+ wallet use v7 keying.
+    // Single source of truth for that predicate — it has drifted/bitten twice.
+    bool LegacyRecordKeying() const {
+        return m_loadedFileVersion != 0 && m_loadedFileVersion < WALLET_FILE_VERSION_7;
+    }
     // LP-7: set true at load when an encrypted wallet was read in a pre-v7 format
     // with a plaintext HD seed at rest (the bug condition). Triggers atomic
     // re-encryption + v7 rewrite on the next successful unlock.


### PR DESCRIPTION
## What
Extracts the v7-MAC keying predicate `(m_loadedFileVersion != 0 && m_loadedFileVersion < WALLET_FILE_VERSION_7)` — duplicated **verbatim at 6 sites** — into one private const helper `CWallet::LegacyRecordKeying()`. Routes all 6 sites through it.

Sites: `GenerateNewKey`, `VerifyRecordMAC`, `ImportKey`, `ChangePassphrase`, `SaveUnlocked`, `DeriveAndCacheHDAddress`. (The ecosystem-sweep note said 5; `SaveUnlocked` was a 6th, undercounted.)

## Why
This predicate decides whether a per-address record's MAC is keyed the legacy (v3–v6) way or v7 — and it MUST match the verify side or a key loads but is silently unspendable / the wallet bricks. It has **drifted/bitten twice** (the C-1 wallet-brick in #128 was a keying-site miss). Single source of truth removes the recurrence surface.

## Safety / equivalence
- **Behavior-preserving.** All 6 predicates were byte-identical pre-change (verified). Local boolean names (`legacyMasterKeying`, `writeLegacyV6`) preserved; only the RHS expression changed.
- The **separate** empty-MAC-policy boolean `isV7 = (m_loadedFileVersion >= WALLET_FILE_VERSION_7)` is deliberately **left as its own expression** (folding it in would be a bug — they are intentionally non-complementary).
- **Fresh-context `red-team-validator`: SAFE-TO-MERGE** — refactor-equivalence confirmed at all 6 sites; const/timing/symmetry checked; arms E/F load-bearing & non-vacuous.

## Tests (folds deferred LOW-1)
Adds two legacy-v6 arms to `Test_V7PerAddressKeyMACRoundTrip`:
- **(E)** ImportKey on a loaded legacy-v6 non-HD wallet → legacy-keyed MAC → imported key **spendable after reload** (privkey byte-equality).
- **(F)** GetNewHDAddress on a loaded v6 non-HD wallet → correctly returns empty (HD guarded off at `wallet.cpp:5372`; no v7 MAC written, no brick) — asserts the genuine guarded outcome.

**Mutation-tested load-bearing:** forcing `legacyKeying = false` at the store sites makes arms D + E FAIL (395/2); reverted → **397/0** green. Build clean (MSYS2).

## Stacking
Based off **PR #128** head `1cc777a0` (the 3 store-site predicates only exist post-#128). Base = `fix/wallet-v7-per-address-mac`; will rebase onto `main` + retarget once #128 merges. INFO-severity, behavior-preserving — not a heavy gate; Cursor optional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)