### PR TITLE
fix(dfmp): blind DNA-verification in the dead V34 gate — Simplified Option C (sweep C-2)

### DIFF
--- a/src/consensus/pow.cpp
+++ b/src/consensus/pow.cpp
@@ -427,11 +427,14 @@ bool CheckProofOfWorkDFMP(
         // read is dropped entirely.
         //
         // Safety premise: isVerified has ZERO live consensus effect outside this V34 gate.
-        // Every consensus reader of isVerified / get_verification_status is enumerated here
+        // Every CONSENSUS reader of isVerified / get_verification_status is enumerated here
         // (pow.cpp, dilithion-node.cpp, dilv-node.cpp — all inside `height >= dfmpV34ActivationHeight`
-        // guards). dfmpV34ActivationHeight=999999999 on both mainnets (chainparams.cpp:96 DIL,
-        // :468 DilV) — this branch is dead code today. Blinding in place is not a live consensus
-        // change; it is safe-by-construction if v3.4 ever activates.
+        // guards). The only other reader is NON-consensus: an RPC reporter at src/rpc/server.cpp:5623
+        // (getdfmpstatus display) — it still reads real status, so if v3.4 is ever activated its
+        // reported penalty must also be blinded to match consensus (tracked pre-activation item).
+        // dfmpV34ActivationHeight=999999999 on all chains (src/core/chainparams.cpp:96 DIL,
+        // :315 testnet, :468 DilV) — this branch is dead code today. Blinding in place is not a live
+        // consensus change; it is safe-by-construction if v3.4 ever activates.
         bool isVerified = false;
 
         // MIK identity heat penalty (v3.4 - verification-aware)

--- a/src/consensus/pow.cpp
+++ b/src/consensus/pow.cpp
@@ -422,14 +422,17 @@ bool CheckProofOfWorkDFMP(
         // Verified MIKs: 12 free blocks, Unverified: 3 free blocks
         // ====================================================================
 
-        // Determine verification status of this MIK
-        bool isVerified = true;  // Default: verified (safe fallback during IBD)
-        if (g_node_context.dna_registry) {
-            std::array<uint8_t, 20> mikArr;
-            std::memcpy(mikArr.data(), identity.data, 20);
-            auto status = g_node_context.dna_registry->get_verification_status(mikArr);
-            isVerified = (status == digital_dna::verification::VerificationStatus::VERIFIED);
-        }
+        // Simplified Option C (D-7): blind verification status — isVerified is forced false
+        // so Q1=STRICT (everyone gets the unverified free-tier=3). The get_verification_status
+        // read is dropped entirely.
+        //
+        // Safety premise: isVerified has ZERO live consensus effect outside this V34 gate.
+        // Every consensus reader of isVerified / get_verification_status is enumerated here
+        // (pow.cpp, dilithion-node.cpp, dilv-node.cpp — all inside `height >= dfmpV34ActivationHeight`
+        // guards). dfmpV34ActivationHeight=999999999 on both mainnets (chainparams.cpp:96 DIL,
+        // :468 DilV) — this branch is dead code today. Blinding in place is not a live consensus
+        // change; it is safe-by-construction if v3.4 ever activates.
+        bool isVerified = false;
 
         // MIK identity heat penalty (v3.4 - verification-aware)
         int64_t mikHeatPenalty = DFMP::CalculateHeatMultiplierFP_V34(blocksInWindow, isVerified, dfmpSat);
@@ -584,14 +587,9 @@ bool CheckProofOfWorkDFMP(
     double multiplier = static_cast<double>(multiplierFP) / DFMP::FP_SCALE;
     if (multiplier > 1.01) {
         if (height >= dfmpV34ActivationHeight) {
-            // Determine verification status for logging
-            bool logIsVerified = true;
-            if (g_node_context.dna_registry) {
-                std::array<uint8_t, 20> mikArr;
-                std::memcpy(mikArr.data(), identity.data, 20);
-                auto status = g_node_context.dna_registry->get_verification_status(mikArr);
-                logIsVerified = (status == digital_dna::verification::VerificationStatus::VERIFIED);
-            }
+            // Simplified Option C (D-7): log-path mirrors dispatch — logIsVerified forced false
+            // (see dispatch-site comment above for full safety premise).
+            bool logIsVerified = false;
             double maturityMult = DFMP::GetPendingPenalty_V34(height, effectiveFirstSeen);
             double heatMult = DFMP::GetHeatMultiplier_V34(blocksInWindow, logIsVerified);
 

--- a/src/node/dilithion-node.cpp
+++ b/src/node/dilithion-node.cpp
@@ -1777,14 +1777,17 @@ std::optional<CBlockTemplate> BuildMiningTemplate(CBlockchainDB& blockchain, CWa
             // DFMP v3.4: Verification-aware free tier
             // Verified MIKs: 12 free blocks, Unverified: 3 free blocks
 
-            // Determine verification status of this MIK
-            bool isVerified = true;  // Default: verified (safe fallback during IBD)
-            if (g_node_context.dna_registry) {
-                std::array<uint8_t, 20> mikArr;
-                std::memcpy(mikArr.data(), mikIdentity.data, 20);
-                auto status = g_node_context.dna_registry->get_verification_status(mikArr);
-                isVerified = (status == digital_dna::verification::VerificationStatus::VERIFIED);
-            }
+            // Simplified Option C (D-7): blind verification status — isVerified is forced false
+            // so Q1=STRICT (everyone gets the unverified free-tier=3). The get_verification_status
+            // read is dropped entirely.
+            //
+            // Safety premise: isVerified has ZERO live consensus effect outside this V34 gate.
+            // Every consensus reader of isVerified / get_verification_status is enumerated here
+            // (pow.cpp, dilithion-node.cpp, dilv-node.cpp — all inside `height >= dfmpV34ActivationHeight`
+            // guards). dfmpV34ActivationHeight=999999999 on both mainnets (chainparams.cpp:96 DIL,
+            // :468 DilV) — this branch is dead code today. Blinding in place is not a live consensus
+            // change; it is safe-by-construction if v3.4 ever activates.
+            bool isVerified = false;
 
             // MIK identity heat penalty (v3.4 - verification-aware)
             int64_t mikHeatPenalty = DFMP::CalculateHeatMultiplierFP_V34(heat, isVerified, dfmpSat);
@@ -1924,17 +1927,12 @@ std::optional<CBlockTemplate> BuildMiningTemplate(CBlockchainDB& blockchain, CWa
         if (multiplier > 1.01) {
             const char* versionTag;
             double maturityMult, heatMult;
-            bool logIsVerified = true;
+            // Simplified Option C (D-7): log-path mirrors dispatch — logIsVerified forced false
+            // (see dispatch-site comment above for full safety premise).
+            bool logIsVerified = false;
             if (static_cast<int>(nHeight) >= dfmpV34ActivationHeight) {
                 versionTag = "v3.4";
                 maturityMult = DFMP::GetPendingPenalty_V34(nHeight, firstSeen);
-                // Determine verification status for logging
-                if (g_node_context.dna_registry) {
-                    std::array<uint8_t, 20> mikArr;
-                    std::memcpy(mikArr.data(), mikIdentity.data, 20);
-                    auto status = g_node_context.dna_registry->get_verification_status(mikArr);
-                    logIsVerified = (status == digital_dna::verification::VerificationStatus::VERIFIED);
-                }
                 heatMult = DFMP::GetHeatMultiplier_V34(heat, logIsVerified);
             } else if (static_cast<int>(nHeight) >= dfmpV33ActivationHeight) {
                 versionTag = "v3.3";

--- a/src/node/dilithion-node.cpp
+++ b/src/node/dilithion-node.cpp
@@ -1782,11 +1782,14 @@ std::optional<CBlockTemplate> BuildMiningTemplate(CBlockchainDB& blockchain, CWa
             // read is dropped entirely.
             //
             // Safety premise: isVerified has ZERO live consensus effect outside this V34 gate.
-            // Every consensus reader of isVerified / get_verification_status is enumerated here
+            // Every CONSENSUS reader of isVerified / get_verification_status is enumerated here
             // (pow.cpp, dilithion-node.cpp, dilv-node.cpp — all inside `height >= dfmpV34ActivationHeight`
-            // guards). dfmpV34ActivationHeight=999999999 on both mainnets (chainparams.cpp:96 DIL,
-            // :468 DilV) — this branch is dead code today. Blinding in place is not a live consensus
-            // change; it is safe-by-construction if v3.4 ever activates.
+            // guards). The only other reader is NON-consensus: an RPC reporter at src/rpc/server.cpp:5623
+            // (getdfmpstatus display) — it still reads real status, so if v3.4 is ever activated its
+            // reported penalty must also be blinded to match consensus (tracked pre-activation item).
+            // dfmpV34ActivationHeight=999999999 on all chains (src/core/chainparams.cpp:96 DIL,
+            // :315 testnet, :468 DilV) — this branch is dead code today. Blinding in place is not a live
+            // consensus change; it is safe-by-construction if v3.4 ever activates.
             bool isVerified = false;
 
             // MIK identity heat penalty (v3.4 - verification-aware)

--- a/src/node/dilv-node.cpp
+++ b/src/node/dilv-node.cpp
@@ -1723,11 +1723,14 @@ std::optional<CBlockTemplate> BuildMiningTemplate(CBlockchainDB& blockchain, CWa
             // read is dropped entirely.
             //
             // Safety premise: isVerified has ZERO live consensus effect outside this V34 gate.
-            // Every consensus reader of isVerified / get_verification_status is enumerated here
+            // Every CONSENSUS reader of isVerified / get_verification_status is enumerated here
             // (pow.cpp, dilithion-node.cpp, dilv-node.cpp — all inside `height >= dfmpV34ActivationHeight`
-            // guards). dfmpV34ActivationHeight=999999999 on both mainnets (chainparams.cpp:96 DIL,
-            // :468 DilV) — this branch is dead code today. Blinding in place is not a live consensus
-            // change; it is safe-by-construction if v3.4 ever activates.
+            // guards). The only other reader is NON-consensus: an RPC reporter at src/rpc/server.cpp:5623
+            // (getdfmpstatus display) — it still reads real status, so if v3.4 is ever activated its
+            // reported penalty must also be blinded to match consensus (tracked pre-activation item).
+            // dfmpV34ActivationHeight=999999999 on all chains (src/core/chainparams.cpp:96 DIL,
+            // :315 testnet, :468 DilV) — this branch is dead code today. Blinding in place is not a live
+            // consensus change; it is safe-by-construction if v3.4 ever activates.
             bool isVerified = false;
 
             // MIK identity heat penalty (v3.4 - verification-aware)

--- a/src/node/dilv-node.cpp
+++ b/src/node/dilv-node.cpp
@@ -1718,14 +1718,17 @@ std::optional<CBlockTemplate> BuildMiningTemplate(CBlockchainDB& blockchain, CWa
             // DFMP v3.4: Verification-aware free tier
             // Verified MIKs: 12 free blocks, Unverified: 3 free blocks
 
-            // Determine verification status of this MIK
-            bool isVerified = true;  // Default: verified (safe fallback)
-            if (g_node_context.dna_registry) {
-                std::array<uint8_t, 20> mikArr;
-                std::memcpy(mikArr.data(), mikIdentity.data, 20);
-                auto status = g_node_context.dna_registry->get_verification_status(mikArr);
-                isVerified = (status == digital_dna::verification::VerificationStatus::VERIFIED);
-            }
+            // Simplified Option C (D-7): blind verification status — isVerified is forced false
+            // so Q1=STRICT (everyone gets the unverified free-tier=3). The get_verification_status
+            // read is dropped entirely.
+            //
+            // Safety premise: isVerified has ZERO live consensus effect outside this V34 gate.
+            // Every consensus reader of isVerified / get_verification_status is enumerated here
+            // (pow.cpp, dilithion-node.cpp, dilv-node.cpp — all inside `height >= dfmpV34ActivationHeight`
+            // guards). dfmpV34ActivationHeight=999999999 on both mainnets (chainparams.cpp:96 DIL,
+            // :468 DilV) — this branch is dead code today. Blinding in place is not a live consensus
+            // change; it is safe-by-construction if v3.4 ever activates.
+            bool isVerified = false;
 
             // MIK identity heat penalty (v3.4 - verification-aware)
             int64_t mikHeatPenalty = DFMP::CalculateHeatMultiplierFP_V34(heat, isVerified, dfmpSat);
@@ -1865,17 +1868,12 @@ std::optional<CBlockTemplate> BuildMiningTemplate(CBlockchainDB& blockchain, CWa
         if (multiplier > 1.01) {
             const char* versionTag;
             double maturityMult, heatMult;
-            bool logIsVerified = true;  // For v3.4 logging
+            // Simplified Option C (D-7): log-path mirrors dispatch — logIsVerified forced false
+            // (see dispatch-site comment above for full safety premise).
+            bool logIsVerified = false;
             if (static_cast<int>(nHeight) >= dfmpV34ActivationHeight) {
                 versionTag = "v3.4";
                 maturityMult = DFMP::GetPendingPenalty_V34(nHeight, firstSeen);
-                // Determine verification status for logging
-                if (g_node_context.dna_registry) {
-                    std::array<uint8_t, 20> mikArr;
-                    std::memcpy(mikArr.data(), mikIdentity.data, 20);
-                    auto status = g_node_context.dna_registry->get_verification_status(mikArr);
-                    logIsVerified = (status == digital_dna::verification::VerificationStatus::VERIFIED);
-                }
                 heatMult = DFMP::GetHeatMultiplier_V34(heat, logIsVerified);
             } else if (static_cast<int>(nHeight) >= dfmpV33ActivationHeight) {
                 versionTag = "v3.3";


### PR DESCRIPTION
**Simplified Option C (D-7)** — removes DNA-verification from consensus by blinding the dormant v3.4 verification branch (force isVerified=false STRICT, drop get_verification_status reads). Below-gate byte-identical; v3.4 dead at 999999999 on all chains → not a live consensus change, safe-by-construction if v3.4 ever activates. Split from H-5/H-6 (separate workstream); cleanly cherry-picked onto merged C-3.

**Review stack (all CLEAN):** red-team-validator SAFE-TO-MERGE · deepseek-pro external_review (BLOCKER code-refuted: gate at pow.cpp:414) · Will-Cursor GO-WITH-REVISIONS · build clean both binaries.

**Pre-activation HARD-GATE (tracked, not merge-blocking):** before any v3.4 activation-height change, blind getdfmpstatus (rpc/server.cpp:5614-5624) to match consensus (F4 LOW).

🤖 Generated with [Claude Code](https://claude.com/claude-code)