### PR TITLE
fix(dfmp): saturating heat-penalty math — close int64 overflow nullifying concentration defense (sweep C-3)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -400,6 +400,7 @@ TX_VALIDATION_TEST_SOURCE := src/test/tx_validation_tests.cpp
 TX_RELAY_TEST_SOURCE := src/test/tx_relay_tests.cpp
 MINING_INTEGRATION_TEST_SOURCE := src/test/mining_integration_tests.cpp
 DFMP_MIK_TEST_SOURCE := src/test/dfmp_mik_tests.cpp
+DFMP_HEAT_OVERFLOW_TEST_SOURCE := src/test/dfmp_heat_overflow_tests.cpp
 MIK_REG_PERSIST_TEST_SOURCE := src/test/mik_registration_persistence_tests.cpp
 REGISTRATION_MANAGER_TEST_SOURCE := src/test/registration_manager_tests.cpp
 DNA_PROPAGATION_TEST_SOURCE := src/test/dna_propagation_tests.cpp
@@ -494,7 +495,7 @@ dilv-genesis-vdf: $(CORE_OBJECTS) $(OBJ_DIR)/tools/dilv_genesis_vdf.o $(DILITHIU
 # Test Binaries
 # ============================================================================
 
-tests: phase1_test miner_tests wallet_tests rpc_tests rpc_auth_tests rpc_host_header_tests http_server_wallet_gate_tests ratelimiter_tests timestamp_tests crypter_tests seed_attestation_key_tests wallet_encryption_integration_tests wallet_persistence_tests integration_tests net_tests connman_tests tx_validation_tests tx_relay_tests mining_integration_tests bug_003_block_size_tests dfmp_mik_tests mik_registration_persistence_tests dna_propagation_tests test_passphrase_validator script_tests addrman_v2_tests peer_scorer_tests peer_scorer_banman_integration_tests header_proof_checker_tests chain_selector_tests getchaintips_equivalence_tests chain_case_2_5_equivalence_tests chain_work_smoke_tests reorg_wal_crash_injection_tests competing_sibling_below_checkpoint_tests headers_manager_to_chain_selector_wiring_tests fast_path_2_boundary_tests v4_1_checkpoint_enforcement_tests v4_1_chain_selector_suppression_tests auto_rebuild_marker_mode_symmetry_tests add_block_index_flag_merge_tests port_chain_selector_invariants_tests legacy_vs_port_differential_tests chainstate_integrity_tests
+tests: phase1_test miner_tests wallet_tests rpc_tests rpc_auth_tests rpc_host_header_tests http_server_wallet_gate_tests ratelimiter_tests timestamp_tests crypter_tests seed_attestation_key_tests wallet_encryption_integration_tests wallet_persistence_tests integration_tests net_tests connman_tests tx_validation_tests tx_relay_tests mining_integration_tests bug_003_block_size_tests dfmp_mik_tests dfmp_heat_overflow_tests mik_registration_persistence_tests dna_propagation_tests test_passphrase_validator script_tests addrman_v2_tests peer_scorer_tests peer_scorer_banman_integration_tests header_proof_checker_tests chain_selector_tests getchaintips_equivalence_tests chain_case_2_5_equivalence_tests chain_work_smoke_tests reorg_wal_crash_injection_tests competing_sibling_below_checkpoint_tests headers_manager_to_chain_selector_wiring_tests fast_path_2_boundary_tests v4_1_checkpoint_enforcement_tests v4_1_chain_selector_suppression_tests auto_rebuild_marker_mode_symmetry_tests add_block_index_flag_merge_tests port_chain_selector_invariants_tests legacy_vs_port_differential_tests chainstate_integrity_tests
 	@echo "$(COLOR_GREEN)✓ All tests built successfully$(COLOR_RESET)"
 
 phase1_test: $(CORE_OBJECTS) $(OBJ_DIR)/test/phase1_simple_test.o $(DILITHIUM_OBJECTS) $(CHIAVDF_OBJECTS)
@@ -608,6 +609,10 @@ bug_003_block_size_tests: $(CORE_OBJECTS) $(OBJ_DIR)/test/bug_003_block_size_tes
 	@$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LIBS)
 
 dfmp_mik_tests: $(CORE_OBJECTS) $(OBJ_DIR)/test/dfmp_mik_tests.o $(DILITHIUM_OBJECTS) $(CHIAVDF_OBJECTS)
+	@echo "$(COLOR_BLUE)[LINK]$(COLOR_RESET) $@"
+	@$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LIBS)
+
+dfmp_heat_overflow_tests: $(CORE_OBJECTS) $(OBJ_DIR)/test/dfmp_heat_overflow_tests.o $(DILITHIUM_OBJECTS) $(CHIAVDF_OBJECTS)
 	@echo "$(COLOR_BLUE)[LINK]$(COLOR_RESET) $@"
 	@$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LIBS)
 

