### PR TITLE
fix(consensus): retune reorg bound 100→60 + single-source + F-08 static_assert

### DIFF
--- a/src/consensus/chain.cpp
+++ b/src/consensus/chain.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license
 
 #include <consensus/chain.h>
+#include <consensus/params.h>    // Consensus::MAX_REORG_DEPTH (single source of truth)
 #include <consensus/pow.h>
 #include <consensus/reorg_wal.h>  // P1-4: WAL for atomic reorgs
 #include <consensus/validation.h> // BUG #109 FIX: DeserializeBlockTransactions
@@ -840,16 +841,17 @@ bool CChainState::ActivateBestChain(CBlockIndex* pindexNew, const CBlock& block,
     // VULN-008 FIX: Protect against excessively deep reorganizations
     // CID 1675248 FIX: Use int64_t to prevent overflow when computing reorg depth
     // and add validation to ensure reorg_depth is non-negative
-    static const int64_t MAX_REORG_DEPTH = 100;  // Similar to Bitcoin's practical limit
+    // Single source of truth: Consensus::MAX_REORG_DEPTH (consensus/params.h).
+    const int64_t reorg_cap = static_cast<int64_t>(Consensus::MAX_REORG_DEPTH);
     int64_t reorg_depth = static_cast<int64_t>(pindexTip->nHeight) - static_cast<int64_t>(pindexFork->nHeight);
     if (reorg_depth < 0) {
         std::cerr << "[Chain] ERROR: Invalid reorg depth (negative): " << reorg_depth << std::endl;
         std::cerr << "  Tip height: " << pindexTip->nHeight << ", Fork height: " << pindexFork->nHeight << std::endl;
         return false;
     }
-    if (reorg_depth > MAX_REORG_DEPTH) {
+    if (reorg_depth > reorg_cap) {
         std::cerr << "[Chain] ERROR: Reorganization too deep: " << reorg_depth << " blocks" << std::endl;
-        std::cerr << "  Maximum allowed: " << MAX_REORG_DEPTH << " blocks" << std::endl;
+        std::cerr << "  Maximum allowed: " << reorg_cap << " blocks" << std::endl;
         std::cerr << "  This may indicate a long-range attack or network partition" << std::endl;
         return false;
     }
@@ -2764,7 +2766,8 @@ bool CChainState::ActivateBestChainStep(CBlockIndex* pindexMostWork,
     // disconnect list is empty; connect list walks pindexMostWork all the way back.
 
     // 1.5) v4.3.3 F4 (audit modality 1 I2 / modality 2 MEDIUM-6): reorg depth
-    // cap on the port path. Mirrors legacy chain.cpp:780-792 MAX_REORG_DEPTH=100.
+    // cap on the port path. Mirrors the legacy cap using the single-source
+    // Consensus::MAX_REORG_DEPTH (consensus/params.h) — no literal copy here.
     //
     // Pre-fix, the port path's ActivateBestChainStep had no depth check —
     // canary 3 attempted a 441-block reorg unconstrained. The legacy cap
@@ -2794,13 +2797,14 @@ bool CChainState::ActivateBestChainStep(CBlockIndex* pindexMostWork,
     // M1 helper's plumbing is the only path that respects --datadir=PATH
     // (the H1 defect Layer-3 caught on v4.3.2-M1).
     if (pindexTip != nullptr && pindexFork != nullptr) {
-        static const int64_t MAX_REORG_DEPTH = 100;  // matches legacy chain.cpp:780
+        // Single source of truth: Consensus::MAX_REORG_DEPTH (consensus/params.h).
+        const int64_t reorg_cap = static_cast<int64_t>(Consensus::MAX_REORG_DEPTH);
         const int64_t reorg_depth =
             static_cast<int64_t>(pindexTip->nHeight) -
             static_cast<int64_t>(pindexFork->nHeight);
-        if (reorg_depth > MAX_REORG_DEPTH) {
+        if (reorg_depth > reorg_cap) {
             std::cerr << "[Chain] ActivateBestChainStep: reorg depth " << reorg_depth
-                      << " exceeds MAX_REORG_DEPTH=" << MAX_REORG_DEPTH
+                      << " exceeds MAX_REORG_DEPTH=" << reorg_cap
                       << " (tip h=" << pindexTip->nHeight
                       << ", fork h=" << pindexFork->nHeight
                       << "). Dropping candidate (NOT marking failed); flagging "

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -154,8 +154,17 @@ static const int DIFFICULTY_ADJUSTMENT_INTERVAL_V2 = 360;
 // Chain Security Parameters
 //==============================================================================
 
-/** Maximum allowed chain reorganization depth (similar to Bitcoin's practical limit) */
-static const int MAX_REORG_DEPTH = 100;
+/**
+ * Maximum allowed chain reorganization depth — the ROLLING reorg cap
+ * (Bitcoin-practical-limit lineage). SINGLE SOURCE OF TRUTH: every reorg-bound
+ * check references this constant; there must be no literal copies elsewhere.
+ *
+ * Value = 60 (ION decision F-02, 2026-07-01: tightened from the inherited 100).
+ * On a constant-VDF-work chain nChainWork ~= block-count, so this hard depth
+ * cap + attested-identity scarcity are the deep-reorg defense (not PoW
+ * cumulative-work cost). See ION_DECISION_REGISTER F-02.
+ */
+static const int MAX_REORG_DEPTH = 60;
 
 /** Maximum number of block headers to process in one message */
 static const unsigned int MAX_HEADERS_RESULTS = 2000;
@@ -239,6 +248,22 @@ static const int64_t MAX_FUTURE_BLOCK_TIME_V2 = 10 * 60;
 
 /** Maximum block timestamp drift (median time of past 11 blocks) */
 static const int MEDIAN_TIME_SPAN = 11;
+
+//==============================================================================
+// Compile-time safety invariants
+//==============================================================================
+
+/**
+ * F-08 safety invariant: a reorg must never be able to un-mature (and thus
+ * un-spend) a matured coinbase. The rolling reorg cap must therefore be no
+ * deeper than coinbase maturity, i.e. MAX_REORG_DEPTH <= COINBASE_MATURITY.
+ * Machine-checked at compile time so any future retune of either constant that
+ * would violate the invariant fails the build instead of shipping silently.
+ * (See ION_DECISION_REGISTER F-08 / K-08.)
+ */
+static_assert(MAX_REORG_DEPTH <= COINBASE_MATURITY,
+              "F-08 violated: MAX_REORG_DEPTH must be <= COINBASE_MATURITY — "
+              "a reorg deeper than coinbase maturity can un-spend a matured coinbase");
 
 } // namespace Consensus
 

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -257,9 +257,16 @@ static const int MEDIAN_TIME_SPAN = 11;
  * F-08 safety invariant: a reorg must never be able to un-mature (and thus
  * un-spend) a matured coinbase. The rolling reorg cap must therefore be no
  * deeper than coinbase maturity, i.e. MAX_REORG_DEPTH <= COINBASE_MATURITY.
- * Machine-checked at compile time so any future retune of either constant that
- * would violate the invariant fails the build instead of shipping silently.
- * (See ION_DECISION_REGISTER F-08 / K-08.)
+ *
+ * SCOPE (do NOT over-read this): the static_assert below guards only the
+ * COMPILE-TIME constant (DIL: COINBASE_MATURITY = 100). The check that actually
+ * enforces maturity at runtime reads the PER-CHAIN value
+ * g_chainParams->coinbaseMaturity (e.g. DilV = 6, utxo_set.cpp), which this
+ * assert does NOT cover. On a chain whose runtime maturity is below
+ * MAX_REORG_DEPTH (DilV: 6 < 60), a reorg in the (maturity, cap] window can
+ * still un-spend a matured coinbase — a separate live-chain finding, not caught
+ * here. This assert protects DIL's compile-time invariant only.
+ * (See ION_DECISION_REGISTER F-08 / K-08 + the DilV maturity item.)
  */
 static_assert(MAX_REORG_DEPTH <= COINBASE_MATURITY,
               "F-08 violated: MAX_REORG_DEPTH must be <= COINBASE_MATURITY — "

--- a/src/net/headers_manager.cpp
+++ b/src/net/headers_manager.cpp
@@ -452,10 +452,12 @@ bool CHeadersManager::ProcessHeaders(NodeId peer, const std::vector<CBlockHeader
                 // Parent not found - this is a competing chain (fork on PoW, normal on VDF)
 
                 // STALE FORK FILTER: If the expected height is far below our chain tip,
-                // this fork can never trigger an automatic reorg (MAX_AUTO_REORG_DEPTH=100).
-                // Skip fork detection to avoid log noise, unnecessary GETHEADERS, and
-                // wasted CPU on obviously-stale competing chains.
-                static const int STALE_FORK_THRESHOLD = 100;
+                // this fork can never trigger an automatic reorg (its depth exceeds the
+                // consensus reorg cap Consensus::MAX_REORG_DEPTH, which the in-place
+                // auto-reorg bound MAX_AUTO_REORG_DEPTH also tracks). Skip fork detection
+                // to avoid log noise, unnecessary GETHEADERS, and wasted CPU on
+                // obviously-stale competing chains. Keep in lockstep with the reorg cap.
+                static const int STALE_FORK_THRESHOLD = Consensus::MAX_REORG_DEPTH;
                 if (chainstateHeightPreFetched > 0 && expectedHeight > 0 &&
                     (chainstateHeightPreFetched - expectedHeight) > STALE_FORK_THRESHOLD) {
                     if (g_verbose.load(std::memory_order_relaxed)) {

--- a/src/node/fork_manager.cpp
+++ b/src/node/fork_manager.cpp
@@ -322,7 +322,7 @@ std::shared_ptr<ForkCandidate> ForkManager::CreateForkCandidate(
 
     // Deep forks (> MAX_AUTO_REORG_DEPTH) are handled by DisconnectToHeight()
     // in AttemptForkRecovery() before reaching this point.
-    // ActivateBestChain() enforces MAX_REORG_DEPTH=100 for shallow forks.
+    // ActivateBestChain() enforces Consensus::MAX_REORG_DEPTH for shallow forks.
 
     m_activeFork = std::make_shared<ForkCandidate>(forkTipHash, forkPointHeight, expectedTipHeight, expectedHashes);
 

--- a/src/node/ibd_coordinator.h
+++ b/src/node/ibd_coordinator.h
@@ -5,6 +5,7 @@
 #define DILITHION_NODE_IBD_COORDINATOR_H
 
 #include <uint256.h>
+#include <consensus/params.h>  // Consensus::MAX_REORG_DEPTH (auto-reorg bound tracks the consensus cap)
 #include <atomic>
 #include <chrono>
 #include <set>
@@ -287,7 +288,13 @@ private:
     std::atomic<int64_t> m_last_block_connected_ticks;
     // Layer 3: Deep fork handling - requires manual reindex for security
     bool m_requires_reindex{false};
-    static constexpr int MAX_AUTO_REORG_DEPTH = 100;  // Max blocks to auto-reorg
+    // Max blocks to auto-reorg in place. Tracks the consensus reorg cap
+    // (Consensus::MAX_REORG_DEPTH, currently 60) so the cheap in-place
+    // DisconnectToHeight recovery branch fires for EVERY fork the consensus
+    // cap will accept. If this exceeded the cap, forks in the (cap, this]
+    // band would skip in-place recovery, get consensus-rejected, and force a
+    // wasteful full datadir wipe + genesis re-sync. (ION F-02 retune fold.)
+    static constexpr int MAX_AUTO_REORG_DEPTH = Consensus::MAX_REORG_DEPTH;
 
     // Resync tracking for completion message
     bool m_resync_in_progress{false};

--- a/src/test/port_chain_selector_invariants_tests.cpp
+++ b/src/test/port_chain_selector_invariants_tests.cpp
@@ -255,8 +255,9 @@ void test_t1_2_reorg_depth_cap_rejects_deep_sibling()
     CBlockIndex* genesis = active.genesis;
 
     // Sibling chain forking at genesis (h=0), walking to h=350. Reorg depth
-    // when activating sibling-leaf: tip(200) - fork(0) = 200 > 100. F4 trips.
-    // ALL ancestors have BLOCK_HAVE_DATA so F5 wouldn't reject — F4 must.
+    // when activating sibling-leaf: tip(200) - fork(0) = 200 > MAX_REORG_DEPTH
+    // (60). F4 trips. ALL ancestors have BLOCK_HAVE_DATA so F5 wouldn't
+    // reject — F4 must.
     CBlockIndex* sibPrev = genesis;
     for (int h = 1; h <= 350; ++h) {
         auto p = MakeIdx(/*chain_id=*/0x80, sibPrev, h,
@@ -285,7 +286,7 @@ void test_t1_2_reorg_depth_cap_rejects_deep_sibling()
                                        fInvalidFound);
 
     // F4 (post-F8 semantics, Layer-3 HIGH-2 + state-replay S3): depth
-    // 200 > 100 → erase from candidates (NOT MarkBlockAsFailed) + set
+    // 200 > MAX_REORG_DEPTH (60) → erase from candidates (NOT MarkBlockAsFailed) + set
     // m_chain_needs_rebuild for wrapper-driven recovery via the
     // v4.3.2-M1 main-loop helper.
     assert(!ok);


### PR DESCRIPTION
## What

Retunes the rolling reorg-depth cap **100 → 60** (ION decision F-02, 2026-07-01), single-sources the constant, machine-checks the coinbase-maturity invariant, and aligns the sibling operational bounds so recovery stays cheap across the whole consensus-acceptable range.

## Changes
- `MAX_REORG_DEPTH = 60` — now the **single source of truth** (`consensus/params.h`); both consensus cap sites (`chain.cpp` legacy `:845` + port `:2801`) reference it instead of local `100` literals.
- **`static_assert(MAX_REORG_DEPTH <= COINBASE_MATURITY)`** — F-08 machine-check: a reorg must never un-mature a spent coinbase. Any future retune violating it fails the build.
- Sibling operational bounds aligned to the cap (red-team should-fold): `MAX_AUTO_REORG_DEPTH` (`ibd_coordinator.h`) and `STALE_FORK_THRESHOLD` (`headers_manager.cpp`) now `= Consensus::MAX_REORG_DEPTH`. Without this, a 61–100-deep fork skips cheap in-place auto-reorg, gets consensus-rejected, and forces a wasteful full datadir wipe + genesis re-sync.

## Verification
- Red-team (`_REDTEAM_reorg_retune_2026-07-01.md`): consensus bound CLEAN (no missed site, no width/signedness hazard); sibling fold was its explicit recommendation, now implemented + diff-reviewed.
- Build clean (both nodes); reorg/IBD/chain-selector/headers suites pass.
- Pre-existing unrelated failure `chain_case_2_5_equivalence test_scenario_2` (depth-1 fixture, documented at `:458-462`) reproduces on `main` — not introduced here.

## ⚠️ Separate finding for Will + Zach (NOT fixed here)
DilV runtime `coinbaseMaturity = 6` sits **below** the 60 cap, so a depth 7–60 reorg could un-spend a matured DilV coinbase. This is **pre-existing** (the cap was 100 before — worse); this PR *narrows* the window but does not close it. The compile-time `static_assert` guards only the DIL compile-time `COINBASE_MATURITY=100`, not DilV's runtime value. Full fix (per-chain assert or raising DilV maturity) is a live-chain consensus decision.

Draft pending CI + Will's merge.