### PR TITLE
fix(genesis): single-source integrity guard for the genesis hash

### DIFF
--- a/src/net/headers_manager.cpp
+++ b/src/net/headers_manager.cpp
@@ -108,7 +108,10 @@ CHeadersManager::CHeadersManager()
     // Without this, block 1's pprev is nullptr and chainWork doesn't include genesis work
     CBlock genesis = (Dilithion::g_chainParams && Dilithion::g_chainParams->IsDilV()) ?
         Genesis::CreateDilVGenesisBlock() : Genesis::CreateGenesisBlock();
-    uint256 genesisHash = genesis.GetHash();
+    // Single-source, integrity-validated genesis hash (see node/genesis.cpp
+    // GetGenesisHash): keeps the headers-manager key consistent with the DB key
+    // and the P2P-advertised hash, and never keys off a transient miscompute.
+    uint256 genesisHash = Genesis::GetGenesisHash();
     uint256 genesisWork = GetBlockWork(genesis.nBits);
 
     HeaderWithChainWork genesisData(static_cast<CBlockHeader>(genesis), 0);  // height 0

--- a/src/node/dilithion-node.cpp
+++ b/src/node/dilithion-node.cpp
@@ -2654,13 +2654,19 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
         }
 
         std::cout << "  Network: " << Dilithion::g_chainParams->GetNetworkName() << std::endl;
-        std::cout << "  Genesis hash: " << genesis.GetHash().GetHex() << std::endl;
+        std::cout << "  Genesis hash: " << Genesis::GetGenesisHash().GetHex() << std::endl;
         std::cout << "  Genesis time: " << genesis.nTime << std::endl;
         std::cout << " ✓" << std::endl;
         std::cout << "  [OK] Genesis block verified" << std::endl;
 
-        // Initialize blockchain with genesis block if needed
-        uint256 genesisHash = genesis.GetHash();
+        // Initialize blockchain with genesis block if needed.
+        // Use the single-source, integrity-validated accessor (Genesis::GetGenesisHash)
+        // instead of recomputing genesis.GetHash() here: it self-corrects a transient
+        // genesis miscompute to the chainparams-pinned value, so the DB key can never
+        // be a wrong genesis (which would strand the node on a private chain peers
+        // ban for `invalid_genesis`). See node/genesis.cpp GetGenesisHash().
+        uint256 genesisHash = Genesis::GetGenesisHash();
+
         if (!blockchain.BlockExists(genesisHash)) {
             std::cout << "Initializing blockchain with genesis block..." << std::endl;
 

--- a/src/node/dilv-node.cpp
+++ b/src/node/dilv-node.cpp
@@ -2519,13 +2519,16 @@ load_genesis_block:  // Bug #29: Label for automatic retry after blockchain wipe
         }
 
         std::cout << "  Network: " << Dilithion::g_chainParams->GetNetworkName() << std::endl;
-        std::cout << "  Genesis hash: " << genesis.GetHash().GetHex() << std::endl;
+        std::cout << "  Genesis hash: " << Genesis::GetGenesisHash().GetHex() << std::endl;
         std::cout << "  Genesis time: " << genesis.nTime << std::endl;
         std::cout << " ✓" << std::endl;
         std::cout << "  [OK] Genesis block verified" << std::endl;
 
