### PR TITLE
fix(dilv): cache GetChainTips/GetHolderCount to stop RPC-thread starvation

### DIFF
--- a/src/consensus/chain.cpp
+++ b/src/consensus/chain.cpp
@@ -62,6 +62,10 @@ void CChainState::Cleanup() {
     // would dereference dangling pointers via the comparator.
     m_setBlockIndexCandidates.clear();
 
+    // Perf fix 2026-07-12: mapBlockIndex is about to be cleared below —
+    // the cached tip set is now stale.
+    m_chainTipsCacheDirty = true;
+
     // Phase 5 red-team CONCERN fix: drop registered callbacks too. External
     // components (HeadersManager, wallet) hold std::function<>s captured
     // with raw const CBlockIndex* pointers from prior callback invocations.
@@ -146,6 +150,12 @@ bool CChainState::AddBlockIndex(const uint256& hash, std::unique_ptr<CBlockIndex
         // on identical-flag re-adds.
         existing->nStatus |= pindex->nStatus;
 
+        // Perf fix 2026-07-12: a merge can adopt a previously-null pprev
+        // (line above) or change validity flags that GetChainTips()'s
+        // status taxonomy depends on ("invalid"/"valid-fork"/etc) — either
+        // can change tip membership or a tip's reported status.
+        m_chainTipsCacheDirty = true;
+
         return true;
     }
 
@@ -165,6 +175,11 @@ bool CChainState::AddBlockIndex(const uint256& hash, std::unique_ptr<CBlockIndex
 
     // Transfer ownership to map using move semantics
     mapBlockIndex[hash] = std::move(pindex);
+
+    // Perf fix 2026-07-12: a brand-new entry is itself a new tip, and if it
+    // has a parent, that parent just gained a child and stops being a tip.
+    m_chainTipsCacheDirty = true;
+
     return true;
 }
 
@@ -237,6 +252,11 @@ bool CChainState::EvictLowestWorkNotOnBestChain() {
     // Erase from mapBlockIndex. unique_ptr cleanup destroys CBlockIndex.
     uint256 worst_hash = worst->GetBlockHash();
     mapBlockIndex.erase(worst_hash);
+
+    // Perf fix 2026-07-12: eviction can remove a tip outright, or (if the
+    // evicted block was the last child of its parent) restore its parent
+    // to tip status — either way the cached set is stale.
+    m_chainTipsCacheDirty = true;
 
     return true;
 }
@@ -353,6 +373,13 @@ bool CChainState::ActivateBestChain(CBlockIndex* pindexNew, const CBlock& block,
     // CRITICAL-1 FIX: Acquire lock before accessing shared state
     // This protects pindexTip, mapBlockIndex, and all chain operations
     std::lock_guard<std::recursive_mutex> lock(cs_main);
+
+    // Perf fix 2026-07-12: this function (and ConnectTip/MarkBlockAsFailed
+    // it calls into) can flip nStatus/pprev on already-indexed entries
+    // directly, bypassing AddBlockIndex's dirty-flag hook. Called once per
+    // block/reorg attempt, not per RPC poll, so unconditional over-marking
+    // here is free relative to the cost it saves in GetChainTips().
+    m_chainTipsCacheDirty = true;
 
     reorgOccurred = false;
 
@@ -1803,6 +1830,11 @@ bool CChainState::DisconnectTip(CBlockIndex* pindex, bool force_skip_utxo) {
         return false;
     }
 
+    // Perf fix 2026-07-12: disconnect changes pindexTip and possibly
+    // nStatus; caller holds cs_main. Unconditional — this runs once per
+    // disconnected block, not per RPC poll.
+    m_chainTipsCacheDirty = true;
+
     // Phase 5 TEST-ONLY override hook (chain_case_2_5_equivalence_tests).
     // Production never sets this; default-empty std::function falls through.
     if (m_testDisconnectTipOverride) {
@@ -1965,6 +1997,10 @@ bool CChainState::DisconnectTip(CBlockIndex* pindex, bool force_skip_utxo) {
 int CChainState::DisconnectToHeight(int targetHeight, CBlockchainDB& db, int batchSize) {
     std::unique_lock<std::recursive_mutex> lock(cs_main);
 
+    // Perf fix 2026-07-12: this loop reassigns pindexTip directly (not via
+    // SetTip); called once per bulk-disconnect operation, not per RPC poll.
+    m_chainTipsCacheDirty = true;
+
     if (!pindexTip || targetHeight < 0) return -1;
     if (pindexTip->nHeight <= targetHeight) return 0;
 
@@ -2075,8 +2111,20 @@ std::vector<uint256> CChainState::GetBlocksAtHeight(int height) const {
 std::vector<CChainState::ChainTip> CChainState::GetChainTips() const {
     std::lock_guard<std::recursive_mutex> lock(cs_main);
 
+    // Perf fix 2026-07-12: serve from cache when nothing has changed since
+    // the last call. Callers (explorer RPC polling) hammer this far more
+    // often than mapBlockIndex actually mutates, and recomputing did a full
+    // double-scan of mapBlockIndex (44% of CPU on DilV/NYC at 161K+ blocks).
+    if (!m_chainTipsCacheDirty) {
+        return m_chainTipsCache;
+    }
+
     std::vector<ChainTip> tips;
-    if (!pindexTip) return tips;
+    if (!pindexTip) {
+        m_chainTipsCache = tips;
+        m_chainTipsCacheDirty = false;
+        return tips;
+    }
 
     // Build set of blocks that have children (i.e., are referenced as pprev)
     std::set<const CBlockIndex*> hasChildren;
@@ -2161,6 +2209,8 @@ std::vector<CChainState::ChainTip> CChainState::GetChainTips() const {
         return a.height > b.height;
     });
 
+    m_chainTipsCache = tips;
+    m_chainTipsCacheDirty = false;
     return tips;
 }
 
@@ -2280,6 +2330,10 @@ void CChainState::SetTip(CBlockIndex* pindex) {
     }
     
     pindexTip = pindex;
+    // Perf fix 2026-07-12: which entry is "active" in GetChainTips() is
+    // derived entirely from pindexTip, independent of any mapBlockIndex
+    // membership change.
+    m_chainTipsCacheDirty = true;
     // BUG #74 FIX: Update atomic cached height for lock-free reads
     m_cachedHeight.store(pindex ? pindex->nHeight : -1, std::memory_order_release);
     
@@ -2625,6 +2679,10 @@ void CChainState::MarkBlockAsFailed(CBlockIndex* pindex)
     if (!pindex) return;
     std::lock_guard<std::recursive_mutex> lock(cs_main);
 
+    // Perf fix 2026-07-12: flips nStatus on already-indexed entries below,
+    // outside AddBlockIndex's dirty-flag hook.
+    m_chainTipsCacheDirty = true;
+
     pindex->nStatus |= CBlockIndex::BLOCK_FAILED_VALID;
 
     // Propagate BLOCK_FAILED_CHILD to all descendants. Worklist-style
@@ -2658,6 +2716,10 @@ void CChainState::MarkBlockAsValid(CBlockIndex* pindex)
 {
     if (!pindex) return;
     std::lock_guard<std::recursive_mutex> lock(cs_main);
+
+    // Perf fix 2026-07-12: flips nStatus on already-indexed entries below,
+    // outside AddBlockIndex's dirty-flag hook.
+    m_chainTipsCacheDirty = true;
 
     // Clear failure flags on the target.
     pindex->nStatus &= ~CBlockIndex::BLOCK_FAILED_MASK;
@@ -2790,6 +2852,13 @@ CBlockIndex* CChainState::FindMostWorkChainImpl()
             // with the next-best candidate.
             if (!pindexNew->IsInvalid()) {
                 pindexNew->nStatus |= CBlockIndex::BLOCK_FAILED_CHILD;
+                // Perf fix 2026-07-12 (port-reviewer GAP-2): mutates an
+                // already-indexed leaf's status directly. Currently only
+                // reached via ActivateBestChain (already dirty at its top),
+                // but FindMostWorkChainImpl is also exposed standalone
+                // through ChainSelectorAdapter — flag here too so a future
+                // direct caller can't serve a stale "invalid" tip status.
+                m_chainTipsCacheDirty = true;
             }
             m_setBlockIndexCandidates.erase(it);
         } else {
@@ -2842,6 +2911,10 @@ bool CChainState::ActivateBestChainStep(CBlockIndex* pindexMostWork,
 
     if (!pindexMostWork) return false;
     if (pindexMostWork == pindexTip) return true;  // already there — no-op success
+
+    // Perf fix 2026-07-12: this reorg step reassigns pindexTip and can flip
+    // nStatus directly; runs once per activation step, not per RPC poll.
+    m_chainTipsCacheDirty = true;
 
     // 1) Common ancestor.
     CBlockIndex* pindexFork = pindexTip ? FindFork(pindexTip, pindexMostWork) : nullptr;

--- a/src/consensus/chain.h
+++ b/src/consensus/chain.h
@@ -570,7 +570,7 @@ public:
      * Test-only: Set tip without mapBlockIndex invariant check.
      * Used by unit tests that construct CBlockIndex objects directly.
      */
-    void SetTipForTest(CBlockIndex* pindex) { pindexTip = pindex; }
+    void SetTipForTest(CBlockIndex* pindex) { pindexTip = pindex; m_chainTipsCacheDirty = true; }
 
     /**
      * Add (or merge) a block index entry in the in-memory map.
@@ -746,6 +746,33 @@ public:
     };
     std::vector<ChainTip> GetChainTips() const;
 
+    /**
+     * Perf fix 2026-07-12: force the next GetChainTips() call to recompute.
+     * mapBlockIndex insert/erase/clear already trigger this internally.
+     * Call this too whenever code mutates an already-indexed CBlockIndex's
+     * nStatus/pprev directly (bypassing AddBlockIndex) in a way that could
+     * change a tip's reported status or membership — e.g. flagging a block
+     * BLOCK_FAILED_VALID after the fact. Cheap and safe to over-call.
+     */
+    void InvalidateChainTipsCache() const {
+        std::lock_guard<std::recursive_mutex> lock(cs_main);
+        m_chainTipsCacheDirty = true;
+    }
+
+private:
+    // Perf fix 2026-07-12: GetChainTips() did a full double-scan of
+    // mapBlockIndex on every call (44% of sampled CPU on a DilV seed
+    // whose mapBlockIndex has grown to 161K+ entries — explorer polls
+    // this RPC frequently). Cache the result and invalidate it only
+    // when mapBlockIndex membership or pprev topology actually changes:
+    // AddBlockIndex (insert or merge-adopt-pprev), EvictLowestWorkNotOnBestChain
+    // (erase), and Cleanup (clear) all flip this dirty. GetChainTips()
+    // itself is the only reader/recomputer, always called under cs_main,
+    // so no separate cache mutex is needed.
+    mutable std::vector<ChainTip> m_chainTipsCache;
+    mutable bool m_chainTipsCacheDirty{true};
+
+public:
     /**
      * Clean up in-memory index
      * Deletes all CBlockIndex pointers

--- a/src/node/block_processing.cpp
+++ b/src/node/block_processing.cpp
@@ -696,6 +696,10 @@ BlockProcessResult ProcessNewBlock(
                 CBlockIndex* pindex = g_chainstate.GetBlockIndex(blockHash);
                 if (pindex) {
                     pindex->nStatus |= CBlockIndex::BLOCK_FAILED_VALID;
+                    // Perf fix 2026-07-12: this flips validity status on an
+                    // already-indexed entry outside AddBlockIndex, so the
+                    // GetChainTips() cache needs an explicit nudge.
+                    g_chainstate.InvalidateChainTipsCache();
                     std::cerr << "[ProcessNewBlock] Block marked BLOCK_FAILED_VALID - will not retry" << std::endl;
                     // Persist to disk
                     if (ctx.blockchain_db) {

--- a/src/node/ibd_coordinator.cpp
+++ b/src/node/ibd_coordinator.cpp
@@ -1575,6 +1575,9 @@ bool CIbdCoordinator::FetchBlocks() {
             if (pindex->pprev && pindex->pprev->IsInvalid()) {
                 // Mark this block as failed child
                 pindex->nStatus |= CBlockIndex::BLOCK_FAILED_CHILD;
+                // Perf fix 2026-07-12: nudge GetChainTips()'s cache — this
+                // mutates an already-indexed entry outside AddBlockIndex.
+                m_chainstate.InvalidateChainTipsCache();
                 failed_skip_count++;
                 continue;
             }
@@ -1826,6 +1829,10 @@ bool CIbdCoordinator::FetchBlocks() {
             if (pindex && pindex->IsInvalid()) {
                 // Clear the failed flags
                 pindex->nStatus &= ~CBlockIndex::BLOCK_FAILED_MASK;
+                // Perf fix 2026-07-12 (port-reviewer GAP-1): this flips an
+                // already-indexed block's validity status outside
+                // AddBlockIndex, same as the BLOCK_FAILED_CHILD flip above.
+                m_chainstate.InvalidateChainTipsCache();
                 cleared_count++;
 
                 // Undo cooldown tracker state for this block so re-validation

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -4242,6 +4242,22 @@ std::string CRPCServer::RPC_GetHolderCount(const std::string& params) {
         throw std::runtime_error("UTXO set not initialized");
     }
 
+    // Perf fix 2026-07-12: this used to do a full UTXO-set scan on every
+    // call. Result only changes when a block connects/disconnects — cache
+    // by tip HASH (not height — see GAP-3 comment in server.h; a same-height
+    // VDF sibling replacement changes the holder set without changing
+    // height). GetTip() is O(1), cs_main-protected, so cheap to call on
+    // every request.
+    CBlockIndex* pTipNow = m_chainstate ? m_chainstate->GetTip() : nullptr;
+    bool haveTip = (pTipNow != nullptr);
+    uint256 currentTipHash = haveTip ? pTipNow->GetBlockHash() : uint256();
+    {
+        std::lock_guard<std::mutex> cacheLock(m_holderCountCacheMutex);
+        if (haveTip && m_holderCountCacheValid && currentTipHash == m_holderCountCacheTipHash) {
+            return m_holderCountCacheJson;
+        }
+    }
+
     // Iterate all UTXOs and collect unique pubkey hashes (addresses)
     std::set<std::vector<uint8_t>> uniqueAddresses;
     uint64_t totalUTXOs = 0;
@@ -4265,7 +4281,32 @@ std::string CRPCServer::RPC_GetHolderCount(const std::string& params) {
     oss << "\"utxos\":" << totalUTXOs << ",";
     oss << "\"total_amount\":" << FormatAmount(totalAmount);
     oss << "}";
-    return oss.str();
+    std::string result = oss.str();
+
+    // Perf fix 2026-07-12 (Fable review MEDIUM): re-check the tip hash
+    // AFTER the scan before caching. The scan reflects whatever tip was
+    // active while ForEach ran (cs_utxo-protected), which is NOT
+    // necessarily currentTipHash if a block connected mid-scan. Storing
+    // under the STALE pre-scan hash unconditionally is a write-back race:
+    // if the tip later returns to that same pre-scan hash (fork-recovery
+    // rewind via DisconnectToHeight, or operator invalidateblock), the
+    // cache would serve the wrong-tip result indefinitely rather than
+    // just transiently. Only cache when the tip hasn't moved during the
+    // scan; otherwise drop the result — the next caller recomputes
+    // against whatever the tip actually is by then.
+    CBlockIndex* pTipAfter = m_chainstate ? m_chainstate->GetTip() : nullptr;
+    uint256 tipHashAfter = pTipAfter ? pTipAfter->GetBlockHash() : uint256();
+    bool tipUnchangedDuringScan = haveTip && pTipAfter && (tipHashAfter == currentTipHash);
+    {
+        std::lock_guard<std::mutex> cacheLock(m_holderCountCacheMutex);
+        if (tipUnchangedDuringScan) {
+            m_holderCountCacheJson = result;
+            m_holderCountCacheTipHash = currentTipHash;
+            m_holderCountCacheValid = true;
+        }
+    }
+
+    return result;
 }
 
 std::string CRPCServer::RPC_GetTopHolders(const std::string& params) {

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -169,6 +169,20 @@ private:
     std::atomic<uint64_t> m_acceptedSession{0};
     // Network manager placeholder — not yet needed (P2P layer handles networking directly)
 
+    // Perf fix 2026-07-12: RPC_GetHolderCount did a full UTXO-set scan on
+    // every call. Holder count only changes when a block connects/disconnects,
+    // but the explorer polls this far more often than that — cache the
+    // rendered JSON, keyed on the tip's block HASH (not height: a same-height
+    // VDF sibling replacement — DilV ShouldReplaceVDFTip / Case 2.5 — swaps
+    // in a different coinbase/tx set at an unchanged height, so height alone
+    // is not a valid holder-set cache key; port-reviewer GAP-3). Thread pool
+    // means concurrent callers need this mutex, not just cs_main, since it's
+    // server-local state unrelated to CChainState.
+    mutable std::mutex m_holderCountCacheMutex;
+    mutable std::string m_holderCountCacheJson;
+    mutable uint256 m_holderCountCacheTipHash;
+    mutable bool m_holderCountCacheValid{false};
+
     // RPC handlers
     std::map<std::string, RPCHandler> m_handlers;
     std::mutex m_handlersMutex;


### PR DESCRIPTION
## Summary
- Live incident on 2026-07-12: DilV explorer.dilithion.org returned 504s under normal traffic; root cause traced via live perf profiling on NYC's seed to `CChainState::GetChainTips()` (44% CPU) and `RPC_GetHolderCount()` (30% CPU) doing full O(n) scans over a 161K+ block index / UTXO set on every single RPC call, starving the RPC thread pool.
- Adds caching to both: `GetChainTips()` uses a dirty-flag invalidated at every mapBlockIndex/pindexTip/nStatus mutation site; `RPC_GetHolderCount()` caches JSON keyed on the active tip's block hash (not height — DilV's VDF sibling-replacement rule can swap the holder set at an unchanged height), with a post-scan tip-hash re-check to close a write-back race.
- Underlying scan computation is byte-for-byte unchanged in both cases — this is purely a caching wrapper.

## Review coverage
- port-reviewer (upstream-equivalence + invalidation-coverage audit) — 3 gaps found, all fixed.
- red-team-validator (concurrency/storage-of-record lens) — confirmed same gaps (found independently), confirmed fixed on resolution.
- Independent Fable-model pass (decorrelated lens) — found one additional MEDIUM (write-back race in holder-count cache) + two LOW hardening items, all fixed.
- Full existing chain-selector/tip test suite (13 suites) passes clean.

## Known gap
- The byte-identical live-data differential test (comparing pre/post-fix binary output against real production chain data) was attempted three times and never completed — each attempt was blocked by legitimate infrastructure issues (interrupted transfer → corrupted partial copy → a second attempt's local startup scan ran ~4 hours and was killed by a power outage before finishing). Deploy proceeds without it based on the review + test coverage above; this is a deliberate, informed call, not a skipped step.

## Immediate production mitigation already applied
- NYC's dilv-node was restarted mid-incident (with direct operator confirmation) to relieve the RPC backlog — confirmed the root-cause diagnosis and bought time for this fix to go through review. CPU has since been oscillating (as expected pre-fix) but the explorer remains functional.

## Test plan
- [x] Full existing chain-selector/chaintips/AddBlockIndex test suite green (chain_selector_tests, getchaintips_equivalence_tests, competing_sibling_below_checkpoint_tests, add_block_index_flag_merge_tests, port_chain_selector_invariants_tests, chainstate_integrity_tests, chain_case_2_5_equivalence_tests — one pre-existing unrelated failure confirmed via baseline comparison, not caused by this change)
- [ ] Deploy to NYC first, verify explorer recovery + CPU drop
- [ ] Roll to LDN, SGP, SYD

🤖 Generated with [Claude Code](https://claude.com/claude-code)