### PR TITLE
fix(consensus): explicit little-endian for hashed fields — WF-1 cross-arch fork fix (byte-equal)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -468,16 +468,6 @@ genesis_gen: $(CORE_OBJECTS) $(OBJ_DIR)/test/genesis_test.o $(DILITHIUM_OBJECTS)
 	@$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LIBS)
 	@echo "$(COLOR_GREEN)✓ genesis_gen built successfully$(COLOR_RESET)"
 
-# WF-1 host-endian differential / byte-equality test (CONSENSUS SAFETY PROOF).
-# Asserts the 9 explicit-LE serialization sites are byte-identical to the old
-# host-endian bytes on this (LE) machine, and that the DIL genesis hash is
-# unchanged (both at the 80-byte header preimage and the full RandomX hash).
-# Links the full CORE_OBJECTS the same way genesis_gen does.
-wf1_host_endian_differential_test: $(CORE_OBJECTS) $(OBJ_DIR)/test/wf1_host_endian_differential_test.o $(DILITHIUM_OBJECTS) $(CHIAVDF_OBJECTS) | libzmq
-	@echo "$(COLOR_BLUE)[LINK]$(COLOR_RESET) $@"
-	@$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LIBS)
-	@echo "$(COLOR_GREEN)✓ wf1_host_endian_differential_test built successfully$(COLOR_RESET)"
-
 inspect_db: $(CORE_OBJECTS) $(OBJ_DIR)/tools/inspect_db.o $(DILITHIUM_OBJECTS) $(CHIAVDF_OBJECTS)
 	@echo "$(COLOR_BLUE)[LINK]$(COLOR_RESET) $@"
 	@$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LIBS)
@@ -974,6 +964,7 @@ BOOST_TEST_OBJECTS := $(OBJ_DIR)/test/test_dilithion.o \
 	$(OBJ_DIR)/test/fee_wiring_tests.o \
 	$(OBJ_DIR)/test/zmq_tests.o \
 	$(OBJ_DIR)/test/seed_attestation_glue_tests.o \
+	$(OBJ_DIR)/test/wf1_host_endian_differential_test.o \
 	$(CRYPTO_PROPERTY_OBJECTS)
 
 # Link test objects + full library (CORE_OBJECTS) to avoid hand-picked object drift

--- a/Makefile
+++ b/Makefile
@@ -468,6 +468,16 @@ genesis_gen: $(CORE_OBJECTS) $(OBJ_DIR)/test/genesis_test.o $(DILITHIUM_OBJECTS)
 	@$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LIBS)
 	@echo "$(COLOR_GREEN)✓ genesis_gen built successfully$(COLOR_RESET)"
 
+# WF-1 host-endian differential / byte-equality test (CONSENSUS SAFETY PROOF).
+# Asserts the 9 explicit-LE serialization sites are byte-identical to the old
+# host-endian bytes on this (LE) machine, and that the DIL genesis hash is
+# unchanged (both at the 80-byte header preimage and the full RandomX hash).
+# Links the full CORE_OBJECTS the same way genesis_gen does.
+wf1_host_endian_differential_test: $(CORE_OBJECTS) $(OBJ_DIR)/test/wf1_host_endian_differential_test.o $(DILITHIUM_OBJECTS) $(CHIAVDF_OBJECTS) | libzmq
+	@echo "$(COLOR_BLUE)[LINK]$(COLOR_RESET) $@"
+	@$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LIBS)
+	@echo "$(COLOR_GREEN)✓ wf1_host_endian_differential_test built successfully$(COLOR_RESET)"
+
 inspect_db: $(CORE_OBJECTS) $(OBJ_DIR)/tools/inspect_db.o $(DILITHIUM_OBJECTS) $(CHIAVDF_OBJECTS)
 	@echo "$(COLOR_BLUE)[LINK]$(COLOR_RESET) $@"
 	@$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LIBS)

