### PR TITLE
refactor(wallet): extract LegacyRecordKeying() helper — dedup v7-MAC keying predicate (sweep INFO-1)

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -244,8 +244,7 @@ bool CWallet::GenerateNewKey() {
         // non-HD v6 wallet never migrates — so a v7-keyed MAC written here would
         // make the freshly-minted key UNSPENDABLE on the next load. Select keying
         // by the loaded file version, exactly as EncryptWallet/ChangePassphrase do.
-        const bool legacyKeying =
-            (m_loadedFileVersion != 0 && m_loadedFileVersion < WALLET_FILE_VERSION_7);
+        const bool legacyKeying = LegacyRecordKeying();
         if (!ComputeRecordMAC(crypter, encKey.vchCryptedKey, encKey.vchMAC, legacyKeying)) {
             memory_cleanse(masterKeyVec.data(), masterKeyVec.size());
             key.Clear();   // defense-in-depth: wipe the plaintext key on the failure
@@ -378,8 +377,7 @@ bool CWallet::VerifyRecordMAC(CCrypter& crypter,
     // matches the on-disk version: legacy AES-keyed HMAC for v3-v6, separated
     // MAC key for v7. (m_loadedFileVersion == 0 means a freshly-created in-memory
     // wallet whose records this build wrote with the default separated keying.)
-    const bool legacyKeying =
-        (m_loadedFileVersion != 0 && m_loadedFileVersion < WALLET_FILE_VERSION_7);
+    const bool legacyKeying = LegacyRecordKeying();
     return crypter.VerifyMAC(ciphertext, mac, legacyKeying);
 }
 
@@ -511,8 +509,7 @@ bool CWallet::ImportKey(const CKey& key, const CDilithiumAddress& address) {
         // non-HD v6 wallet never migrates — so a v7-keyed MAC written here would
         // make the freshly-minted key UNSPENDABLE on the next load. Select keying
         // by the loaded file version, exactly as EncryptWallet/ChangePassphrase do.
-        const bool legacyKeying =
-            (m_loadedFileVersion != 0 && m_loadedFileVersion < WALLET_FILE_VERSION_7);
+        const bool legacyKeying = LegacyRecordKeying();
         if (!ComputeRecordMAC(crypter, encKey.vchCryptedKey, encKey.vchMAC, legacyKeying)) {
             memory_cleanse(masterKeyVec.data(), masterKeyVec.size());
             return false;
@@ -1917,8 +1914,7 @@ bool CWallet::ChangePassphrase(const std::string& passphraseOld,
     //   - loaded v7 / 0 -> separated v7 keying (file is/stays v7)
     // (The single v6->v7 migration — which DOES recompute every MAC to separated
     // keying — still happens exactly once, on the next Unlock, never here.)
-    const bool legacyMasterKeying =
-        (m_loadedFileVersion != 0 && m_loadedFileVersion < WALLET_FILE_VERSION_7);
+    const bool legacyMasterKeying = LegacyRecordKeying();
     std::vector<uint8_t> newMAC;
     if (!ComputeRecordMAC(crypterNew, newCryptedKey, newMAC, legacyMasterKeying)) {
         memory_cleanse(derivedKeyOld.data(), derivedKeyOld.size());
@@ -3062,8 +3058,7 @@ bool CWallet::SaveUnlocked(const std::string& filename) const {
     // m_loadedFileVersion to v7, so this writer then emits v7 from then on. A freshly
     // created in-memory wallet (m_loadedFileVersion == 0) and an already-v7 wallet
     // both write v7.
-    const bool writeLegacyV6 =
-        (m_loadedFileVersion != 0 && m_loadedFileVersion < WALLET_FILE_VERSION_7);
+    const bool writeLegacyV6 = LegacyRecordKeying();
 
     if (writeLegacyV6) {
         file.write(WALLET_FILE_MAGIC_V6, 8);  // "DILWLT06" — keep the loaded version
@@ -5741,8 +5736,7 @@ bool CWallet::DeriveAndCacheHDAddress(const CHDKeyPath& path) {
         // non-HD v6 wallet never migrates — so a v7-keyed MAC written here would
         // make the freshly-minted key UNSPENDABLE on the next load. Select keying
         // by the loaded file version, exactly as EncryptWallet/ChangePassphrase do.
-        const bool legacyKeying =
-            (m_loadedFileVersion != 0 && m_loadedFileVersion < WALLET_FILE_VERSION_7);
+        const bool legacyKeying = LegacyRecordKeying();
         if (!ComputeRecordMAC(crypter, encKey.vchCryptedKey, encKey.vchMAC, legacyKeying)) {
             memory_cleanse(masterKeyVec.data(), masterKeyVec.size());
             key.Clear();

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -302,6 +302,14 @@ private:
     // HD seed. Used to (a) verify legacy MACs with the correct keying, and (b)
     // detect a legacy plaintext-seed encrypted wallet that needs migration on unlock.
     uint32_t m_loadedFileVersion{0};
+    // LP-7 / ecosystem-sweep C-1: a per-record MAC must be keyed to MATCH the
+    // verify side. A wallet loaded from a pre-v7 file (and a non-HD v6 wallet that
+    // never migrates) uses legacy AES-keyed HMAC; a freshly-created in-memory
+    // wallet (m_loadedFileVersion==0) and a loaded v7+ wallet use v7 keying.
+    // Single source of truth for that predicate — it has drifted/bitten twice.
+    bool LegacyRecordKeying() const {
+        return m_loadedFileVersion != 0 && m_loadedFileVersion < WALLET_FILE_VERSION_7;
+    }
     // LP-7: set true at load when an encrypted wallet was read in a pre-v7 format
     // with a plaintext HD seed at rest (the bug condition). Triggers atomic
     // re-encryption + v7 rewrite on the next successful unlock.


### PR DESCRIPTION
**Recreated off current main** — supersedes #130, which became un-rebasable (squash-merged #128 duplicated underneath its branch + a stale test base). Same dedup, clean history.

Extracts the `(m_loadedFileVersion != 0 && m_loadedFileVersion < WALLET_FILE_VERSION_7)` MAC-keying predicate (which drifted/bit twice — the C-1 brick was a keying-site miss) into one private const helper `LegacyRecordKeying()`, routing all **6 sites** through it: GenerateNewKey, VerifyRecordMAC, ImportKey, ChangePassphrase, SaveUnlocked, DeriveAndCacheHDAddress.

**Equivalence (grep-proven):** 6 helper calls, 1 definition, **0 residual inline predicates**. Behavior-preserving.
**Review:** logic identical to the original #130 (red-team SAFE-TO-MERGE + GLM-5.2 GO + DeepSeek-Pro GO in the finalization pass); CI build/test confirms on this base.

Closes #130.

🤖 Generated with [Claude Code](https://claude.com/claude-code)