-        // Initialize blockchain with genesis block if needed
-        uint256 genesisHash = genesis.GetHash();
+        // Initialize blockchain with genesis block if needed.
+        // Single-source, integrity-validated accessor (see node/genesis.cpp
+        // GetGenesisHash): self-corrects a transient genesis miscompute to the
+        // chainparams-pinned value so the DB key is never a wrong genesis.
+        uint256 genesisHash = Genesis::GetGenesisHash();
         if (!blockchain.BlockExists(genesisHash)) {
             std::cout << "Initializing blockchain with genesis block..." << std::endl;
 

--- a/src/node/genesis.cpp
+++ b/src/node/genesis.cpp
@@ -9,6 +9,7 @@
 #include <core/chainparams.h>
 #include <vdf/coinbase_vdf.h>
 #include <util/base58.h>
+#include <util/logging.h>
 
 #include <cstring>
 #include <iostream>
@@ -258,10 +259,11 @@ uint256 GetGenesisHash() {
         if (Dilithion::g_chainParams && !Dilithion::g_chainParams->genesisHash.empty()) {
             const uint256 pinned = uint256S(Dilithion::g_chainParams->genesisHash);
             if (!(computed == pinned)) {
-                std::cerr << "[GENESIS] ERROR: recomputed genesis hash " << computed.GetHex()
-                          << " does not match the value pinned in chainparams " << pinned.GetHex()
-                          << " — using the pinned value (transient compute fault; see ops board "
-                             "randomx-genesis-init-corruption)." << std::endl;
+                LogPrintf(ALL, ERROR,
+                    "[GENESIS] recomputed genesis hash %s does not match the value pinned in "
+                    "chainparams %s — using the pinned value (transient compute fault; see ops "
+                    "board randomx-genesis-init-corruption)",
+                    computed.GetHex().c_str(), pinned.GetHex().c_str());
                 computed = pinned;
             }
         }

--- a/src/node/genesis.cpp
+++ b/src/node/genesis.cpp
@@ -213,9 +213,39 @@ CBlock CreateDilVGenesisBlock() {
 
 uint256 GetGenesisHash() {
     static uint256 hash;
-    static bool initialized = false;
+    static std::once_flag genesisHashOnce;
 
-    if (!initialized) {
+    // ── SINGLE-SOURCE GENESIS HASH + INTEGRITY GUARD (2026-06-28) ─────────────
+    // call_once: the previous `static bool initialized` lazy-init was an unguarded
+    // data race — C++ magic-statics protect only the FIRST default construction of
+    // `hash`, NOT the later assignment inside the `if`, so two threads racing the
+    // first call could both enter the block (or read `hash` before the other's
+    // write was visible). call_once serializes it.
+    //
+    // Integrity: this accessor is the SINGLE canonical source of the genesis hash
+    // consumed across the node — the startup DB key (dilithion-node/dilv-node), the
+    // headers manager, the P2P version message AND the per-peer genesis/ban check
+    // (net.cpp:2248/:582). The RandomX (legacy) / SHA3 (VDF) recompute was observed
+    // once, on an 8GB+ miner, to transiently produce a WRONG value; persisting OR
+    // advertising it strands the node on a private 1-block chain and gets its IP
+    // banned (`invalid_genesis`). chainparams pins the canonical hash for mainnet +
+    // DilV and the pin cannot be attacker-influenced, so when a pin exists we TRUST
+    // IT: if the recompute disagrees, log loudly (fault stays visible) and use the
+    // pinned value — no consumer ever sees a miscomputed genesis. Testnet leaves the
+    // pin empty (computed at startup) → unguarded, as before.
+    std::call_once(genesisHashOnce, []() {
+        // Refuse to populate the cache before chainparams are selected: caching an
+        // UNVALIDATED (un-pinned) hash for the process lifetime would silently
+        // defeat the integrity check below. CreateGenesisBlock() already throws on
+        // null params, but enforce the invariant locally so it is self-documenting
+        // and survives a future refactor of that helper. Throwing leaves the
+        // once_flag un-armed, so a correctly-ordered later call performs the
+        // validated compute rather than poisoning the cache. (No such early caller
+        // exists today — g_chainParams is set at startup before any genesis work.)
+        if (!Dilithion::g_chainParams) {
+            throw std::runtime_error("GetGenesisHash() called before chainparams initialized");
+        }
+
         // Use VDF genesis for any chain with VDF active from genesis (DilV, or testnet in VDF-only mode)
         bool useVdfGenesis = Dilithion::g_chainParams &&
             (Dilithion::g_chainParams->IsDilV() ||
@@ -223,9 +253,20 @@ uint256 GetGenesisHash() {
               Dilithion::g_chainParams->vdfExclusiveHeight == 0));
         CBlock genesis = useVdfGenesis ?
             CreateDilVGenesisBlock() : CreateGenesisBlock();
-        hash = genesis.GetHash();
-        initialized = true;
-    }
+        uint256 computed = genesis.GetHash();
+
+        if (Dilithion::g_chainParams && !Dilithion::g_chainParams->genesisHash.empty()) {
+            const uint256 pinned = uint256S(Dilithion::g_chainParams->genesisHash);
+            if (!(computed == pinned)) {
+                std::cerr << "[GENESIS] ERROR: recomputed genesis hash " << computed.GetHex()
+                          << " does not match the value pinned in chainparams " << pinned.GetHex()
+                          << " — using the pinned value (transient compute fault; see ops board "
+                             "randomx-genesis-init-corruption)." << std::endl;
+                computed = pinned;
+            }
+        }
+        hash = computed;
+    });
 
     return hash;
 }


### PR DESCRIPTION
## Problem
A miner's node, after `--reset-chain`, **intermittently rebuilt and persisted a WRONG genesis hash** (`e7684470…` instead of the pinned mainnet `0000009e…`), stranding it on a private 1-block chain and getting its IP banned by all seeds (`misbehavior_type: invalid_genesis`). A second reset produced the correct hash → intermittent.

The mechanism of the bad *compute* is unresolved (rare; not reproduced in 100 fresh-genesis boots on a 31 GB box; possibly transient RandomX/Argon2 fault or hardware — see ops board `randomx-genesis-init-corruption`). But the **load-bearing defect is mechanism-independent**: the canonical genesis hash was recomputed independently in several places (startup DB key, headers manager, P2P version message, ban check) and **never checked against the chainparams-pinned constant**, so any single transient miscompute was silently persisted *and advertised to peers*.

## Fix — consolidate to one validated source
- `Genesis::GetGenesisHash()` is now the single canonical accessor: `std::call_once` (fixes a pre-existing unguarded lazy-static data race), and when chainparams pins the hash (mainnet + DilV) it compares the recompute to the pin and, on mismatch, **logs loudly and uses the pinned value** (the pin is authoritative and not attacker-influenceable). An explicit guard refuses to populate the cache before `g_chainParams` is set (defense against a future early-caller refactor). Testnet leaves the pin empty → computed as before.
- Routed the previously-independent computes through it: `dilithion-node.cpp`, `dilv-node.cpp`, `headers_manager.cpp` (net.cpp already used it). DB key, headers, version message, and ban check now share one validated hash.

Local self-check only — **no consensus/network rule change**; on mismatch the node self-heals onto the pin instead of bricking.

## Review convergence (on this final artifact)
- **red-team-validator** (fresh context): CLEAN — verified all consumers route through the validated accessor; init-order & key/content risks don't land.
- **external multi-model consensus**: flagged an init-order caching risk → verified unreachable (`CreateGenesisBlock` throws on null params; `g_chainParams` set before any genesis work) and hardened with the explicit guard.
- **behavioral mutation test**: a deliberately-divergent genesis compute self-corrects to the pin — DB key = pin, `[GENESIS] ERROR` fires, `Chain integrity validation passed` (no crash). Verified under the real 8GB+ async-init startup.

## Deferred follow-ups (LOW)
- Release checklist should diff the pinned hash vs a fresh compute (a genuinely-wrong *pin* would now self-heal silently onto itself).
- `[GENESIS] ERROR` uses `stderr` (can be lost under redirection) — consider the structured logger.
- Testnet path stays unguarded by design (no pin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)