--- a/src/consensus/pow.cpp
+++ b/src/consensus/pow.cpp
@@ -409,6 +409,11 @@ bool CheckProofOfWorkDFMP(
     int dfmpV34ActivationHeight = Dilithion::g_chainParams ?
         Dilithion::g_chainParams->dfmpV34ActivationHeight : 999999999;
 
+    // C-3: saturating heat math gate. At/above the activation height, heat-penalty fns
+    // saturate at FP_HEAT_MULTIPLIER_MAX instead of overflowing int64 (which wrapped the
+    // heaviest miner to the easiest 1.0x target). Below the gate: byte-identical legacy math.
+    bool dfmpSat = Dilithion::g_chainParams && height >= Dilithion::g_chainParams->dfmpOverflowFixActivationHeight;
+
     int64_t multiplierFP;
 
     if (height >= dfmpV34ActivationHeight) {
@@ -427,7 +432,7 @@ bool CheckProofOfWorkDFMP(
         }
 
         // MIK identity heat penalty (v3.4 - verification-aware)
-        int64_t mikHeatPenalty = DFMP::CalculateHeatMultiplierFP_V34(blocksInWindow, isVerified);
+        int64_t mikHeatPenalty = DFMP::CalculateHeatMultiplierFP_V34(blocksInWindow, isVerified, dfmpSat);
 
         // Payout address heat penalty (uses same verification status as the MIK)
         int64_t payoutHeatPenalty = DFMP::FP_SCALE;  // 1.0x default
@@ -435,7 +440,7 @@ bool CheckProofOfWorkDFMP(
             DFMP::Identity payoutIdentity = DFMP::DeriveIdentityFromScript(
                 coinbaseTx.vout[0].scriptPubKey);
             int payoutHeat = DFMP::g_payoutHeatTracker->GetHeat(payoutIdentity);
-            payoutHeatPenalty = DFMP::CalculateHeatMultiplierFP_V34(payoutHeat, isVerified);
+            payoutHeatPenalty = DFMP::CalculateHeatMultiplierFP_V34(payoutHeat, isVerified, dfmpSat);
         }
 
         // Effective heat = max(MIK heat, payout heat)
@@ -445,7 +450,7 @@ bool CheckProofOfWorkDFMP(
         int64_t maturityPenalty = DFMP::CalculatePendingPenaltyFP_V34(height, effectiveFirstSeen);
 
         // Total = maturity x heat
-        multiplierFP = (maturityPenalty * effectiveHeatPenalty) / DFMP::FP_SCALE;
+        multiplierFP = DFMP::CombineMaturityHeatFP(maturityPenalty, effectiveHeatPenalty, dfmpSat);
 
     } else if (height >= dfmpV33ActivationHeight) {
         // ====================================================================
@@ -454,7 +459,7 @@ bool CheckProofOfWorkDFMP(
         // ====================================================================
 
         // MIK identity heat penalty (v3.3 - no dynamic scaling, no uniqueMiners param)
-        int64_t mikHeatPenalty = DFMP::CalculateHeatMultiplierFP_V33(blocksInWindow);
+        int64_t mikHeatPenalty = DFMP::CalculateHeatMultiplierFP_V33(blocksInWindow, dfmpSat);
 
         // Payout address heat penalty (v3.3 - same formula, no dynamic scaling)
         int64_t payoutHeatPenalty = DFMP::FP_SCALE;  // 1.0x default
@@ -462,7 +467,7 @@ bool CheckProofOfWorkDFMP(
             DFMP::Identity payoutIdentity = DFMP::DeriveIdentityFromScript(
                 coinbaseTx.vout[0].scriptPubKey);
             int payoutHeat = DFMP::g_payoutHeatTracker->GetHeat(payoutIdentity);
-            payoutHeatPenalty = DFMP::CalculateHeatMultiplierFP_V33(payoutHeat);
+            payoutHeatPenalty = DFMP::CalculateHeatMultiplierFP_V33(payoutHeat, dfmpSat);
         }
 
         // Effective heat = max(MIK heat, payout heat)
@@ -472,7 +477,7 @@ bool CheckProofOfWorkDFMP(
         int64_t maturityPenalty = DFMP::CalculatePendingPenaltyFP_V33(height, effectiveFirstSeen);
 
         // Total = maturity x heat
-        multiplierFP = (maturityPenalty * effectiveHeatPenalty) / DFMP::FP_SCALE;
+        multiplierFP = DFMP::CombineMaturityHeatFP(maturityPenalty, effectiveHeatPenalty, dfmpSat);
 
     } else if (height >= dfmpV32ActivationHeight) {
         // ====================================================================
@@ -481,7 +486,7 @@ bool CheckProofOfWorkDFMP(
         // ====================================================================
 
         // MIK identity heat penalty (v3.2 aggressive)
-        int64_t mikHeatPenalty = DFMP::CalculateHeatMultiplierFP_V32(blocksInWindow, uniqueMiners);
+        int64_t mikHeatPenalty = DFMP::CalculateHeatMultiplierFP_V32(blocksInWindow, uniqueMiners, dfmpSat);
 
         // Payout address heat penalty (v3.2 aggressive)
         int64_t payoutHeatPenalty = DFMP::FP_SCALE;  // 1.0x default
@@ -493,7 +498,7 @@ bool CheckProofOfWorkDFMP(
             if (height >= dfmpDynamicScalingHeight) {
                 payoutUniqueMiners = DFMP::g_payoutHeatTracker->GetUniqueMinerCount();
             }
-            payoutHeatPenalty = DFMP::CalculateHeatMultiplierFP_V32(payoutHeat, payoutUniqueMiners);
+            payoutHeatPenalty = DFMP::CalculateHeatMultiplierFP_V32(payoutHeat, payoutUniqueMiners, dfmpSat);
         }
 
         // Effective heat = max(MIK heat, payout heat)
@@ -503,7 +508,7 @@ bool CheckProofOfWorkDFMP(
         int64_t maturityPenalty = DFMP::CalculatePendingPenaltyFP_V32(height, effectiveFirstSeen);
 
         // Total = maturity x heat
-        multiplierFP = (maturityPenalty * effectiveHeatPenalty) / DFMP::FP_SCALE;
+        multiplierFP = DFMP::CombineMaturityHeatFP(maturityPenalty, effectiveHeatPenalty, dfmpSat);
 
     } else if (height >= dfmpV31ActivationHeight) {
         // ====================================================================
@@ -512,7 +517,7 @@ bool CheckProofOfWorkDFMP(
         // ====================================================================
 
         // MIK identity heat penalty (v3.1 softened)
-        int64_t mikHeatPenalty = DFMP::CalculateHeatMultiplierFP_V31(blocksInWindow, uniqueMiners);
+        int64_t mikHeatPenalty = DFMP::CalculateHeatMultiplierFP_V31(blocksInWindow, uniqueMiners, dfmpSat);
 
         // Payout address heat penalty (v3.1 softened)
         int64_t payoutHeatPenalty = DFMP::FP_SCALE;  // 1.0x default
@@ -524,7 +529,7 @@ bool CheckProofOfWorkDFMP(
             if (height >= dfmpDynamicScalingHeight) {
                 payoutUniqueMiners = DFMP::g_payoutHeatTracker->GetUniqueMinerCount();
             }
-            payoutHeatPenalty = DFMP::CalculateHeatMultiplierFP_V31(payoutHeat, payoutUniqueMiners);
+            payoutHeatPenalty = DFMP::CalculateHeatMultiplierFP_V31(payoutHeat, payoutUniqueMiners, dfmpSat);
         }
 
         // Effective heat = max(MIK heat, payout heat)
@@ -534,7 +539,7 @@ bool CheckProofOfWorkDFMP(
         int64_t maturityPenalty = DFMP::CalculatePendingPenaltyFP_V31(height, effectiveFirstSeen);
 
         // Total = maturity x heat
-        multiplierFP = (maturityPenalty * effectiveHeatPenalty) / DFMP::FP_SCALE;
+        multiplierFP = DFMP::CombineMaturityHeatFP(maturityPenalty, effectiveHeatPenalty, dfmpSat);
 
     } else if (height >= dfmpV3ActivationHeight) {
         // ====================================================================
@@ -542,7 +547,7 @@ bool CheckProofOfWorkDFMP(
         // ====================================================================
 
         // MIK identity heat penalty (with dynamic scaling)
-        int64_t mikHeatPenalty = DFMP::CalculateHeatMultiplierFP(blocksInWindow, uniqueMiners);
+        int64_t mikHeatPenalty = DFMP::CalculateHeatMultiplierFP(blocksInWindow, uniqueMiners, dfmpSat);
 
         // Payout address heat penalty (closes primary exploit)
         int64_t payoutHeatPenalty = DFMP::FP_SCALE;  // 1.0x default
@@ -554,7 +559,7 @@ bool CheckProofOfWorkDFMP(
             if (height >= dfmpDynamicScalingHeight) {
                 payoutUniqueMiners = DFMP::g_payoutHeatTracker->GetUniqueMinerCount();
             }
-            payoutHeatPenalty = DFMP::CalculateHeatMultiplierFP(payoutHeat, payoutUniqueMiners);
+            payoutHeatPenalty = DFMP::CalculateHeatMultiplierFP(payoutHeat, payoutUniqueMiners, dfmpSat);
         }
 
         // Effective heat = max(MIK heat, payout heat)
@@ -564,7 +569,7 @@ bool CheckProofOfWorkDFMP(
         int64_t maturityPenalty = DFMP::CalculatePendingPenaltyFP(height, effectiveFirstSeen);
 
         // Total = maturity x heat
-        multiplierFP = (maturityPenalty * effectiveHeatPenalty) / DFMP::FP_SCALE;
+        multiplierFP = DFMP::CombineMaturityHeatFP(maturityPenalty, effectiveHeatPenalty, dfmpSat);
     } else {
         // ====================================================================
         // DFMP v2.0: Standard penalty (MIK heat only, original thresholds)

--- a/src/core/chainparams.cpp
+++ b/src/core/chainparams.cpp
@@ -94,6 +94,7 @@ ChainParams ChainParams::Mainnet() {
 
     // DFMP v3.4: verification-aware free tier (verified=12, unverified=3)
     params.dfmpV34ActivationHeight = 999999999;  // Disabled until DNA verification matures
+    params.dfmpOverflowFixActivationHeight = 999999999;  // C-3 saturating heat math OFF until deploy
 
     // Compact encoding fix: fixes BigToCompact sign bit bug that caused
     // difficulty to be ~5x harder than intended due to EDA + sign bit compounding.
@@ -313,6 +314,7 @@ ChainParams ChainParams::Testnet() {
 
     // DFMP v3.4 - disabled on testnet until DNA verification matures
     params.dfmpV34ActivationHeight = 999999999;
+    params.dfmpOverflowFixActivationHeight = 999999999;  // C-3 saturating heat math OFF until deploy
 
     // Compact encoding fix: always active on testnet (no legacy blocks to worry about)
     params.compactEncodingFixHeight = 0;
@@ -466,6 +468,7 @@ ChainParams ChainParams::DilV() {
     params.dfmpV32ActivationHeight = 0;
     params.dfmpV33ActivationHeight = 0;
     params.dfmpV34ActivationHeight = 999999999;  // Disabled until DNA verification matures
+    params.dfmpOverflowFixActivationHeight = 999999999;  // C-3 saturating heat math OFF until deploy
 
     // Compact encoding fix: active from genesis
     params.compactEncodingFixHeight = 0;

--- a/src/core/chainparams.h
+++ b/src/core/chainparams.h
@@ -139,6 +139,9 @@ public:
     // After this height: verified MIKs get 12, unverified get 3 free blocks
     int dfmpV34ActivationHeight;
 
+    // C-3 overflow fix: below = legacy heat math (frozen); at/above = saturating. OFF until set at deploy.
+    int dfmpOverflowFixActivationHeight;
+
     // Phase 3 port: minimum chain-work threshold for HeadersSync PRESYNC
     // gating. A peer's claimed header chain must accumulate at least this
     // much work in PRESYNC before transitioning to REDOWNLOAD. Mainnet:

--- a/src/dfmp/dfmp.cpp
+++ b/src/dfmp/dfmp.cpp
@@ -372,8 +372,13 @@ int64_t CalculateTotalMultiplierFP(int currentHeight, int firstSeenHeight, int h
     // saturate=false keeps the exact legacy int64 expression (byte-identical below gate).
     if (saturate) {
         __uint128_t prod = (static_cast<__uint128_t>(pendingFP) * static_cast<__uint128_t>(heatFP)) / FP_SCALE;
-        return prod > static_cast<__uint128_t>(FP_HEAT_MULTIPLIER_MAX)
-            ? FP_HEAT_MULTIPLIER_MAX : static_cast<int64_t>(prod);
+        // Clamp at the TRUE int64 overflow boundary, NOT the heat-fn cap: the maturity×heat
+        // PRODUCT legitimately exceeds FP_HEAT_MULTIPLIER_MAX (maturity up to ~5x stacks on the
+        // capped heat) and still fits int64 (max ~2.9e17 < INT64_MAX). Ceiling at the heat cap
+        // would flatten the stack ~2.5-5x EASIER at heat cap (Cursor MED-1). This clamp is
+        // defensive — with capped heatFP the product never actually reaches INT64_MAX.
+        return prod > static_cast<__uint128_t>(INT64_MAX)
+            ? INT64_MAX : static_cast<int64_t>(prod);
     }
     return (pendingFP * heatFP) / FP_SCALE;
 }
@@ -383,8 +388,13 @@ int64_t CombineMaturityHeatFP(int64_t maturityFP, int64_t heatFP, bool saturate)
     // to the legacy inline `(maturityFP * heatFP) / FP_SCALE`.
     if (saturate) {
         __uint128_t prod = (static_cast<__uint128_t>(maturityFP) * static_cast<__uint128_t>(heatFP)) / FP_SCALE;
-        return prod > static_cast<__uint128_t>(FP_HEAT_MULTIPLIER_MAX)
-            ? FP_HEAT_MULTIPLIER_MAX : static_cast<int64_t>(prod);
+        // Clamp at the TRUE int64 overflow boundary, NOT the heat-fn cap: the maturity×heat
+        // PRODUCT legitimately exceeds FP_HEAT_MULTIPLIER_MAX (maturity up to ~5x stacks on the
+        // capped heat) and still fits int64 (max ~2.9e17 < INT64_MAX). Ceiling at the heat cap
+        // would flatten the stack ~2.5-5x EASIER at heat cap (Cursor MED-1). This clamp is
+        // defensive — with capped heatFP the product never actually reaches INT64_MAX.
+        return prod > static_cast<__uint128_t>(INT64_MAX)
+            ? INT64_MAX : static_cast<int64_t>(prod);
     }
     return (maturityFP * heatFP) / FP_SCALE;
 }
@@ -565,8 +575,13 @@ int64_t CalculateTotalMultiplierFP_V31(int currentHeight, int firstSeenHeight, i
     // total = maturity × heat (C-3: 128-bit + clamp under saturate; see base combinator)
     if (saturate) {
         __uint128_t prod = (static_cast<__uint128_t>(pendingFP) * static_cast<__uint128_t>(heatFP)) / FP_SCALE;
-        return prod > static_cast<__uint128_t>(FP_HEAT_MULTIPLIER_MAX)
-            ? FP_HEAT_MULTIPLIER_MAX : static_cast<int64_t>(prod);
+        // Clamp at the TRUE int64 overflow boundary, NOT the heat-fn cap: the maturity×heat
+        // PRODUCT legitimately exceeds FP_HEAT_MULTIPLIER_MAX (maturity up to ~5x stacks on the
+        // capped heat) and still fits int64 (max ~2.9e17 < INT64_MAX). Ceiling at the heat cap
+        // would flatten the stack ~2.5-5x EASIER at heat cap (Cursor MED-1). This clamp is
+        // defensive — with capped heatFP the product never actually reaches INT64_MAX.
+        return prod > static_cast<__uint128_t>(INT64_MAX)
+            ? INT64_MAX : static_cast<int64_t>(prod);
     }
     return (pendingFP * heatFP) / FP_SCALE;
 }
@@ -631,8 +646,13 @@ int64_t CalculateTotalMultiplierFP_V32(int currentHeight, int firstSeenHeight, i
     // total = maturity × heat (C-3: 128-bit + clamp under saturate; see base combinator)
     if (saturate) {
         __uint128_t prod = (static_cast<__uint128_t>(pendingFP) * static_cast<__uint128_t>(heatFP)) / FP_SCALE;
-        return prod > static_cast<__uint128_t>(FP_HEAT_MULTIPLIER_MAX)
-            ? FP_HEAT_MULTIPLIER_MAX : static_cast<int64_t>(prod);
+        // Clamp at the TRUE int64 overflow boundary, NOT the heat-fn cap: the maturity×heat
+        // PRODUCT legitimately exceeds FP_HEAT_MULTIPLIER_MAX (maturity up to ~5x stacks on the
+        // capped heat) and still fits int64 (max ~2.9e17 < INT64_MAX). Ceiling at the heat cap
+        // would flatten the stack ~2.5-5x EASIER at heat cap (Cursor MED-1). This clamp is
+        // defensive — with capped heatFP the product never actually reaches INT64_MAX.
+        return prod > static_cast<__uint128_t>(INT64_MAX)
+            ? INT64_MAX : static_cast<int64_t>(prod);
     }
     return (pendingFP * heatFP) / FP_SCALE;
 }
@@ -686,8 +706,13 @@ int64_t CalculateTotalMultiplierFP_V33(int currentHeight, int firstSeenHeight, i
     // total = maturity × heat (C-3: 128-bit + clamp under saturate; see base combinator)
     if (saturate) {
         __uint128_t prod = (static_cast<__uint128_t>(pendingFP) * static_cast<__uint128_t>(heatFP)) / FP_SCALE;
-        return prod > static_cast<__uint128_t>(FP_HEAT_MULTIPLIER_MAX)
-            ? FP_HEAT_MULTIPLIER_MAX : static_cast<int64_t>(prod);
+        // Clamp at the TRUE int64 overflow boundary, NOT the heat-fn cap: the maturity×heat
+        // PRODUCT legitimately exceeds FP_HEAT_MULTIPLIER_MAX (maturity up to ~5x stacks on the
+        // capped heat) and still fits int64 (max ~2.9e17 < INT64_MAX). Ceiling at the heat cap
+        // would flatten the stack ~2.5-5x EASIER at heat cap (Cursor MED-1). This clamp is
+        // defensive — with capped heatFP the product never actually reaches INT64_MAX.
+        return prod > static_cast<__uint128_t>(INT64_MAX)
+            ? INT64_MAX : static_cast<int64_t>(prod);
     }
     return (pendingFP * heatFP) / FP_SCALE;
 }
@@ -751,8 +776,13 @@ int64_t CalculateTotalMultiplierFP_V34(int currentHeight, int firstSeenHeight, i
     // total = maturity × heat (C-3: 128-bit + clamp under saturate; see base combinator)
     if (saturate) {
         __uint128_t prod = (static_cast<__uint128_t>(pendingFP) * static_cast<__uint128_t>(heatFP)) / FP_SCALE;
-        return prod > static_cast<__uint128_t>(FP_HEAT_MULTIPLIER_MAX)
-            ? FP_HEAT_MULTIPLIER_MAX : static_cast<int64_t>(prod);
+        // Clamp at the TRUE int64 overflow boundary, NOT the heat-fn cap: the maturity×heat
+        // PRODUCT legitimately exceeds FP_HEAT_MULTIPLIER_MAX (maturity up to ~5x stacks on the
+        // capped heat) and still fits int64 (max ~2.9e17 < INT64_MAX). Ceiling at the heat cap
+        // would flatten the stack ~2.5-5x EASIER at heat cap (Cursor MED-1). This clamp is
+        // defensive — with capped heatFP the product never actually reaches INT64_MAX.
+        return prod > static_cast<__uint128_t>(INT64_MAX)
+            ? INT64_MAX : static_cast<int64_t>(prod);
     }
     return (pendingFP * heatFP) / FP_SCALE;
 }

--- a/src/dfmp/dfmp.cpp
+++ b/src/dfmp/dfmp.cpp
@@ -15,6 +15,13 @@
 
 namespace DFMP {
 
+// C-3: the saturating maturity×heat combiner uses __uint128_t (a GCC/Clang extension) —
+// the SAME 128-bit integer support already required by CalculateEffectiveTarget below.
+// Fail the build LOUDLY on any toolchain lacking it rather than silently miscompiling
+// consensus math. (Dilithion ships via MSYS2 GCC/Clang; this asserts the invariant.)
+static_assert(sizeof(__uint128_t) == 16,
+              "C-3 / DFMP requires 128-bit integer support (__uint128_t; GCC/Clang)");
+
 // ============================================================================
 // GLOBAL STATE
 // ============================================================================
@@ -713,7 +720,11 @@ int64_t CalculateHeatMultiplierFP_V34(int heat, bool isVerified, bool saturate) 
     if (heat <= LINEAR_ZONE_END_V34) {
         int excess = heat - freeTier;
         int linearSpan = LINEAR_ZONE_END_V34 - freeTier;
-        if (linearSpan <= 0) return FP_SCALE;  // defensive: unreachable with current constants
+        // Defensive: unreachable with current constants (freeTier 3|12 < LINEAR_ZONE_END 24,
+        // so linearSpan is always > 0). If a future constant change made the linear zone
+        // degenerate, fail SAFE to the HARDER zone-3 base (4.0x), NEVER the easiest 1.0x —
+        // a concentration defense must never hand a degenerate case the easiest target.
+        if (linearSpan <= 0) return FP_LINEAR_END_PENALTY_V34;
         // Ramp from 1.0x to 4.0x over linearSpan blocks
         // penalty = 1.0 + excess × 3.0 / linearSpan
         int64_t ramp = (static_cast<int64_t>(excess) * 3 * FP_SCALE) / linearSpan;

--- a/src/dfmp/dfmp.cpp
+++ b/src/dfmp/dfmp.cpp
@@ -321,7 +321,7 @@ int64_t CalculatePendingPenaltyFP(int currentHeight, int firstSeenHeight) {
     return FP_PENDING_END;           // 1.0x (mature)
 }
 
-int64_t CalculateHeatMultiplierFP(int heat, int uniqueMiners) {
+int64_t CalculateHeatMultiplierFP(int heat, int uniqueMiners, bool saturate) {
     // DFMP v3.0 Heat Penalty with Dynamic Scaling:
     // Free tier scales by active miner count:
     //   effectiveFreeThreshold = max(FREE_TIER_THRESHOLD, OBSERVATION_WINDOW / uniqueMiners)
@@ -345,19 +345,41 @@ int64_t CalculateHeatMultiplierFP(int heat, int uniqueMiners) {
     int exponent = heat - effectiveFreeThreshold - 1;
 
     for (int i = 0; i < exponent; i++) {
+        if (saturate && penalty > FP_HEAT_MULTIPLIER_MAX) { penalty = FP_HEAT_MULTIPLIER_MAX; break; }
         penalty = (penalty * FP_HEAT_GROWTH) / 100;  // × 1.58
     }
 
+    if (saturate && penalty > FP_HEAT_MULTIPLIER_MAX) penalty = FP_HEAT_MULTIPLIER_MAX;
     return penalty;
 }
 
-int64_t CalculateTotalMultiplierFP(int currentHeight, int firstSeenHeight, int heat, int uniqueMiners) {
+int64_t CalculateTotalMultiplierFP(int currentHeight, int firstSeenHeight, int heat, int uniqueMiners, bool saturate) {
     int64_t pendingFP = CalculatePendingPenaltyFP(currentHeight, firstSeenHeight);
-    int64_t heatFP = CalculateHeatMultiplierFP(heat, uniqueMiners);
+    int64_t heatFP = CalculateHeatMultiplierFP(heat, uniqueMiners, saturate);
 
     // total = maturity × heat
     // In fixed-point: total_fp = (maturity_fp × heat_fp) / FP_SCALE
+    // C-3: when saturating, a capped heatFP (≤ FP_HEAT_MULTIPLIER_MAX ≈ 5.83e16) times
+    // maturity (≤ 5e6) would still overflow int64 in the raw multiply, so compute the
+    // product in 128-bit and clamp to FP_HEAT_MULTIPLIER_MAX (already the hardest target).
+    // saturate=false keeps the exact legacy int64 expression (byte-identical below gate).
+    if (saturate) {
+        __uint128_t prod = (static_cast<__uint128_t>(pendingFP) * static_cast<__uint128_t>(heatFP)) / FP_SCALE;
+        return prod > static_cast<__uint128_t>(FP_HEAT_MULTIPLIER_MAX)
+            ? FP_HEAT_MULTIPLIER_MAX : static_cast<int64_t>(prod);
+    }
     return (pendingFP * heatFP) / FP_SCALE;
+}
+
+int64_t CombineMaturityHeatFP(int64_t maturityFP, int64_t heatFP, bool saturate) {
+    // C-3: overflow-safe maturity × heat. See header. saturate=false is byte-identical
+    // to the legacy inline `(maturityFP * heatFP) / FP_SCALE`.
+    if (saturate) {
+        __uint128_t prod = (static_cast<__uint128_t>(maturityFP) * static_cast<__uint128_t>(heatFP)) / FP_SCALE;
+        return prod > static_cast<__uint128_t>(FP_HEAT_MULTIPLIER_MAX)
+            ? FP_HEAT_MULTIPLIER_MAX : static_cast<int64_t>(prod);
+    }
+    return (maturityFP * heatFP) / FP_SCALE;
 }
 
 uint256 CalculateEffectiveTarget(const uint256& baseTarget, int64_t multiplierFP) {
@@ -365,6 +387,9 @@ uint256 CalculateEffectiveTarget(const uint256& baseTarget, int64_t multiplierFP
     // In fixed-point: effective_target = baseTarget × FP_SCALE / multiplierFP
 
     // Ensure multiplier is at least 1× (shouldn't happen but be safe)
+    // C-3: with the saturating cap upstream (saturate=true at/above the gate), every
+    // multiplierFP reaching here is in [FP_SCALE, FP_HEAT_MULTIPLIER_MAX] and never
+    // negative/wrapped, so this floor is now a true safety floor rather than a wrap-catcher.
     if (multiplierFP < FP_SCALE) {
         multiplierFP = FP_SCALE;
     }
@@ -495,7 +520,7 @@ int64_t CalculatePendingPenaltyFP_V31(int currentHeight, int firstSeenHeight) {
     return FP_PENDING_END;           // 1.0x (mature)
 }
 
-int64_t CalculateHeatMultiplierFP_V31(int heat, int uniqueMiners) {
+int64_t CalculateHeatMultiplierFP_V31(int heat, int uniqueMiners, bool saturate) {
     // DFMP v3.1: Softened heat penalty
     // Free tier: 36 blocks (or dynamic if higher)
     // Above free tier: 1.5x cliff, then 1.08x per block
@@ -518,17 +543,24 @@ int64_t CalculateHeatMultiplierFP_V31(int heat, int uniqueMiners) {
     int exponent = heat - effectiveFreeThreshold - 1;
 
     for (int i = 0; i < exponent; i++) {
+        if (saturate && penalty > FP_HEAT_MULTIPLIER_MAX) { penalty = FP_HEAT_MULTIPLIER_MAX; break; }
         penalty = (penalty * FP_HEAT_GROWTH_V31) / 100;  // × 1.08
     }
 
+    if (saturate && penalty > FP_HEAT_MULTIPLIER_MAX) penalty = FP_HEAT_MULTIPLIER_MAX;
     return penalty;
 }
 
-int64_t CalculateTotalMultiplierFP_V31(int currentHeight, int firstSeenHeight, int heat, int uniqueMiners) {
+int64_t CalculateTotalMultiplierFP_V31(int currentHeight, int firstSeenHeight, int heat, int uniqueMiners, bool saturate) {
     int64_t pendingFP = CalculatePendingPenaltyFP_V31(currentHeight, firstSeenHeight);
-    int64_t heatFP = CalculateHeatMultiplierFP_V31(heat, uniqueMiners);
+    int64_t heatFP = CalculateHeatMultiplierFP_V31(heat, uniqueMiners, saturate);
 
-    // total = maturity × heat
+    // total = maturity × heat (C-3: 128-bit + clamp under saturate; see base combinator)
+    if (saturate) {
+        __uint128_t prod = (static_cast<__uint128_t>(pendingFP) * static_cast<__uint128_t>(heatFP)) / FP_SCALE;
+        return prod > static_cast<__uint128_t>(FP_HEAT_MULTIPLIER_MAX)
+            ? FP_HEAT_MULTIPLIER_MAX : static_cast<int64_t>(prod);
+    }
     return (pendingFP * heatFP) / FP_SCALE;
 }
 
@@ -554,7 +586,7 @@ int64_t CalculatePendingPenaltyFP_V32(int currentHeight, int firstSeenHeight) {
     return FP_PENDING_END;           // 1.0x (mature)
 }
 
-int64_t CalculateHeatMultiplierFP_V32(int heat, int uniqueMiners) {
+int64_t CalculateHeatMultiplierFP_V32(int heat, int uniqueMiners, bool saturate) {
     // DFMP v3.2: Aggressive heat penalty (same formula as v3.0)
     // Free tier: 12 blocks (or dynamic if higher)
     // Above free tier: 2.0x cliff, then 1.58x per block
@@ -577,17 +609,24 @@ int64_t CalculateHeatMultiplierFP_V32(int heat, int uniqueMiners) {
     int exponent = heat - effectiveFreeThreshold - 1;
 
     for (int i = 0; i < exponent; i++) {
+        if (saturate && penalty > FP_HEAT_MULTIPLIER_MAX) { penalty = FP_HEAT_MULTIPLIER_MAX; break; }
         penalty = (penalty * FP_HEAT_GROWTH_V32) / 100;  // × 1.58
     }
 
+    if (saturate && penalty > FP_HEAT_MULTIPLIER_MAX) penalty = FP_HEAT_MULTIPLIER_MAX;
     return penalty;
 }
 
-int64_t CalculateTotalMultiplierFP_V32(int currentHeight, int firstSeenHeight, int heat, int uniqueMiners) {
+int64_t CalculateTotalMultiplierFP_V32(int currentHeight, int firstSeenHeight, int heat, int uniqueMiners, bool saturate) {
     int64_t pendingFP = CalculatePendingPenaltyFP_V32(currentHeight, firstSeenHeight);
-    int64_t heatFP = CalculateHeatMultiplierFP_V32(heat, uniqueMiners);
+    int64_t heatFP = CalculateHeatMultiplierFP_V32(heat, uniqueMiners, saturate);
 
-    // total = maturity × heat
+    // total = maturity × heat (C-3: 128-bit + clamp under saturate; see base combinator)
+    if (saturate) {
+        __uint128_t prod = (static_cast<__uint128_t>(pendingFP) * static_cast<__uint128_t>(heatFP)) / FP_SCALE;
+        return prod > static_cast<__uint128_t>(FP_HEAT_MULTIPLIER_MAX)
+            ? FP_HEAT_MULTIPLIER_MAX : static_cast<int64_t>(prod);
+    }
     return (pendingFP * heatFP) / FP_SCALE;
 }
 
@@ -600,7 +639,7 @@ int64_t CalculatePendingPenaltyFP_V33(int currentHeight, int firstSeenHeight) {
     return CalculatePendingPenaltyFP_V32(currentHeight, firstSeenHeight);
 }
 
-int64_t CalculateHeatMultiplierFP_V33(int heat) {
+int64_t CalculateHeatMultiplierFP_V33(int heat, bool saturate) {
     // DFMP v3.3: Three-zone penalty, NO dynamic scaling
     //   Zone 1 (Free):        0-12 blocks  → 1.0x
     //   Zone 2 (Linear):     13-24 blocks  → 1.0 + (heat-12) × 0.25  (ramps to 4.0x)
@@ -625,17 +664,24 @@ int64_t CalculateHeatMultiplierFP_V33(int heat) {
     int exponent = heat - LINEAR_ZONE_END_V33;
 
     for (int i = 0; i < exponent; i++) {
+        if (saturate && penalty > FP_HEAT_MULTIPLIER_MAX) { penalty = FP_HEAT_MULTIPLIER_MAX; break; }
         penalty = (penalty * FP_HEAT_GROWTH_V33) / 100;  // × 1.58
     }
 
+    if (saturate && penalty > FP_HEAT_MULTIPLIER_MAX) penalty = FP_HEAT_MULTIPLIER_MAX;
     return penalty;
 }
 
-int64_t CalculateTotalMultiplierFP_V33(int currentHeight, int firstSeenHeight, int heat) {
+int64_t CalculateTotalMultiplierFP_V33(int currentHeight, int firstSeenHeight, int heat, bool saturate) {
     int64_t pendingFP = CalculatePendingPenaltyFP_V33(currentHeight, firstSeenHeight);
-    int64_t heatFP = CalculateHeatMultiplierFP_V33(heat);
+    int64_t heatFP = CalculateHeatMultiplierFP_V33(heat, saturate);
 
-    // total = maturity × heat
+    // total = maturity × heat (C-3: 128-bit + clamp under saturate; see base combinator)
+    if (saturate) {
+        __uint128_t prod = (static_cast<__uint128_t>(pendingFP) * static_cast<__uint128_t>(heatFP)) / FP_SCALE;
+        return prod > static_cast<__uint128_t>(FP_HEAT_MULTIPLIER_MAX)
+            ? FP_HEAT_MULTIPLIER_MAX : static_cast<int64_t>(prod);
+    }
     return (pendingFP * heatFP) / FP_SCALE;
 }
 
@@ -648,7 +694,7 @@ int64_t CalculatePendingPenaltyFP_V34(int currentHeight, int firstSeenHeight) {
     return CalculatePendingPenaltyFP_V32(currentHeight, firstSeenHeight);
 }
 
-int64_t CalculateHeatMultiplierFP_V34(int heat, bool isVerified) {
+int64_t CalculateHeatMultiplierFP_V34(int heat, bool isVerified, bool saturate) {
     // DFMP v3.4: Same three-zone curve as v3.3, but free tier depends on
     // DNA verification status:
     //   Verified:   12 free blocks
@@ -667,6 +713,7 @@ int64_t CalculateHeatMultiplierFP_V34(int heat, bool isVerified) {
     if (heat <= LINEAR_ZONE_END_V34) {
         int excess = heat - freeTier;
         int linearSpan = LINEAR_ZONE_END_V34 - freeTier;
+        if (linearSpan <= 0) return FP_SCALE;  // defensive: unreachable with current constants
         // Ramp from 1.0x to 4.0x over linearSpan blocks
         // penalty = 1.0 + excess × 3.0 / linearSpan
         int64_t ramp = (static_cast<int64_t>(excess) * 3 * FP_SCALE) / linearSpan;
@@ -678,17 +725,24 @@ int64_t CalculateHeatMultiplierFP_V34(int heat, bool isVerified) {
     int exponent = heat - LINEAR_ZONE_END_V34;
 
     for (int i = 0; i < exponent; i++) {
+        if (saturate && penalty > FP_HEAT_MULTIPLIER_MAX) { penalty = FP_HEAT_MULTIPLIER_MAX; break; }
         penalty = (penalty * FP_HEAT_GROWTH_V34) / 100;  // × 1.58
     }
 
+    if (saturate && penalty > FP_HEAT_MULTIPLIER_MAX) penalty = FP_HEAT_MULTIPLIER_MAX;
     return penalty;
 }
 
-int64_t CalculateTotalMultiplierFP_V34(int currentHeight, int firstSeenHeight, int heat, bool isVerified) {
+int64_t CalculateTotalMultiplierFP_V34(int currentHeight, int firstSeenHeight, int heat, bool isVerified, bool saturate) {
     int64_t pendingFP = CalculatePendingPenaltyFP_V34(currentHeight, firstSeenHeight);
-    int64_t heatFP = CalculateHeatMultiplierFP_V34(heat, isVerified);
+    int64_t heatFP = CalculateHeatMultiplierFP_V34(heat, isVerified, saturate);
 
-    // total = maturity × heat
+    // total = maturity × heat (C-3: 128-bit + clamp under saturate; see base combinator)
+    if (saturate) {
+        __uint128_t prod = (static_cast<__uint128_t>(pendingFP) * static_cast<__uint128_t>(heatFP)) / FP_SCALE;
+        return prod > static_cast<__uint128_t>(FP_HEAT_MULTIPLIER_MAX)
+            ? FP_HEAT_MULTIPLIER_MAX : static_cast<int64_t>(prod);
+    }
     return (pendingFP * heatFP) / FP_SCALE;
 }
 

--- a/src/dfmp/dfmp.h
+++ b/src/dfmp/dfmp.h
@@ -68,6 +68,12 @@ constexpr int64_t FP_PENDING_END = 1000000;     // 1.0 × 1,000,000
 constexpr int64_t FP_HEAT_CLIFF = 2000000;      // 2.0 × 1,000,000 (cliff at free tier + 1)
 constexpr int64_t FP_HEAT_GROWTH = 158;          // 1.58x per block (multiply by 158, divide by 100)
 
+// C-3: saturating cap for the heat-penalty exponential. = INT64_MAX / FP_HEAT_GROWTH
+// (the largest growth factor, 158) so the next (penalty*FP_HEAT_GROWTH) can never overflow
+// int64. Minimal-behavior-change: only inputs that WOULD overflow are flattened — they
+// saturate to the HARDEST target instead of wrapping to the easiest 1.0x. Activation-gated.
+constexpr int64_t FP_HEAT_MULTIPLIER_MAX = INT64_MAX / FP_HEAT_GROWTH;  // ≈ 5.83e16
+
 // DFMP v3.0: Dormancy decay constants
 constexpr int DORMANCY_THRESHOLD = 720;           // Blocks of inactivity before maturity resets
 constexpr int DORMANCY_DECAY_BLOCKS = 400;         // Decay duration after dormancy reset
@@ -358,7 +364,7 @@ int64_t CalculatePendingPenaltyFP(int currentHeight, int firstSeenHeight);
  * @param uniqueMiners Number of unique miners in window (0 = use static threshold)
  * @return Heat multiplier × FP_SCALE (e.g., 1000000 for 1.0×)
  */
-int64_t CalculateHeatMultiplierFP(int heat, int uniqueMiners = 0);
+int64_t CalculateHeatMultiplierFP(int heat, int uniqueMiners = 0, bool saturate = false);
 
 /**
  * Calculate total DFMP multiplier (fixed-point)
@@ -371,7 +377,7 @@ int64_t CalculateHeatMultiplierFP(int heat, int uniqueMiners = 0);
  * @param uniqueMiners Number of unique miners in window (0 = use static threshold)
  * @return Total multiplier × FP_SCALE
  */
-int64_t CalculateTotalMultiplierFP(int currentHeight, int firstSeenHeight, int heat, int uniqueMiners = 0);
+int64_t CalculateTotalMultiplierFP(int currentHeight, int firstSeenHeight, int heat, int uniqueMiners = 0, bool saturate = false);
 
 /**
  * Calculate effective target (256-bit integer division)
@@ -384,6 +390,21 @@ int64_t CalculateTotalMultiplierFP(int currentHeight, int firstSeenHeight, int h
  */
 uint256 CalculateEffectiveTarget(const uint256& baseTarget, int64_t multiplierFP);
 
+/**
+ * C-3: combine maturity × heat into a total multiplier (fixed-point), overflow-safe.
+ *
+ * Computes (maturityFP × heatFP) / FP_SCALE. When `saturate` is true (at/above the
+ * overflow-fix activation height), the product is evaluated in 128-bit and clamped to
+ * FP_HEAT_MULTIPLIER_MAX so a capped heat penalty (≤ ~5.83e16) times maturity (≤ 5e6)
+ * cannot overflow int64. When `saturate` is false the result is byte-identical to the
+ * legacy inline `(maturityFP * heatFP) / FP_SCALE` int64 expression (consensus-frozen).
+ *
+ * Used by the consensus validator (pow.cpp) and the mining-state mirror (dilithion-node.cpp),
+ * which combine the maturity and effective-heat penalties inline rather than via the
+ * CalculateTotalMultiplierFP* combinators.
+ */
+int64_t CombineMaturityHeatFP(int64_t maturityFP, int64_t heatFP, bool saturate = false);
+
 // ============================================================================
 // DFMP v3.1 MULTIPLIER CALCULATION (Fixed-Point)
 // ============================================================================
@@ -392,10 +413,10 @@ uint256 CalculateEffectiveTarget(const uint256& baseTarget, int64_t multiplierFP
 int64_t CalculatePendingPenaltyFP_V31(int currentHeight, int firstSeenHeight);
 
 /** v3.1 heat multiplier: 36-block free tier, 1.5x cliff, 1.08x growth */
-int64_t CalculateHeatMultiplierFP_V31(int heat, int uniqueMiners = 0);
+int64_t CalculateHeatMultiplierFP_V31(int heat, int uniqueMiners = 0, bool saturate = false);
 
 /** v3.1 total multiplier: maturity × heat */
-int64_t CalculateTotalMultiplierFP_V31(int currentHeight, int firstSeenHeight, int heat, int uniqueMiners = 0);
+int64_t CalculateTotalMultiplierFP_V31(int currentHeight, int firstSeenHeight, int heat, int uniqueMiners = 0, bool saturate = false);
 
 // ============================================================================
 // CONVENIENCE FUNCTIONS
@@ -428,10 +449,10 @@ double GetHeatMultiplier_V31(int heat, int uniqueMiners = 0);
 int64_t CalculatePendingPenaltyFP_V32(int currentHeight, int firstSeenHeight);
 
 /** v3.2 heat multiplier: 12-block free tier, 2.0x cliff, 1.58x growth */
-int64_t CalculateHeatMultiplierFP_V32(int heat, int uniqueMiners = 0);
+int64_t CalculateHeatMultiplierFP_V32(int heat, int uniqueMiners = 0, bool saturate = false);
 
 /** v3.2 total multiplier: maturity × heat */
-int64_t CalculateTotalMultiplierFP_V32(int currentHeight, int firstSeenHeight, int heat, int uniqueMiners = 0);
+int64_t CalculateTotalMultiplierFP_V32(int currentHeight, int firstSeenHeight, int heat, int uniqueMiners = 0, bool saturate = false);
 
 /** v3.2 convenience functions for logging */
 double GetPendingPenalty_V32(int currentHeight, int firstSeenHeight);
@@ -445,10 +466,10 @@ double GetHeatMultiplier_V32(int heat, int uniqueMiners = 0);
 int64_t CalculatePendingPenaltyFP_V33(int currentHeight, int firstSeenHeight);
 
 /** v3.3 heat multiplier: 12-block free, linear to 4.0x at 24, then exponential (NO dynamic scaling) */
-int64_t CalculateHeatMultiplierFP_V33(int heat);
+int64_t CalculateHeatMultiplierFP_V33(int heat, bool saturate = false);
 
 /** v3.3 total multiplier: maturity × heat */
-int64_t CalculateTotalMultiplierFP_V33(int currentHeight, int firstSeenHeight, int heat);
+int64_t CalculateTotalMultiplierFP_V33(int currentHeight, int firstSeenHeight, int heat, bool saturate = false);
 
 /** v3.3 convenience functions for logging */
 double GetPendingPenalty_V33(int currentHeight, int firstSeenHeight);
@@ -462,10 +483,10 @@ double GetHeatMultiplier_V33(int heat);
 int64_t CalculatePendingPenaltyFP_V34(int currentHeight, int firstSeenHeight);
 
 /** v3.4 heat multiplier: free tier depends on verification status */
-int64_t CalculateHeatMultiplierFP_V34(int heat, bool isVerified);
+int64_t CalculateHeatMultiplierFP_V34(int heat, bool isVerified, bool saturate = false);
 
 /** v3.4 total multiplier: maturity × heat */
-int64_t CalculateTotalMultiplierFP_V34(int currentHeight, int firstSeenHeight, int heat, bool isVerified);
+int64_t CalculateTotalMultiplierFP_V34(int currentHeight, int firstSeenHeight, int heat, bool isVerified, bool saturate = false);
 
 /** v3.4 convenience functions for logging */
 double GetPendingPenalty_V34(int currentHeight, int firstSeenHeight);

--- a/src/miner/controller.cpp
+++ b/src/miner/controller.cpp
@@ -1191,15 +1191,18 @@ std::optional<CBlockTemplate> CMiningController::CreateBlockTemplate(
                 Dilithion::g_chainParams->dfmpV32ActivationHeight : 999999999;
             int dfmpV33Height = Dilithion::g_chainParams ?
                 Dilithion::g_chainParams->dfmpV33ActivationHeight : 999999999;
+            // C-3: saturating heat math gate (must match validator pow.cpp exactly).
+            bool dfmpSat = Dilithion::g_chainParams &&
+                static_cast<int>(nHeight) >= Dilithion::g_chainParams->dfmpOverflowFixActivationHeight;
             int64_t multiplierFP;
             if (static_cast<int>(nHeight) >= dfmpV33Height) {
-                multiplierFP = DFMP::CalculateTotalMultiplierFP_V33(nHeight, firstSeen, heat);
+                multiplierFP = DFMP::CalculateTotalMultiplierFP_V33(nHeight, firstSeen, heat, dfmpSat);
             } else if (static_cast<int>(nHeight) >= dfmpV32Height) {
-                multiplierFP = DFMP::CalculateTotalMultiplierFP_V32(nHeight, firstSeen, heat);
+                multiplierFP = DFMP::CalculateTotalMultiplierFP_V32(nHeight, firstSeen, heat, 0, dfmpSat);
             } else if (static_cast<int>(nHeight) >= dfmpV31Height) {
-                multiplierFP = DFMP::CalculateTotalMultiplierFP_V31(nHeight, firstSeen, heat);
+                multiplierFP = DFMP::CalculateTotalMultiplierFP_V31(nHeight, firstSeen, heat, 0, dfmpSat);
             } else {
-                multiplierFP = DFMP::CalculateTotalMultiplierFP(nHeight, firstSeen, heat);
+                multiplierFP = DFMP::CalculateTotalMultiplierFP(nHeight, firstSeen, heat, 0, dfmpSat);
             }
 
             // Apply multiplier to get effective target

--- a/src/node/dilithion-node.cpp
+++ b/src/node/dilithion-node.cpp
@@ -1766,6 +1766,10 @@ std::optional<CBlockTemplate> BuildMiningTemplate(CBlockchainDB& blockchain, CWa
         int dfmpV34ActivationHeight = Dilithion::g_chainParams ?
             Dilithion::g_chainParams->dfmpV34ActivationHeight : 999999999;
 
+        // C-3: saturating heat math gate (must match validator pow.cpp exactly).
+        bool dfmpSat = Dilithion::g_chainParams &&
+            static_cast<int>(nHeight) >= Dilithion::g_chainParams->dfmpOverflowFixActivationHeight;
+
         int64_t multiplierFP;
         double payoutHeatMult = 1.0;
 
@@ -1783,7 +1787,7 @@ std::optional<CBlockTemplate> BuildMiningTemplate(CBlockchainDB& blockchain, CWa
             }
 
             // MIK identity heat penalty (v3.4 - verification-aware)
-            int64_t mikHeatPenalty = DFMP::CalculateHeatMultiplierFP_V34(heat, isVerified);
+            int64_t mikHeatPenalty = DFMP::CalculateHeatMultiplierFP_V34(heat, isVerified, dfmpSat);
 
             // Payout address heat penalty (uses same verification status as the MIK)
             int64_t payoutHeatPenalty = DFMP::FP_SCALE;  // 1.0x default
@@ -1791,7 +1795,7 @@ std::optional<CBlockTemplate> BuildMiningTemplate(CBlockchainDB& blockchain, CWa
                 DFMP::Identity payoutIdentity = DFMP::DeriveIdentityFromScript(
                     coinbaseTx.vout[0].scriptPubKey);
                 int payoutHeat = DFMP::g_payoutHeatTracker->GetHeat(payoutIdentity);
-                payoutHeatPenalty = DFMP::CalculateHeatMultiplierFP_V34(payoutHeat, isVerified);
+                payoutHeatPenalty = DFMP::CalculateHeatMultiplierFP_V34(payoutHeat, isVerified, dfmpSat);
                 payoutHeatMult = static_cast<double>(payoutHeatPenalty) / DFMP::FP_SCALE;
             }
 
@@ -1802,11 +1806,11 @@ std::optional<CBlockTemplate> BuildMiningTemplate(CBlockchainDB& blockchain, CWa
             int64_t maturityPenalty = DFMP::CalculatePendingPenaltyFP_V34(nHeight, firstSeen);
 
             // Total = maturity x heat
-            multiplierFP = (maturityPenalty * effectiveHeatPenalty) / DFMP::FP_SCALE;
+            multiplierFP = DFMP::CombineMaturityHeatFP(maturityPenalty, effectiveHeatPenalty, dfmpSat);
 
         } else if (static_cast<int>(nHeight) >= dfmpV33ActivationHeight) {
             // DFMP v3.3: No dynamic scaling, linear+exponential penalty (must match validator exactly)
-            int64_t mikHeatPenalty = DFMP::CalculateHeatMultiplierFP_V33(heat);
+            int64_t mikHeatPenalty = DFMP::CalculateHeatMultiplierFP_V33(heat, dfmpSat);
 
             // Payout address heat penalty (v3.3, no dynamic scaling)
             int64_t payoutHeatPenalty = DFMP::FP_SCALE;  // 1.0x default
@@ -1814,7 +1818,7 @@ std::optional<CBlockTemplate> BuildMiningTemplate(CBlockchainDB& blockchain, CWa
                 DFMP::Identity payoutIdentity = DFMP::DeriveIdentityFromScript(
                     coinbaseTx.vout[0].scriptPubKey);
                 int payoutHeat = DFMP::g_payoutHeatTracker->GetHeat(payoutIdentity);
-                payoutHeatPenalty = DFMP::CalculateHeatMultiplierFP_V33(payoutHeat);
+                payoutHeatPenalty = DFMP::CalculateHeatMultiplierFP_V33(payoutHeat, dfmpSat);
                 payoutHeatMult = static_cast<double>(payoutHeatPenalty) / DFMP::FP_SCALE;
             }
 
@@ -1825,11 +1829,11 @@ std::optional<CBlockTemplate> BuildMiningTemplate(CBlockchainDB& blockchain, CWa
             int64_t maturityPenalty = DFMP::CalculatePendingPenaltyFP_V33(nHeight, firstSeen);
 
             // Total = maturity × effective heat
-            multiplierFP = (maturityPenalty * effectiveHeatPenalty) / DFMP::FP_SCALE;
+            multiplierFP = DFMP::CombineMaturityHeatFP(maturityPenalty, effectiveHeatPenalty, dfmpSat);
 
         } else if (static_cast<int>(nHeight) >= dfmpV32ActivationHeight) {
             // DFMP v3.2: Tightened anti-whale (must match validator exactly)
-            int64_t mikHeatPenalty = DFMP::CalculateHeatMultiplierFP_V32(heat, uniqueMiners);
+            int64_t mikHeatPenalty = DFMP::CalculateHeatMultiplierFP_V32(heat, uniqueMiners, dfmpSat);
 
             // Payout address heat penalty (v3.2 aggressive)
             int64_t payoutHeatPenalty = DFMP::FP_SCALE;  // 1.0x default
@@ -1841,7 +1845,7 @@ std::optional<CBlockTemplate> BuildMiningTemplate(CBlockchainDB& blockchain, CWa
                 if (static_cast<int>(nHeight) >= dfmpDynamicScalingHeight) {
                     payoutUniqueMiners = DFMP::g_payoutHeatTracker->GetUniqueMinerCount();
                 }
-                payoutHeatPenalty = DFMP::CalculateHeatMultiplierFP_V32(payoutHeat, payoutUniqueMiners);
+                payoutHeatPenalty = DFMP::CalculateHeatMultiplierFP_V32(payoutHeat, payoutUniqueMiners, dfmpSat);
                 payoutHeatMult = static_cast<double>(payoutHeatPenalty) / DFMP::FP_SCALE;
             }
 
@@ -1852,11 +1856,11 @@ std::optional<CBlockTemplate> BuildMiningTemplate(CBlockchainDB& blockchain, CWa
             int64_t maturityPenalty = DFMP::CalculatePendingPenaltyFP_V32(nHeight, firstSeen);
 
             // Total = maturity × effective heat
-            multiplierFP = (maturityPenalty * effectiveHeatPenalty) / DFMP::FP_SCALE;
+            multiplierFP = DFMP::CombineMaturityHeatFP(maturityPenalty, effectiveHeatPenalty, dfmpSat);
 
         } else if (static_cast<int>(nHeight) >= dfmpV31ActivationHeight) {
             // DFMP v3.1: Softened parameters (must match validator exactly)
-            int64_t mikHeatPenalty = DFMP::CalculateHeatMultiplierFP_V31(heat, uniqueMiners);
+            int64_t mikHeatPenalty = DFMP::CalculateHeatMultiplierFP_V31(heat, uniqueMiners, dfmpSat);
 
             // Payout address heat penalty (v3.1 softened)
             int64_t payoutHeatPenalty = DFMP::FP_SCALE;  // 1.0x default
@@ -1868,7 +1872,7 @@ std::optional<CBlockTemplate> BuildMiningTemplate(CBlockchainDB& blockchain, CWa
                 if (static_cast<int>(nHeight) >= dfmpDynamicScalingHeight) {
                     payoutUniqueMiners = DFMP::g_payoutHeatTracker->GetUniqueMinerCount();
                 }
-                payoutHeatPenalty = DFMP::CalculateHeatMultiplierFP_V31(payoutHeat, payoutUniqueMiners);
+                payoutHeatPenalty = DFMP::CalculateHeatMultiplierFP_V31(payoutHeat, payoutUniqueMiners, dfmpSat);
                 payoutHeatMult = static_cast<double>(payoutHeatPenalty) / DFMP::FP_SCALE;
             }
 
@@ -1879,11 +1883,11 @@ std::optional<CBlockTemplate> BuildMiningTemplate(CBlockchainDB& blockchain, CWa
             int64_t maturityPenalty = DFMP::CalculatePendingPenaltyFP_V31(nHeight, firstSeen);
 
             // Total = maturity × effective heat
-            multiplierFP = (maturityPenalty * effectiveHeatPenalty) / DFMP::FP_SCALE;
+            multiplierFP = DFMP::CombineMaturityHeatFP(maturityPenalty, effectiveHeatPenalty, dfmpSat);
 
         } else if (static_cast<int>(nHeight) >= dfmpV3ActivationHeight) {
             // DFMP v3.0: Multi-layer penalty (must match validator exactly)
-            int64_t mikHeatPenalty = DFMP::CalculateHeatMultiplierFP(heat, uniqueMiners);
+            int64_t mikHeatPenalty = DFMP::CalculateHeatMultiplierFP(heat, uniqueMiners, dfmpSat);
 
             // Payout address heat penalty
             int64_t payoutHeatPenalty = DFMP::FP_SCALE;  // 1.0x default
@@ -1895,7 +1899,7 @@ std::optional<CBlockTemplate> BuildMiningTemplate(CBlockchainDB& blockchain, CWa
                 if (static_cast<int>(nHeight) >= dfmpDynamicScalingHeight) {
                     payoutUniqueMiners = DFMP::g_payoutHeatTracker->GetUniqueMinerCount();
                 }
-                payoutHeatPenalty = DFMP::CalculateHeatMultiplierFP(payoutHeat, payoutUniqueMiners);
+                payoutHeatPenalty = DFMP::CalculateHeatMultiplierFP(payoutHeat, payoutUniqueMiners, dfmpSat);
                 payoutHeatMult = static_cast<double>(payoutHeatPenalty) / DFMP::FP_SCALE;
             }
 
@@ -1906,7 +1910,7 @@ std::optional<CBlockTemplate> BuildMiningTemplate(CBlockchainDB& blockchain, CWa
             int64_t maturityPenalty = DFMP::CalculatePendingPenaltyFP(nHeight, firstSeen);
 
             // Total = maturity × effective heat
-            multiplierFP = (maturityPenalty * effectiveHeatPenalty) / DFMP::FP_SCALE;
+            multiplierFP = DFMP::CombineMaturityHeatFP(maturityPenalty, effectiveHeatPenalty, dfmpSat);
         } else {
             // DFMP v2.0: Standard penalty
             multiplierFP = DFMP::CalculateTotalMultiplierFP(nHeight, firstSeen, heat, uniqueMiners);

--- a/src/node/dilv-node.cpp
+++ b/src/node/dilv-node.cpp
@@ -1707,6 +1707,10 @@ std::optional<CBlockTemplate> BuildMiningTemplate(CBlockchainDB& blockchain, CWa
         int dfmpV34ActivationHeight = Dilithion::g_chainParams ?
             Dilithion::g_chainParams->dfmpV34ActivationHeight : 999999999;
 
+        // C-3: saturating heat math gate (must match validator pow.cpp exactly).
+        bool dfmpSat = Dilithion::g_chainParams &&
+            static_cast<int>(nHeight) >= Dilithion::g_chainParams->dfmpOverflowFixActivationHeight;
+
         int64_t multiplierFP;
         double payoutHeatMult = 1.0;
 
@@ -1724,7 +1728,7 @@ std::optional<CBlockTemplate> BuildMiningTemplate(CBlockchainDB& blockchain, CWa
             }
 
             // MIK identity heat penalty (v3.4 - verification-aware)
-            int64_t mikHeatPenalty = DFMP::CalculateHeatMultiplierFP_V34(heat, isVerified);
+            int64_t mikHeatPenalty = DFMP::CalculateHeatMultiplierFP_V34(heat, isVerified, dfmpSat);
 
             // Payout address heat penalty (uses same verification status as the MIK)
             int64_t payoutHeatPenalty = DFMP::FP_SCALE;  // 1.0x default
@@ -1732,7 +1736,7 @@ std::optional<CBlockTemplate> BuildMiningTemplate(CBlockchainDB& blockchain, CWa
                 DFMP::Identity payoutIdentity = DFMP::DeriveIdentityFromScript(
                     coinbaseTx.vout[0].scriptPubKey);
                 int payoutHeat = DFMP::g_payoutHeatTracker->GetHeat(payoutIdentity);
-                payoutHeatPenalty = DFMP::CalculateHeatMultiplierFP_V34(payoutHeat, isVerified);
+                payoutHeatPenalty = DFMP::CalculateHeatMultiplierFP_V34(payoutHeat, isVerified, dfmpSat);
                 payoutHeatMult = static_cast<double>(payoutHeatPenalty) / DFMP::FP_SCALE;
             }
 
@@ -1743,11 +1747,11 @@ std::optional<CBlockTemplate> BuildMiningTemplate(CBlockchainDB& blockchain, CWa
             int64_t maturityPenalty = DFMP::CalculatePendingPenaltyFP_V34(nHeight, firstSeen);
 
             // Total = maturity x heat
-            multiplierFP = (maturityPenalty * effectiveHeatPenalty) / DFMP::FP_SCALE;
+            multiplierFP = DFMP::CombineMaturityHeatFP(maturityPenalty, effectiveHeatPenalty, dfmpSat);
 
         } else if (static_cast<int>(nHeight) >= dfmpV33ActivationHeight) {
             // DFMP v3.3: No dynamic scaling, linear+exponential penalty (must match validator exactly)
-            int64_t mikHeatPenalty = DFMP::CalculateHeatMultiplierFP_V33(heat);
+            int64_t mikHeatPenalty = DFMP::CalculateHeatMultiplierFP_V33(heat, dfmpSat);
 
             // Payout address heat penalty (v3.3, no dynamic scaling)
             int64_t payoutHeatPenalty = DFMP::FP_SCALE;  // 1.0x default
@@ -1755,7 +1759,7 @@ std::optional<CBlockTemplate> BuildMiningTemplate(CBlockchainDB& blockchain, CWa
                 DFMP::Identity payoutIdentity = DFMP::DeriveIdentityFromScript(
                     coinbaseTx.vout[0].scriptPubKey);
                 int payoutHeat = DFMP::g_payoutHeatTracker->GetHeat(payoutIdentity);
-                payoutHeatPenalty = DFMP::CalculateHeatMultiplierFP_V33(payoutHeat);
+                payoutHeatPenalty = DFMP::CalculateHeatMultiplierFP_V33(payoutHeat, dfmpSat);
                 payoutHeatMult = static_cast<double>(payoutHeatPenalty) / DFMP::FP_SCALE;
             }
 
@@ -1766,11 +1770,11 @@ std::optional<CBlockTemplate> BuildMiningTemplate(CBlockchainDB& blockchain, CWa
             int64_t maturityPenalty = DFMP::CalculatePendingPenaltyFP_V33(nHeight, firstSeen);
 
             // Total = maturity × effective heat
-            multiplierFP = (maturityPenalty * effectiveHeatPenalty) / DFMP::FP_SCALE;
+            multiplierFP = DFMP::CombineMaturityHeatFP(maturityPenalty, effectiveHeatPenalty, dfmpSat);
 
         } else if (static_cast<int>(nHeight) >= dfmpV32ActivationHeight) {
             // DFMP v3.2: Tightened anti-whale (must match validator exactly)
-            int64_t mikHeatPenalty = DFMP::CalculateHeatMultiplierFP_V32(heat, uniqueMiners);
+            int64_t mikHeatPenalty = DFMP::CalculateHeatMultiplierFP_V32(heat, uniqueMiners, dfmpSat);
 
             // Payout address heat penalty (v3.2 aggressive)
             int64_t payoutHeatPenalty = DFMP::FP_SCALE;  // 1.0x default
@@ -1782,7 +1786,7 @@ std::optional<CBlockTemplate> BuildMiningTemplate(CBlockchainDB& blockchain, CWa
                 if (static_cast<int>(nHeight) >= dfmpDynamicScalingHeight) {
                     payoutUniqueMiners = DFMP::g_payoutHeatTracker->GetUniqueMinerCount();
                 }
-                payoutHeatPenalty = DFMP::CalculateHeatMultiplierFP_V32(payoutHeat, payoutUniqueMiners);
+                payoutHeatPenalty = DFMP::CalculateHeatMultiplierFP_V32(payoutHeat, payoutUniqueMiners, dfmpSat);
                 payoutHeatMult = static_cast<double>(payoutHeatPenalty) / DFMP::FP_SCALE;
             }
 
@@ -1793,11 +1797,11 @@ std::optional<CBlockTemplate> BuildMiningTemplate(CBlockchainDB& blockchain, CWa
             int64_t maturityPenalty = DFMP::CalculatePendingPenaltyFP_V32(nHeight, firstSeen);
 
             // Total = maturity × effective heat
-            multiplierFP = (maturityPenalty * effectiveHeatPenalty) / DFMP::FP_SCALE;
+            multiplierFP = DFMP::CombineMaturityHeatFP(maturityPenalty, effectiveHeatPenalty, dfmpSat);
 
         } else if (static_cast<int>(nHeight) >= dfmpV31ActivationHeight) {
             // DFMP v3.1: Softened parameters (must match validator exactly)
-            int64_t mikHeatPenalty = DFMP::CalculateHeatMultiplierFP_V31(heat, uniqueMiners);
+            int64_t mikHeatPenalty = DFMP::CalculateHeatMultiplierFP_V31(heat, uniqueMiners, dfmpSat);
 
             // Payout address heat penalty (v3.1 softened)
             int64_t payoutHeatPenalty = DFMP::FP_SCALE;  // 1.0x default
@@ -1809,7 +1813,7 @@ std::optional<CBlockTemplate> BuildMiningTemplate(CBlockchainDB& blockchain, CWa
                 if (static_cast<int>(nHeight) >= dfmpDynamicScalingHeight) {
                     payoutUniqueMiners = DFMP::g_payoutHeatTracker->GetUniqueMinerCount();
                 }
-                payoutHeatPenalty = DFMP::CalculateHeatMultiplierFP_V31(payoutHeat, payoutUniqueMiners);
+                payoutHeatPenalty = DFMP::CalculateHeatMultiplierFP_V31(payoutHeat, payoutUniqueMiners, dfmpSat);
                 payoutHeatMult = static_cast<double>(payoutHeatPenalty) / DFMP::FP_SCALE;
             }
 
@@ -1820,11 +1824,11 @@ std::optional<CBlockTemplate> BuildMiningTemplate(CBlockchainDB& blockchain, CWa
             int64_t maturityPenalty = DFMP::CalculatePendingPenaltyFP_V31(nHeight, firstSeen);
 
             // Total = maturity × effective heat
-            multiplierFP = (maturityPenalty * effectiveHeatPenalty) / DFMP::FP_SCALE;
+            multiplierFP = DFMP::CombineMaturityHeatFP(maturityPenalty, effectiveHeatPenalty, dfmpSat);
 
         } else if (static_cast<int>(nHeight) >= dfmpV3ActivationHeight) {
             // DFMP v3.0: Multi-layer penalty (must match validator exactly)
-            int64_t mikHeatPenalty = DFMP::CalculateHeatMultiplierFP(heat, uniqueMiners);
+            int64_t mikHeatPenalty = DFMP::CalculateHeatMultiplierFP(heat, uniqueMiners, dfmpSat);
 
             // Payout address heat penalty
             int64_t payoutHeatPenalty = DFMP::FP_SCALE;  // 1.0x default
@@ -1836,7 +1840,7 @@ std::optional<CBlockTemplate> BuildMiningTemplate(CBlockchainDB& blockchain, CWa
                 if (static_cast<int>(nHeight) >= dfmpDynamicScalingHeight) {
                     payoutUniqueMiners = DFMP::g_payoutHeatTracker->GetUniqueMinerCount();
                 }
-                payoutHeatPenalty = DFMP::CalculateHeatMultiplierFP(payoutHeat, payoutUniqueMiners);
+                payoutHeatPenalty = DFMP::CalculateHeatMultiplierFP(payoutHeat, payoutUniqueMiners, dfmpSat);
                 payoutHeatMult = static_cast<double>(payoutHeatPenalty) / DFMP::FP_SCALE;
             }
 
@@ -1847,7 +1851,7 @@ std::optional<CBlockTemplate> BuildMiningTemplate(CBlockchainDB& blockchain, CWa
             int64_t maturityPenalty = DFMP::CalculatePendingPenaltyFP(nHeight, firstSeen);
 
             // Total = maturity × effective heat
-            multiplierFP = (maturityPenalty * effectiveHeatPenalty) / DFMP::FP_SCALE;
+            multiplierFP = DFMP::CombineMaturityHeatFP(maturityPenalty, effectiveHeatPenalty, dfmpSat);
         } else {
             // DFMP v2.0: Standard penalty
             multiplierFP = DFMP::CalculateTotalMultiplierFP(nHeight, firstSeen, heat, uniqueMiners);

--- a/src/test/dfmp_heat_overflow_tests.cpp
+++ b/src/test/dfmp_heat_overflow_tests.cpp
@@ -166,10 +166,12 @@ TEST(s3_overflow_input_hardest_and_load_bearing) {
     // gate genuinely changes behavior. If the gate were a no-op this assertion would fail.)
     ASSERT(legacyV33 != satV33,
         "V33 heat=90: legacy path must differ from saturated path (load-bearing check)");
-    // And it must match the independent legacy replica (same wrapped bit pattern),
-    // confirming saturate=false faithfully reproduces the pre-fix binary.
-    ASSERT(legacyV33 == legacyHeatV33(kOverflowHeat),
-        "V33 heat=90 saturate=false must match the hand-replicated legacy formula");
+    // NOTE: we deliberately do NOT assert legacyV33 equals a hand-replicated OVERFLOWED
+    // value — the legacy int64 multiply is UB on overflow, so the exact wrapped bits are not
+    // a portable contract (asserting it would rest the test on UB matching across compilers).
+    // Below-gate byte-identity is proven instead by S4 over the WELL-DEFINED sub-overflow
+    // range (heat 0..70) — which is what consensus actually relies on — plus the collapse
+    // proof below (legacy drops below FP_SCALE; saturated returns MAX).
 
     // The exact C-3 defect (easiest-target collapse): somewhere in the heat sweep the legacy
     // int64 wrap drops the heaviest miner BELOW FP_SCALE (1.0x) — which CalculateEffectiveTarget

--- a/src/test/dfmp_heat_overflow_tests.cpp
+++ b/src/test/dfmp_heat_overflow_tests.cpp
@@ -1,0 +1,292 @@
+// Copyright (c) 2026 The Dilithion Core developers
+// Distributed under the MIT software license
+
+/**
+ * C-3: DFMP heat-penalty integer-overflow hardening — behavioral validator (§3.2)
+ *
+ * The bug: each versioned heat fn ran `penalty = (penalty * GROWTH) / 100` in a loop.
+ * At high heat the `penalty * GROWTH` intermediate overflows int64, wraps to a small/
+ * negative value, and CalculateEffectiveTarget then clamps it UP to 1.0x — handing the
+ * HEAVIEST miner the EASIEST target (concentration defense nullified, monotonicity broken).
+ *
+ * The fix: activation-gated saturating fixed-point. With saturate=true the penalty is
+ * capped at FP_HEAT_MULTIPLIER_MAX before it can overflow. With saturate=false the math
+ * is byte-identical to the legacy binary (below-gate consensus-frozen).
+ *
+ * Assertions:
+ *  - S1/S2  saturate=TRUE: every version, heat 0..360, result in [FP_SCALE, MAX] AND
+ *           monotonic non-decreasing. No crash/UB.
+ *  - S3     saturate=TRUE at a known overflow input returns MAX (hardest); the legacy
+ *           (saturate=FALSE) path differs — proving the fix is load-bearing.
+ *  - S4     saturate=FALSE, sub-overflow heat: byte-identical to a hand-replicated legacy
+ *           formula (consensus-frozen below gate).
+ *  - combinator: CalculateTotalMultiplierFP_V33 with near-cap heat + saturate=TRUE stays
+ *           bounded (no product overflow).
+ */
+
+#include <dfmp/dfmp.h>
+
+#include <iostream>
+#include <string>
+#include <cstdint>
+#include <climits>
+
+// ANSI color codes
+#define RESET   "\033[0m"
+#define GREEN   "\033[32m"
+#define RED     "\033[31m"
+#define YELLOW  "\033[33m"
+#define BLUE    "\033[34m"
+
+int g_tests_passed = 0;
+int g_tests_failed = 0;
+
+#define TEST(name) \
+    void test_##name(); \
+    void test_##name##_wrapper() { \
+        std::cout << BLUE << "[TEST] " << #name << RESET << std::endl; \
+        try { \
+            test_##name(); \
+            std::cout << GREEN << "  PASSED" << RESET << std::endl; \
+            g_tests_passed++; \
+        } catch (const std::exception& e) { \
+            std::cout << RED << "  FAILED: " << e.what() << RESET << std::endl; \
+            g_tests_failed++; \
+        } catch (...) { \
+            std::cout << RED << "  FAILED: Unknown exception" << RESET << std::endl; \
+            g_tests_failed++; \
+        } \
+    } \
+    void test_##name()
+
+#define ASSERT(condition, message) \
+    if (!(condition)) { \
+        throw std::runtime_error(message); \
+    }
+
+using namespace DFMP;
+
+// ---------------------------------------------------------------------------
+// Hand-replicated LEGACY formulas (the exact unmodified pre-fix math).
+// Used to prove saturate=false is byte-identical (S4) and that the saturated
+// path is load-bearing vs the legacy wrap (S3). NOTE: these intentionally
+// reproduce the int64 overflow for high heat (well-defined here only as the
+// reference for "what the old binary did" — we compare divergence, not the
+// wrapped value itself, to stay clear of relying on signed-overflow UB).
+// ---------------------------------------------------------------------------
+
+// Legacy v3.3 heat (no dynamic scaling). Mirrors CalculateHeatMultiplierFP_V33
+// with saturate omitted. Uses unsigned accumulation to model the bit pattern
+// without invoking signed-overflow UB in the test harness itself.
+static int64_t legacyHeatV33(int heat) {
+    if (heat <= FREE_TIER_THRESHOLD_V33) return FP_SCALE;
+    if (heat <= LINEAR_ZONE_END_V33) {
+        int excess = heat - FREE_TIER_THRESHOLD_V33;
+        return FP_SCALE + (static_cast<int64_t>(excess) * FP_SCALE) / 4;
+    }
+    int64_t penalty = FP_LINEAR_END_PENALTY_V33;
+    int exponent = heat - LINEAR_ZONE_END_V33;
+    for (int i = 0; i < exponent; i++) {
+        // Replicate (penalty * 158)/100 in the int64 bit-pattern via uint64.
+        uint64_t prod = static_cast<uint64_t>(penalty) * static_cast<uint64_t>(FP_HEAT_GROWTH_V33);
+        penalty = static_cast<int64_t>(prod) / 100;
+    }
+    return penalty;
+}
+
+// ---------------------------------------------------------------------------
+// Generic per-version heat invocation (saturate threaded through).
+// ---------------------------------------------------------------------------
+static int64_t heatBase(int heat, bool sat) { return CalculateHeatMultiplierFP(heat, 0, sat); }
+static int64_t heatV31(int heat, bool sat)  { return CalculateHeatMultiplierFP_V31(heat, 0, sat); }
+static int64_t heatV32(int heat, bool sat)  { return CalculateHeatMultiplierFP_V32(heat, 0, sat); }
+static int64_t heatV33(int heat, bool sat)  { return CalculateHeatMultiplierFP_V33(heat, sat); }
+static int64_t heatV34v(int heat, bool sat) { return CalculateHeatMultiplierFP_V34(heat, true, sat); }
+static int64_t heatV34u(int heat, bool sat) { return CalculateHeatMultiplierFP_V34(heat, false, sat); }
+
+struct VersionFn {
+    const char* name;
+    int64_t (*fn)(int, bool);
+};
+
+static const VersionFn kVersions[] = {
+    {"base(v3.0)", heatBase},
+    {"v3.1",       heatV31},
+    {"v3.2",       heatV32},
+    {"v3.3",       heatV33},
+    {"v3.4-verified",   heatV34v},
+    {"v3.4-unverified", heatV34u},
+};
+
+// =======================================================================
+// S1 + S2: bounded + monotonic for every version, saturate=TRUE, heat 0..360
+// =======================================================================
+TEST(s1_s2_bounded_monotonic_all_versions) {
+    for (const auto& v : kVersions) {
+        int64_t prev = -1;
+        for (int heat = 0; heat <= OBSERVATION_WINDOW; heat++) {
+            int64_t r = v.fn(heat, /*saturate=*/true);
+
+            // S1: bounded in [FP_SCALE, FP_HEAT_MULTIPLIER_MAX]
+            ASSERT(r >= FP_SCALE,
+                std::string(v.name) + " heat=" + std::to_string(heat) +
+                " below FP_SCALE: " + std::to_string(r));
+            ASSERT(r <= FP_HEAT_MULTIPLIER_MAX,
+                std::string(v.name) + " heat=" + std::to_string(heat) +
+                " above MAX: " + std::to_string(r));
+
+            // S2: monotonic non-decreasing — more history NEVER yields an easier target
+            ASSERT(r >= prev,
+                std::string(v.name) + " NON-MONOTONIC at heat=" + std::to_string(heat) +
+                " (" + std::to_string(r) + " < prev " + std::to_string(prev) + ")");
+            prev = r;
+        }
+        std::cout << "    " << v.name << ": bounded + monotonic over heat 0..360 (max="
+                  << v.fn(OBSERVATION_WINDOW, true) << ")" << std::endl;
+    }
+}
+
+// =======================================================================
+// S3: known overflow input → saturate=TRUE returns MAX (hardest);
+//     legacy saturate=FALSE differs (proves the fix is load-bearing).
+// =======================================================================
+TEST(s3_overflow_input_hardest_and_load_bearing) {
+    const int kOverflowHeat = 90;  // well past where (penalty*158) overflows int64
+
+    // V33 (a live version)
+    int64_t satV33 = heatV33(kOverflowHeat, /*saturate=*/true);
+    ASSERT(satV33 == FP_HEAT_MULTIPLIER_MAX,
+        "V33 heat=90 saturate=true must return FP_HEAT_MULTIPLIER_MAX, got " +
+        std::to_string(satV33));
+
+    int64_t legacyV33 = heatV33(kOverflowHeat, /*saturate=*/false);
+    // Load-bearing: the legacy path must DIFFER from the saturated path at this input.
+    // (The legacy int64 multiply overflows and wraps; the exact wrapped value is not a
+    // stable contract — what matters is that it is NOT the saturated hardest value, so the
+    // gate genuinely changes behavior. If the gate were a no-op this assertion would fail.)
+    ASSERT(legacyV33 != satV33,
+        "V33 heat=90: legacy path must differ from saturated path (load-bearing check)");
+    // And it must match the independent legacy replica (same wrapped bit pattern),
+    // confirming saturate=false faithfully reproduces the pre-fix binary.
+    ASSERT(legacyV33 == legacyHeatV33(kOverflowHeat),
+        "V33 heat=90 saturate=false must match the hand-replicated legacy formula");
+
+    // The exact C-3 defect (easiest-target collapse): somewhere in the heat sweep the legacy
+    // int64 wrap drops the heaviest miner BELOW FP_SCALE (1.0x) — which CalculateEffectiveTarget
+    // then floors UP to 1.0x, handing the heaviest miner the EASIEST target. Prove such a heat
+    // exists in legacy, and that at the SAME heat the saturated path returns the HARDEST (MAX),
+    // i.e. monotonic. This is the precise concentration-defense nullification C-3 closes.
+    int collapseHeat = -1;
+    for (int h = LINEAR_ZONE_END_V33 + 1; h <= OBSERVATION_WINDOW; h++) {
+        int64_t legacy = heatV33(h, /*saturate=*/false);
+        if (legacy < FP_SCALE) {  // wrapped to "no penalty" or negative — the collapse
+            collapseHeat = h;
+            break;
+        }
+    }
+    ASSERT(collapseHeat != -1,
+        "expected at least one heat where the legacy wrap collapses below FP_SCALE "
+        "(the easiest-target defect); none found");
+    int64_t legacyCollapse = heatV33(collapseHeat, /*saturate=*/false);
+    int64_t satCollapse    = heatV33(collapseHeat, /*saturate=*/true);
+    ASSERT(satCollapse == FP_HEAT_MULTIPLIER_MAX,
+        "at collapse heat the saturated path must return MAX (hardest), got " +
+        std::to_string(satCollapse));
+    std::cout << "    collapse heat=" << collapseHeat << ": legacy=" << legacyCollapse
+              << " (< FP_SCALE → floored to easiest 1.0x) vs saturated=" << satCollapse
+              << " (MAX, hardest)" << std::endl;
+
+    // V34 verified (also live-adjacent)
+    int64_t satV34 = heatV34v(kOverflowHeat, /*saturate=*/true);
+    ASSERT(satV34 == FP_HEAT_MULTIPLIER_MAX,
+        "V34 heat=90 saturate=true must return FP_HEAT_MULTIPLIER_MAX, got " +
+        std::to_string(satV34));
+
+    std::cout << "    V33 heat=90: saturated=" << satV33
+              << " (MAX) vs legacy=" << legacyV33 << " (wrapped, easier)" << std::endl;
+}
+
+// =======================================================================
+// S4: below-gate identity — saturate=FALSE byte-identical to legacy formula
+//     across sub-overflow heat 0..70 (V33).
+// =======================================================================
+TEST(s4_below_gate_byte_identical_v33) {
+    for (int heat = 0; heat <= 70; heat++) {
+        int64_t live   = heatV33(heat, /*saturate=*/false);
+        int64_t golden = legacyHeatV33(heat);
+        ASSERT(live == golden,
+            "V33 saturate=false diverged from legacy at heat=" + std::to_string(heat) +
+            " (live=" + std::to_string(live) + ", golden=" + std::to_string(golden) + ")");
+    }
+    std::cout << "    V33 saturate=false == legacy formula for heat 0..70 (consensus-frozen)"
+              << std::endl;
+}
+
+// =======================================================================
+// Combinator: CalculateTotalMultiplierFP_V33 near-cap heat + saturate=TRUE
+//     stays bounded (the (pendingFP * heatFP)/FP_SCALE product cannot overflow).
+// =======================================================================
+TEST(combinator_v33_near_cap_bounded) {
+    // firstSeenHeight=-1 → maturity 2.5x (FP_PENDING_START_V32). heat=90 → heatFP saturates.
+    int64_t total = CalculateTotalMultiplierFP_V33(/*currentHeight=*/0, /*firstSeenHeight=*/-1,
+                                                   /*heat=*/90, /*saturate=*/true);
+    // maturity=2.5x, heatFP saturates to MAX (5.83e16). The raw int64 product
+    // (2.5e6 * 5.83e16 = 1.46e23) overflows int64, so the combinator computes it in 128-bit
+    // and clamps to FP_HEAT_MULTIPLIER_MAX. Result MUST be exactly MAX (positive, bounded).
+    ASSERT(total > 0, "V33 combinator total must be positive (no overflow), got " +
+        std::to_string(total));
+    ASSERT(total == FP_HEAT_MULTIPLIER_MAX,
+        "V33 combinator at heat=90 must clamp to FP_HEAT_MULTIPLIER_MAX, got " +
+        std::to_string(total));
+    // It must NOT have collapsed to <= 1.0x (the wrapped-overflow defect).
+    ASSERT(total > FP_SCALE,
+        "V33 combinator at heat=90 collapsed to <= 1.0x: " + std::to_string(total));
+    std::cout << "    V33 combinator (heat=90, maturity 2.5x, saturate): total=" << total
+              << " (bounded, no overflow)" << std::endl;
+}
+
+// =======================================================================
+// Constant sanity: FP_HEAT_MULTIPLIER_MAX margin proof holds.
+// =======================================================================
+TEST(constant_overflow_margin) {
+    // The next multiply must not overflow: MAX * FP_HEAT_GROWTH <= INT64_MAX.
+    ASSERT(FP_HEAT_MULTIPLIER_MAX == INT64_MAX / FP_HEAT_GROWTH,
+        "FP_HEAT_MULTIPLIER_MAX must equal INT64_MAX / FP_HEAT_GROWTH");
+    // Margin: MAX * 158 fits (proven via the quotient property; check via uint128-free bound).
+    ASSERT(FP_HEAT_MULTIPLIER_MAX <= INT64_MAX / FP_HEAT_GROWTH,
+        "FP_HEAT_MULTIPLIER_MAX * FP_HEAT_GROWTH would overflow int64");
+    ASSERT(FP_HEAT_MULTIPLIER_MAX > FP_SCALE,
+        "FP_HEAT_MULTIPLIER_MAX must be well above FP_SCALE");
+    std::cout << "    FP_HEAT_MULTIPLIER_MAX = " << FP_HEAT_MULTIPLIER_MAX
+              << " (INT64_MAX / " << FP_HEAT_GROWTH << ")" << std::endl;
+}
+
+int main() {
+    std::cout << YELLOW << "========================================" << RESET << std::endl;
+    std::cout << YELLOW << "C-3 DFMP Heat Overflow Tests" << RESET << std::endl;
+    std::cout << YELLOW << "========================================" << RESET << std::endl;
+    std::cout << std::endl;
+
+    test_constant_overflow_margin_wrapper();
+    test_s1_s2_bounded_monotonic_all_versions_wrapper();
+    test_s3_overflow_input_hardest_and_load_bearing_wrapper();
+    test_s4_below_gate_byte_identical_v33_wrapper();
+    test_combinator_v33_near_cap_bounded_wrapper();
+
+    std::cout << std::endl;
+    std::cout << YELLOW << "========================================" << RESET << std::endl;
+    std::cout << YELLOW << "Test Summary" << RESET << std::endl;
+    std::cout << YELLOW << "========================================" << RESET << std::endl;
+    std::cout << GREEN << "Passed: " << g_tests_passed << RESET << std::endl;
+    std::cout << RED << "Failed: " << g_tests_failed << RESET << std::endl;
+    std::cout << YELLOW << "Total:  " << (g_tests_passed + g_tests_failed) << RESET << std::endl;
+    std::cout << std::endl;
+
+    if (g_tests_failed == 0) {
+        std::cout << GREEN << "ALL TESTS PASSED!" << RESET << std::endl;
+        return 0;
+    } else {
+        std::cout << RED << "SOME TESTS FAILED" << RESET << std::endl;
+        return 1;
+    }
+}

--- a/src/test/dfmp_heat_overflow_tests.cpp
+++ b/src/test/dfmp_heat_overflow_tests.cpp
@@ -222,6 +222,38 @@ TEST(s4_below_gate_byte_identical_v33) {
     }
     std::cout << "    V33 saturate=false == legacy formula for heat 0..70 (consensus-frozen)"
               << std::endl;
+
+    // Cursor MED-2: broaden below-gate identity to ALL versions. saturate is a NO-OP below
+    // each version's overflow point — i.e. saturate=true == saturate=false for every
+    // sub-overflow heat. This proves per-version byte-identity without a per-version replica.
+    // At the FIRST true/false divergence (the cap point) the saturated path must be exactly MAX
+    // (it caps + breaks); below it the two are bit-identical.
+    for (const auto& v : kVersions) {
+        int boundary = -1;
+        for (int heat = 0; heat <= OBSERVATION_WINDOW; heat++) {
+            int64_t sat = v.fn(heat, /*saturate=*/true);
+            int64_t leg = v.fn(heat, /*saturate=*/false);
+            if (sat == leg) continue;  // identical below the cap
+            boundary = heat;
+            ASSERT(sat == FP_HEAT_MULTIPLIER_MAX,
+                std::string(v.name) + ": first saturate true/false divergence at heat=" +
+                std::to_string(heat) + " but saturated != MAX (got " + std::to_string(sat) + ")");
+            break;
+        }
+        std::cout << "    " << v.name << ": saturate is a no-op below heat="
+                  << (boundary < 0 ? OBSERVATION_WINDOW : boundary) << " (byte-identical)" << std::endl;
+    }
+
+    // Combinator below-gate identity (Cursor MED-2): the saturate flag must not change any
+    // sub-overflow combinator value either.
+    for (int heat = 0; heat <= 50; heat++) {
+        int64_t s = CalculateTotalMultiplierFP_V33(0, -1, heat, /*saturate=*/true);
+        int64_t l = CalculateTotalMultiplierFP_V33(0, -1, heat, /*saturate=*/false);
+        ASSERT(s == l,
+            "V33 combinator saturate flag changed a sub-overflow value at heat=" +
+            std::to_string(heat) + " (s=" + std::to_string(s) + ", l=" + std::to_string(l) + ")");
+    }
+    std::cout << "    V33 combinator saturate=true == false for sub-overflow heat 0..50" << std::endl;
 }
 
 // =======================================================================
@@ -232,15 +264,23 @@ TEST(combinator_v33_near_cap_bounded) {
     // firstSeenHeight=-1 → maturity 2.5x (FP_PENDING_START_V32). heat=90 → heatFP saturates.
     int64_t total = CalculateTotalMultiplierFP_V33(/*currentHeight=*/0, /*firstSeenHeight=*/-1,
                                                    /*heat=*/90, /*saturate=*/true);
-    // maturity=2.5x, heatFP saturates to MAX (5.83e16). The raw int64 product
-    // (2.5e6 * 5.83e16 = 1.46e23) overflows int64, so the combinator computes it in 128-bit
-    // and clamps to FP_HEAT_MULTIPLIER_MAX. Result MUST be exactly MAX (positive, bounded).
+    // maturity stacks ON TOP of the capped heat: product = maturityFP * heatCap / FP_SCALE.
+    // The 128-bit math computes it exactly; it must clamp at the TRUE int64 boundary, NOT at
+    // FP_HEAT_MULTIPLIER_MAX (Cursor MED-1) — else the maturity multiplier is discarded and the
+    // target is ~2.5x easier than it should be. The real product (~1.46e17) fits int64.
+    int64_t maturityFP = CalculatePendingPenaltyFP_V33(0, -1);  // the maturity at this height
+    int64_t heatCap    = heatV33(90, /*saturate=*/true);        // = FP_HEAT_MULTIPLIER_MAX
+    int64_t expected   = static_cast<int64_t>(
+        (static_cast<__uint128_t>(maturityFP) * static_cast<__uint128_t>(heatCap)) / FP_SCALE);
     ASSERT(total > 0, "V33 combinator total must be positive (no overflow), got " +
         std::to_string(total));
-    ASSERT(total == FP_HEAT_MULTIPLIER_MAX,
-        "V33 combinator at heat=90 must clamp to FP_HEAT_MULTIPLIER_MAX, got " +
-        std::to_string(total));
-    // It must NOT have collapsed to <= 1.0x (the wrapped-overflow defect).
+    ASSERT(total == expected,
+        "V33 combinator must return the exact maturity x heat product " + std::to_string(expected) +
+        ", got " + std::to_string(total));
+    // LOAD-BEARING for MED-1: the stacked product MUST exceed the heat cap alone — if the code
+    // still ceilinged at FP_HEAT_MULTIPLIER_MAX this fails (maturity stacking lost).
+    ASSERT(total > FP_HEAT_MULTIPLIER_MAX,
+        "V33 combinator must stack maturity above the heat cap (MED-1), got " + std::to_string(total));
     ASSERT(total > FP_SCALE,
         "V33 combinator at heat=90 collapsed to <= 1.0x: " + std::to_string(total));
     std::cout << "    V33 combinator (heat=90, maturity 2.5x, saturate): total=" << total

--- a/src/test/dfmp_heat_overflow_tests.cpp
+++ b/src/test/dfmp_heat_overflow_tests.cpp
@@ -240,6 +240,18 @@ TEST(s4_below_gate_byte_identical_v33) {
                 std::to_string(heat) + " but saturated != MAX (got " + std::to_string(sat) + ")");
             break;
         }
+        // Guard against vacuity (red-team LOW-1): if NO true/false divergence was seen in range,
+        // saturate genuinely never fired — which is only legitimate if the version is properly
+        // bounded at max heat (its whole curve fits below the cap). If it instead reached the cap
+        // (or wrapped) without the loop catching a split, the saturate branch is broken or the
+        // test range is too short. Assert genuine boundedness in that case.
+        if (boundary == -1) {
+            int64_t mx = v.fn(OBSERVATION_WINDOW, /*saturate=*/true);
+            ASSERT(mx >= FP_SCALE && mx < FP_HEAT_MULTIPLIER_MAX,
+                std::string(v.name) + ": no saturate divergence in heat 0.." +
+                std::to_string(OBSERVATION_WINDOW) + " but max-heat value " + std::to_string(mx) +
+                " is not bounded below the cap (range too short, or saturate cap not firing)");
+        }
         std::cout << "    " << v.name << ": saturate is a no-op below heat="
                   << (boundary < 0 ? OBSERVATION_WINDOW : boundary) << " (byte-identical)" << std::endl;
     }


### PR DESCRIPTION
## CRITICAL — DFMP concentration-defense nullification (sweep C-3)

The DFMP heat-penalty exponential `penalty=(penalty*FP_HEAT_GROWTH)/100` overflows int64 at heat ~75+ of the 360-block window. The wrapped (negative) value is then floored to `FP_SCALE` (1.0×) in `CalculateEffectiveTarget` → **the heaviest miner gets the EASIEST target**, nullifying the anti-concentration defense. The maturity×heat product `(pendingFP*heatFP)` also overflows pre-divide.

Concrete (test): V33 heat=77 legacy = **−49,295,805,092,645,298** → floored to easiest; saturated = MAX (hardest).

## Fix — activation-gated saturating fixed-point (OFF by default)
- New per-chain `dfmpOverflowFixActivationHeight` (default `999999999`). **Below** the gate every value is **byte-identical** to legacy (consensus-frozen); **at/above** it saturates.
- Saturating cap `FP_HEAT_MULTIPLIER_MAX = INT64_MAX/FP_HEAT_GROWTH (~5.84e16)` in all 5 versioned heat fns — minimal-change (only flattens inputs that would overflow → hardest, never wraps). **Monotonic: more history never yields an easier target.**
- Overflow-safe maturity×heat via `__uint128_t`+clamp (`CombineMaturityHeatFP`), applied to the 5 combinators **and** the inline products on the consensus/build paths (validator combines inline).
- Ungated `linearSpan<=0` guard in V34 (fail-safe to the harder zone-3 base; unreachable with current constants).
- `bool saturate=false` threaded so display callers are untouched.

## Scope notes (for reviewers)
- **V33 is the LIVE path** — `dfmpV34ActivationHeight=999999999` (V34 disabled) on all chains; the de-correlation cited V34, but the live fix surface is V33. All 5 versions fixed (gated) regardless.
- **`dilv-node.cpp` is in the diff** — it carries a full parallel DFMP penalty block (the DilV binary's miner-build); gating only `dilithion-node.cpp` would have left DilV (the live C-3 chain) unfixed / divergent. Gated identically (coordinator-confirmed in-scope).
- **Contract F2/F6 self-correction** — the approved contract claimed the maturity×heat product was safe; it overflows *before* the divide (5e6×5.84e16=2.9e23 > int64). Caught during impl, fixed via the 128-bit path. See the disposition.

## Reviews
- ✅ **red-team-validator** (fresh): **SAFE-TO-MERGE** (0 CRIT/HIGH; byte-identity, gate-completeness across all 4 sites, monotonicity, cap, default-OFF, load-bearing tests all verified).
- ✅ **external_consensus** (4/5 GO-WITH-REVISIONS; lone gpt-oss NO-GO **code-refuted** — function-wrapping doesn't change below-gate arithmetic; below-gate UB is pre-existing+frozen-by-design). 3 findings **folded** at `5f8e21de` (`__uint128` static_assert, portable overflow test, fail-safe linearSpan). Disposition: `dilithion-strategy/missions/ecosystem-security-sweep-2026-06/c3-hardening/EXTERNAL_REVIEW_disposition.md`.
- ⬜ **Will-Cursor close-readiness** — final gate (no Zach: DIL/DilV maintenance = Will's).

## Tests
`dfmp_heat_overflow_tests` (new) 5/5: constant margin, S1/S2 bounded+monotonic across all 6 versions (heat 0..360), S3 overflow→hardest + load-bearing collapse proof, S4 below-gate byte-identical, combinator bounded. Build clean both binaries; dfmp.cpp clean under `-fsanitize=signed-integer-overflow`.

## NOT in scope (do not merge / separate gates)
Activation-height + deploy = separate Will gate (set above live tip + rollout, #111-style). Pre-existing controller↔validator full-formula divergence (red-team MED-1) routed to a separate sweep finding. **Merge order: C-3 first → C-2 (W2) rebases on it.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)