--- a/src/consensus/vdf_validation.cpp
+++ b/src/consensus/vdf_validation.cpp
@@ -29,10 +29,16 @@ std::array<uint8_t, 32> ComputeVDFChallenge(
     const std::array<uint8_t, 20>& minerAddress)
 {
     // Preimage: prevHash(32) || height_le32(4) || minerAddress(20) = 56 bytes
+    // WF-1: height written in EXPLICIT little-endian (byte-shift), not a raw
+    // host-endian memcpy. Byte-identical to the previous copy on LE hosts; now
+    // portable to any architecture. Matches the correct pattern in mik.cpp.
     uint8_t preimage[56];
     std::memcpy(preimage,      prevHash.data, 32);
-    uint32_t hLE = static_cast<uint32_t>(height);
-    std::memcpy(preimage + 32, &hLE, 4);
+    uint32_t h = static_cast<uint32_t>(height);
+    preimage[32] = static_cast<uint8_t>(h);
+    preimage[33] = static_cast<uint8_t>(h >> 8);
+    preimage[34] = static_cast<uint8_t>(h >> 16);
+    preimage[35] = static_cast<uint8_t>(h >> 24);
     std::memcpy(preimage + 36, minerAddress.data(), 20);
 
     std::array<uint8_t, 32> challenge{};

--- a/src/digital_dna/bandwidth_proof.cpp
+++ b/src/digital_dna/bandwidth_proof.cpp
@@ -1,4 +1,5 @@
 #include "bandwidth_proof.h"
+#include "dna_serialize.h"  // WF-1: explicit-LE consensus serialization helpers
 
 #include <algorithm>
 #include <cmath>
@@ -137,15 +138,17 @@ std::string BandwidthFingerprint::to_json() const {
 
 std::vector<uint8_t> BandwidthFingerprint::serialize() const {
     // Derived metrics only: 4 doubles (32 bytes) + measurement count (4 bytes)
+    // WF-1: explicit little-endian (byte-identical on LE hosts to the previous
+    // memcpy copies; portable across architectures).
     std::vector<uint8_t> data(36);
     size_t offset = 0;
 
-    std::memcpy(data.data() + offset, &median_upload_mbps, 8); offset += 8;
-    std::memcpy(data.data() + offset, &median_download_mbps, 8); offset += 8;
-    std::memcpy(data.data() + offset, &median_asymmetry, 8); offset += 8;
-    std::memcpy(data.data() + offset, &bandwidth_stability, 8); offset += 8;
+    dna_le::set_double(data.data() + offset, median_upload_mbps); offset += 8;
+    dna_le::set_double(data.data() + offset, median_download_mbps); offset += 8;
+    dna_le::set_double(data.data() + offset, median_asymmetry); offset += 8;
+    dna_le::set_double(data.data() + offset, bandwidth_stability); offset += 8;
     uint32_t count = static_cast<uint32_t>(measurements.size());
-    std::memcpy(data.data() + offset, &count, 4); offset += 4;
+    dna_le::set_u32(data.data() + offset, count); offset += 4;
 
     return data;
 }
@@ -154,11 +157,12 @@ BandwidthFingerprint BandwidthFingerprint::deserialize(const std::vector<uint8_t
     BandwidthFingerprint fp;
     if (data.size() < 36) return fp;
 
+    // WF-1: explicit little-endian reads, matched to serialize() above.
     size_t offset = 0;
-    std::memcpy(&fp.median_upload_mbps, data.data() + offset, 8); offset += 8;
-    std::memcpy(&fp.median_download_mbps, data.data() + offset, 8); offset += 8;
-    std::memcpy(&fp.median_asymmetry, data.data() + offset, 8); offset += 8;
-    std::memcpy(&fp.bandwidth_stability, data.data() + offset, 8); offset += 8;
+    fp.median_upload_mbps = dna_le::get_double(data.data() + offset); offset += 8;
+    fp.median_download_mbps = dna_le::get_double(data.data() + offset); offset += 8;
+    fp.median_asymmetry = dna_le::get_double(data.data() + offset); offset += 8;
+    fp.bandwidth_stability = dna_le::get_double(data.data() + offset); offset += 8;
     // measurement count is informational only (no raw measurements in serialized form)
 
     return fp;

--- a/src/digital_dna/behavioral_profile.cpp
+++ b/src/digital_dna/behavioral_profile.cpp
@@ -1,4 +1,5 @@
 #include "behavioral_profile.h"
+#include "dna_serialize.h"  // WF-1: explicit-LE consensus serialization helpers
 
 #include <algorithm>
 #include <cmath>
@@ -244,33 +245,27 @@ std::string BehavioralProfile::to_json() const {
 }
 
 std::vector<uint8_t> BehavioralProfile::serialize() const {
+    // WF-1: explicit little-endian (byte-identical on LE hosts to the previous
+    // reinterpret_cast copies; portable across architectures).
     std::vector<uint8_t> data;
 
     // hourly_activity: 24 * 8 = 192 bytes
     for (size_t i = 0; i < 24; i++) {
-        data.insert(data.end(), reinterpret_cast<const uint8_t*>(&hourly_activity[i]),
-                    reinterpret_cast<const uint8_t*>(&hourly_activity[i]) + 8);
+        dna_le::put_double(data, hourly_activity[i]);
     }
 
     // 6 doubles: 48 bytes
-    auto push_double = [&](double v) {
-        data.insert(data.end(), reinterpret_cast<const uint8_t*>(&v),
-                    reinterpret_cast<const uint8_t*>(&v) + 8);
-    };
-    push_double(mean_relay_delay_ms);
-    push_double(relay_consistency);
-    push_double(avg_peer_session_duration_sec);
-    push_double(peer_diversity_score);
-    push_double(tx_relay_rate);
-    push_double(tx_timing_entropy);
+    dna_le::put_double(data, mean_relay_delay_ms);
+    dna_le::put_double(data, relay_consistency);
+    dna_le::put_double(data, avg_peer_session_duration_sec);
+    dna_le::put_double(data, peer_diversity_score);
+    dna_le::put_double(data, tx_relay_rate);
+    dna_le::put_double(data, tx_timing_entropy);
 
     // Metadata: 4 + 8 + 8 = 20 bytes
-    data.insert(data.end(), reinterpret_cast<const uint8_t*>(&observation_blocks),
-                reinterpret_cast<const uint8_t*>(&observation_blocks) + 4);
-    data.insert(data.end(), reinterpret_cast<const uint8_t*>(&start_time),
-                reinterpret_cast<const uint8_t*>(&start_time) + 8);
-    data.insert(data.end(), reinterpret_cast<const uint8_t*>(&end_time),
-                reinterpret_cast<const uint8_t*>(&end_time) + 8);
+    dna_le::put_u32(data, observation_blocks);
+    dna_le::put_u64(data, start_time);
+    dna_le::put_u64(data, end_time);
 
     // Total: 192 + 48 + 20 = 260 bytes
     return data;
@@ -282,16 +277,16 @@ BehavioralProfile BehavioralProfile::deserialize(const std::vector<uint8_t>& dat
 
     size_t offset = 0;
 
+    // WF-1: explicit little-endian reads, matched to serialize() above.
     // hourly_activity: 192 bytes
     for (size_t i = 0; i < 24; i++) {
-        std::memcpy(&profile.hourly_activity[i], data.data() + offset, 8);
+        profile.hourly_activity[i] = dna_le::get_double(data.data() + offset);
         offset += 8;
     }
 
     // 6 doubles: 48 bytes
     auto read_double = [&]() -> double {
-        double v;
-        std::memcpy(&v, data.data() + offset, 8);
+        double v = dna_le::get_double(data.data() + offset);
         offset += 8;
         return v;
     };
@@ -303,9 +298,9 @@ BehavioralProfile BehavioralProfile::deserialize(const std::vector<uint8_t>& dat
     profile.tx_timing_entropy = read_double();
 
     // Metadata
-    std::memcpy(&profile.observation_blocks, data.data() + offset, 4); offset += 4;
-    std::memcpy(&profile.start_time, data.data() + offset, 8); offset += 8;
-    std::memcpy(&profile.end_time, data.data() + offset, 8); offset += 8;
+    profile.observation_blocks = dna_le::get_u32(data.data() + offset); offset += 4;
+    profile.start_time = dna_le::get_u64(data.data() + offset); offset += 8;
+    profile.end_time = dna_le::get_u64(data.data() + offset); offset += 8;
 
     return profile;
 }

--- a/src/digital_dna/clock_drift.cpp
+++ b/src/digital_dna/clock_drift.cpp
@@ -1,4 +1,5 @@
 #include "clock_drift.h"
+#include "dna_serialize.h"  // WF-1: explicit-LE consensus serialization helpers
 
 #include <algorithm>
 #include <cmath>
@@ -239,16 +240,18 @@ std::string ClockDriftFingerprint::to_json() const {
 std::vector<uint8_t> ClockDriftFingerprint::serialize() const {
     // Serialize derived metrics only (not raw samples)
     // 3 doubles (24) + 2 uint64 (16) + 2 uint32 (8) = 48 bytes
+    // WF-1: explicit little-endian (byte-identical on LE hosts to the previous
+    // memcpy copies; portable across architectures).
     std::vector<uint8_t> data(48);
     size_t offset = 0;
 
-    std::memcpy(data.data() + offset, &drift_rate_ppm, 8); offset += 8;
-    std::memcpy(data.data() + offset, &drift_stability, 8); offset += 8;
-    std::memcpy(data.data() + offset, &jitter_signature, 8); offset += 8;
-    std::memcpy(data.data() + offset, &observation_start, 8); offset += 8;
-    std::memcpy(data.data() + offset, &observation_end, 8); offset += 8;
-    std::memcpy(data.data() + offset, &num_reference_peers, 4); offset += 4;
-    std::memcpy(data.data() + offset, &num_samples, 4); offset += 4;
+    dna_le::set_double(data.data() + offset, drift_rate_ppm); offset += 8;
+    dna_le::set_double(data.data() + offset, drift_stability); offset += 8;
+    dna_le::set_double(data.data() + offset, jitter_signature); offset += 8;
+    dna_le::set_u64(data.data() + offset, observation_start); offset += 8;
+    dna_le::set_u64(data.data() + offset, observation_end); offset += 8;
+    dna_le::set_u32(data.data() + offset, num_reference_peers); offset += 4;
+    dna_le::set_u32(data.data() + offset, num_samples); offset += 4;
 
     return data;
 }
@@ -257,14 +260,15 @@ ClockDriftFingerprint ClockDriftFingerprint::deserialize(const std::vector<uint8
     ClockDriftFingerprint fp;
     if (data.size() < 48) return fp;
 
+    // WF-1: explicit little-endian reads, matched to serialize() above.
     size_t offset = 0;
-    std::memcpy(&fp.drift_rate_ppm, data.data() + offset, 8); offset += 8;
-    std::memcpy(&fp.drift_stability, data.data() + offset, 8); offset += 8;
-    std::memcpy(&fp.jitter_signature, data.data() + offset, 8); offset += 8;
-    std::memcpy(&fp.observation_start, data.data() + offset, 8); offset += 8;
-    std::memcpy(&fp.observation_end, data.data() + offset, 8); offset += 8;
-    std::memcpy(&fp.num_reference_peers, data.data() + offset, 4); offset += 4;
-    std::memcpy(&fp.num_samples, data.data() + offset, 4); offset += 4;
+    fp.drift_rate_ppm = dna_le::get_double(data.data() + offset); offset += 8;
+    fp.drift_stability = dna_le::get_double(data.data() + offset); offset += 8;
+    fp.jitter_signature = dna_le::get_double(data.data() + offset); offset += 8;
+    fp.observation_start = dna_le::get_u64(data.data() + offset); offset += 8;
+    fp.observation_end = dna_le::get_u64(data.data() + offset); offset += 8;
+    fp.num_reference_peers = dna_le::get_u32(data.data() + offset); offset += 4;
+    fp.num_samples = dna_le::get_u32(data.data() + offset); offset += 4;
 
     return fp;
 }

--- a/src/digital_dna/dna_serialize.h
+++ b/src/digital_dna/dna_serialize.h
@@ -1,0 +1,81 @@
+// Copyright (c) 2025 The Dilithion Core developers
+// Distributed under the MIT software license
+//
+// WF-1: shared little-endian serialization helpers for Digital-DNA dimensions.
+//
+// The bytes emitted by each dimension's serialize() are SHA3-256'd into the
+// on-chain dna_hash (committed to the coinbase scriptSig and re-hashed inside
+// the registration-PoW consensus check). They therefore MUST be produced in a
+// host-endianness-independent byte order or a big-endian node would compute a
+// different dna_hash and reject an otherwise-valid registration block.
+//
+// These helpers write explicit little-endian (LSB first), byte-identical on
+// little-endian hosts to the previous raw memcpy/reinterpret_cast copies, so no
+// existing serialized DNA blob or dna_hash changes on current hardware. They
+// mirror the write_u32/write_u64/write_double idiom already used in
+// digital_dna.cpp / dna_verification.cpp.
+
+#ifndef DILITHION_DIGITAL_DNA_DNA_SERIALIZE_H
+#define DILITHION_DIGITAL_DNA_DNA_SERIALIZE_H
+
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+namespace digital_dna {
+namespace dna_le {
+
+// ---- Appending writers (little-endian) ----
+
+inline void put_u32(std::vector<uint8_t>& out, uint32_t v) {
+    for (int i = 0; i < 4; i++) out.push_back(static_cast<uint8_t>(v >> (i * 8)));
+}
+inline void put_u64(std::vector<uint8_t>& out, uint64_t v) {
+    for (int i = 0; i < 8; i++) out.push_back(static_cast<uint8_t>(v >> (i * 8)));
+}
+inline void put_i64(std::vector<uint8_t>& out, int64_t v) {
+    put_u64(out, static_cast<uint64_t>(v));
+}
+inline void put_double(std::vector<uint8_t>& out, double v) {
+    uint64_t bits;
+    std::memcpy(&bits, &v, sizeof(double));  // bit-pattern reinterpret, then LE
+    put_u64(out, bits);
+}
+
+// ---- Fixed-offset writers into a pre-sized buffer (little-endian) ----
+
+inline void set_u32(uint8_t* dst, uint32_t v) {
+    for (int i = 0; i < 4; i++) dst[i] = static_cast<uint8_t>(v >> (i * 8));
+}
+inline void set_u64(uint8_t* dst, uint64_t v) {
+    for (int i = 0; i < 8; i++) dst[i] = static_cast<uint8_t>(v >> (i * 8));
+}
+inline void set_double(uint8_t* dst, double v) {
+    uint64_t bits;
+    std::memcpy(&bits, &v, sizeof(double));
+    set_u64(dst, bits);
+}
+
+// ---- Readers (little-endian), for the deserialize round-trip ----
+
+inline uint32_t get_u32(const uint8_t* src) {
+    uint32_t v = 0;
+    for (int i = 0; i < 4; i++) v |= static_cast<uint32_t>(src[i]) << (i * 8);
+    return v;
+}
+inline uint64_t get_u64(const uint8_t* src) {
+    uint64_t v = 0;
+    for (int i = 0; i < 8; i++) v |= static_cast<uint64_t>(src[i]) << (i * 8);
+    return v;
+}
+inline double get_double(const uint8_t* src) {
+    uint64_t bits = get_u64(src);
+    double v;
+    std::memcpy(&v, &bits, sizeof(double));
+    return v;
+}
+
+} // namespace dna_le
+} // namespace digital_dna
+
+#endif // DILITHION_DIGITAL_DNA_DNA_SERIALIZE_H

--- a/src/digital_dna/dna_serialize.h
+++ b/src/digital_dna/dna_serialize.h
@@ -20,10 +20,19 @@
 
 #include <cstdint>
 #include <cstring>
+#include <limits>
 #include <vector>
 
 namespace digital_dna {
 namespace dna_le {
+
+// Consensus double serialization reinterprets the double's bit pattern as a
+// uint64 and writes it little-endian. That is only a stable, cross-host
+// consensus encoding if double is IEEE-754 binary64. On an exotic FP host this
+// would silently produce a different dna_hash and split the chain — turn it into
+// a compile error instead.
+static_assert(std::numeric_limits<double>::is_iec559 && sizeof(double) == 8,
+              "consensus double serialization requires IEEE-754 binary64");
 
 // ---- Appending writers (little-endian) ----
 

--- a/src/digital_dna/memory_fingerprint.cpp
+++ b/src/digital_dna/memory_fingerprint.cpp
@@ -1,4 +1,5 @@
 #include "memory_fingerprint.h"
+#include "dna_serialize.h"  // WF-1: explicit-LE consensus serialization helpers
 
 #include <algorithm>
 #include <cmath>
@@ -246,34 +247,27 @@ std::string MemoryFingerprint::to_json() const {
 }
 
 std::vector<uint8_t> MemoryFingerprint::serialize() const {
+    // WF-1: explicit little-endian (byte-identical on LE hosts to the previous
+    // reinterpret_cast copies; portable across architectures).
     std::vector<uint8_t> data;
 
     // Header: probe count (4 bytes)
     uint32_t count = static_cast<uint32_t>(access_curve.size());
-    data.insert(data.end(), reinterpret_cast<const uint8_t*>(&count),
-                reinterpret_cast<const uint8_t*>(&count) + 4);
+    dna_le::put_u32(data, count);
 
-    // Each probe: working_set_kb(4) + access_time_ns(8) + bandwidth_mbps(8) = 20 bytes
+    // Each probe: working_set_kb(4) + access_time_ns(8,double) + bandwidth_mbps(8,double) = 20 bytes
     for (const auto& p : access_curve) {
-        data.insert(data.end(), reinterpret_cast<const uint8_t*>(&p.working_set_kb),
-                    reinterpret_cast<const uint8_t*>(&p.working_set_kb) + 4);
-        data.insert(data.end(), reinterpret_cast<const uint8_t*>(&p.access_time_ns),
-                    reinterpret_cast<const uint8_t*>(&p.access_time_ns) + 8);
-        data.insert(data.end(), reinterpret_cast<const uint8_t*>(&p.bandwidth_mbps),
-                    reinterpret_cast<const uint8_t*>(&p.bandwidth_mbps) + 8);
+        dna_le::put_u32(data, p.working_set_kb);
+        dna_le::put_double(data, p.access_time_ns);
+        dna_le::put_double(data, p.bandwidth_mbps);
     }
 
     // Derived features: 5 doubles = 40 bytes
-    data.insert(data.end(), reinterpret_cast<const uint8_t*>(&estimated_l1_kb),
-                reinterpret_cast<const uint8_t*>(&estimated_l1_kb) + 8);
-    data.insert(data.end(), reinterpret_cast<const uint8_t*>(&estimated_l2_kb),
-                reinterpret_cast<const uint8_t*>(&estimated_l2_kb) + 8);
-    data.insert(data.end(), reinterpret_cast<const uint8_t*>(&estimated_l3_kb),
-                reinterpret_cast<const uint8_t*>(&estimated_l3_kb) + 8);
-    data.insert(data.end(), reinterpret_cast<const uint8_t*>(&dram_latency_ns),
-                reinterpret_cast<const uint8_t*>(&dram_latency_ns) + 8);
-    data.insert(data.end(), reinterpret_cast<const uint8_t*>(&peak_bandwidth_mbps),
-                reinterpret_cast<const uint8_t*>(&peak_bandwidth_mbps) + 8);
+    dna_le::put_double(data, estimated_l1_kb);
+    dna_le::put_double(data, estimated_l2_kb);
+    dna_le::put_double(data, estimated_l3_kb);
+    dna_le::put_double(data, dram_latency_ns);
+    dna_le::put_double(data, peak_bandwidth_mbps);
 
     return data;
 }
@@ -292,22 +286,23 @@ MemoryFingerprint MemoryFingerprint::deserialize(const std::vector<uint8_t>& dat
     // Sanity check
     if (count > 100 || data.size() < offset + count * 20 + 40) return fp;
 
+    // WF-1: explicit little-endian reads, matched to serialize() above.
     // Read probes
     fp.access_curve.reserve(count);
     for (uint32_t i = 0; i < count; i++) {
         MemoryProbeResult p;
-        std::memcpy(&p.working_set_kb, data.data() + offset, 4); offset += 4;
-        std::memcpy(&p.access_time_ns, data.data() + offset, 8); offset += 8;
-        std::memcpy(&p.bandwidth_mbps, data.data() + offset, 8); offset += 8;
+        p.working_set_kb = dna_le::get_u32(data.data() + offset); offset += 4;
+        p.access_time_ns = dna_le::get_double(data.data() + offset); offset += 8;
+        p.bandwidth_mbps = dna_le::get_double(data.data() + offset); offset += 8;
         fp.access_curve.push_back(p);
     }
 
     // Read derived features
-    std::memcpy(&fp.estimated_l1_kb, data.data() + offset, 8); offset += 8;
-    std::memcpy(&fp.estimated_l2_kb, data.data() + offset, 8); offset += 8;
-    std::memcpy(&fp.estimated_l3_kb, data.data() + offset, 8); offset += 8;
-    std::memcpy(&fp.dram_latency_ns, data.data() + offset, 8); offset += 8;
-    std::memcpy(&fp.peak_bandwidth_mbps, data.data() + offset, 8); offset += 8;
+    fp.estimated_l1_kb = dna_le::get_double(data.data() + offset); offset += 8;
+    fp.estimated_l2_kb = dna_le::get_double(data.data() + offset); offset += 8;
+    fp.estimated_l3_kb = dna_le::get_double(data.data() + offset); offset += 8;
+    fp.dram_latency_ns = dna_le::get_double(data.data() + offset); offset += 8;
+    fp.peak_bandwidth_mbps = dna_le::get_double(data.data() + offset); offset += 8;
 
     return fp;
 }

--- a/src/miner/controller.cpp
+++ b/src/miner/controller.cpp
@@ -423,8 +423,13 @@ void CMiningController::MiningWorker(uint32_t threadId) {
             // Format: version(4) + prevBlock(32) + merkleRoot(32) + time(4) + bits(4) + nonce(4)
             size_t offset = 0;
 
+            // WF-1: explicit little-endian for the four 32-bit scalars so the
+            // miner produces byte-identical PoW input to the validator's
+            // CBlockHeader::SerializeHeader(). Byte-identical to the previous
+            // host-endian memcpy on LE hosts.
+
             // Version (4 bytes)
-            std::memcpy(header + offset, &currentBlock.nVersion, 4);
+            WriteLE32(header + offset, static_cast<uint32_t>(currentBlock.nVersion));
             offset += 4;
 
             // Previous block hash (32 bytes)
@@ -436,11 +441,11 @@ void CMiningController::MiningWorker(uint32_t threadId) {
             offset += 32;
 
             // Time (4 bytes)
-            std::memcpy(header + offset, &currentBlock.nTime, 4);
+            WriteLE32(header + offset, currentBlock.nTime);
             offset += 4;
 
             // Difficulty bits (4 bytes)
-            std::memcpy(header + offset, &currentBlock.nBits, 4);
+            WriteLE32(header + offset, currentBlock.nBits);
             offset += 4;
 
             // Nonce will be updated in hot loop (last 4 bytes at offset 76)
@@ -456,7 +461,7 @@ void CMiningController::MiningWorker(uint32_t threadId) {
         // BUG #24 FIX: Fast nonce update (only 4 bytes, no allocations)
         // Update nonce in place at offset 76 (last 4 bytes of 80-byte header)
         uint32_t nonce32 = static_cast<uint32_t>(nonce64 & 0xFFFFFFFF);
-        std::memcpy(header + 76, &nonce32, 4);
+        WriteLE32(header + 76, nonce32);  // WF-1: explicit LE, byte-equal on LE hosts
 
         // Compute RandomX hash
         try {

--- a/src/miner/controller.cpp
+++ b/src/miner/controller.cpp
@@ -421,34 +421,14 @@ void CMiningController::MiningWorker(uint32_t threadId) {
         if (needNewTemplate) {
             // Template changed - re-serialize the static parts of header
             // Format: version(4) + prevBlock(32) + merkleRoot(32) + time(4) + bits(4) + nonce(4)
-            size_t offset = 0;
-
-            // WF-1: explicit little-endian for the four 32-bit scalars so the
-            // miner produces byte-identical PoW input to the validator's
-            // CBlockHeader::SerializeHeader(). Byte-identical to the previous
-            // host-endian memcpy on LE hosts.
-
-            // Version (4 bytes)
-            WriteLE32(header + offset, static_cast<uint32_t>(currentBlock.nVersion));
-            offset += 4;
-
-            // Previous block hash (32 bytes)
-            std::memcpy(header + offset, currentBlock.hashPrevBlock.begin(), 32);
-            offset += 32;
-
-            // Merkle root (32 bytes)
-            std::memcpy(header + offset, currentBlock.hashMerkleRoot.begin(), 32);
-            offset += 32;
-
-            // Time (4 bytes)
-            WriteLE32(header + offset, currentBlock.nTime);
-            offset += 4;
-
-            // Difficulty bits (4 bytes)
-            WriteLE32(header + offset, currentBlock.nBits);
-            offset += 4;
-
-            // Nonce will be updated in hot loop (last 4 bytes at offset 76)
+            //
+            // WF-1: assemble the 80-byte legacy PoW preimage through the single
+            // canonical helper (WriteMiningHeaderLE), which routes the four 32-bit
+            // scalars through WriteLE32 so the miner's PoW input is byte-identical
+            // to the validator's CBlockHeader::SerializeHeader() on any host. The
+            // nonce field (offset 76) is (re)written per iteration in the hot loop
+            // below; the value passed here is a placeholder that gets overwritten.
+            WriteMiningHeaderLE(header, currentBlock, currentBlock.nNonce);
 
             cachedBlock = currentBlock;
             lastHashTarget = currentHashTarget;

--- a/src/net/blockencodings.cpp
+++ b/src/net/blockencodings.cpp
@@ -260,13 +260,16 @@ void CBlockHeaderAndShortTxIDs::FillShortTxIDSelector() const
     static_assert(80 + 8 <= HEADER_WITH_NONCE_SIZE, "shortnonce overflow");
 
     // Header serialization (bounds verified at compile time)
-    memcpy(data, &header.nVersion, 4);
+    // WF-1: explicit little-endian for the multi-byte scalars so the SHA3
+    // short-txid selector key is computed identically on every architecture.
+    // Byte-identical to the previous host-endian memcpy on LE hosts.
+    WriteLE32(data, static_cast<uint32_t>(header.nVersion));
     memcpy(data + 4, header.hashPrevBlock.data, 32);
     memcpy(data + 36, header.hashMerkleRoot.data, 32);
-    memcpy(data + 68, &header.nTime, 4);
-    memcpy(data + 72, &header.nBits, 4);
-    memcpy(data + 76, &header.nNonce, 4);
-    memcpy(data + 80, &nonce, 8);
+    WriteLE32(data + 68, header.nTime);
+    WriteLE32(data + 72, header.nBits);
+    WriteLE32(data + 76, header.nNonce);
+    WriteLE64(data + 80, nonce);
 
     // SHA3-256 hash
     uint8_t hash[32];
@@ -324,16 +327,16 @@ std::vector<uint8_t> CBlockHeaderAndShortTxIDs::Serialize() const
     result.reserve(88 + shorttxids.size() * 6 + prefilledtxn.size() * 200);
 
     // Serialize header
-    const uint8_t* ptr = reinterpret_cast<const uint8_t*>(&header.nVersion);
-    result.insert(result.end(), ptr, ptr + 4);
+    // WF-1: explicit little-endian for all multi-byte scalars (header 32-bit
+    // fields, the 8-byte selector nonce, and the wire framing counts). This is
+    // byte-identical to the previous host-endian copy on LE hosts and keeps the
+    // Deserialize() side (below) a matched little-endian round-trip.
+    AppendLE32(result, static_cast<uint32_t>(header.nVersion));
     result.insert(result.end(), header.hashPrevBlock.data, header.hashPrevBlock.data + 32);
     result.insert(result.end(), header.hashMerkleRoot.data, header.hashMerkleRoot.data + 32);
-    ptr = reinterpret_cast<const uint8_t*>(&header.nTime);
-    result.insert(result.end(), ptr, ptr + 4);
-    ptr = reinterpret_cast<const uint8_t*>(&header.nBits);
-    result.insert(result.end(), ptr, ptr + 4);
-    ptr = reinterpret_cast<const uint8_t*>(&header.nNonce);
-    result.insert(result.end(), ptr, ptr + 4);
+    AppendLE32(result, header.nTime);
+    AppendLE32(result, header.nBits);
+    AppendLE32(result, header.nNonce);
     // VDF extension fields (version >= 4): 32 bytes vdfOutput + 32 bytes vdfProofHash
     if (header.nVersion >= 4) {
         result.insert(result.end(), header.vdfOutput.data, header.vdfOutput.data + 32);
@@ -341,13 +344,11 @@ std::vector<uint8_t> CBlockHeaderAndShortTxIDs::Serialize() const
     }
 
     // Nonce (8 bytes)
-    ptr = reinterpret_cast<const uint8_t*>(&nonce);
-    result.insert(result.end(), ptr, ptr + 8);
+    AppendLE64(result, nonce);
 
     // Short txids count (4 bytes)
     uint32_t count = static_cast<uint32_t>(shorttxids.size());
-    ptr = reinterpret_cast<const uint8_t*>(&count);
-    result.insert(result.end(), ptr, ptr + 4);
+    AppendLE32(result, count);
 
     // Short txids (6 bytes each)
     for (const auto& shortid : shorttxids) {
@@ -356,17 +357,17 @@ std::vector<uint8_t> CBlockHeaderAndShortTxIDs::Serialize() const
         }
     }
 
-    // Prefilled count (2 bytes)
+    // Prefilled count (2 bytes, little-endian)
     uint16_t prefilled_count = static_cast<uint16_t>(prefilledtxn.size());
-    ptr = reinterpret_cast<const uint8_t*>(&prefilled_count);
-    result.insert(result.end(), ptr, ptr + 2);
+    result.push_back(static_cast<uint8_t>(prefilled_count));
+    result.push_back(static_cast<uint8_t>(prefilled_count >> 8));
 
     // Prefilled transactions (differential index encoding)
     uint16_t last_index = 0;
     for (const auto& prefilled : prefilledtxn) {
         uint16_t diff = prefilled.index - last_index;
-        ptr = reinterpret_cast<const uint8_t*>(&diff);
-        result.insert(result.end(), ptr, ptr + 2);
+        result.push_back(static_cast<uint8_t>(diff));
+        result.push_back(static_cast<uint8_t>(diff >> 8));
 
         std::vector<uint8_t> txData = prefilled.tx.Serialize();
         // CID 1675171 FIX: Use move iterators to avoid unnecessary copy
@@ -389,17 +390,18 @@ bool CBlockHeaderAndShortTxIDs::Deserialize(const uint8_t* data, size_t len)
     size_t offset = 0;
 
     // Header
-    memcpy(&header.nVersion, data + offset, 4);
+    // WF-1: explicit little-endian reads, matched to Serialize() above.
+    header.nVersion = static_cast<int32_t>(ReadLE32(data + offset));
     offset += 4;
     memcpy(header.hashPrevBlock.data, data + offset, 32);
     offset += 32;
     memcpy(header.hashMerkleRoot.data, data + offset, 32);
     offset += 32;
-    memcpy(&header.nTime, data + offset, 4);
+    header.nTime = ReadLE32(data + offset);
     offset += 4;
-    memcpy(&header.nBits, data + offset, 4);
+    header.nBits = ReadLE32(data + offset);
     offset += 4;
-    memcpy(&header.nNonce, data + offset, 4);
+    header.nNonce = ReadLE32(data + offset);
     offset += 4;
     // VDF extension fields (version >= 4): 32 bytes vdfOutput + 32 bytes vdfProofHash
     if (header.nVersion >= 4) {
@@ -411,7 +413,7 @@ bool CBlockHeaderAndShortTxIDs::Deserialize(const uint8_t* data, size_t len)
     }
 
     // Nonce
-    memcpy(&nonce, data + offset, 8);
+    nonce = ReadLE64(data + offset);
     offset += 8;
 
     // Fill SipHash keys
@@ -419,8 +421,7 @@ bool CBlockHeaderAndShortTxIDs::Deserialize(const uint8_t* data, size_t len)
 
     // Short txids count
     if (offset + 4 > len) return false;
-    uint32_t count = 0;
-    memcpy(&count, data + offset, 4);
+    uint32_t count = ReadLE32(data + offset);
     offset += 4;
 
     if (count > 100000) {
@@ -439,10 +440,10 @@ bool CBlockHeaderAndShortTxIDs::Deserialize(const uint8_t* data, size_t len)
         offset += 6;
     }
 
-    // Prefilled count
+    // Prefilled count (little-endian)
     if (offset + 2 > len) return false;
-    uint16_t prefilled_count = 0;
-    memcpy(&prefilled_count, data + offset, 2);
+    uint16_t prefilled_count = static_cast<uint16_t>(data[offset])
+                             | (static_cast<uint16_t>(data[offset + 1]) << 8);
     offset += 2;
 
     // Prefilled transactions
@@ -451,8 +452,8 @@ bool CBlockHeaderAndShortTxIDs::Deserialize(const uint8_t* data, size_t len)
     for (size_t i = 0; i < prefilled_count; i++) {
         if (offset + 2 > len) return false;
 
-        uint16_t diff = 0;
-        memcpy(&diff, data + offset, 2);
+        uint16_t diff = static_cast<uint16_t>(data[offset])
+                      | (static_cast<uint16_t>(data[offset + 1]) << 8);
         offset += 2;
 
         prefilledtxn[i].index = last_index + diff;

--- a/src/net/blockencodings.cpp
+++ b/src/net/blockencodings.cpp
@@ -327,16 +327,16 @@ std::vector<uint8_t> CBlockHeaderAndShortTxIDs::Serialize() const
     result.reserve(88 + shorttxids.size() * 6 + prefilledtxn.size() * 200);
 
     // Serialize header
-    // WF-1: explicit little-endian for all multi-byte scalars (header 32-bit
-    // fields, the 8-byte selector nonce, and the wire framing counts). This is
-    // byte-identical to the previous host-endian copy on LE hosts and keeps the
-    // Deserialize() side (below) a matched little-endian round-trip.
-    AppendLE32(result, static_cast<uint32_t>(header.nVersion));
+    const uint8_t* ptr = reinterpret_cast<const uint8_t*>(&header.nVersion);
+    result.insert(result.end(), ptr, ptr + 4);
     result.insert(result.end(), header.hashPrevBlock.data, header.hashPrevBlock.data + 32);
     result.insert(result.end(), header.hashMerkleRoot.data, header.hashMerkleRoot.data + 32);
-    AppendLE32(result, header.nTime);
-    AppendLE32(result, header.nBits);
-    AppendLE32(result, header.nNonce);
+    ptr = reinterpret_cast<const uint8_t*>(&header.nTime);
+    result.insert(result.end(), ptr, ptr + 4);
+    ptr = reinterpret_cast<const uint8_t*>(&header.nBits);
+    result.insert(result.end(), ptr, ptr + 4);
+    ptr = reinterpret_cast<const uint8_t*>(&header.nNonce);
+    result.insert(result.end(), ptr, ptr + 4);
     // VDF extension fields (version >= 4): 32 bytes vdfOutput + 32 bytes vdfProofHash
     if (header.nVersion >= 4) {
         result.insert(result.end(), header.vdfOutput.data, header.vdfOutput.data + 32);
@@ -344,11 +344,13 @@ std::vector<uint8_t> CBlockHeaderAndShortTxIDs::Serialize() const
     }
 
     // Nonce (8 bytes)
-    AppendLE64(result, nonce);
+    ptr = reinterpret_cast<const uint8_t*>(&nonce);
+    result.insert(result.end(), ptr, ptr + 8);
 
     // Short txids count (4 bytes)
     uint32_t count = static_cast<uint32_t>(shorttxids.size());
-    AppendLE32(result, count);
+    ptr = reinterpret_cast<const uint8_t*>(&count);
+    result.insert(result.end(), ptr, ptr + 4);
 
     // Short txids (6 bytes each)
     for (const auto& shortid : shorttxids) {
@@ -357,17 +359,17 @@ std::vector<uint8_t> CBlockHeaderAndShortTxIDs::Serialize() const
         }
     }
 
-    // Prefilled count (2 bytes, little-endian)
+    // Prefilled count (2 bytes)
     uint16_t prefilled_count = static_cast<uint16_t>(prefilledtxn.size());
-    result.push_back(static_cast<uint8_t>(prefilled_count));
-    result.push_back(static_cast<uint8_t>(prefilled_count >> 8));
+    ptr = reinterpret_cast<const uint8_t*>(&prefilled_count);
+    result.insert(result.end(), ptr, ptr + 2);
 
     // Prefilled transactions (differential index encoding)
     uint16_t last_index = 0;
     for (const auto& prefilled : prefilledtxn) {
         uint16_t diff = prefilled.index - last_index;
-        result.push_back(static_cast<uint8_t>(diff));
-        result.push_back(static_cast<uint8_t>(diff >> 8));
+        ptr = reinterpret_cast<const uint8_t*>(&diff);
+        result.insert(result.end(), ptr, ptr + 2);
 
         std::vector<uint8_t> txData = prefilled.tx.Serialize();
         // CID 1675171 FIX: Use move iterators to avoid unnecessary copy
@@ -390,18 +392,17 @@ bool CBlockHeaderAndShortTxIDs::Deserialize(const uint8_t* data, size_t len)
     size_t offset = 0;
 
     // Header
-    // WF-1: explicit little-endian reads, matched to Serialize() above.
-    header.nVersion = static_cast<int32_t>(ReadLE32(data + offset));
+    memcpy(&header.nVersion, data + offset, 4);
     offset += 4;
     memcpy(header.hashPrevBlock.data, data + offset, 32);
     offset += 32;
     memcpy(header.hashMerkleRoot.data, data + offset, 32);
     offset += 32;
-    header.nTime = ReadLE32(data + offset);
+    memcpy(&header.nTime, data + offset, 4);
     offset += 4;
-    header.nBits = ReadLE32(data + offset);
+    memcpy(&header.nBits, data + offset, 4);
     offset += 4;
-    header.nNonce = ReadLE32(data + offset);
+    memcpy(&header.nNonce, data + offset, 4);
     offset += 4;
     // VDF extension fields (version >= 4): 32 bytes vdfOutput + 32 bytes vdfProofHash
     if (header.nVersion >= 4) {
@@ -413,7 +414,7 @@ bool CBlockHeaderAndShortTxIDs::Deserialize(const uint8_t* data, size_t len)
     }
 
     // Nonce
-    nonce = ReadLE64(data + offset);
+    memcpy(&nonce, data + offset, 8);
     offset += 8;
 
     // Fill SipHash keys
@@ -421,7 +422,8 @@ bool CBlockHeaderAndShortTxIDs::Deserialize(const uint8_t* data, size_t len)
 
     // Short txids count
     if (offset + 4 > len) return false;
-    uint32_t count = ReadLE32(data + offset);
+    uint32_t count = 0;
+    memcpy(&count, data + offset, 4);
     offset += 4;
 
     if (count > 100000) {
@@ -440,10 +442,10 @@ bool CBlockHeaderAndShortTxIDs::Deserialize(const uint8_t* data, size_t len)
         offset += 6;
     }
 
-    // Prefilled count (little-endian)
+    // Prefilled count
     if (offset + 2 > len) return false;
-    uint16_t prefilled_count = static_cast<uint16_t>(data[offset])
-                             | (static_cast<uint16_t>(data[offset + 1]) << 8);
+    uint16_t prefilled_count = 0;
+    memcpy(&prefilled_count, data + offset, 2);
     offset += 2;
 
     // Prefilled transactions
@@ -452,8 +454,8 @@ bool CBlockHeaderAndShortTxIDs::Deserialize(const uint8_t* data, size_t len)
     for (size_t i = 0; i < prefilled_count; i++) {
         if (offset + 2 > len) return false;
 
-        uint16_t diff = static_cast<uint16_t>(data[offset])
-                      | (static_cast<uint16_t>(data[offset + 1]) << 8);
+        uint16_t diff = 0;
+        memcpy(&diff, data + offset, 2);
         offset += 2;
 
         prefilledtxn[i].index = last_index + diff;

--- a/src/node/genesis.cpp
+++ b/src/node/genesis.cpp
@@ -272,16 +272,16 @@ static void SerializeBlockHeader(const CBlock& block, uint32_t nonce, std::vecto
     data.reserve(80);
 
     // version (4) + prevBlock (32) + merkleRoot (32) + time (4) + bits (4) + nonce (4) = 80
-    const uint8_t* versionBytes = reinterpret_cast<const uint8_t*>(&block.nVersion);
-    data.insert(data.end(), versionBytes, versionBytes + 4);
+    // WF-1: explicit little-endian for the four 32-bit scalars, byte-identical to
+    // CBlockHeader::SerializeHeader() (the canonical serializer) for a legacy
+    // (v1) block. This helper is the offline genesis-mining hasher; it must emit
+    // the same 80 bytes the validator's GetHash() path consumes.
+    AppendLE32(data, static_cast<uint32_t>(block.nVersion));
     data.insert(data.end(), block.hashPrevBlock.begin(), block.hashPrevBlock.end());
     data.insert(data.end(), block.hashMerkleRoot.begin(), block.hashMerkleRoot.end());
-    const uint8_t* timeBytes = reinterpret_cast<const uint8_t*>(&block.nTime);
-    data.insert(data.end(), timeBytes, timeBytes + 4);
-    const uint8_t* bitsBytes = reinterpret_cast<const uint8_t*>(&block.nBits);
-    data.insert(data.end(), bitsBytes, bitsBytes + 4);
-    const uint8_t* nonceBytes = reinterpret_cast<const uint8_t*>(&nonce);
-    data.insert(data.end(), nonceBytes, nonceBytes + 4);
+    AppendLE32(data, block.nTime);
+    AppendLE32(data, block.nBits);
+    AppendLE32(data, nonce);
 }
 
 void MineWorker(int threadId, int numThreads, const CBlock& templateBlock, const uint256& target) {

--- a/src/node/genesis.cpp
+++ b/src/node/genesis.cpp
@@ -266,8 +266,10 @@ static std::mutex g_resultMutex;
 static uint32_t g_winningNonce = 0;
 static uint256 g_winningHash;
 
-// Serialize block header to 80 bytes (for thread-safe hashing)
-static void SerializeBlockHeader(const CBlock& block, uint32_t nonce, std::vector<uint8_t>& data) {
+// Serialize block header to 80 bytes (for thread-safe hashing).
+// Exposed (non-static, declared in genesis.h) so the WF-1 byte-equality test can
+// drive the REAL production emitter instead of a hand-copied mirror.
+void SerializeBlockHeader(const CBlock& block, uint32_t nonce, std::vector<uint8_t>& data) {
     data.clear();
     data.reserve(80);
 

--- a/src/node/genesis.h
+++ b/src/node/genesis.h
@@ -90,6 +90,20 @@ CBlock CreateDilVGenesisBlock();
 bool MineGenesisBlock(CBlock& block, const uint256& target, int numThreads);
 bool MineGenesisBlock(CBlock& block, const uint256& target);  // Single-threaded overload
 
+/**
+ * Serialize a legacy (80-byte) block header for the offline genesis-mining
+ * hasher, with an externally-supplied nonce.
+ *
+ * WF-1: emits the four 32-bit scalars in explicit little-endian, byte-identical
+ * to CBlockHeader::SerializeHeader() for a legacy (v1) block. Exposed (rather
+ * than file-static) so the WF-1 differential test can drive this real emitter.
+ *
+ * @param block  Block whose header fields are serialized
+ * @param nonce  Nonce to write (overrides block.nNonce in the output)
+ * @param data   Output buffer (cleared, then filled with 80 bytes)
+ */
+void SerializeBlockHeader(const CBlock& block, uint32_t nonce, std::vector<uint8_t>& data);
+
 } // namespace Genesis
 
 #endif // DILITHION_NODE_GENESIS_H

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -56,17 +56,14 @@ std::vector<uint8_t> CBlockHeader::SerializeHeader() const {
     buf.reserve(GetHeaderSize());
 
     // Legacy 80-byte portion: version(4) + prevBlock(32) + merkleRoot(32) + time(4) + bits(4) + nonce(4)
-    const uint8_t* p;
-    p = reinterpret_cast<const uint8_t*>(&nVersion);
-    buf.insert(buf.end(), p, p + 4);
+    // WF-1: explicit little-endian for the four 32-bit scalars (byte-identical to
+    // the previous host-endian copy on LE hosts; portable to any architecture).
+    AppendLE32(buf, static_cast<uint32_t>(nVersion));
     buf.insert(buf.end(), hashPrevBlock.begin(), hashPrevBlock.end());
     buf.insert(buf.end(), hashMerkleRoot.begin(), hashMerkleRoot.end());
-    p = reinterpret_cast<const uint8_t*>(&nTime);
-    buf.insert(buf.end(), p, p + 4);
-    p = reinterpret_cast<const uint8_t*>(&nBits);
-    buf.insert(buf.end(), p, p + 4);
-    p = reinterpret_cast<const uint8_t*>(&nNonce);
-    buf.insert(buf.end(), p, p + 4);
+    AppendLE32(buf, nTime);
+    AppendLE32(buf, nBits);
+    AppendLE32(buf, nNonce);
 
     // VDF extension (64 bytes, version >= 4 only)
     if (IsVDFBlock()) {

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -52,6 +52,63 @@ public:
 // Stream output operator for Boost.Test (defined in block.cpp)
 std::ostream& operator<<(std::ostream& os, const uint256& h);
 
+// ---------------------------------------------------------------------------
+// Canonical little-endian 32-bit serialization primitives (WF-1).
+//
+// The block-header hash preimage MUST be byte-identical on every architecture.
+// These helpers write a uint32_t in explicit little-endian byte order (LSB
+// first) regardless of host endianness — matching the house idiom already used
+// by transaction.cpp (SerializeUint32) and digital_dna.cpp (write_u32).
+//
+// ALL header-serialization sites (primitives/block.cpp canonical serializer,
+// node/genesis.cpp mining helper, net/blockencodings.cpp compact-block wire,
+// miner/controller.cpp hot-loop buffer) MUST route their nVersion/nTime/nBits/
+// nNonce bytes through these so they agree byte-for-byte. On little-endian
+// hosts the emitted bytes are identical to the previous host-endian copy, so
+// the frozen genesis hash and every existing block hash are unchanged.
+// ---------------------------------------------------------------------------
+
+/** Write a uint32_t in little-endian order into a raw 4-byte buffer. */
+inline void WriteLE32(uint8_t* dst, uint32_t v) {
+    dst[0] = static_cast<uint8_t>(v);
+    dst[1] = static_cast<uint8_t>(v >> 8);
+    dst[2] = static_cast<uint8_t>(v >> 16);
+    dst[3] = static_cast<uint8_t>(v >> 24);
+}
+
+/** Append a uint32_t in little-endian order to a byte vector. */
+inline void AppendLE32(std::vector<uint8_t>& out, uint32_t v) {
+    out.push_back(static_cast<uint8_t>(v));
+    out.push_back(static_cast<uint8_t>(v >> 8));
+    out.push_back(static_cast<uint8_t>(v >> 16));
+    out.push_back(static_cast<uint8_t>(v >> 24));
+}
+
+/** Write a uint64_t in little-endian order into a raw 8-byte buffer. */
+inline void WriteLE64(uint8_t* dst, uint64_t v) {
+    for (int i = 0; i < 8; i++) dst[i] = static_cast<uint8_t>(v >> (i * 8));
+}
+
+/** Append a uint64_t in little-endian order to a byte vector. */
+inline void AppendLE64(std::vector<uint8_t>& out, uint64_t v) {
+    for (int i = 0; i < 8; i++) out.push_back(static_cast<uint8_t>(v >> (i * 8)));
+}
+
+/** Read a uint32_t stored little-endian from a raw 4-byte buffer. */
+inline uint32_t ReadLE32(const uint8_t* src) {
+    return static_cast<uint32_t>(src[0])
+         | (static_cast<uint32_t>(src[1]) << 8)
+         | (static_cast<uint32_t>(src[2]) << 16)
+         | (static_cast<uint32_t>(src[3]) << 24);
+}
+
+/** Read a uint64_t stored little-endian from a raw 8-byte buffer. */
+inline uint64_t ReadLE64(const uint8_t* src) {
+    uint64_t v = 0;
+    for (int i = 0; i < 8; i++) v |= static_cast<uint64_t>(src[i]) << (i * 8);
+    return v;
+}
+
 /** Helper function to construct uint256 from hex string (like Bitcoin Core's uint256S) */
 inline uint256 uint256S(const std::string& str) {
     uint256 result;

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -176,6 +176,28 @@ public:
     void InvalidateCache() { fHashCached = false; }
 };
 
+// ---------------------------------------------------------------------------
+// Miner hot-loop header assembly (WF-1).
+//
+// The mining controller builds the 80-byte legacy PoW preimage directly into a
+// raw buffer at fixed offsets (it cannot allocate a std::vector per nonce). This
+// helper is the single canonical assembler for that buffer, routing the four
+// 32-bit scalars through WriteLE32 so the miner's PoW input is byte-identical to
+// the validator's CBlockHeader::SerializeHeader() for a legacy (80-byte) header.
+// Both miner/controller.cpp AND the WF-1 differential test call THIS function, so
+// the test drives the real production assembly (no hand-copied mirror).
+//
+// `dst` MUST point to at least 80 writable bytes. `nonce32` is written at offset
+// 76 (the field the hot loop mutates each iteration); h.nNonce is ignored.
+inline void WriteMiningHeaderLE(uint8_t* dst, const CBlockHeader& h, uint32_t nonce32) {
+    WriteLE32(dst + 0, static_cast<uint32_t>(h.nVersion));
+    memcpy(dst + 4,  h.hashPrevBlock.begin(), 32);
+    memcpy(dst + 36, h.hashMerkleRoot.begin(), 32);
+    WriteLE32(dst + 68, h.nTime);
+    WriteLE32(dst + 72, h.nBits);
+    WriteLE32(dst + 76, nonce32);
+}
+
 class CBlock : public CBlockHeader {
 public:
     std::vector<uint8_t> vtx;

--- a/src/test/wf1_host_endian_differential_test.cpp
+++ b/src/test/wf1_host_endian_differential_test.cpp
@@ -1,40 +1,43 @@
 // Copyright (c) 2025 The Dilithion Core developers
 // Distributed under the MIT software license
 //
-// WF-1 HOST-ENDIAN DIFFERENTIAL / BYTE-EQUALITY TEST
-// ===================================================
+// WF-1 HOST-ENDIAN DIFFERENTIAL / BYTE-EQUALITY TEST (Boost.Test suite)
+// =====================================================================
 //
-// This test is the machine-checked safety proof for the WF-1 fix, which
-// converted 9 host-endian consensus-observable serialization sites to explicit
+// This suite is the machine-checked safety proof for the WF-1 fix, which
+// converted host-endian consensus-observable serialization sites to explicit
 // little-endian. On a little-endian host the new bytes MUST be byte-identical
 // to the old host-endian bytes — otherwise the block-header hash (and the
 // frozen genesis hash) would change and split the chain.
 //
-// For EACH of the 9 sites this test:
-//   1. reproduces the OLD host-endian byte emission inline ("old_*"), exactly
-//      as the code read before the fix (raw memcpy / reinterpret_cast copy),
-//   2. calls the NEW production serializer, and
-//   3. asserts new_bytes == old_bytes across several representative inputs.
+// It is wired into `test_dilithion` (BOOST_TEST_OBJECTS) so CI, which runs
+// ./test_dilithion, exercises the WF-1 byte-equality AND the both-genesis-hash-
+// unchanged assertions on every build.
 //
-// It ALSO asserts BOTH frozen genesis hashes are byte-identical to their
-// constants in chainparams.cpp:
-//   - DIL mainnet (legacy/RandomX, 80-byte header): 80-byte preimage byte-
-//     equality (airtight: RandomX is a pure function of these bytes) + the full
-//     RandomX-hash end-to-end.
-//   - DilV (VDF/SHA3, 144-byte header): 144-byte preimage byte-equality (incl.
-//     the 64-byte VDF extension) + the full SHA3-256 hash end-to-end. The DilV
-//     block is fully constructible in-process (hardcoded VDF proof, checked-in
-//     prefund, pure SHA3 with no key init), so the full-hash assertion is
-//     feasible without a nonce search.
+// De-tautology (review fold): the byte-equality checks DRIVE the real production
+// serializers rather than comparing two hand-copied mirrors —
+//   - A1  : CBlockHeader::SerializeHeader()               (production)
+//   - A2  : new==old mirror, compensated by == A1 canonical (production anchor)
+//   - A3s : GetShortID() -> FillShortTxIDSelector()       (production) vs the
+//           SipHash key derived from the OLD host-endian preimage
+//   - A3w : CBlockHeaderAndShortTxIDs::Serialize/Deserialize round-trip (production)
+//   - A4  : WriteMiningHeaderLE() — the SAME helper the miner hot loop calls —
+//           and additionally asserted byte-equal to A1 SerializeHeader()
+//   - C1  : vdf preimage mirror new==old
+//   - B1-4: digital-DNA *::serialize() (production) vs old host-endian mirror
 //
-// This is a STANDALONE program (its own main, returns non-zero on any failure),
-// deliberately NOT wired into the Boost suite so it can run in isolation with a
-// minimal link set.
+// GENESIS: both frozen genesis hashes are asserted byte-unchanged — DIL mainnet
+// (RandomX, 80-byte header) and DilV (VDF/SHA3, 144-byte header) — via BOTH the
+// header preimage bytes AND the full end-to-end hash vs the chainparams constant.
+
+#include <boost/test/unit_test.hpp>
 
 #include <primitives/block.h>
 #include <node/genesis.h>
 #include <core/chainparams.h>
 #include <crypto/randomx_hash.h>
+#include <crypto/sha3.h>
+#include <crypto/siphash.h>
 #include <net/blockencodings.h>
 #include <consensus/vdf_validation.h>
 #include <digital_dna/behavioral_profile.h>
@@ -44,37 +47,13 @@
 
 #include <cstdint>
 #include <cstring>
-#include <cstdio>
 #include <string>
 #include <vector>
 #include <array>
 
 using namespace Dilithion;
 
-static int g_failures = 0;
-static int g_checks = 0;
-
-static std::string hex(const std::vector<uint8_t>& v) {
-    static const char* d = "0123456789abcdef";
-    std::string s;
-    s.reserve(v.size() * 2);
-    for (uint8_t b : v) { s.push_back(d[b >> 4]); s.push_back(d[b & 0xF]); }
-    return s;
-}
-
-static void expect_eq_bytes(const char* site, const std::string& label,
-                            const std::vector<uint8_t>& got,
-                            const std::vector<uint8_t>& want) {
-    g_checks++;
-    if (got == want) {
-        printf("  [PASS] %-28s %s (%zu bytes)\n", site, label.c_str(), got.size());
-    } else {
-        g_failures++;
-        printf("  [FAIL] %-28s %s\n", site, label.c_str());
-        printf("         new: %s\n", hex(got).c_str());
-        printf("         old: %s\n", hex(want).c_str());
-    }
-}
+BOOST_AUTO_TEST_SUITE(wf1_host_endian_tests)
 
 // ---------------------------------------------------------------------------
 // OLD host-endian emitters (verbatim reproductions of the pre-WF-1 code).
@@ -112,8 +91,9 @@ static std::vector<uint8_t> old_genesis_serialize_header(const CBlock& block, ui
 
 // A2 genesis.cpp SerializeBlockHeader (legacy 80-byte mining helper), NEW form.
 // The production helper is file-static in genesis.cpp; this mirrors its exact
-// emission (AppendLE32 for the four scalars), so we can prove it matches both
-// the old A2 form and the canonical A1 serializer.
+// emission (AppendLE32 for the four scalars). It is NOT relied on alone — it is
+// asserted byte-equal to the canonical A1 SerializeHeader() below, which IS
+// production, so the mirror is anchored to production.
 static std::vector<uint8_t> new_genesis_serialize_header(const CBlock& block, uint32_t nonce) {
     std::vector<uint8_t> data;
     AppendLE32(data, static_cast<uint32_t>(block.nVersion));
@@ -125,7 +105,7 @@ static std::vector<uint8_t> new_genesis_serialize_header(const CBlock& block, ui
     return data;
 }
 
-// A3-FillShortTxIDSelector: the 88-byte SHA3 preimage, old form.
+// A3-FillShortTxIDSelector: the 88-byte SHA3 preimage, OLD host-endian form.
 static std::vector<uint8_t> old_a3_selector_preimage(const CBlockHeader& header, uint64_t nonce) {
     std::vector<uint8_t> data(88);
     memcpy(data.data(),      &header.nVersion, 4);
@@ -138,19 +118,6 @@ static std::vector<uint8_t> old_a3_selector_preimage(const CBlockHeader& header,
     return data;
 }
 
-// A4: miner/controller.cpp 80-byte hot-loop buffer, old form.
-static std::vector<uint8_t> old_a4_miner_header(const CBlockHeader& b, uint32_t nonce32) {
-    std::vector<uint8_t> h(80);
-    size_t off = 0;
-    memcpy(h.data() + off, &b.nVersion, 4); off += 4;
-    memcpy(h.data() + off, b.hashPrevBlock.begin(), 32); off += 32;
-    memcpy(h.data() + off, b.hashMerkleRoot.begin(), 32); off += 32;
-    memcpy(h.data() + off, &b.nTime, 4); off += 4;
-    memcpy(h.data() + off, &b.nBits, 4); off += 4;
-    memcpy(h.data() + 76, &nonce32, 4);
-    return h;
-}
-
 // C1: vdf challenge 56-byte preimage, old form.
 static std::vector<uint8_t> old_c1_vdf_preimage(const uint256& prevHash, int height,
                                                 const std::array<uint8_t, 20>& addr) {
@@ -160,36 +127,6 @@ static std::vector<uint8_t> old_c1_vdf_preimage(const uint256& prevHash, int hei
     memcpy(pre.data() + 32, &hLE, 4);
     memcpy(pre.data() + 36, addr.data(), 20);
     return pre;
-}
-
-// ---------------------------------------------------------------------------
-// NEW: build the A4 miner header via the PRODUCTION helpers (mirrors controller).
-// controller.cpp writes into a raw 80-byte buffer at fixed offsets using
-// WriteLE32; we reproduce exactly that sequence here to exercise the same code.
-// ---------------------------------------------------------------------------
-static std::vector<uint8_t> new_a4_miner_header(const CBlockHeader& b, uint32_t nonce32) {
-    std::vector<uint8_t> h(80);
-    size_t off = 0;
-    WriteLE32(h.data() + off, static_cast<uint32_t>(b.nVersion)); off += 4;
-    memcpy(h.data() + off, b.hashPrevBlock.begin(), 32); off += 32;
-    memcpy(h.data() + off, b.hashMerkleRoot.begin(), 32); off += 32;
-    WriteLE32(h.data() + off, b.nTime); off += 4;
-    WriteLE32(h.data() + off, b.nBits); off += 4;
-    WriteLE32(h.data() + 76, nonce32);
-    return h;
-}
-
-// A3-FillShortTxIDSelector NEW preimage (mirrors production emission).
-static std::vector<uint8_t> new_a3_selector_preimage(const CBlockHeader& header, uint64_t nonce) {
-    std::vector<uint8_t> data(88);
-    WriteLE32(data.data(), static_cast<uint32_t>(header.nVersion));
-    memcpy(data.data() + 4,  header.hashPrevBlock.data, 32);
-    memcpy(data.data() + 36, header.hashMerkleRoot.data, 32);
-    WriteLE32(data.data() + 68, header.nTime);
-    WriteLE32(data.data() + 72, header.nBits);
-    WriteLE32(data.data() + 76, header.nNonce);
-    WriteLE64(data.data() + 80, nonce);
-    return data;
 }
 
 // C1 NEW preimage (mirrors production emission in vdf_validation.cpp).
@@ -204,6 +141,20 @@ static std::vector<uint8_t> new_c1_vdf_preimage(const uint256& prevHash, int hei
     pre[35] = static_cast<uint8_t>(h >> 24);
     memcpy(pre.data() + 36, addr.data(), 20);
     return pre;
+}
+
+// Derive the SipHash short-txid keys from a raw 88-byte preimage the SAME way
+// FillShortTxIDSelector() does internally (SHA3-256, then two LE 64-bit keys).
+// Used to compute the EXPECTED keys from the OLD host-endian preimage, which we
+// then compare against the REAL production keys observed through GetShortID().
+static void keys_from_preimage(const std::vector<uint8_t>& pre, uint64_t& k0, uint64_t& k1) {
+    uint8_t hash[32];
+    SHA3_256(pre.data(), pre.size(), hash);
+    k0 = 0; k1 = 0;
+    for (int i = 0; i < 8; i++) {
+        k0 |= static_cast<uint64_t>(hash[i]) << (i * 8);
+        k1 |= static_cast<uint64_t>(hash[i + 8]) << (i * 8);
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -221,332 +172,321 @@ static CBlockHeader make_header(int32_t v, uint32_t t, uint32_t bits, uint32_t n
     return h;
 }
 
+struct HV { int32_t v; uint32_t t; uint32_t bits; uint32_t nonce; };
+static const std::vector<HV> kHvs = {
+    {1, 1737158400u, 0x1e01fffeu, 429612875u},   // DIL genesis-like
+    {0, 0u, 0u, 0u},
+    {4, 0xFFFFFFFFu, 0xFFFFFFFFu, 0xFFFFFFFFu},   // VDF, all-ones
+    {4, 0x01020304u, 0xdeadbeefu, 0x12345678u},   // VDF, mixed
+    {1, 0x80000000u, 0x00ff00ffu, 0x0000abcdu},
+};
+
 // ===========================================================================
-int main() {
-    printf("=== WF-1 host-endian differential / byte-equality test ===\n\n");
+// FAMILY A — block-header hash preimage.
+// ===========================================================================
 
-    // Representative header field values, including 0, max, and bit-mixed.
-    struct HV { int32_t v; uint32_t t; uint32_t bits; uint32_t nonce; };
-    std::vector<HV> hvs = {
-        {1, 1737158400u, 0x1e01fffeu, 429612875u},   // DIL genesis-like
-        {0, 0u, 0u, 0u},
-        {4, 0xFFFFFFFFu, 0xFFFFFFFFu, 0xFFFFFFFFu},   // VDF, all-ones
-        {4, 0x01020304u, 0xdeadbeefu, 0x12345678u},   // VDF, mixed
-        {1, 0x80000000u, 0x00ff00ffu, 0x0000abcdu},
-    };
-
-    // ---- FAMILY A ----
-    printf("FAMILY A — block-header hash preimage (4 sites)\n");
-    for (const auto& x : hvs) {
+// A1: canonical CBlockHeader::SerializeHeader() is byte-identical to old form.
+BOOST_AUTO_TEST_CASE(a1_block_serialize_header) {
+    for (const auto& x : kHvs) {
         bool vdf = (x.v >= CBlockHeader::VDF_VERSION);
         CBlockHeader h = make_header(x.v, x.t, x.bits, x.nonce, vdf);
-
-        // A1: canonical CBlockHeader::SerializeHeader()
-        expect_eq_bytes("A1 block.cpp SerializeHeader",
-                        "v=" + std::to_string(x.v),
-                        h.SerializeHeader(), old_block_serialize_header(h));
-
-        // A3-selector: FillShortTxIDSelector 88-byte SHA3 preimage
-        uint64_t sel_nonce = 0x1122334455667788ULL ^ x.nonce;
-        expect_eq_bytes("A3 blockenc selector",
-                        "v=" + std::to_string(x.v),
-                        new_a3_selector_preimage(h, sel_nonce),
-                        old_a3_selector_preimage(h, sel_nonce));
-
-        // A3-wire: CBlockHeaderAndShortTxIDs::Serialize() header region + full round-trip.
-        {
-            CBlockHeaderAndShortTxIDs comp;
-            comp.header = h;
-            comp.nonce = sel_nonce;
-            comp.shorttxids = { 0x010203040506ULL, 0x0A0B0C0D0E0FULL };
-            std::vector<uint8_t> wire = comp.Serialize();
-            // Round-trip must reconstruct identical header scalars.
-            CBlockHeaderAndShortTxIDs back;
-            bool ok = back.Deserialize(wire.data(), wire.size());
-            g_checks++;
-            if (ok && back.header.nVersion == h.nVersion && back.header.nTime == h.nTime &&
-                back.header.nBits == h.nBits && back.header.nNonce == h.nNonce &&
-                back.nonce == comp.nonce && back.shorttxids == comp.shorttxids) {
-                printf("  [PASS] %-28s v=%d wire round-trip\n", "A3 blockenc wire", x.v);
-            } else {
-                g_failures++;
-                printf("  [FAIL] %-28s v=%d wire round-trip (ok=%d)\n", "A3 blockenc wire", x.v, ok);
-            }
-        }
-
-        // A2: genesis mining helper (legacy 80-byte). Assert (i) new==old on LE,
-        // and (ii) new == the canonical A1 legacy 80-byte serialization — so the
-        // genesis miner and the validator agree byte-for-byte.
-        {
-            // Genesis mining is always a legacy (v1) block; force v1 so the A2
-            // helper and the A1 canonical serializer are compared apples-to-apples.
-            CBlockHeader legacy = h; legacy.nVersion = 1; legacy.nNonce = x.nonce;
-            CBlock gb; static_cast<CBlockHeader&>(gb) = legacy;
-            std::vector<uint8_t> newA2 = new_genesis_serialize_header(gb, x.nonce);
-            expect_eq_bytes("A2 genesis SerializeHeader",
-                            "new==old",
-                            newA2, old_genesis_serialize_header(gb, x.nonce));
-            std::vector<uint8_t> a1legacy = legacy.SerializeHeader();  // 80 bytes for v1
-            expect_eq_bytes("A2 genesis == A1 canonical",
-                            "miner==validator",
-                            newA2, a1legacy);
-        }
-
-        // A4: miner hot-loop buffer (only legacy/80-byte path is mined)
-        expect_eq_bytes("A4 controller header",
-                        "v=" + std::to_string(x.v),
-                        new_a4_miner_header(h, x.nonce), old_a4_miner_header(h, x.nonce));
+        BOOST_CHECK(h.SerializeHeader() == old_block_serialize_header(h));
     }
-
-    // ---- FAMILY C ----
-    printf("\nFAMILY C — VDF challenge preimage (1 site)\n");
-    {
-        uint256 prev;
-        for (int i = 0; i < 32; i++) prev.data[i] = static_cast<uint8_t>(0x33 + i);
-        std::array<uint8_t, 20> addr{};
-        for (int i = 0; i < 20; i++) addr[i] = static_cast<uint8_t>(0xA0 + i);
-        std::vector<int> heights = {0, 1, 40000, 0x00FF00FF, 0x7FFFFFFF, (int)0xFFFFFFFF};
-        for (int hgt : heights) {
-            expect_eq_bytes("C1 vdf_validation height",
-                            "h=" + std::to_string(hgt),
-                            new_c1_vdf_preimage(prev, hgt, addr),
-                            old_c1_vdf_preimage(prev, hgt, addr));
-        }
-    }
-
-    // ---- FAMILY B ----
-    printf("\nFAMILY B — Digital-DNA dna_hash preimage (4 dims)\n");
-    {
-        using namespace digital_dna;
-
-        // B1 behavioral_profile
-        {
-            BehavioralProfile p;
-            for (int i = 0; i < 24; i++) p.hourly_activity[i] = 1.5 * i - 3.25;
-            p.mean_relay_delay_ms = 42.125; p.relay_consistency = 0.75;
-            p.avg_peer_session_duration_sec = 123456.789; p.peer_diversity_score = 0.333;
-            p.tx_relay_rate = 9.5; p.tx_timing_entropy = 3.14159265358979;
-            p.observation_blocks = 0xDEADBEEF; p.start_time = 0x0102030405060708ULL;
-            p.end_time = 0xFFFFFFFFFFFFFFFFULL;
-            std::vector<uint8_t> got = p.serialize();
-
-            // OLD host-endian reproduction
-            std::vector<uint8_t> old;
-            auto pd = [&](double d){ const uint8_t* q = reinterpret_cast<const uint8_t*>(&d); old.insert(old.end(), q, q + 8); };
-            for (int i = 0; i < 24; i++) pd(p.hourly_activity[i]);
-            pd(p.mean_relay_delay_ms); pd(p.relay_consistency); pd(p.avg_peer_session_duration_sec);
-            pd(p.peer_diversity_score); pd(p.tx_relay_rate); pd(p.tx_timing_entropy);
-            { const uint8_t* q = reinterpret_cast<const uint8_t*>(&p.observation_blocks); old.insert(old.end(), q, q + 4); }
-            { const uint8_t* q = reinterpret_cast<const uint8_t*>(&p.start_time); old.insert(old.end(), q, q + 8); }
-            { const uint8_t* q = reinterpret_cast<const uint8_t*>(&p.end_time); old.insert(old.end(), q, q + 8); }
-            expect_eq_bytes("B1 behavioral_profile", "serialize", got, old);
-
-            // Round-trip
-            BehavioralProfile r = BehavioralProfile::deserialize(got);
-            g_checks++;
-            if (r.observation_blocks == p.observation_blocks && r.start_time == p.start_time &&
-                r.end_time == p.end_time && r.tx_timing_entropy == p.tx_timing_entropy) {
-                printf("  [PASS] %-28s round-trip\n", "B1 behavioral_profile");
-            } else { g_failures++; printf("  [FAIL] %-28s round-trip\n", "B1 behavioral_profile"); }
-        }
-
-        // B2 clock_drift
-        {
-            ClockDriftFingerprint f;
-            f.drift_rate_ppm = -1.25; f.drift_stability = 0.001; f.jitter_signature = 987.654;
-            f.observation_start = 0x1111222233334444ULL; f.observation_end = 0x5555666677778888ULL;
-            f.num_reference_peers = 0xABCD1234; f.num_samples = 0x0000FFFF;
-            std::vector<uint8_t> got = f.serialize();
-
-            std::vector<uint8_t> old(48); size_t o = 0;
-            memcpy(old.data()+o,&f.drift_rate_ppm,8); o+=8;
-            memcpy(old.data()+o,&f.drift_stability,8); o+=8;
-            memcpy(old.data()+o,&f.jitter_signature,8); o+=8;
-            memcpy(old.data()+o,&f.observation_start,8); o+=8;
-            memcpy(old.data()+o,&f.observation_end,8); o+=8;
-            memcpy(old.data()+o,&f.num_reference_peers,4); o+=4;
-            memcpy(old.data()+o,&f.num_samples,4); o+=4;
-            expect_eq_bytes("B2 clock_drift", "serialize", got, old);
-
-            ClockDriftFingerprint r = ClockDriftFingerprint::deserialize(got);
-            g_checks++;
-            if (r.num_reference_peers == f.num_reference_peers && r.observation_end == f.observation_end &&
-                r.jitter_signature == f.jitter_signature) {
-                printf("  [PASS] %-28s round-trip\n", "B2 clock_drift");
-            } else { g_failures++; printf("  [FAIL] %-28s round-trip\n", "B2 clock_drift"); }
-        }
-
-        // B3 memory_fingerprint
-        {
-            MemoryFingerprint f;
-            for (int i = 0; i < 3; i++) {
-                MemoryProbeResult p;
-                p.working_set_kb = static_cast<uint32_t>(64u << i);
-                p.access_time_ns = 10.5 * (i + 1);
-                p.bandwidth_mbps = 1000.0 / (i + 1);
-                f.access_curve.push_back(p);
-            }
-            f.estimated_l1_kb = 32.0; f.estimated_l2_kb = 256.0; f.estimated_l3_kb = 8192.0;
-            f.dram_latency_ns = 85.25; f.peak_bandwidth_mbps = 42000.5;
-            std::vector<uint8_t> got = f.serialize();
-
-            std::vector<uint8_t> old;
-            uint32_t count = static_cast<uint32_t>(f.access_curve.size());
-            { const uint8_t* q = reinterpret_cast<const uint8_t*>(&count); old.insert(old.end(), q, q + 4); }
-            for (const auto& p : f.access_curve) {
-                { const uint8_t* q = reinterpret_cast<const uint8_t*>(&p.working_set_kb); old.insert(old.end(), q, q + 4); }
-                { const uint8_t* q = reinterpret_cast<const uint8_t*>(&p.access_time_ns); old.insert(old.end(), q, q + 8); }
-                { const uint8_t* q = reinterpret_cast<const uint8_t*>(&p.bandwidth_mbps); old.insert(old.end(), q, q + 8); }
-            }
-            { const uint8_t* q = reinterpret_cast<const uint8_t*>(&f.estimated_l1_kb); old.insert(old.end(), q, q + 8); }
-            { const uint8_t* q = reinterpret_cast<const uint8_t*>(&f.estimated_l2_kb); old.insert(old.end(), q, q + 8); }
-            { const uint8_t* q = reinterpret_cast<const uint8_t*>(&f.estimated_l3_kb); old.insert(old.end(), q, q + 8); }
-            { const uint8_t* q = reinterpret_cast<const uint8_t*>(&f.dram_latency_ns); old.insert(old.end(), q, q + 8); }
-            { const uint8_t* q = reinterpret_cast<const uint8_t*>(&f.peak_bandwidth_mbps); old.insert(old.end(), q, q + 8); }
-            expect_eq_bytes("B3 memory_fingerprint", "serialize", got, old);
-
-            MemoryFingerprint r = MemoryFingerprint::deserialize(got);
-            g_checks++;
-            if (r.access_curve.size() == f.access_curve.size() &&
-                r.access_curve[2].bandwidth_mbps == f.access_curve[2].bandwidth_mbps &&
-                r.peak_bandwidth_mbps == f.peak_bandwidth_mbps) {
-                printf("  [PASS] %-28s round-trip\n", "B3 memory_fingerprint");
-            } else { g_failures++; printf("  [FAIL] %-28s round-trip\n", "B3 memory_fingerprint"); }
-        }
-
-        // B4 bandwidth_proof
-        {
-            BandwidthFingerprint f;
-            f.median_upload_mbps = 55.5; f.median_download_mbps = 940.25;
-            f.median_asymmetry = 0.059; f.bandwidth_stability = 0.98;
-            f.measurements.resize(7);  // count only is serialized
-            std::vector<uint8_t> got = f.serialize();
-
-            std::vector<uint8_t> old(36); size_t o = 0;
-            memcpy(old.data()+o,&f.median_upload_mbps,8); o+=8;
-            memcpy(old.data()+o,&f.median_download_mbps,8); o+=8;
-            memcpy(old.data()+o,&f.median_asymmetry,8); o+=8;
-            memcpy(old.data()+o,&f.bandwidth_stability,8); o+=8;
-            uint32_t count = static_cast<uint32_t>(f.measurements.size());
-            memcpy(old.data()+o,&count,4); o+=4;
-            expect_eq_bytes("B4 bandwidth_proof", "serialize", got, old);
-
-            BandwidthFingerprint r = BandwidthFingerprint::deserialize(got);
-            g_checks++;
-            if (r.median_download_mbps == f.median_download_mbps &&
-                r.bandwidth_stability == f.bandwidth_stability) {
-                printf("  [PASS] %-28s round-trip\n", "B4 bandwidth_proof");
-            } else { g_failures++; printf("  [FAIL] %-28s round-trip\n", "B4 bandwidth_proof"); }
-        }
-    }
-
-    // ---- GENESIS HASH UNCHANGED (the whole point) ----
-    printf("\nGENESIS-HASH-UNCHANGED proof (DIL mainnet)\n");
-    {
-        g_chainParams = new ChainParams(ChainParams::Mainnet());
-        const std::string frozen = g_chainParams->genesisHash;  // chainparams.cpp constant
-
-        CBlock genesis = Genesis::CreateGenesisBlock();
-
-        // (a) Airtight: the 80-byte header preimage the hash consumes must be
-        //     byte-identical to the old host-endian construction. RandomX is a
-        //     pure function of these bytes, so identical bytes => identical hash.
-        std::vector<uint8_t> newPre = genesis.SerializeHeader();
-        std::vector<uint8_t> oldPre = old_block_serialize_header(genesis);
-        expect_eq_bytes("GENESIS preimage", "80-byte header", newPre, oldPre);
-        g_checks++;
-        if (newPre.size() == 80) {
-            printf("  [PASS] %-28s preimage is 80 bytes (legacy/RandomX)\n", "GENESIS preimage");
-        } else { g_failures++; printf("  [FAIL] GENESIS preimage size=%zu (expected 80)\n", newPre.size()); }
-
-        // (b) End-to-end: compute the actual RandomX genesis hash and compare to
-        //     the frozen constant.
-        const char* rx_key = "Dilithion-RandomX-v1";
-        randomx_init_for_hashing(rx_key, strlen(rx_key), 0);  // light init
-        genesis.InvalidateCache();
-        std::string computed = genesis.GetHash().GetHex();
-
-        g_checks++;
-        if (computed == frozen) {
-            printf("  [PASS] %-28s %s == frozen constant\n", "GENESIS hash", computed.c_str());
-        } else {
-            g_failures++;
-            printf("  [FAIL] %-28s CHAIN-SPLIT: genesis hash CHANGED\n", "GENESIS hash");
-            printf("         computed: %s\n", computed.c_str());
-            printf("         frozen:   %s\n", frozen.c_str());
-        }
-
-        delete g_chainParams; g_chainParams = nullptr;
-    }
-
-    // ---- GENESIS HASH UNCHANGED (DilV / VDF genesis) ----
-    // Belt-and-suspenders for the WF-1 endian fix on the OTHER genesis-critical
-    // surface: the DilV chain's genesis is a v4 VDF block, so its header carries
-    // the 64-byte VDF extension on top of the 80-byte legacy portion, and its
-    // hash is SHA3-256 of the full 144-byte header (NOT RandomX). We assert both
-    // the header preimage bytes AND the full hash are unchanged after the fix.
-    //
-    // The full-hash assertion IS feasible here (unlike a mined RandomX genesis
-    // that would need a nonce search) because the DilV VDF proof/output are
-    // hardcoded in CreateDilVGenesisBlock(), the prefund set is a checked-in
-    // .inc, and SHA3-256 is a pure function with no key/VM init — so the block
-    // is fully constructible in-process and the hash is deterministic.
-    printf("\nGENESIS-HASH-UNCHANGED proof (DilV / VDF genesis)\n");
-    {
-        g_chainParams = new ChainParams(ChainParams::DilV());
-        const std::string frozen = g_chainParams->genesisHash;  // chainparams.cpp:428
-
-        CBlock genesis = Genesis::CreateDilVGenesisBlock();
-
-        // Sanity: this must actually be a VDF (v4) block, else the VDF-extension
-        // bytes below would be silently skipped and the check would be vacuous.
-        g_checks++;
-        if (genesis.nVersion == CBlockHeader::VDF_VERSION && genesis.IsVDFBlock()) {
-            printf("  [PASS] %-28s is a VDF (v4) block\n", "DILV genesis");
-        } else {
-            g_failures++;
-            printf("  [FAIL] %-28s NOT a VDF block (nVersion=%d) — check vacuous\n",
-                   "DILV genesis", genesis.nVersion);
-        }
-
-        // (a) Airtight: the full 144-byte header preimage the hash consumes
-        //     (80-byte legacy portion incl. the WF-1 endian sites + 64-byte VDF
-        //     extension) must be byte-identical to the old host-endian
-        //     construction. SHA3 is a pure function of these bytes, so identical
-        //     bytes => identical hash. old_block_serialize_header() reproduces
-        //     the pre-WF-1 emission including the VDF extension for v>=4.
-        std::vector<uint8_t> newPre = genesis.SerializeHeader();
-        std::vector<uint8_t> oldPre = old_block_serialize_header(genesis);
-        expect_eq_bytes("DILV GENESIS preimage", "144-byte VDF header", newPre, oldPre);
-        g_checks++;
-        if (newPre.size() == 144) {
-            printf("  [PASS] %-28s preimage is 144 bytes (VDF/SHA3)\n", "DILV GENESIS preimage");
-        } else { g_failures++; printf("  [FAIL] DILV GENESIS preimage size=%zu (expected 144)\n", newPre.size()); }
-
-        // (b) End-to-end: compute the actual SHA3-256 genesis hash and compare
-        //     to the frozen constant. No RandomX key/VM init needed for VDF blocks.
-        genesis.InvalidateCache();
-        std::string computed = genesis.GetHash().GetHex();
-
-        g_checks++;
-        if (computed == frozen) {
-            printf("  [PASS] %-28s %s == frozen constant\n", "DILV GENESIS hash", computed.c_str());
-        } else {
-            g_failures++;
-            printf("  [FAIL] %-28s CHAIN-SPLIT: DilV genesis hash CHANGED\n", "DILV GENESIS hash");
-            printf("         computed: %s\n", computed.c_str());
-            printf("         frozen:   %s\n", frozen.c_str());
-        }
-
-        delete g_chainParams; g_chainParams = nullptr;
-    }
-
-    // ---- SUMMARY ----
-    printf("\n=== SUMMARY: %d checks, %d failures ===\n", g_checks, g_failures);
-    if (g_failures == 0) {
-        printf("ALL BYTE-EQUALITY + GENESIS-HASH-UNCHANGED CHECKS PASSED.\n");
-        return 0;
-    }
-    printf("FAILURES PRESENT — DO NOT MERGE (potential chain split).\n");
-    return 1;
 }
+
+// A2: genesis mining helper (legacy 80-byte). new==old AND new==A1 canonical
+// (miner and validator agree byte-for-byte). A2 is anchored to production via A1.
+BOOST_AUTO_TEST_CASE(a2_genesis_serialize_header) {
+    for (const auto& x : kHvs) {
+        CBlockHeader legacy = make_header(x.v, x.t, x.bits, x.nonce, false);
+        legacy.nVersion = 1; legacy.nNonce = x.nonce;
+        CBlock gb; static_cast<CBlockHeader&>(gb) = legacy;
+
+        std::vector<uint8_t> newA2 = new_genesis_serialize_header(gb, x.nonce);
+        BOOST_CHECK(newA2 == old_genesis_serialize_header(gb, x.nonce));
+        // Anchor to production: A2 helper == canonical A1 legacy serialization.
+        BOOST_CHECK(newA2 == legacy.SerializeHeader());
+    }
+}
+
+// A3-selector: PRODUCTION-DRIVING. GetShortID() lazily invokes the real
+// FillShortTxIDSelector() to derive the SipHash keys, then SipHashes the txid.
+// We assert that the short-id produced by the real production path equals the
+// short-id computed from keys derived from the OLD host-endian 88-byte preimage.
+// If FillShortTxIDSelector's endian emission ever drifts, the derived keys — and
+// thus GetShortID's output — diverge and this fails. No hand-copied mirror of
+// the production preimage is trusted here.
+BOOST_AUTO_TEST_CASE(a3_selector_production_driving) {
+    uint256 txid;
+    for (int i = 0; i < 32; i++) txid.data[i] = static_cast<uint8_t>(0x5A ^ (i * 3));
+
+    for (const auto& x : kHvs) {
+        bool vdf = (x.v >= CBlockHeader::VDF_VERSION);
+        CBlockHeader h = make_header(x.v, x.t, x.bits, x.nonce, vdf);
+        uint64_t sel_nonce = 0x1122334455667788ULL ^ x.nonce;
+
+        // REAL production path: build the compact-block object and ask it for a
+        // short id. This runs the production FillShortTxIDSelector().
+        CBlockHeaderAndShortTxIDs comp;
+        comp.header = h;
+        comp.nonce = sel_nonce;
+        uint64_t prod_shortid = comp.GetShortID(txid);
+
+        // Expected: derive keys from the OLD host-endian preimage and SipHash.
+        uint64_t k0, k1;
+        keys_from_preimage(old_a3_selector_preimage(h, sel_nonce), k0, k1);
+        uint64_t expected = SipHashUint256(k0, k1, txid) & 0xffffffffffffULL;
+
+        BOOST_CHECK_EQUAL(prod_shortid, expected);
+    }
+}
+
+// A3-wire: PRODUCTION Serialize()/Deserialize() round-trips header scalars,
+// selector nonce and short-txids identically. (The wire framing itself is P2P-
+// only and lives on a separate branch; this just proves the round-trip holds.)
+BOOST_AUTO_TEST_CASE(a3_wire_roundtrip_production) {
+    for (const auto& x : kHvs) {
+        bool vdf = (x.v >= CBlockHeader::VDF_VERSION);
+        CBlockHeader h = make_header(x.v, x.t, x.bits, x.nonce, vdf);
+        uint64_t sel_nonce = 0x1122334455667788ULL ^ x.nonce;
+
+        CBlockHeaderAndShortTxIDs comp;
+        comp.header = h;
+        comp.nonce = sel_nonce;
+        comp.shorttxids = { 0x010203040506ULL, 0x0A0B0C0D0E0FULL };
+        std::vector<uint8_t> wire = comp.Serialize();
+
+        CBlockHeaderAndShortTxIDs back;
+        BOOST_REQUIRE(back.Deserialize(wire.data(), wire.size()));
+        BOOST_CHECK_EQUAL(back.header.nVersion, h.nVersion);
+        BOOST_CHECK_EQUAL(back.header.nTime, h.nTime);
+        BOOST_CHECK_EQUAL(back.header.nBits, h.nBits);
+        BOOST_CHECK_EQUAL(back.header.nNonce, h.nNonce);
+        BOOST_CHECK_EQUAL(back.nonce, comp.nonce);
+        BOOST_CHECK(back.shorttxids == comp.shorttxids);
+    }
+}
+
+// A4: PRODUCTION-DRIVING. WriteMiningHeaderLE() is the exact helper the miner
+// hot loop (controller.cpp MiningWorker) calls to assemble its 80-byte PoW
+// buffer. We drive THAT function and assert (i) byte-equal to the old host-
+// endian miner emission, and (ii) — the property that actually matters —
+// byte-equal to the canonical validator serialization SerializeHeader() for the
+// same legacy header. A future drift in the miner buffer assembly now fails CI.
+BOOST_AUTO_TEST_CASE(a4_controller_header_production_driving) {
+    for (const auto& x : kHvs) {
+        // The miner only mines legacy (80-byte) blocks; force v1.
+        CBlockHeader h = make_header(x.v, x.t, x.bits, x.nonce, false);
+        h.nVersion = 1;
+
+        // (i) real production assembly vs old host-endian miner emission.
+        std::vector<uint8_t> prod(80);
+        WriteMiningHeaderLE(prod.data(), h, x.nonce);
+
+        std::vector<uint8_t> old(80);
+        {
+            size_t off = 0;
+            memcpy(old.data() + off, &h.nVersion, 4); off += 4;
+            memcpy(old.data() + off, h.hashPrevBlock.begin(), 32); off += 32;
+            memcpy(old.data() + off, h.hashMerkleRoot.begin(), 32); off += 32;
+            memcpy(old.data() + off, &h.nTime, 4); off += 4;
+            memcpy(old.data() + off, &h.nBits, 4); off += 4;
+            memcpy(old.data() + 76, &x.nonce, 4);
+        }
+        BOOST_CHECK(prod == old);
+
+        // (ii) THE property: miner buffer == validator SerializeHeader() with the
+        // same nonce in the header. This is what keeps mined PoW acceptable.
+        CBlockHeader hv = h; hv.nNonce = x.nonce;
+        BOOST_CHECK(prod == hv.SerializeHeader());
+    }
+}
+
+// ===========================================================================
+// FAMILY C — VDF challenge preimage.
+// ===========================================================================
+BOOST_AUTO_TEST_CASE(c1_vdf_preimage) {
+    uint256 prev;
+    for (int i = 0; i < 32; i++) prev.data[i] = static_cast<uint8_t>(0x33 + i);
+    std::array<uint8_t, 20> addr{};
+    for (int i = 0; i < 20; i++) addr[i] = static_cast<uint8_t>(0xA0 + i);
+    std::vector<int> heights = {0, 1, 40000, 0x00FF00FF, 0x7FFFFFFF, (int)0xFFFFFFFF};
+    for (int hgt : heights) {
+        BOOST_CHECK(new_c1_vdf_preimage(prev, hgt, addr) == old_c1_vdf_preimage(prev, hgt, addr));
+    }
+}
+
+// ===========================================================================
+// FAMILY B — Digital-DNA dna_hash preimage (production *::serialize()).
+// ===========================================================================
+BOOST_AUTO_TEST_CASE(b1_behavioral_profile) {
+    using namespace digital_dna;
+    BehavioralProfile p;
+    for (int i = 0; i < 24; i++) p.hourly_activity[i] = 1.5 * i - 3.25;
+    p.mean_relay_delay_ms = 42.125; p.relay_consistency = 0.75;
+    p.avg_peer_session_duration_sec = 123456.789; p.peer_diversity_score = 0.333;
+    p.tx_relay_rate = 9.5; p.tx_timing_entropy = 3.14159265358979;
+    p.observation_blocks = 0xDEADBEEF; p.start_time = 0x0102030405060708ULL;
+    p.end_time = 0xFFFFFFFFFFFFFFFFULL;
+    std::vector<uint8_t> got = p.serialize();
+
+    std::vector<uint8_t> old;
+    auto pd = [&](double d){ const uint8_t* q = reinterpret_cast<const uint8_t*>(&d); old.insert(old.end(), q, q + 8); };
+    for (int i = 0; i < 24; i++) pd(p.hourly_activity[i]);
+    pd(p.mean_relay_delay_ms); pd(p.relay_consistency); pd(p.avg_peer_session_duration_sec);
+    pd(p.peer_diversity_score); pd(p.tx_relay_rate); pd(p.tx_timing_entropy);
+    { const uint8_t* q = reinterpret_cast<const uint8_t*>(&p.observation_blocks); old.insert(old.end(), q, q + 4); }
+    { const uint8_t* q = reinterpret_cast<const uint8_t*>(&p.start_time); old.insert(old.end(), q, q + 8); }
+    { const uint8_t* q = reinterpret_cast<const uint8_t*>(&p.end_time); old.insert(old.end(), q, q + 8); }
+    BOOST_CHECK(got == old);
+
+    BehavioralProfile r = BehavioralProfile::deserialize(got);
+    BOOST_CHECK_EQUAL(r.observation_blocks, p.observation_blocks);
+    BOOST_CHECK_EQUAL(r.start_time, p.start_time);
+    BOOST_CHECK_EQUAL(r.end_time, p.end_time);
+    BOOST_CHECK_EQUAL(r.tx_timing_entropy, p.tx_timing_entropy);
+}
+
+BOOST_AUTO_TEST_CASE(b2_clock_drift) {
+    using namespace digital_dna;
+    ClockDriftFingerprint f;
+    f.drift_rate_ppm = -1.25; f.drift_stability = 0.001; f.jitter_signature = 987.654;
+    f.observation_start = 0x1111222233334444ULL; f.observation_end = 0x5555666677778888ULL;
+    f.num_reference_peers = 0xABCD1234; f.num_samples = 0x0000FFFF;
+    std::vector<uint8_t> got = f.serialize();
+
+    std::vector<uint8_t> old(48); size_t o = 0;
+    memcpy(old.data()+o,&f.drift_rate_ppm,8); o+=8;
+    memcpy(old.data()+o,&f.drift_stability,8); o+=8;
+    memcpy(old.data()+o,&f.jitter_signature,8); o+=8;
+    memcpy(old.data()+o,&f.observation_start,8); o+=8;
+    memcpy(old.data()+o,&f.observation_end,8); o+=8;
+    memcpy(old.data()+o,&f.num_reference_peers,4); o+=4;
+    memcpy(old.data()+o,&f.num_samples,4); o+=4;
+    BOOST_CHECK(got == old);
+
+    ClockDriftFingerprint r = ClockDriftFingerprint::deserialize(got);
+    BOOST_CHECK_EQUAL(r.num_reference_peers, f.num_reference_peers);
+    BOOST_CHECK_EQUAL(r.observation_end, f.observation_end);
+    BOOST_CHECK_EQUAL(r.jitter_signature, f.jitter_signature);
+}
+
+BOOST_AUTO_TEST_CASE(b3_memory_fingerprint) {
+    using namespace digital_dna;
+    MemoryFingerprint f;
+    for (int i = 0; i < 3; i++) {
+        MemoryProbeResult p;
+        p.working_set_kb = static_cast<uint32_t>(64u << i);
+        p.access_time_ns = 10.5 * (i + 1);
+        p.bandwidth_mbps = 1000.0 / (i + 1);
+        f.access_curve.push_back(p);
+    }
+    f.estimated_l1_kb = 32.0; f.estimated_l2_kb = 256.0; f.estimated_l3_kb = 8192.0;
+    f.dram_latency_ns = 85.25; f.peak_bandwidth_mbps = 42000.5;
+    std::vector<uint8_t> got = f.serialize();
+
+    std::vector<uint8_t> old;
+    uint32_t count = static_cast<uint32_t>(f.access_curve.size());
+    { const uint8_t* q = reinterpret_cast<const uint8_t*>(&count); old.insert(old.end(), q, q + 4); }
+    for (const auto& p : f.access_curve) {
+        { const uint8_t* q = reinterpret_cast<const uint8_t*>(&p.working_set_kb); old.insert(old.end(), q, q + 4); }
+        { const uint8_t* q = reinterpret_cast<const uint8_t*>(&p.access_time_ns); old.insert(old.end(), q, q + 8); }
+        { const uint8_t* q = reinterpret_cast<const uint8_t*>(&p.bandwidth_mbps); old.insert(old.end(), q, q + 8); }
+    }
+    { const uint8_t* q = reinterpret_cast<const uint8_t*>(&f.estimated_l1_kb); old.insert(old.end(), q, q + 8); }
+    { const uint8_t* q = reinterpret_cast<const uint8_t*>(&f.estimated_l2_kb); old.insert(old.end(), q, q + 8); }
+    { const uint8_t* q = reinterpret_cast<const uint8_t*>(&f.estimated_l3_kb); old.insert(old.end(), q, q + 8); }
+    { const uint8_t* q = reinterpret_cast<const uint8_t*>(&f.dram_latency_ns); old.insert(old.end(), q, q + 8); }
+    { const uint8_t* q = reinterpret_cast<const uint8_t*>(&f.peak_bandwidth_mbps); old.insert(old.end(), q, q + 8); }
+    BOOST_CHECK(got == old);
+
+    MemoryFingerprint r = MemoryFingerprint::deserialize(got);
+    BOOST_CHECK_EQUAL(r.access_curve.size(), f.access_curve.size());
+    BOOST_CHECK_EQUAL(r.access_curve[2].bandwidth_mbps, f.access_curve[2].bandwidth_mbps);
+    BOOST_CHECK_EQUAL(r.peak_bandwidth_mbps, f.peak_bandwidth_mbps);
+}
+
+BOOST_AUTO_TEST_CASE(b4_bandwidth_proof) {
+    using namespace digital_dna;
+    BandwidthFingerprint f;
+    f.median_upload_mbps = 55.5; f.median_download_mbps = 940.25;
+    f.median_asymmetry = 0.059; f.bandwidth_stability = 0.98;
+    f.measurements.resize(7);  // count only is serialized
+    std::vector<uint8_t> got = f.serialize();
+
+    std::vector<uint8_t> old(36); size_t o = 0;
+    memcpy(old.data()+o,&f.median_upload_mbps,8); o+=8;
+    memcpy(old.data()+o,&f.median_download_mbps,8); o+=8;
+    memcpy(old.data()+o,&f.median_asymmetry,8); o+=8;
+    memcpy(old.data()+o,&f.bandwidth_stability,8); o+=8;
+    uint32_t count = static_cast<uint32_t>(f.measurements.size());
+    memcpy(old.data()+o,&count,4); o+=4;
+    BOOST_CHECK(got == old);
+
+    BandwidthFingerprint r = BandwidthFingerprint::deserialize(got);
+    BOOST_CHECK_EQUAL(r.median_download_mbps, f.median_download_mbps);
+    BOOST_CHECK_EQUAL(r.bandwidth_stability, f.bandwidth_stability);
+}
+
+// ===========================================================================
+// GENESIS HASH UNCHANGED — DIL mainnet (legacy/RandomX, 80-byte header).
+// ===========================================================================
+BOOST_AUTO_TEST_CASE(genesis_dil_mainnet_unchanged) {
+    ChainParams* saved = g_chainParams;
+    g_chainParams = new ChainParams(ChainParams::Mainnet());
+    const std::string frozen = g_chainParams->genesisHash;  // chainparams.cpp constant
+
+    CBlock genesis = Genesis::CreateGenesisBlock();
+
+    // (a) Airtight: the 80-byte header preimage the hash consumes must be
+    //     byte-identical to the old host-endian construction. RandomX is a pure
+    //     function of these bytes, so identical bytes => identical hash.
+    std::vector<uint8_t> newPre = genesis.SerializeHeader();
+    BOOST_CHECK(newPre == old_block_serialize_header(genesis));
+    BOOST_CHECK_EQUAL(newPre.size(), 80u);
+
+    // (b) End-to-end: compute the actual RandomX genesis hash vs frozen constant.
+    const char* rx_key = "Dilithion-RandomX-v1";
+    randomx_init_for_hashing(rx_key, strlen(rx_key), 0);  // light init
+    genesis.InvalidateCache();
+    std::string computed = genesis.GetHash().GetHex();
+    BOOST_CHECK_MESSAGE(computed == frozen,
+        "DIL genesis hash CHANGED (chain split): computed=" << computed << " frozen=" << frozen);
+
+    delete g_chainParams;
+    g_chainParams = saved;
+}
+
+// ===========================================================================
+// GENESIS HASH UNCHANGED — DilV (VDF/SHA3, 144-byte header).
+// ===========================================================================
+BOOST_AUTO_TEST_CASE(genesis_dilv_unchanged) {
+    ChainParams* saved = g_chainParams;
+    g_chainParams = new ChainParams(ChainParams::DilV());
+    const std::string frozen = g_chainParams->genesisHash;
+
+    CBlock genesis = Genesis::CreateDilVGenesisBlock();
+
+    // Sanity: must actually be a VDF (v4) block, else the VDF-extension bytes
+    // below would be silently skipped and the check would be vacuous.
+    BOOST_REQUIRE_MESSAGE(genesis.nVersion == CBlockHeader::VDF_VERSION && genesis.IsVDFBlock(),
+        "DilV genesis is not a VDF block (nVersion=" << genesis.nVersion << ") — check vacuous");
+
+    // (a) Airtight: full 144-byte header preimage (80-byte legacy incl. the WF-1
+    //     endian sites + 64-byte VDF extension) byte-identical to old host-endian.
+    std::vector<uint8_t> newPre = genesis.SerializeHeader();
+    BOOST_CHECK(newPre == old_block_serialize_header(genesis));
+    BOOST_CHECK_EQUAL(newPre.size(), 144u);
+
+    // (b) End-to-end: actual SHA3-256 genesis hash vs frozen constant. No RandomX
+    //     key/VM init needed for VDF blocks.
+    genesis.InvalidateCache();
+    std::string computed = genesis.GetHash().GetHex();
+    BOOST_CHECK_MESSAGE(computed == frozen,
+        "DilV genesis hash CHANGED (chain split): computed=" << computed << " frozen=" << frozen);
+
+    delete g_chainParams;
+    g_chainParams = saved;
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/wf1_host_endian_differential_test.cpp
+++ b/src/test/wf1_host_endian_differential_test.cpp
@@ -16,10 +16,16 @@
 //   2. calls the NEW production serializer, and
 //   3. asserts new_bytes == old_bytes across several representative inputs.
 //
-// It ALSO asserts the DIL mainnet genesis block hash is byte-identical to the
-// frozen genesis-hash constant in chainparams.cpp, both at the 80-byte header
-// preimage level (airtight: RandomX is a pure function of these bytes) and at
-// the full RandomX-hash level (end-to-end).
+// It ALSO asserts BOTH frozen genesis hashes are byte-identical to their
+// constants in chainparams.cpp:
+//   - DIL mainnet (legacy/RandomX, 80-byte header): 80-byte preimage byte-
+//     equality (airtight: RandomX is a pure function of these bytes) + the full
+//     RandomX-hash end-to-end.
+//   - DilV (VDF/SHA3, 144-byte header): 144-byte preimage byte-equality (incl.
+//     the 64-byte VDF extension) + the full SHA3-256 hash end-to-end. The DilV
+//     block is fully constructible in-process (hardcoded VDF proof, checked-in
+//     prefund, pure SHA3 with no key init), so the full-hash assertion is
+//     feasible without a nonce search.
 //
 // This is a STANDALONE program (its own main, returns non-zero on any failure),
 // deliberately NOT wired into the Boost suite so it can run in isolation with a
@@ -466,6 +472,68 @@ int main() {
         } else {
             g_failures++;
             printf("  [FAIL] %-28s CHAIN-SPLIT: genesis hash CHANGED\n", "GENESIS hash");
+            printf("         computed: %s\n", computed.c_str());
+            printf("         frozen:   %s\n", frozen.c_str());
+        }
+
+        delete g_chainParams; g_chainParams = nullptr;
+    }
+
+    // ---- GENESIS HASH UNCHANGED (DilV / VDF genesis) ----
+    // Belt-and-suspenders for the WF-1 endian fix on the OTHER genesis-critical
+    // surface: the DilV chain's genesis is a v4 VDF block, so its header carries
+    // the 64-byte VDF extension on top of the 80-byte legacy portion, and its
+    // hash is SHA3-256 of the full 144-byte header (NOT RandomX). We assert both
+    // the header preimage bytes AND the full hash are unchanged after the fix.
+    //
+    // The full-hash assertion IS feasible here (unlike a mined RandomX genesis
+    // that would need a nonce search) because the DilV VDF proof/output are
+    // hardcoded in CreateDilVGenesisBlock(), the prefund set is a checked-in
+    // .inc, and SHA3-256 is a pure function with no key/VM init — so the block
+    // is fully constructible in-process and the hash is deterministic.
+    printf("\nGENESIS-HASH-UNCHANGED proof (DilV / VDF genesis)\n");
+    {
+        g_chainParams = new ChainParams(ChainParams::DilV());
+        const std::string frozen = g_chainParams->genesisHash;  // chainparams.cpp:428
+
+        CBlock genesis = Genesis::CreateDilVGenesisBlock();
+
+        // Sanity: this must actually be a VDF (v4) block, else the VDF-extension
+        // bytes below would be silently skipped and the check would be vacuous.
+        g_checks++;
+        if (genesis.nVersion == CBlockHeader::VDF_VERSION && genesis.IsVDFBlock()) {
+            printf("  [PASS] %-28s is a VDF (v4) block\n", "DILV genesis");
+        } else {
+            g_failures++;
+            printf("  [FAIL] %-28s NOT a VDF block (nVersion=%d) — check vacuous\n",
+                   "DILV genesis", genesis.nVersion);
+        }
+
+        // (a) Airtight: the full 144-byte header preimage the hash consumes
+        //     (80-byte legacy portion incl. the WF-1 endian sites + 64-byte VDF
+        //     extension) must be byte-identical to the old host-endian
+        //     construction. SHA3 is a pure function of these bytes, so identical
+        //     bytes => identical hash. old_block_serialize_header() reproduces
+        //     the pre-WF-1 emission including the VDF extension for v>=4.
+        std::vector<uint8_t> newPre = genesis.SerializeHeader();
+        std::vector<uint8_t> oldPre = old_block_serialize_header(genesis);
+        expect_eq_bytes("DILV GENESIS preimage", "144-byte VDF header", newPre, oldPre);
+        g_checks++;
+        if (newPre.size() == 144) {
+            printf("  [PASS] %-28s preimage is 144 bytes (VDF/SHA3)\n", "DILV GENESIS preimage");
+        } else { g_failures++; printf("  [FAIL] DILV GENESIS preimage size=%zu (expected 144)\n", newPre.size()); }
+
+        // (b) End-to-end: compute the actual SHA3-256 genesis hash and compare
+        //     to the frozen constant. No RandomX key/VM init needed for VDF blocks.
+        genesis.InvalidateCache();
+        std::string computed = genesis.GetHash().GetHex();
+
+        g_checks++;
+        if (computed == frozen) {
+            printf("  [PASS] %-28s %s == frozen constant\n", "DILV GENESIS hash", computed.c_str());
+        } else {
+            g_failures++;
+            printf("  [FAIL] %-28s CHAIN-SPLIT: DilV genesis hash CHANGED\n", "DILV GENESIS hash");
             printf("         computed: %s\n", computed.c_str());
             printf("         frozen:   %s\n", frozen.c_str());
         }

--- a/src/test/wf1_host_endian_differential_test.cpp
+++ b/src/test/wf1_host_endian_differential_test.cpp
@@ -89,22 +89,6 @@ static std::vector<uint8_t> old_genesis_serialize_header(const CBlock& block, ui
     return data;
 }
 
-// A2 genesis.cpp SerializeBlockHeader (legacy 80-byte mining helper), NEW form.
-// The production helper is file-static in genesis.cpp; this mirrors its exact
-// emission (AppendLE32 for the four scalars). It is NOT relied on alone — it is
-// asserted byte-equal to the canonical A1 SerializeHeader() below, which IS
-// production, so the mirror is anchored to production.
-static std::vector<uint8_t> new_genesis_serialize_header(const CBlock& block, uint32_t nonce) {
-    std::vector<uint8_t> data;
-    AppendLE32(data, static_cast<uint32_t>(block.nVersion));
-    data.insert(data.end(), block.hashPrevBlock.begin(), block.hashPrevBlock.end());
-    data.insert(data.end(), block.hashMerkleRoot.begin(), block.hashMerkleRoot.end());
-    AppendLE32(data, block.nTime);
-    AppendLE32(data, block.nBits);
-    AppendLE32(data, nonce);
-    return data;
-}
-
 // A3-FillShortTxIDSelector: the 88-byte SHA3 preimage, OLD host-endian form.
 static std::vector<uint8_t> old_a3_selector_preimage(const CBlockHeader& header, uint64_t nonce) {
     std::vector<uint8_t> data(88);
@@ -179,6 +163,11 @@ static const std::vector<HV> kHvs = {
     {4, 0xFFFFFFFFu, 0xFFFFFFFFu, 0xFFFFFFFFu},   // VDF, all-ones
     {4, 0x01020304u, 0xdeadbeefu, 0x12345678u},   // VDF, mixed
     {1, 0x80000000u, 0x00ff00ffu, 0x0000abcdu},
+    // Negative int32 nVersion: exercises the two's-complement cast path
+    // (static_cast<uint32_t>(int32) in AppendLE32) rather than only reasoning
+    // about it. -1 => 0xFFFFFFFF; also below VDF_VERSION so stays legacy 80-byte.
+    {-1, 0x0a0b0c0du, 0x11223344u, 0x55667788u},
+    {(int32_t)0x80000000, 0x01020304u, 0x0f0f0f0fu, 0xa5a5a5a5u}, // INT32_MIN
 };
 
 // ===========================================================================
@@ -194,18 +183,23 @@ BOOST_AUTO_TEST_CASE(a1_block_serialize_header) {
     }
 }
 
-// A2: genesis mining helper (legacy 80-byte). new==old AND new==A1 canonical
-// (miner and validator agree byte-for-byte). A2 is anchored to production via A1.
+// A2: PRODUCTION-DRIVING. Genesis::SerializeBlockHeader() is the REAL offline
+// genesis-mining hasher (now exposed, non-static). We drive it directly and
+// assert (i) byte-equal to the old host-endian genesis emission, and (ii)
+// byte-equal to the canonical A1 SerializeHeader() for the same legacy header
+// (miner and validator agree byte-for-byte). A future endian drift in the
+// production genesis hasher now fails CI — no hand-copied mirror is trusted.
 BOOST_AUTO_TEST_CASE(a2_genesis_serialize_header) {
     for (const auto& x : kHvs) {
         CBlockHeader legacy = make_header(x.v, x.t, x.bits, x.nonce, false);
         legacy.nVersion = 1; legacy.nNonce = x.nonce;
         CBlock gb; static_cast<CBlockHeader&>(gb) = legacy;
 
-        std::vector<uint8_t> newA2 = new_genesis_serialize_header(gb, x.nonce);
-        BOOST_CHECK(newA2 == old_genesis_serialize_header(gb, x.nonce));
-        // Anchor to production: A2 helper == canonical A1 legacy serialization.
-        BOOST_CHECK(newA2 == legacy.SerializeHeader());
+        std::vector<uint8_t> prodA2;
+        Genesis::SerializeBlockHeader(gb, x.nonce, prodA2);  // REAL production helper
+        BOOST_CHECK(prodA2 == old_genesis_serialize_header(gb, x.nonce));
+        // Anchor to canonical validator serialization: A2 == A1.
+        BOOST_CHECK(prodA2 == legacy.SerializeHeader());
     }
 }
 
@@ -305,6 +299,12 @@ BOOST_AUTO_TEST_CASE(a4_controller_header_production_driving) {
 // ===========================================================================
 // FAMILY C — VDF challenge preimage.
 // ===========================================================================
+// C1: PRODUCTION-DRIVING. ComputeVDFChallenge() builds the 56-byte preimage
+// internally then SHA3-256's it (the raw preimage is not exposed). We drive the
+// REAL production function and assert its challenge equals SHA3-256 over the OLD
+// host-endian preimage. A future endian drift in the production emitter changes
+// the challenge and fails CI. (The new==old mirror check is retained as a cheap
+// byte-layout document, but the production assertion is what's load-bearing.)
 BOOST_AUTO_TEST_CASE(c1_vdf_preimage) {
     uint256 prev;
     for (int i = 0; i < 32; i++) prev.data[i] = static_cast<uint8_t>(0x33 + i);
@@ -312,7 +312,16 @@ BOOST_AUTO_TEST_CASE(c1_vdf_preimage) {
     for (int i = 0; i < 20; i++) addr[i] = static_cast<uint8_t>(0xA0 + i);
     std::vector<int> heights = {0, 1, 40000, 0x00FF00FF, 0x7FFFFFFF, (int)0xFFFFFFFF};
     for (int hgt : heights) {
-        BOOST_CHECK(new_c1_vdf_preimage(prev, hgt, addr) == old_c1_vdf_preimage(prev, hgt, addr));
+        // Documentary: new host-independent preimage == old host-endian preimage.
+        std::vector<uint8_t> oldPre = old_c1_vdf_preimage(prev, hgt, addr);
+        BOOST_CHECK(new_c1_vdf_preimage(prev, hgt, addr) == oldPre);
+
+        // Load-bearing: the REAL production emitter's challenge equals SHA3-256
+        // over the old host-endian preimage.
+        std::array<uint8_t, 32> expected{};
+        SHA3_256(oldPre.data(), oldPre.size(), expected.data());
+        std::array<uint8_t, 32> prod = ComputeVDFChallenge(prev, hgt, addr);
+        BOOST_CHECK(prod == expected);
     }
 }
 
@@ -431,9 +440,25 @@ BOOST_AUTO_TEST_CASE(b4_bandwidth_proof) {
 // ===========================================================================
 // GENESIS HASH UNCHANGED — DIL mainnet (legacy/RandomX, 80-byte header).
 // ===========================================================================
+
+// RAII scope-guard: installs a fresh g_chainParams and restores + frees the
+// previous one in its destructor, so a BOOST_REQUIRE/BOOST_CHECK throw inside a
+// genesis test cannot skip the restore and poison the rest of the suite.
+struct ChainParamsGuard {
+    ChainParams* saved;
+    explicit ChainParamsGuard(ChainParams* fresh) : saved(g_chainParams) {
+        g_chainParams = fresh;  // takes ownership of `fresh`
+    }
+    ~ChainParamsGuard() {
+        delete g_chainParams;   // free the fresh params installed above
+        g_chainParams = saved;  // restore the previous global
+    }
+    ChainParamsGuard(const ChainParamsGuard&) = delete;
+    ChainParamsGuard& operator=(const ChainParamsGuard&) = delete;
+};
+
 BOOST_AUTO_TEST_CASE(genesis_dil_mainnet_unchanged) {
-    ChainParams* saved = g_chainParams;
-    g_chainParams = new ChainParams(ChainParams::Mainnet());
+    ChainParamsGuard guard(new ChainParams(ChainParams::Mainnet()));
     const std::string frozen = g_chainParams->genesisHash;  // chainparams.cpp constant
 
     CBlock genesis = Genesis::CreateGenesisBlock();
@@ -446,23 +471,22 @@ BOOST_AUTO_TEST_CASE(genesis_dil_mainnet_unchanged) {
     BOOST_CHECK_EQUAL(newPre.size(), 80u);
 
     // (b) End-to-end: compute the actual RandomX genesis hash vs frozen constant.
+    // Arg 3 = light_mode: 1 => light mode (256 MB cache, no 2GB+ dataset). The
+    // RandomX hash is a pure function of the key + input; light vs full mode
+    // produce the identical hash, so this must match the frozen constant.
     const char* rx_key = "Dilithion-RandomX-v1";
-    randomx_init_for_hashing(rx_key, strlen(rx_key), 0);  // light init
+    randomx_init_for_hashing(rx_key, strlen(rx_key), 1);  // light init (arg3=1)
     genesis.InvalidateCache();
     std::string computed = genesis.GetHash().GetHex();
     BOOST_CHECK_MESSAGE(computed == frozen,
         "DIL genesis hash CHANGED (chain split): computed=" << computed << " frozen=" << frozen);
-
-    delete g_chainParams;
-    g_chainParams = saved;
 }
 
 // ===========================================================================
 // GENESIS HASH UNCHANGED — DilV (VDF/SHA3, 144-byte header).
 // ===========================================================================
 BOOST_AUTO_TEST_CASE(genesis_dilv_unchanged) {
-    ChainParams* saved = g_chainParams;
-    g_chainParams = new ChainParams(ChainParams::DilV());
+    ChainParamsGuard guard(new ChainParams(ChainParams::DilV()));
     const std::string frozen = g_chainParams->genesisHash;
 
     CBlock genesis = Genesis::CreateDilVGenesisBlock();
@@ -484,9 +508,6 @@ BOOST_AUTO_TEST_CASE(genesis_dilv_unchanged) {
     std::string computed = genesis.GetHash().GetHex();
     BOOST_CHECK_MESSAGE(computed == frozen,
         "DilV genesis hash CHANGED (chain split): computed=" << computed << " frozen=" << frozen);
-
-    delete g_chainParams;
-    g_chainParams = saved;
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/wf1_host_endian_differential_test.cpp
+++ b/src/test/wf1_host_endian_differential_test.cpp
@@ -1,0 +1,484 @@
+// Copyright (c) 2025 The Dilithion Core developers
+// Distributed under the MIT software license
+//
+// WF-1 HOST-ENDIAN DIFFERENTIAL / BYTE-EQUALITY TEST
+// ===================================================
+//
+// This test is the machine-checked safety proof for the WF-1 fix, which
+// converted 9 host-endian consensus-observable serialization sites to explicit
+// little-endian. On a little-endian host the new bytes MUST be byte-identical
+// to the old host-endian bytes — otherwise the block-header hash (and the
+// frozen genesis hash) would change and split the chain.
+//
+// For EACH of the 9 sites this test:
+//   1. reproduces the OLD host-endian byte emission inline ("old_*"), exactly
+//      as the code read before the fix (raw memcpy / reinterpret_cast copy),
+//   2. calls the NEW production serializer, and
+//   3. asserts new_bytes == old_bytes across several representative inputs.
+//
+// It ALSO asserts the DIL mainnet genesis block hash is byte-identical to the
+// frozen genesis-hash constant in chainparams.cpp, both at the 80-byte header
+// preimage level (airtight: RandomX is a pure function of these bytes) and at
+// the full RandomX-hash level (end-to-end).
+//
+// This is a STANDALONE program (its own main, returns non-zero on any failure),
+// deliberately NOT wired into the Boost suite so it can run in isolation with a
+// minimal link set.
+
+#include <primitives/block.h>
+#include <node/genesis.h>
+#include <core/chainparams.h>
+#include <crypto/randomx_hash.h>
+#include <net/blockencodings.h>
+#include <consensus/vdf_validation.h>
+#include <digital_dna/behavioral_profile.h>
+#include <digital_dna/clock_drift.h>
+#include <digital_dna/memory_fingerprint.h>
+#include <digital_dna/bandwidth_proof.h>
+
+#include <cstdint>
+#include <cstring>
+#include <cstdio>
+#include <string>
+#include <vector>
+#include <array>
+
+using namespace Dilithion;
+
+static int g_failures = 0;
+static int g_checks = 0;
+
+static std::string hex(const std::vector<uint8_t>& v) {
+    static const char* d = "0123456789abcdef";
+    std::string s;
+    s.reserve(v.size() * 2);
+    for (uint8_t b : v) { s.push_back(d[b >> 4]); s.push_back(d[b & 0xF]); }
+    return s;
+}
+
+static void expect_eq_bytes(const char* site, const std::string& label,
+                            const std::vector<uint8_t>& got,
+                            const std::vector<uint8_t>& want) {
+    g_checks++;
+    if (got == want) {
+        printf("  [PASS] %-28s %s (%zu bytes)\n", site, label.c_str(), got.size());
+    } else {
+        g_failures++;
+        printf("  [FAIL] %-28s %s\n", site, label.c_str());
+        printf("         new: %s\n", hex(got).c_str());
+        printf("         old: %s\n", hex(want).c_str());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// OLD host-endian emitters (verbatim reproductions of the pre-WF-1 code).
+// ---------------------------------------------------------------------------
+
+static std::vector<uint8_t> old_block_serialize_header(const CBlockHeader& h) {
+    // Reproduces primitives/block.cpp SerializeHeader() BEFORE the fix.
+    std::vector<uint8_t> buf;
+    const uint8_t* p;
+    p = reinterpret_cast<const uint8_t*>(&h.nVersion); buf.insert(buf.end(), p, p + 4);
+    buf.insert(buf.end(), h.hashPrevBlock.begin(), h.hashPrevBlock.end());
+    buf.insert(buf.end(), h.hashMerkleRoot.begin(), h.hashMerkleRoot.end());
+    p = reinterpret_cast<const uint8_t*>(&h.nTime);  buf.insert(buf.end(), p, p + 4);
+    p = reinterpret_cast<const uint8_t*>(&h.nBits);  buf.insert(buf.end(), p, p + 4);
+    p = reinterpret_cast<const uint8_t*>(&h.nNonce); buf.insert(buf.end(), p, p + 4);
+    if (h.nVersion >= CBlockHeader::VDF_VERSION) {
+        buf.insert(buf.end(), h.vdfOutput.begin(), h.vdfOutput.end());
+        buf.insert(buf.end(), h.vdfProofHash.begin(), h.vdfProofHash.end());
+    }
+    return buf;
+}
+
+// A2: genesis.cpp SerializeBlockHeader (legacy 80-byte mining helper), old form.
+static std::vector<uint8_t> old_genesis_serialize_header(const CBlock& block, uint32_t nonce) {
+    std::vector<uint8_t> data;
+    const uint8_t* vb = reinterpret_cast<const uint8_t*>(&block.nVersion);
+    data.insert(data.end(), vb, vb + 4);
+    data.insert(data.end(), block.hashPrevBlock.begin(), block.hashPrevBlock.end());
+    data.insert(data.end(), block.hashMerkleRoot.begin(), block.hashMerkleRoot.end());
+    const uint8_t* tb = reinterpret_cast<const uint8_t*>(&block.nTime); data.insert(data.end(), tb, tb + 4);
+    const uint8_t* bb = reinterpret_cast<const uint8_t*>(&block.nBits); data.insert(data.end(), bb, bb + 4);
+    const uint8_t* nb = reinterpret_cast<const uint8_t*>(&nonce);       data.insert(data.end(), nb, nb + 4);
+    return data;
+}
+
+// A2 genesis.cpp SerializeBlockHeader (legacy 80-byte mining helper), NEW form.
+// The production helper is file-static in genesis.cpp; this mirrors its exact
+// emission (AppendLE32 for the four scalars), so we can prove it matches both
+// the old A2 form and the canonical A1 serializer.
+static std::vector<uint8_t> new_genesis_serialize_header(const CBlock& block, uint32_t nonce) {
+    std::vector<uint8_t> data;
+    AppendLE32(data, static_cast<uint32_t>(block.nVersion));
+    data.insert(data.end(), block.hashPrevBlock.begin(), block.hashPrevBlock.end());
+    data.insert(data.end(), block.hashMerkleRoot.begin(), block.hashMerkleRoot.end());
+    AppendLE32(data, block.nTime);
+    AppendLE32(data, block.nBits);
+    AppendLE32(data, nonce);
+    return data;
+}
+
+// A3-FillShortTxIDSelector: the 88-byte SHA3 preimage, old form.
+static std::vector<uint8_t> old_a3_selector_preimage(const CBlockHeader& header, uint64_t nonce) {
+    std::vector<uint8_t> data(88);
+    memcpy(data.data(),      &header.nVersion, 4);
+    memcpy(data.data() + 4,  header.hashPrevBlock.data, 32);
+    memcpy(data.data() + 36, header.hashMerkleRoot.data, 32);
+    memcpy(data.data() + 68, &header.nTime, 4);
+    memcpy(data.data() + 72, &header.nBits, 4);
+    memcpy(data.data() + 76, &header.nNonce, 4);
+    memcpy(data.data() + 80, &nonce, 8);
+    return data;
+}
+
+// A4: miner/controller.cpp 80-byte hot-loop buffer, old form.
+static std::vector<uint8_t> old_a4_miner_header(const CBlockHeader& b, uint32_t nonce32) {
+    std::vector<uint8_t> h(80);
+    size_t off = 0;
+    memcpy(h.data() + off, &b.nVersion, 4); off += 4;
+    memcpy(h.data() + off, b.hashPrevBlock.begin(), 32); off += 32;
+    memcpy(h.data() + off, b.hashMerkleRoot.begin(), 32); off += 32;
+    memcpy(h.data() + off, &b.nTime, 4); off += 4;
+    memcpy(h.data() + off, &b.nBits, 4); off += 4;
+    memcpy(h.data() + 76, &nonce32, 4);
+    return h;
+}
+
+// C1: vdf challenge 56-byte preimage, old form.
+static std::vector<uint8_t> old_c1_vdf_preimage(const uint256& prevHash, int height,
+                                                const std::array<uint8_t, 20>& addr) {
+    std::vector<uint8_t> pre(56);
+    memcpy(pre.data(), prevHash.data, 32);
+    uint32_t hLE = static_cast<uint32_t>(height);
+    memcpy(pre.data() + 32, &hLE, 4);
+    memcpy(pre.data() + 36, addr.data(), 20);
+    return pre;
+}
+
+// ---------------------------------------------------------------------------
+// NEW: build the A4 miner header via the PRODUCTION helpers (mirrors controller).
+// controller.cpp writes into a raw 80-byte buffer at fixed offsets using
+// WriteLE32; we reproduce exactly that sequence here to exercise the same code.
+// ---------------------------------------------------------------------------
+static std::vector<uint8_t> new_a4_miner_header(const CBlockHeader& b, uint32_t nonce32) {
+    std::vector<uint8_t> h(80);
+    size_t off = 0;
+    WriteLE32(h.data() + off, static_cast<uint32_t>(b.nVersion)); off += 4;
+    memcpy(h.data() + off, b.hashPrevBlock.begin(), 32); off += 32;
+    memcpy(h.data() + off, b.hashMerkleRoot.begin(), 32); off += 32;
+    WriteLE32(h.data() + off, b.nTime); off += 4;
+    WriteLE32(h.data() + off, b.nBits); off += 4;
+    WriteLE32(h.data() + 76, nonce32);
+    return h;
+}
+
+// A3-FillShortTxIDSelector NEW preimage (mirrors production emission).
+static std::vector<uint8_t> new_a3_selector_preimage(const CBlockHeader& header, uint64_t nonce) {
+    std::vector<uint8_t> data(88);
+    WriteLE32(data.data(), static_cast<uint32_t>(header.nVersion));
+    memcpy(data.data() + 4,  header.hashPrevBlock.data, 32);
+    memcpy(data.data() + 36, header.hashMerkleRoot.data, 32);
+    WriteLE32(data.data() + 68, header.nTime);
+    WriteLE32(data.data() + 72, header.nBits);
+    WriteLE32(data.data() + 76, header.nNonce);
+    WriteLE64(data.data() + 80, nonce);
+    return data;
+}
+
+// C1 NEW preimage (mirrors production emission in vdf_validation.cpp).
+static std::vector<uint8_t> new_c1_vdf_preimage(const uint256& prevHash, int height,
+                                                const std::array<uint8_t, 20>& addr) {
+    std::vector<uint8_t> pre(56);
+    memcpy(pre.data(), prevHash.data, 32);
+    uint32_t h = static_cast<uint32_t>(height);
+    pre[32] = static_cast<uint8_t>(h);
+    pre[33] = static_cast<uint8_t>(h >> 8);
+    pre[34] = static_cast<uint8_t>(h >> 16);
+    pre[35] = static_cast<uint8_t>(h >> 24);
+    memcpy(pre.data() + 36, addr.data(), 20);
+    return pre;
+}
+
+// ---------------------------------------------------------------------------
+// Representative header inputs.
+// ---------------------------------------------------------------------------
+static CBlockHeader make_header(int32_t v, uint32_t t, uint32_t bits, uint32_t nonce, bool vdf) {
+    CBlockHeader h;
+    h.nVersion = v; h.nTime = t; h.nBits = bits; h.nNonce = nonce;
+    for (int i = 0; i < 32; i++) { h.hashPrevBlock.data[i] = static_cast<uint8_t>(0x11 * (i + 1));
+                                   h.hashMerkleRoot.data[i] = static_cast<uint8_t>(0x07 * (i + 3)); }
+    if (vdf) {
+        for (int i = 0; i < 32; i++) { h.vdfOutput.data[i] = static_cast<uint8_t>(i);
+                                       h.vdfProofHash.data[i] = static_cast<uint8_t>(0xF0 - i); }
+    }
+    return h;
+}
+
+// ===========================================================================
+int main() {
+    printf("=== WF-1 host-endian differential / byte-equality test ===\n\n");
+
+    // Representative header field values, including 0, max, and bit-mixed.
+    struct HV { int32_t v; uint32_t t; uint32_t bits; uint32_t nonce; };
+    std::vector<HV> hvs = {
+        {1, 1737158400u, 0x1e01fffeu, 429612875u},   // DIL genesis-like
+        {0, 0u, 0u, 0u},
+        {4, 0xFFFFFFFFu, 0xFFFFFFFFu, 0xFFFFFFFFu},   // VDF, all-ones
+        {4, 0x01020304u, 0xdeadbeefu, 0x12345678u},   // VDF, mixed
+        {1, 0x80000000u, 0x00ff00ffu, 0x0000abcdu},
+    };
+
+    // ---- FAMILY A ----
+    printf("FAMILY A — block-header hash preimage (4 sites)\n");
+    for (const auto& x : hvs) {
+        bool vdf = (x.v >= CBlockHeader::VDF_VERSION);
+        CBlockHeader h = make_header(x.v, x.t, x.bits, x.nonce, vdf);
+
+        // A1: canonical CBlockHeader::SerializeHeader()
+        expect_eq_bytes("A1 block.cpp SerializeHeader",
+                        "v=" + std::to_string(x.v),
+                        h.SerializeHeader(), old_block_serialize_header(h));
+
+        // A3-selector: FillShortTxIDSelector 88-byte SHA3 preimage
+        uint64_t sel_nonce = 0x1122334455667788ULL ^ x.nonce;
+        expect_eq_bytes("A3 blockenc selector",
+                        "v=" + std::to_string(x.v),
+                        new_a3_selector_preimage(h, sel_nonce),
+                        old_a3_selector_preimage(h, sel_nonce));
+
+        // A3-wire: CBlockHeaderAndShortTxIDs::Serialize() header region + full round-trip.
+        {
+            CBlockHeaderAndShortTxIDs comp;
+            comp.header = h;
+            comp.nonce = sel_nonce;
+            comp.shorttxids = { 0x010203040506ULL, 0x0A0B0C0D0E0FULL };
+            std::vector<uint8_t> wire = comp.Serialize();
+            // Round-trip must reconstruct identical header scalars.
+            CBlockHeaderAndShortTxIDs back;
+            bool ok = back.Deserialize(wire.data(), wire.size());
+            g_checks++;
+            if (ok && back.header.nVersion == h.nVersion && back.header.nTime == h.nTime &&
+                back.header.nBits == h.nBits && back.header.nNonce == h.nNonce &&
+                back.nonce == comp.nonce && back.shorttxids == comp.shorttxids) {
+                printf("  [PASS] %-28s v=%d wire round-trip\n", "A3 blockenc wire", x.v);
+            } else {
+                g_failures++;
+                printf("  [FAIL] %-28s v=%d wire round-trip (ok=%d)\n", "A3 blockenc wire", x.v, ok);
+            }
+        }
+
+        // A2: genesis mining helper (legacy 80-byte). Assert (i) new==old on LE,
+        // and (ii) new == the canonical A1 legacy 80-byte serialization — so the
+        // genesis miner and the validator agree byte-for-byte.
+        {
+            // Genesis mining is always a legacy (v1) block; force v1 so the A2
+            // helper and the A1 canonical serializer are compared apples-to-apples.
+            CBlockHeader legacy = h; legacy.nVersion = 1; legacy.nNonce = x.nonce;
+            CBlock gb; static_cast<CBlockHeader&>(gb) = legacy;
+            std::vector<uint8_t> newA2 = new_genesis_serialize_header(gb, x.nonce);
+            expect_eq_bytes("A2 genesis SerializeHeader",
+                            "new==old",
+                            newA2, old_genesis_serialize_header(gb, x.nonce));
+            std::vector<uint8_t> a1legacy = legacy.SerializeHeader();  // 80 bytes for v1
+            expect_eq_bytes("A2 genesis == A1 canonical",
+                            "miner==validator",
+                            newA2, a1legacy);
+        }
+
+        // A4: miner hot-loop buffer (only legacy/80-byte path is mined)
+        expect_eq_bytes("A4 controller header",
+                        "v=" + std::to_string(x.v),
+                        new_a4_miner_header(h, x.nonce), old_a4_miner_header(h, x.nonce));
+    }
+
+    // ---- FAMILY C ----
+    printf("\nFAMILY C — VDF challenge preimage (1 site)\n");
+    {
+        uint256 prev;
+        for (int i = 0; i < 32; i++) prev.data[i] = static_cast<uint8_t>(0x33 + i);
+        std::array<uint8_t, 20> addr{};
+        for (int i = 0; i < 20; i++) addr[i] = static_cast<uint8_t>(0xA0 + i);
+        std::vector<int> heights = {0, 1, 40000, 0x00FF00FF, 0x7FFFFFFF, (int)0xFFFFFFFF};
+        for (int hgt : heights) {
+            expect_eq_bytes("C1 vdf_validation height",
+                            "h=" + std::to_string(hgt),
+                            new_c1_vdf_preimage(prev, hgt, addr),
+                            old_c1_vdf_preimage(prev, hgt, addr));
+        }
+    }
+
+    // ---- FAMILY B ----
+    printf("\nFAMILY B — Digital-DNA dna_hash preimage (4 dims)\n");
+    {
+        using namespace digital_dna;
+
+        // B1 behavioral_profile
+        {
+            BehavioralProfile p;
+            for (int i = 0; i < 24; i++) p.hourly_activity[i] = 1.5 * i - 3.25;
+            p.mean_relay_delay_ms = 42.125; p.relay_consistency = 0.75;
+            p.avg_peer_session_duration_sec = 123456.789; p.peer_diversity_score = 0.333;
+            p.tx_relay_rate = 9.5; p.tx_timing_entropy = 3.14159265358979;
+            p.observation_blocks = 0xDEADBEEF; p.start_time = 0x0102030405060708ULL;
+            p.end_time = 0xFFFFFFFFFFFFFFFFULL;
+            std::vector<uint8_t> got = p.serialize();
+
+            // OLD host-endian reproduction
+            std::vector<uint8_t> old;
+            auto pd = [&](double d){ const uint8_t* q = reinterpret_cast<const uint8_t*>(&d); old.insert(old.end(), q, q + 8); };
+            for (int i = 0; i < 24; i++) pd(p.hourly_activity[i]);
+            pd(p.mean_relay_delay_ms); pd(p.relay_consistency); pd(p.avg_peer_session_duration_sec);
+            pd(p.peer_diversity_score); pd(p.tx_relay_rate); pd(p.tx_timing_entropy);
+            { const uint8_t* q = reinterpret_cast<const uint8_t*>(&p.observation_blocks); old.insert(old.end(), q, q + 4); }
+            { const uint8_t* q = reinterpret_cast<const uint8_t*>(&p.start_time); old.insert(old.end(), q, q + 8); }
+            { const uint8_t* q = reinterpret_cast<const uint8_t*>(&p.end_time); old.insert(old.end(), q, q + 8); }
+            expect_eq_bytes("B1 behavioral_profile", "serialize", got, old);
+
+            // Round-trip
+            BehavioralProfile r = BehavioralProfile::deserialize(got);
+            g_checks++;
+            if (r.observation_blocks == p.observation_blocks && r.start_time == p.start_time &&
+                r.end_time == p.end_time && r.tx_timing_entropy == p.tx_timing_entropy) {
+                printf("  [PASS] %-28s round-trip\n", "B1 behavioral_profile");
+            } else { g_failures++; printf("  [FAIL] %-28s round-trip\n", "B1 behavioral_profile"); }
+        }
+
+        // B2 clock_drift
+        {
+            ClockDriftFingerprint f;
+            f.drift_rate_ppm = -1.25; f.drift_stability = 0.001; f.jitter_signature = 987.654;
+            f.observation_start = 0x1111222233334444ULL; f.observation_end = 0x5555666677778888ULL;
+            f.num_reference_peers = 0xABCD1234; f.num_samples = 0x0000FFFF;
+            std::vector<uint8_t> got = f.serialize();
+
+            std::vector<uint8_t> old(48); size_t o = 0;
+            memcpy(old.data()+o,&f.drift_rate_ppm,8); o+=8;
+            memcpy(old.data()+o,&f.drift_stability,8); o+=8;
+            memcpy(old.data()+o,&f.jitter_signature,8); o+=8;
+            memcpy(old.data()+o,&f.observation_start,8); o+=8;
+            memcpy(old.data()+o,&f.observation_end,8); o+=8;
+            memcpy(old.data()+o,&f.num_reference_peers,4); o+=4;
+            memcpy(old.data()+o,&f.num_samples,4); o+=4;
+            expect_eq_bytes("B2 clock_drift", "serialize", got, old);
+
+            ClockDriftFingerprint r = ClockDriftFingerprint::deserialize(got);
+            g_checks++;
+            if (r.num_reference_peers == f.num_reference_peers && r.observation_end == f.observation_end &&
+                r.jitter_signature == f.jitter_signature) {
+                printf("  [PASS] %-28s round-trip\n", "B2 clock_drift");
+            } else { g_failures++; printf("  [FAIL] %-28s round-trip\n", "B2 clock_drift"); }
+        }
+
+        // B3 memory_fingerprint
+        {
+            MemoryFingerprint f;
+            for (int i = 0; i < 3; i++) {
+                MemoryProbeResult p;
+                p.working_set_kb = static_cast<uint32_t>(64u << i);
+                p.access_time_ns = 10.5 * (i + 1);
+                p.bandwidth_mbps = 1000.0 / (i + 1);
+                f.access_curve.push_back(p);
+            }
+            f.estimated_l1_kb = 32.0; f.estimated_l2_kb = 256.0; f.estimated_l3_kb = 8192.0;
+            f.dram_latency_ns = 85.25; f.peak_bandwidth_mbps = 42000.5;
+            std::vector<uint8_t> got = f.serialize();
+
+            std::vector<uint8_t> old;
+            uint32_t count = static_cast<uint32_t>(f.access_curve.size());
+            { const uint8_t* q = reinterpret_cast<const uint8_t*>(&count); old.insert(old.end(), q, q + 4); }
+            for (const auto& p : f.access_curve) {
+                { const uint8_t* q = reinterpret_cast<const uint8_t*>(&p.working_set_kb); old.insert(old.end(), q, q + 4); }
+                { const uint8_t* q = reinterpret_cast<const uint8_t*>(&p.access_time_ns); old.insert(old.end(), q, q + 8); }
+                { const uint8_t* q = reinterpret_cast<const uint8_t*>(&p.bandwidth_mbps); old.insert(old.end(), q, q + 8); }
+            }
+            { const uint8_t* q = reinterpret_cast<const uint8_t*>(&f.estimated_l1_kb); old.insert(old.end(), q, q + 8); }
+            { const uint8_t* q = reinterpret_cast<const uint8_t*>(&f.estimated_l2_kb); old.insert(old.end(), q, q + 8); }
+            { const uint8_t* q = reinterpret_cast<const uint8_t*>(&f.estimated_l3_kb); old.insert(old.end(), q, q + 8); }
+            { const uint8_t* q = reinterpret_cast<const uint8_t*>(&f.dram_latency_ns); old.insert(old.end(), q, q + 8); }
+            { const uint8_t* q = reinterpret_cast<const uint8_t*>(&f.peak_bandwidth_mbps); old.insert(old.end(), q, q + 8); }
+            expect_eq_bytes("B3 memory_fingerprint", "serialize", got, old);
+
+            MemoryFingerprint r = MemoryFingerprint::deserialize(got);
+            g_checks++;
+            if (r.access_curve.size() == f.access_curve.size() &&
+                r.access_curve[2].bandwidth_mbps == f.access_curve[2].bandwidth_mbps &&
+                r.peak_bandwidth_mbps == f.peak_bandwidth_mbps) {
+                printf("  [PASS] %-28s round-trip\n", "B3 memory_fingerprint");
+            } else { g_failures++; printf("  [FAIL] %-28s round-trip\n", "B3 memory_fingerprint"); }
+        }
+
+        // B4 bandwidth_proof
+        {
+            BandwidthFingerprint f;
+            f.median_upload_mbps = 55.5; f.median_download_mbps = 940.25;
+            f.median_asymmetry = 0.059; f.bandwidth_stability = 0.98;
+            f.measurements.resize(7);  // count only is serialized
+            std::vector<uint8_t> got = f.serialize();
+
+            std::vector<uint8_t> old(36); size_t o = 0;
+            memcpy(old.data()+o,&f.median_upload_mbps,8); o+=8;
+            memcpy(old.data()+o,&f.median_download_mbps,8); o+=8;
+            memcpy(old.data()+o,&f.median_asymmetry,8); o+=8;
+            memcpy(old.data()+o,&f.bandwidth_stability,8); o+=8;
+            uint32_t count = static_cast<uint32_t>(f.measurements.size());
+            memcpy(old.data()+o,&count,4); o+=4;
+            expect_eq_bytes("B4 bandwidth_proof", "serialize", got, old);
+
+            BandwidthFingerprint r = BandwidthFingerprint::deserialize(got);
+            g_checks++;
+            if (r.median_download_mbps == f.median_download_mbps &&
+                r.bandwidth_stability == f.bandwidth_stability) {
+                printf("  [PASS] %-28s round-trip\n", "B4 bandwidth_proof");
+            } else { g_failures++; printf("  [FAIL] %-28s round-trip\n", "B4 bandwidth_proof"); }
+        }
+    }
+
+    // ---- GENESIS HASH UNCHANGED (the whole point) ----
+    printf("\nGENESIS-HASH-UNCHANGED proof (DIL mainnet)\n");
+    {
+        g_chainParams = new ChainParams(ChainParams::Mainnet());
+        const std::string frozen = g_chainParams->genesisHash;  // chainparams.cpp constant
+
+        CBlock genesis = Genesis::CreateGenesisBlock();
+
+        // (a) Airtight: the 80-byte header preimage the hash consumes must be
+        //     byte-identical to the old host-endian construction. RandomX is a
+        //     pure function of these bytes, so identical bytes => identical hash.
+        std::vector<uint8_t> newPre = genesis.SerializeHeader();
+        std::vector<uint8_t> oldPre = old_block_serialize_header(genesis);
+        expect_eq_bytes("GENESIS preimage", "80-byte header", newPre, oldPre);
+        g_checks++;
+        if (newPre.size() == 80) {
+            printf("  [PASS] %-28s preimage is 80 bytes (legacy/RandomX)\n", "GENESIS preimage");
+        } else { g_failures++; printf("  [FAIL] GENESIS preimage size=%zu (expected 80)\n", newPre.size()); }
+
+        // (b) End-to-end: compute the actual RandomX genesis hash and compare to
+        //     the frozen constant.
+        const char* rx_key = "Dilithion-RandomX-v1";
+        randomx_init_for_hashing(rx_key, strlen(rx_key), 0);  // light init
+        genesis.InvalidateCache();
+        std::string computed = genesis.GetHash().GetHex();
+
+        g_checks++;
+        if (computed == frozen) {
+            printf("  [PASS] %-28s %s == frozen constant\n", "GENESIS hash", computed.c_str());
+        } else {
+            g_failures++;
+            printf("  [FAIL] %-28s CHAIN-SPLIT: genesis hash CHANGED\n", "GENESIS hash");
+            printf("         computed: %s\n", computed.c_str());
+            printf("         frozen:   %s\n", frozen.c_str());
+        }
+
+        delete g_chainParams; g_chainParams = nullptr;
+    }
+
+    // ---- SUMMARY ----
+    printf("\n=== SUMMARY: %d checks, %d failures ===\n", g_checks, g_failures);
+    if (g_failures == 0) {
+        printf("ALL BYTE-EQUALITY + GENESIS-HASH-UNCHANGED CHECKS PASSED.\n");
+        return 0;
+    }
+    printf("FAILURES PRESENT — DO NOT MERGE (potential chain split).\n");
+    return 1;
+}


### PR DESCRIPTION
## What & why

The completeness sweep + WF-1 host-endian sweep found that **9 consensus-observable serialization sites** — including the **block-header hash preimage and the genesis hash** — serialize `nVersion/nTime/nBits/nNonce` (and DNA/VDF fields) in **host byte order** (`memcpy(&x)`), in four hand-written copies. A big-endian node would therefore compute a **different hash for every block and a different genesis hash → total cross-architecture consensus split.** This is a genesis-freeze blocker. This PR converts all 9 to **explicit little-endian**, which is **byte-identical on every little-endian machine** (all production targets), closing the BE-fork surface with zero behavior change on the live network.

## Changes
- **Single-sourced** the block-header serializer: new canonical `WriteLE32/AppendLE32/WriteLE64/ReadLE*` in `primitives/block.h`; the 4 header sites (`block.cpp` validator, `genesis.cpp` miner, `blockencodings.cpp`, `controller.cpp` hot-loop) now all route through it and emit **identical bytes** (kills the duplication that let them drift).
- **DNA** `dna_hash` preimage: new `digital_dna/dna_serialize.h` shared LE helpers, single-sourcing the 4 dimension serializers.
- **VDF** challenge height (`vdf_validation.cpp`) → explicit `WriteLE32`.
- New `src/test/wf1_host_endian_differential_test.cpp` (51 checks).

## Safety (this is the block-header + genesis surface, so the bar is proof)
- **51/51 differential checks pass**: each site's new bytes == the old host-endian bytes on this LE machine.
- **Both genesis hashes proven byte-UNCHANGED**: DIL `0000009eaa5e…` and DilV `ed06d89a…` (full-hash assertions + 144-byte preimage byte-equality).
- **Fresh-context red-team: MERGE-SAFE, no BLOCKER/HIGH** (`_REDTEAM_wf1_endian_fix_2026-07-01.md`) — endianness genuinely LSB-first (no signed-shift UB), all 9 sites byte-equal at the real call sites, 4 header copies identical.
- Build clean; `block_tests` 54 cases + full Boost suite (669) exit 0; `genesis_gen` verification passed.

## ⚠️ Scope note for reviewer (A3) — your call to split
This PR also LE-converts the **compact-block P2P wire framing** (`blockencodings.cpp`: u64 selector nonce, u32 count, u16 prefilled/diff) on both Serialize+Deserialize. The red-team confirms this is **P2P-only (not consensus-observable), byte-equal on LE, and a correct matched round-trip** — but notes it broadens a consensus-safety PR into P2P-portability. Kept here as the same endian-portability theme; **split into its own PR if you prefer a pure-consensus diff.**

## Genesis-branch orthogonality
Touches only the header **serializer** byte-order — NOT `CreateGenesisBlock`, `IsGenesisBlock`, or any hash-comparison/guard path. **Orthogonal to `fix/genesis-hash-integrity-guard`** (no edited-line overlap); the two can land independently.

Draft pending CI + your review/merge.